### PR TITLE
Add interactive Genesis prototype with enhanced zoom UX

### DIFF
--- a/genesis-prototype.css
+++ b/genesis-prototype.css
@@ -1,0 +1,398 @@
+:root {
+  color-scheme: dark;
+  --bg: #07080a;
+  --bg-alt: #10131a;
+  --fg: #f9fafc;
+  --accent: #71dfff;
+  --accent-muted: rgba(113, 223, 255, 0.2);
+  --zone-bg: rgba(113, 223, 255, 0.12);
+  --zone-bg-hover: rgba(113, 223, 255, 0.3);
+  --border: rgba(255, 255, 255, 0.12);
+  --shadow: 0 24px 50px rgba(0, 0, 0, 0.65);
+  --transition: 340ms ease;
+  --transition-slow: 540ms cubic-bezier(0.16, 1, 0.3, 1);
+  --radius-large: 18px;
+  --radius-medium: 12px;
+  font-size: clamp(16px, 0.9vw + 15px, 18px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition: 0.001ms;
+    --transition-slow: 0.001ms;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at top, #182033, #050608 52%, #010203 100%);
+  color: var(--fg);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(140deg, rgba(71, 182, 255, 0.12), rgba(217, 64, 255, 0.08));
+  opacity: 0.5;
+  filter: blur(180px);
+  z-index: -1;
+}
+
+.app {
+  width: min(1100px, 96vw);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+
+.app__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 2vw, 2rem);
+}
+
+.app__heading {
+  flex: 1;
+}
+
+.app__back {
+  font-size: 0.95rem;
+  color: var(--accent);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+.app__back:hover,
+.app__back:focus-visible {
+  text-decoration: underline;
+}
+
+.app__subtitle {
+  margin-top: 0.35rem;
+  margin-bottom: 0;
+  color: rgba(255, 255, 255, 0.74);
+  max-width: 60ch;
+}
+
+.app__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(2, 9, 18, 0.6);
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+}
+
+.control-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: rgba(113, 223, 255, 0.18);
+  color: var(--fg);
+  font-size: 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 160ms ease, background var(--transition);
+}
+
+.control-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.control-btn:not(:disabled):hover,
+.control-btn:not(:disabled):focus-visible {
+  background: rgba(113, 223, 255, 0.35);
+  transform: translateY(-2px) scale(1.02);
+  border-color: rgba(113, 223, 255, 0.5);
+}
+
+.viewer {
+  position: relative;
+  background: var(--bg-alt);
+  border-radius: var(--radius-large);
+  padding: clamp(1rem, 3vw, 2rem);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.state-chip {
+  align-self: start;
+  justify-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  background: rgba(113, 223, 255, 0.16);
+  border: 1px solid rgba(113, 223, 255, 0.45);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.image-wrapper {
+  position: relative;
+  max-width: min(680px, 100%);
+  margin: 0 auto;
+  border-radius: var(--radius-large);
+  overflow: hidden;
+  border: 1px solid rgba(113, 223, 255, 0.2);
+  background: radial-gradient(circle at top, rgba(113, 223, 255, 0.18), rgba(113, 223, 255, 0.02));
+  transition: box-shadow var(--transition), transform var(--transition);
+}
+
+.image-wrapper::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(113, 223, 255, 0.45), rgba(189, 140, 255, 0.35), rgba(113, 223, 255, 0.45));
+  opacity: 0.35;
+  filter: blur(12px);
+  z-index: -1;
+  transition: opacity var(--transition);
+}
+
+.image-wrapper[data-state="parents"]::before {
+  opacity: 0.6;
+}
+
+.image-wrapper.is-transitioning {
+  transform: scale(0.985);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.45);
+}
+
+.image-wrapper img {
+  width: 100%;
+  display: block;
+  opacity: 1;
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
+  transform-origin: center center;
+}
+
+.image-wrapper.zooming-in img {
+  transform: scale(1.02);
+}
+
+.image-wrapper.zooming-out img {
+  transform: scale(0.985);
+}
+
+.image-wrapper.is-transitioning img {
+  opacity: 0.2;
+}
+
+.loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(1, 4, 8, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+}
+
+.loading[aria-hidden="false"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.loading__spinner {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 4px solid rgba(113, 223, 255, 0.15);
+  border-top-color: rgba(113, 223, 255, 0.9);
+  animation: spin 1.1s linear infinite;
+}
+
+.loading__text {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  text-shadow: 0 0 12px rgba(113, 223, 255, 0.5);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.zone {
+  position: absolute;
+  top: 8%;
+  transform: translate(-50%, -50%);
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(113, 223, 255, 0.4);
+  background: var(--zone-bg);
+  color: var(--fg);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: transform 160ms ease, background var(--transition), border var(--transition);
+  backdrop-filter: blur(6px);
+  white-space: nowrap;
+}
+
+.zone::after {
+  content: attr(data-hotkey);
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.zone[hidden] {
+  display: none;
+}
+
+.zone:focus-visible,
+.zone:hover {
+  background: var(--zone-bg-hover);
+  border-color: rgba(113, 223, 255, 0.7);
+  transform: translate(-50%, -50%) scale(1.03);
+}
+
+.state-description {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.5;
+  min-height: 3.25rem;
+}
+
+.legend {
+  background: rgba(1, 6, 12, 0.65);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-large);
+  padding: clamp(1.25rem, 3vw, 2rem);
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.32);
+}
+
+.legend__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+}
+
+.legend__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.legend__list kbd {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-weight: 600;
+  background: rgba(113, 223, 255, 0.25);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.75rem;
+  border: 1px solid rgba(113, 223, 255, 0.5);
+}
+
+.toast {
+  position: fixed;
+  bottom: clamp(1rem, 4vw, 2rem);
+  right: clamp(1rem, 4vw, 2rem);
+  background: rgba(11, 20, 32, 0.95);
+  color: var(--fg);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(255, 104, 104, 0.6);
+  padding: 0.75rem 1rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  display: none;
+  max-width: min(360px, 80vw);
+  font-size: 0.95rem;
+}
+
+.toast[hidden] {
+  display: none;
+}
+
+.toast.show {
+  display: block;
+  animation: fadeInUp var(--transition-slow);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: clamp(1rem, 4vw, 1.75rem);
+  }
+
+  .app {
+    gap: 1.25rem;
+  }
+
+  .app__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app__controls {
+    position: sticky;
+    top: 1rem;
+    z-index: 4;
+  }
+
+  .legend__list {
+    gap: 0.65rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .control-btn {
+    width: 40px;
+    height: 40px;
+  }
+
+  .state-description {
+    font-size: 0.98rem;
+  }
+
+  .legend__list {
+    font-size: 0.95rem;
+  }
+}

