### PR TITLE
feat(waitlist): switch to FormSubmit ID + add _replyto autoresponse

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
       <p>Drop your name and email. We’ll reach out with next steps.</p>
 
       <form class="waitlistForm"
-            action="https://formsubmit.co/ajax/waitlist@tomboflight.com"
+            action="https://formsubmit.co/ajax/422507e8ae32532a167cff416c7e7c3"
             method="POST" novalidate>
         <div class="wl-row" style="margin-bottom:.5rem;">
           <input class="wl-input" type="text" name="name" placeholder="Your name (optional)">
@@ -103,6 +103,8 @@
           <button class="wl-btn btn btn-primary" type="submit">Join</button>
         </div>
 
+        <input type="hidden" name="_replyto">
+        <input type="hidden" name="_template" value="table">
         <input type="hidden" name="_subject" value="New waitlist signup">
         <input type="hidden" name="_captcha" value="false">
         <input type="hidden" name="_autoresponse"
@@ -161,7 +163,7 @@
       <p>Join the Tomb of Light waitlist for early access and launch updates.</p>
 
       <form class="waitlistForm"
-            action="https://formsubmit.co/ajax/waitlist@tomboflight.com"
+            action="https://formsubmit.co/ajax/422507e8ae32532a167cff416c7e7c3"
             method="POST" novalidate>
         <div class="wl-row" style="margin-bottom:.5rem;">
           <input class="wl-input" type="text" name="name" placeholder="Your name (optional)">
@@ -171,6 +173,8 @@
           <button class="wl-btn btn btn-primary" type="submit">Join</button>
         </div>
 
+        <input type="hidden" name="_replyto">
+        <input type="hidden" name="_template" value="table">
         <input type="hidden" name="_subject" value="New waitlist signup">
         <input type="hidden" name="_captcha" value="false">
         <input type="hidden" name="_autoresponse"
@@ -204,17 +208,25 @@
 
             // Honeypot
             const hp = form.querySelector('[name="website"]');
-            if (hp && hp.value) return;
+            if (hp && hp.value) { msg && (msg.textContent = 'Bot check failed.'); return; }
 
             const original = btn ? btn.textContent : '';
             if (btn) { btn.disabled = true; btn.textContent = 'Sending…'; }
 
             try {
+              const fd = new FormData(form);
+              const emailInput = form.querySelector('input[name="email"]');
+              if (emailInput && emailInput.value) fd.set('_replyto', emailInput.value);
+              fd.set('_template', 'table');
+
               const resp = await fetch(form.action, {
                 method: 'POST',
                 headers: { 'Accept': 'application/json' },
-                body: new FormData(form)
+                body: fd
               });
+
+              // Debug log to help diagnose if needed
+              try { const clone = resp.clone(); clone.text().then(t => console.log('[FormSubmit]', resp.status, t)); } catch {}
 
               if (resp.ok) {
                 msg && (msg.textContent = 'Thanks! You’re on the list.');


### PR DESCRIPTION
### What changed
- Replace naked-email endpoint with FormSubmit **ID** endpoint: https://formsubmit.co/ajax/422507e8ae32532a167cff416c7e7c3 (avoids expired activation links and hides the raw address)
- Add hidden fields to both waitlist forms:
  - `_replyto`  → ensures subscriber gets the thank-you email
  - `_template=table` → cleaner admin notification layout
  - keep `_subject`, `_captcha=false`, `_autoresponse` (thank-you text)
- JS submit handler updates:
  - Builds FormData and **sets `_replyto` from the email input**
  - Sets `_template=table`
  - Keeps honeypot, client-side validation, and error handling
  - On success: shows “Thanks! You’re on the list.”, resets form, closes modal, and remembers dismissal in `localStorage`
  - Adds lightweight console log of the response for quick debugging

### Why
- Previous setup used a raw email action and relied on an activation link that expired; the ID endpoint is stable and more private.
- Some FormSubmit configs only trigger autoresponse when `_replyto` is present. This guarantees the subscriber receives the thank-you message.

### Testing
1) Hard refresh the site (⌘⇧R / Ctrl+Shift+R).
2) Submit the **in-page** form and the **modal** form using a non-admin address
   (e.g., personal Gmail).  
   Expected:
   - Network request to `formsubmit.co` returns **200 OK**.
   - Admin notification arrives at `waitlist@tomboflight.com`.
   - Subscriber receives the **thank-you autoresponse** (check Spam/All Mail once). 3) Close the modal → it should not reappear on subsequent visits (stored in `localStorage`).

### Risks / Notes
- If `waitlist@tomboflight.com` alias or group is misconfigured, admin mail may not arrive.
- Ad-blockers could block external requests; added error messaging + console log.
- Rate limiting by FormSubmit is possible on rapid repeated tests.

### Rollback
- Revert `index.html` to the prior commit or switch the form action back to the previous endpoint.