--- a/genesis-prototype.css
+++ b/genesis-prototype.css
@@ -124,6 +124,15 @@ body::before {
   opacity: 0.4;
 }
 
+.control-btn__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  fill: none;
+  stroke-linecap: round;
+}
+
 .control-btn:not(:disabled):hover,
 .control-btn:not(:disabled):focus-visible {
   background: rgba(113, 223, 255, 0.35);

--- a/genesis-prototype.html
+++ b/genesis-prototype.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Genesis Prototype — Tomb of Light</title>
+  <link rel="stylesheet" href="genesis-prototype.css" />
+</head>
+<body>
+  <main class="app" aria-labelledby="pageTitle">
+    <header class="app__header">
+      <div class="app__heading">
+        <a class="app__back" href="index.html">← Back to Tomb of Light</a>
+        <h1 id="pageTitle">Genesis Prototype – Tomb of Light</h1>
+        <p id="instructionsText" class="app__subtitle">
+          Use scroll, pinch, keyboard arrows, or the onscreen controls to explore the family tree.
+        </p>
+      </div>
+      <div class="app__controls" role="group" aria-label="Zoom controls">
+        <button id="zoomOutBtn" class="control-btn" type="button" aria-label="Zoom out">
+          <span aria-hidden="true">−</span>
+        </button>
+        <button id="zoomInBtn" class="control-btn" type="button" aria-label="Zoom in">
+          <span aria-hidden="true">+</span>
+        </button>
+      </div>
+    </header>
+
+    <section class="viewer" aria-live="polite">
+      <div id="stateChip" class="state-chip" role="status" aria-live="polite"></div>
+      <div id="imageWrapper" class="image-wrapper" data-state="">
+        <button id="zone-julian" class="zone" type="button" aria-label="View Julian Moreland" hidden></button>
+        <button id="zone-malik" class="zone" type="button" aria-label="View Malik Moreland" hidden></button>
+        <button id="zone-selah" class="zone" type="button" aria-label="View Selah Carter" hidden></button>
+
+        <img id="nftImage" src="" alt="" draggable="false" />
+        <div id="loadingSpinner" class="loading" role="status" aria-live="assertive" aria-hidden="true">
+          <span class="loading__spinner" aria-hidden="true"></span>
+          <span class="loading__text">Loading portrait…</span>
+        </div>
+      </div>
+      <p id="stateDescription" class="state-description"></p>
+    </section>
+
+    <section class="legend" aria-label="Navigation tips">
+      <h2 class="legend__title">Navigation Tips</h2>
+      <ul class="legend__list">
+        <li><strong>Scroll / Swipe up</strong> to zoom in. <strong>Scroll / Swipe down</strong> to zoom out.</li>
+        <li><strong>Double tap</strong> or press the <kbd>Enter</kbd> key to zoom in on touch devices.</li>
+        <li><strong>Arrow Up</strong> and <strong>Arrow Down</strong> keys move between generations. <strong>Number keys</strong> jump directly to highlighted siblings.</li>
+        <li>When viewing the parents, <strong>tap a name tag</strong> to jump to that sibling’s branch.</li>
+      </ul>
+    </section>
+  </main>
+
+  <div id="toast" class="toast" role="alert" aria-live="assertive" hidden></div>
+
+  <script src="genesis-prototype.js" type="module"></script>
+</body>
+</html>

--- a/genesis-prototype.html
+++ b/genesis-prototype.html
@@ -18,10 +18,14 @@
       </div>
       <div class="app__controls" role="group" aria-label="Zoom controls">
         <button id="zoomOutBtn" class="control-btn" type="button" aria-label="Zoom out">
-          <span aria-hidden="true">−</span>
+          <svg class="control-btn__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M6 12h12" />
+          </svg>
         </button>
         <button id="zoomInBtn" class="control-btn" type="button" aria-label="Zoom in">
-          <span aria-hidden="true">+</span>
+          <svg class="control-btn__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M12 6v12M6 12h12" />
+          </svg>
         </button>
       </div>
     </header>

--- a/genesis-prototype.js
+++ b/genesis-prototype.js
@@ -1,0 +1,388 @@
+const STATES = {
+  malik: {
+    id: "malik",
+    title: "Malik Moreland",
+    description: "Malik is the narrative anchor for the Moreland line. Zoom in to discover his children and the digital legacies they carry forward.",
+    image: "malik.jpg",
+    zoomIn: "malik_descendants",
+    zoomOut: "parents",
+  },
+  malik_descendants: {
+    id: "malik_descendants",
+    title: "Malik’s Descendants",
+    description: "A closer look at the branches Malik started. Pan through names, dates, and stories that highlight the family’s next chapter.",
+    image: "malik_descendants.jpg",
+    zoomIn: "imani",
+    zoomOut: "malik",
+  },
+  imani: {
+    id: "imani",
+    title: "Imani Moreland",
+    description: "Imani bridges Malik’s generation and the modern stewards of the Moreland legacy.",
+    image: "imani.jpg",
+    zoomIn: "imani_descendants",
+    zoomOut: "malik_descendants",
+  },
+  imani_descendants: {
+    id: "imani_descendants",
+    title: "Imani’s Descendants",
+    description: "Stories of mentorship, migration, and milestones appear as you continue exploring Imani’s branch.",
+    image: "imani_descendants.jpg",
+    zoomOut: "imani",
+  },
+  julian: {
+    id: "julian",
+    title: "Julian Moreland",
+    description: "Julian keeps the family’s artistic traditions alive. Explore to see the creatives who flourish in his wake.",
+    image: "julian.jpg",
+    zoomOut: "parents",
+  },
+  selah: {
+    id: "selah",
+    title: "Selah Carter",
+    description: "Selah’s branch honors the Carter lineage and its connection to the Morelands.",
+    image: "selah.jpg",
+    zoomIn: "selah_descendants",
+    zoomOut: "parents",
+  },
+  selah_descendants: {
+    id: "selah_descendants",
+    title: "Selah’s Descendants",
+    description: "Keep zooming to meet the next generation of Carter storytellers and scholars.",
+    image: "selah_descendants.jpg",
+    zoomOut: "selah",
+  },
+  parents: {
+    id: "parents",
+    title: "The Moreland-Carter Parents",
+    description: "Start here to pick a branch. Hover or tap a name tag to jump directly to a sibling’s story.",
+    image: "parents.jpg",
+    zoomIn: "malik",
+    zones: {
+      julian: { target: "julian", label: "Julian Moreland", position: { left: "18%", top: "15%" }, hotkey: "1" },
+      malik: { target: "malik", label: "Malik Moreland", position: { left: "48%", top: "16%" }, hotkey: "2" },
+      selah: { target: "selah", label: "Selah Carter", position: { left: "78%", top: "17%" }, hotkey: "3" },
+    },
+  },
+};
+
+const INITIAL_STATE = "malik";
+const TRANSITION_DELAY = 260;
+const TRANSITION_BUFFER = 120;
+
+const imageWrapper = document.getElementById("imageWrapper");
+const image = document.getElementById("nftImage");
+const stateChip = document.getElementById("stateChip");
+const stateDescription = document.getElementById("stateDescription");
+const spinner = document.getElementById("loadingSpinner");
+const zoomInBtn = document.getElementById("zoomInBtn");
+const zoomOutBtn = document.getElementById("zoomOutBtn");
+const toast = document.getElementById("toast");
+const instructionsText = document.getElementById("instructionsText");
+
+const zoneElements = {
+  julian: document.getElementById("zone-julian"),
+  malik: document.getElementById("zone-malik"),
+  selah: document.getElementById("zone-selah"),
+};
+
+let currentState = null;
+let transitioning = false;
+let initialPinchDistance = null;
+let lastTapTime = 0;
+
+const imageCache = new Map();
+
+function preloadImage(src) {
+  if (imageCache.has(src)) {
+    return imageCache.get(src);
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(src);
+    img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    img.src = src;
+  });
+
+  imageCache.set(src, promise);
+  return promise;
+}
+
+function showToast(message) {
+  if (!toast) return;
+  toast.textContent = message;
+  toast.hidden = false;
+  toast.classList.add("show");
+  setTimeout(() => {
+    toast.classList.remove("show");
+    toast.hidden = true;
+  }, 4000);
+}
+
+function updateZones(stateId) {
+  const state = STATES[stateId];
+  const zones = state?.zones ?? {};
+
+  Object.entries(zoneElements).forEach(([key, el]) => {
+    const zoneConfig = zones[key];
+    if (zoneConfig) {
+      el.hidden = false;
+      el.style.left = zoneConfig.position?.left ?? "50%";
+      el.style.top = zoneConfig.position?.top ?? "12%";
+      el.textContent = zoneConfig.label;
+      el.dataset.target = zoneConfig.target;
+      if (zoneConfig.hotkey) {
+        el.dataset.hotkey = zoneConfig.hotkey;
+        el.setAttribute("data-hotkey", `⌨ ${zoneConfig.hotkey}`);
+      } else {
+        delete el.dataset.hotkey;
+        el.removeAttribute("data-hotkey");
+      }
+    } else {
+      el.hidden = true;
+      delete el.dataset.target;
+      delete el.dataset.hotkey;
+      el.removeAttribute("data-hotkey");
+    }
+  });
+}
+
+function updateControls(stateId) {
+  const state = STATES[stateId];
+  const zoomInAvailable = Boolean(state?.zoomIn);
+  const zoomOutAvailable = Boolean(state?.zoomOut);
+
+  zoomInBtn.disabled = !zoomInAvailable;
+  zoomOutBtn.disabled = !zoomOutAvailable;
+
+  const instructions = [];
+  if (zoomInAvailable) instructions.push("Zoom in to explore deeper");
+  if (zoomOutAvailable) instructions.push("Zoom out to revisit ancestors");
+  if (state?.zones) instructions.push("Tap a name tag to jump to a branch");
+
+  if (instructions.length > 0) {
+    instructionsText.textContent = `${instructions.join(" · ")}. Use scroll, pinch, keyboard arrows, or the onscreen controls to explore the family tree.`;
+  } else {
+    instructionsText.textContent = "Use scroll, pinch, keyboard arrows, or the onscreen controls to explore the family tree.";
+  }
+}
+
+function updateStateChip(stateId) {
+  const state = STATES[stateId];
+  stateChip.textContent = state?.title ?? "";
+}
+
+function updateDescription(stateId) {
+  const state = STATES[stateId];
+  stateDescription.textContent = state?.description ?? "";
+}
+
+function preloadNeighbors(stateId) {
+  const neighbors = new Set();
+  const state = STATES[stateId];
+  if (!state) return;
+
+  if (state.zoomIn) neighbors.add(state.zoomIn);
+  if (state.zoomOut) neighbors.add(state.zoomOut);
+
+  if (state.zones) {
+    Object.values(state.zones).forEach((zone) => neighbors.add(zone.target));
+  }
+
+  neighbors.forEach((neighborId) => {
+    const neighbor = STATES[neighborId];
+    if (neighbor?.image) {
+      preloadImage(neighbor.image).catch(() => {
+        /* handled on demand */
+      });
+    }
+  });
+}
+
+function setImageAttributes(stateId) {
+  const state = STATES[stateId];
+  if (!state) return;
+
+  image.alt = `${state.title} family tree portrait`;
+}
+
+async function transitionTo(stateId, reason = "navigate") {
+  if (transitioning || stateId === currentState) return;
+  const state = STATES[stateId];
+  if (!state) return;
+
+  transitioning = true;
+  imageWrapper.classList.add("is-transitioning");
+  imageWrapper.classList.toggle("zooming-in", reason === "zoomIn");
+  imageWrapper.classList.toggle("zooming-out", reason === "zoomOut");
+  spinner.setAttribute("aria-hidden", "false");
+
+  try {
+    await Promise.all([
+      preloadImage(state.image),
+      new Promise((resolve) => setTimeout(resolve, TRANSITION_DELAY)),
+    ]);
+  } catch (error) {
+    showToast(error.message);
+    spinner.setAttribute("aria-hidden", "true");
+    imageWrapper.classList.remove("is-transitioning", "zooming-in", "zooming-out");
+    transitioning = false;
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, TRANSITION_BUFFER));
+
+  image.src = state.image;
+  imageWrapper.dataset.state = state.id;
+  currentState = stateId;
+  setImageAttributes(stateId);
+  updateStateChip(stateId);
+  updateDescription(stateId);
+  updateZones(stateId);
+  updateControls(stateId);
+  preloadNeighbors(stateId);
+
+  requestAnimationFrame(() => {
+    imageWrapper.classList.remove("is-transitioning", "zooming-in", "zooming-out");
+    spinner.setAttribute("aria-hidden", "true");
+    transitioning = false;
+  });
+}
+
+function zoomIn() {
+  const next = STATES[currentState]?.zoomIn;
+  if (next) {
+    transitionTo(next, "zoomIn");
+  }
+}
+
+function zoomOut() {
+  const next = STATES[currentState]?.zoomOut;
+  if (next) {
+    transitionTo(next, "zoomOut");
+  }
+}
+
+function handleWheel(event) {
+  event.preventDefault();
+  if (transitioning) return;
+
+  if (event.deltaY < 0) {
+    zoomIn();
+  } else if (event.deltaY > 0) {
+    zoomOut();
+  }
+}
+
+function handleKeydown(event) {
+  if (transitioning) return;
+  const key = event.key.toLowerCase();
+
+  if (key === "arrowup" || key === "w") {
+    event.preventDefault();
+    zoomIn();
+    return;
+  }
+
+  if (key === "arrowdown" || key === "s") {
+    event.preventDefault();
+    zoomOut();
+    return;
+  }
+
+  if (key >= "1" && key <= "9") {
+    const zoneEntry = Object.values(STATES.parents.zones ?? {}).find((zone) => zone.hotkey === key);
+    if (zoneEntry && currentState === "parents") {
+      event.preventDefault();
+      transitionTo(zoneEntry.target, "hotkey");
+    }
+  }
+
+  if (key === "enter") {
+    event.preventDefault();
+    zoomIn();
+  }
+}
+
+function getTouchDistance(touches) {
+  if (touches.length < 2) return 0;
+  const [t1, t2] = touches;
+  const dx = t2.clientX - t1.clientX;
+  const dy = t2.clientY - t1.clientY;
+  return Math.hypot(dx, dy);
+}
+
+function handleTouchStart(event) {
+  if (event.touches.length === 2) {
+    initialPinchDistance = getTouchDistance(event.touches);
+  }
+}
+
+function handleTouchMove(event) {
+  if (transitioning || event.touches.length < 2 || initialPinchDistance === null) return;
+  const distance = getTouchDistance(event.touches);
+  const delta = distance - initialPinchDistance;
+
+  if (Math.abs(delta) > 40) {
+    if (delta > 0) {
+      zoomOut();
+    } else {
+      zoomIn();
+    }
+    initialPinchDistance = null;
+  }
+}
+
+function handleTouchEnd(event) {
+  if (event.touches.length === 0) {
+    initialPinchDistance = null;
+  }
+
+  const now = Date.now();
+  if (now - lastTapTime < 300) {
+    zoomIn();
+    lastTapTime = 0;
+  } else {
+    lastTapTime = now;
+  }
+}
+
+function registerZoneHandlers() {
+  Object.values(zoneElements).forEach((element) => {
+    element.addEventListener("click", () => {
+      if (!element.dataset.target) return;
+      transitionTo(element.dataset.target, "zone");
+    });
+  });
+}
+
+function initialise() {
+  registerZoneHandlers();
+  imageWrapper.addEventListener("wheel", handleWheel, { passive: false });
+  imageWrapper.addEventListener("touchstart", handleTouchStart, { passive: true });
+  imageWrapper.addEventListener("touchmove", handleTouchMove, { passive: true });
+  imageWrapper.addEventListener("touchend", handleTouchEnd, { passive: true });
+  imageWrapper.addEventListener("dblclick", (event) => {
+    event.preventDefault();
+    zoomIn();
+  });
+
+  zoomInBtn.addEventListener("click", zoomIn);
+  zoomOutBtn.addEventListener("click", zoomOut);
+  window.addEventListener("keydown", handleKeydown);
+
+  image.addEventListener("error", () => {
+    showToast("We couldn’t load that portrait. Please try again later.");
+  });
+
+  preloadImage(STATES[INITIAL_STATE].image)
+    .then(() => {
+      transitionTo(INITIAL_STATE);
+    })
+    .catch((error) => {
+      showToast(error.message);
+    });
+}
+
+initialise();

--- a/genesis-prototype.js
+++ b/genesis-prototype.js
@@ -69,6 +69,7 @@ const STATES = {
 const INITIAL_STATE = "malik";
 const TRANSITION_DELAY = 260;
 const TRANSITION_BUFFER = 120;
+const SVG_NS = "http://www.w3.org/2000/svg";
 
 const imageWrapper = document.getElementById("imageWrapper");
 const image = document.getElementById("nftImage");
@@ -101,12 +102,68 @@ function preloadImage(src) {
   const promise = new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => resolve(src);
-    img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    img.onerror = () => {
+      imageCache.delete(src);
+      reject(new Error(`Failed to load image: ${src}`));
+    };
     img.src = src;
   });
 
   imageCache.set(src, promise);
   return promise;
+}
+
+function createFallbackPortrait(state) {
+  const title = state?.title ?? "Portrait unavailable";
+  const subtitle = "Image unavailable in this build";
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("xmlns", SVG_NS);
+  svg.setAttribute("viewBox", "0 0 1200 1500");
+
+  const defs = document.createElementNS(SVG_NS, "defs");
+  const gradient = document.createElementNS(SVG_NS, "linearGradient");
+  gradient.setAttribute("id", "bg");
+  gradient.setAttribute("x1", "0%");
+  gradient.setAttribute("x2", "100%");
+  gradient.setAttribute("y1", "0%");
+  gradient.setAttribute("y2", "100%");
+
+  const stop1 = document.createElementNS(SVG_NS, "stop");
+  stop1.setAttribute("offset", "0%");
+  stop1.setAttribute("stop-color", "#10263d");
+  const stop2 = document.createElementNS(SVG_NS, "stop");
+  stop2.setAttribute("offset", "100%");
+  stop2.setAttribute("stop-color", "#050608");
+
+  gradient.append(stop1, stop2);
+  defs.appendChild(gradient);
+
+  const bg = document.createElementNS(SVG_NS, "rect");
+  bg.setAttribute("width", "1200");
+  bg.setAttribute("height", "1500");
+  bg.setAttribute("fill", "url(#bg)");
+
+  const titleText = document.createElementNS(SVG_NS, "text");
+  titleText.setAttribute("x", "600");
+  titleText.setAttribute("y", "680");
+  titleText.setAttribute("fill", "#f9fafc");
+  titleText.setAttribute("font-size", "64");
+  titleText.setAttribute("font-family", "Segoe UI, Tahoma, Geneva, Verdana, sans-serif");
+  titleText.setAttribute("font-weight", "700");
+  titleText.setAttribute("text-anchor", "middle");
+  titleText.textContent = title;
+
+  const subtitleText = document.createElementNS(SVG_NS, "text");
+  subtitleText.setAttribute("x", "600");
+  subtitleText.setAttribute("y", "770");
+  subtitleText.setAttribute("fill", "#71dfff");
+  subtitleText.setAttribute("font-size", "38");
+  subtitleText.setAttribute("font-family", "Segoe UI, Tahoma, Geneva, Verdana, sans-serif");
+  subtitleText.setAttribute("text-anchor", "middle");
+  subtitleText.textContent = subtitle;
+
+  svg.append(defs, bg, titleText, subtitleText);
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg.outerHTML)}`;
 }
 
 function showToast(message) {
@@ -218,22 +275,21 @@ async function transitionTo(stateId, reason = "navigate") {
   imageWrapper.classList.toggle("zooming-out", reason === "zoomOut");
   spinner.setAttribute("aria-hidden", "false");
 
+  let imageSource = state.image;
   try {
     await Promise.all([
       preloadImage(state.image),
       new Promise((resolve) => setTimeout(resolve, TRANSITION_DELAY)),
     ]);
   } catch (error) {
-    showToast(error.message);
-    spinner.setAttribute("aria-hidden", "true");
-    imageWrapper.classList.remove("is-transitioning", "zooming-in", "zooming-out");
-    transitioning = false;
-    return;
+    showToast(`${error.message}. Showing fallback artwork.`);
+    imageSource = createFallbackPortrait(state);
+    await new Promise((resolve) => setTimeout(resolve, TRANSITION_DELAY));
   }
 
   await new Promise((resolve) => setTimeout(resolve, TRANSITION_BUFFER));
 
-  image.src = state.image;
+  image.src = imageSource;
   imageWrapper.dataset.state = state.id;
   currentState = stateId;
   setImageAttributes(stateId);
@@ -321,6 +377,7 @@ function handleTouchStart(event) {
 
 function handleTouchMove(event) {
   if (transitioning || event.touches.length < 2 || initialPinchDistance === null) return;
+  event.preventDefault();
   const distance = getTouchDistance(event.touches);
   const delta = distance - initialPinchDistance;
 
@@ -335,6 +392,10 @@ function handleTouchMove(event) {
 }
 
 function handleTouchEnd(event) {
+  if (event.changedTouches.length !== 1) {
+    return;
+  }
+
   if (event.touches.length === 0) {
     initialPinchDistance = null;
   }
@@ -361,7 +422,7 @@ function initialise() {
   registerZoneHandlers();
   imageWrapper.addEventListener("wheel", handleWheel, { passive: false });
   imageWrapper.addEventListener("touchstart", handleTouchStart, { passive: true });
-  imageWrapper.addEventListener("touchmove", handleTouchMove, { passive: true });
+  imageWrapper.addEventListener("touchmove", handleTouchMove, { passive: false });
   imageWrapper.addEventListener("touchend", handleTouchEnd, { passive: true });
   imageWrapper.addEventListener("dblclick", (event) => {
     event.preventDefault();
@@ -376,13 +437,7 @@ function initialise() {
     showToast("We couldn’t load that portrait. Please try again later.");
   });
 
-  preloadImage(STATES[INITIAL_STATE].image)
-    .then(() => {
-      transitionTo(INITIAL_STATE);
-    })
-    .catch((error) => {
-      showToast(error.message);
-    });
+  transitionTo(INITIAL_STATE);
 }
 
 initialise();


### PR DESCRIPTION
## Summary
- create a dedicated Genesis prototype page with built-in instructions and toast messaging for the zoomable family tree
- add immersive dark-mode styling, motion states, and on-canvas sibling zone chips for intuitive navigation
- implement modular state machine logic with preloading, keyboard/touch support, and graceful error handling to improve transitions

## Testing
- not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_68cc94351ec0832d9d64008468c56be1