### PR TITLE
Clean up metadata and titles across legal and auth pages

### DIFF
--- a/compliance.html
+++ b/compliance.html
@@ -2,374 +2,259 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
-  <title>Compliance &amp; Legal | Tomb of Light</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compliance | Tomb of Light</title>
   <meta
     name="description"
-    content="Review Tomb of Light’s compliance and legal framework, including privacy-first design, family consent expectations, user rights handling, and policy safeguards."
+    content="Review Tomb of Light’s compliance approach for privacy, consent, responsible family data handling, and platform governance."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/compliance.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html" aria-current="page">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
   <main>
-    <section class="page-hero">
-      <div class="container">
-        <span class="eyebrow">Compliance and legal framework</span>
-        <h1>Compliance &amp; Legal</h1>
+    <section class="legal-page">
+      <div class="container legal-container">
+        <p class="section-kicker">Trust & Governance</p>
+        <h1>Compliance</h1>
+        <p class="legal-date">
+          Effective Date: March 11, 2026<br />
+          Last Updated: March 11, 2026
+        </p>
+
+        <p class="legal-intro">
+          Tomb of Light is being developed with a privacy-first and responsibility-based approach
+          to digital legacy preservation. Because the platform is intended to involve family history,
+          portraits, lineage records, and other potentially sensitive materials, compliance is a core
+          part of how we design policies, workflows, and future platform systems.
+        </p>
+
+        <p class="legal-intro">
+          This page summarizes our current compliance direction and the standards we aim to follow
+          as the Tomb of Light platform grows.
+        </p>
+
+        <h2>1. Privacy and Data Protection</h2>
         <p>
-          Tomb of Light is being built with a privacy-first, consent-aware legal
-          direction intended to protect families, reduce misuse of sensitive legacy
-          information, and support responsible handling of rights, corrections,
-          and family participation concerns.
-        </p>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <div class="notice">
-          This page provides a public-facing overview of Tomb of Light’s compliance
-          direction and policy approach. It is intended to work together with the
-          Privacy Policy, Terms of Service, Security page, Cookie Policy, and Data Request page.
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <span class="eyebrow">Core principles</span>
-        <h2 class="section-title">Built around dignity, consent, and controlled access.</h2>
-        <p class="section-subtitle">
-          Family identity and legacy records can be deeply personal. Tomb of Light’s
-          compliance direction is built around careful participation rules, private-by-default
-          handling, and clear pathways for correction, review, or removal where appropriate.
+          Tomb of Light aims to protect personal information and family legacy content through
+          privacy-conscious design, controlled data handling, and restricted operational access.
+          We are committed to minimizing unnecessary exposure of personal information and maintaining
+          a structure that separates sensitive private data from any future public ownership layers.
         </p>
 
-        <div class="grid grid-3" style="margin-top: 28px;">
-          <article class="card">
-            <h3>Privacy-first design</h3>
-            <p>
-              Private family stories, images, and records should be handled in
-              controlled systems and should not be treated as public blockchain content.
-            </p>
-            <ul class="feature-list">
-              <li>Private-by-default treatment</li>
-              <li>Limited public exposure direction</li>
-              <li>Separation of ownership and sensitive content</li>
-            </ul>
-          </article>
-
-          <article class="card">
-            <h3>Consent-aware participation</h3>
-            <p>
-              Living individuals should not be included casually. Family participation
-              should be based on proper authority, permission, or lawful basis where required.
-            </p>
-            <ul class="feature-list">
-              <li>Respect for living individuals</li>
-              <li>Review pathways for disputes</li>
-              <li>Special care for minors and sensitive family issues</li>
-            </ul>
-          </article>
-
-          <article class="card">
-            <h3>Rights and accountability</h3>
-            <p>
-              Users and affected individuals should have a clear path to request review,
-              correction, deletion consideration, or other rights handling where applicable.
-            </p>
-            <ul class="feature-list">
-              <li>Data request pathway</li>
-              <li>Policy-linked accountability</li>
-              <li>Operational review expectations</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <span class="eyebrow">Family participation</span>
-          <h2>Living individuals and family consent</h2>
-          <p>
-            Tomb of Light’s public-facing direction is that living individuals should
-            not be added to a family legacy experience in a careless or deceptive way.
-            Where consent, authority, or lawful basis is required, users are expected
-            to act responsibly and accurately.
-          </p>
-          <ul class="check-list">
-            <li>Do not misrepresent identity, authority, or family relationships</li>
-            <li>Do not upload or publish protected family material without proper basis</li>
-            <li>Disputed, inaccurate, or harmful entries should be reviewable</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">Minors</span>
-          <h2>Children and protected family content</h2>
-          <p>
-            If minors are ever included within a family legacy experience, parental
-            or guardian permission should be required. Material involving minors
-            should receive heightened protection and should not be treated as casually shareable.
-          </p>
-          <ul class="check-list">
-            <li>Parent or guardian authorization expectations</li>
-            <li>Private-by-default treatment for minor-related content</li>
-            <li>Faster review for sensitive child-related concerns</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">Off-chain treatment</span>
-          <h2>Family data should not become permanent public exposure by default</h2>
-          <p>
-            Tomb of Light’s legal and compliance direction distinguishes between
-            family content and any future blockchain ownership layer. Sensitive
-            family data is intended to remain outside public on-chain visibility.
-          </p>
-          <ul class="check-list">
-            <li>Private family records intended to remain off-chain</li>
-            <li>Ownership references should avoid exposing personal information</li>
-            <li>Policy language supports privacy-preserving architecture choices</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">User rights</span>
-          <h2>Correction, deletion requests, and review</h2>
-          <p>
-            Individuals should have a clear way to raise concerns regarding inaccurate,
-            outdated, unauthorized, or harmful information. Tomb of Light provides a
-            Data Request page and related policy pathways for such issues.
-          </p>
-          <ul class="check-list">
-            <li>Correction requests for inaccurate information</li>
-            <li>Deletion or removal review where applicable</li>
-            <li>Appeal or follow-up communication where necessary</li>
-          </ul>
-        </article>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <span class="eyebrow">Operational expectations</span>
-        <h2 class="section-title">Company protection also means clear internal discipline.</h2>
-        <p class="section-subtitle">
-          Compliance is not only about public policy text. It also depends on how
-          systems are built, how access is limited, and how the company responds
-          when privacy, consent, or dispute concerns are raised.
+        <p>
+          Additional details about personal data handling are available in our
+          <a href="privacy.html">Privacy Policy</a>.
         </p>
 
-        <div class="grid grid-2" style="margin-top: 28px;">
-          <article class="card">
-            <h3>Internal handling direction</h3>
-            <p>
-              Tomb of Light’s long-term compliance posture is strengthened by role-based
-              access, limited handling of sensitive records, and review processes for
-              potential misuse, disputes, or rights-related concerns.
-            </p>
-            <ul class="policy-list">
-              <li>Restricted handling of sensitive family records</li>
-              <li>Operational review of reported issues</li>
-              <li>Separation of user and privileged actions where possible</li>
-            </ul>
-          </article>
+        <h2>2. Consent and Authority Requirements</h2>
+        <p>
+          Users are responsible for ensuring they have the necessary authority, permission, or legal
+          basis before submitting personal information, portraits, lineage details, or family records
+          involving other living individuals.
+        </p>
 
-          <article class="card">
-            <h3>Policy-linked security posture</h3>
-            <p>
-              Privacy, security, and compliance should reinforce one another. That is
-              why Tomb of Light’s trust framework connects legal expectations with
-              off-chain protection, incident awareness, and access control direction.
-            </p>
-            <ul class="policy-list">
-              <li>Security page supports compliance position</li>
-              <li>Data request workflow supports user rights</li>
-              <li>Terms and privacy policies support account accountability</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
+        <p>
+          Where family submissions involve spouses, children, relatives, or other living persons,
+          users should not provide that information unless they have proper consent or another lawful
+          basis to do so.
+        </p>
 
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <span class="eyebrow">Important limits</span>
-          <h2>What this page does and does not do</h2>
-          <p>
-            This page is a public compliance overview, not a substitute for the full
-            Privacy Policy, Terms of Service, Cookie Policy, or individual legal advice.
-            Users remain responsible for reviewing the full policy documents that govern
-            their use of the site and future platform services.
-          </p>
-        </article>
+        <h3>Minor-Related Information</h3>
+        <p>
+          If a submission includes information relating to a minor, the submitting user must have
+          appropriate parental or guardian authority to provide that information. Sensitive information
+          regarding minors should be handled with elevated caution.
+        </p>
 
-        <article class="card">
-          <span class="eyebrow">Contact</span>
-          <h2>Questions or concerns</h2>
-          <p>
-            If you have a question about privacy, consent, correction, or legal handling,
-            please review the linked policies first and then contact Tomb of Light
-            through the available support or policy channels.
-          </p>
-          <p style="margin-top: 18px;">
-            Policy contact:
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>
-          </p>
-        </article>
-      </div>
-    </section>
+        <h2>3. Off-Chain Treatment of Sensitive Information</h2>
+        <p>
+          Tomb of Light is being developed with the intention that sensitive family information,
+          legacy narratives, personal records, and identifying materials are not written directly
+          to public blockchain systems. Where future blockchain-backed ownership features are used,
+          they are intended to reference ownership or platform relationships without publicly exposing
+          private family data.
+        </p>
 
-    <section class="section-sm">
-      <div class="container">
-        <div class="cta-banner">
-          <h3>Read the related trust pages.</h3>
-          <p>
-            Compliance works together with privacy, security, cookies, and rights handling.
-            Review the supporting pages below.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="privacy.html">Privacy Policy</a>
-            <a class="btn btn-secondary" href="security.html">Security</a>
-            <a class="btn btn-secondary" href="terms.html">Terms of Service</a>
-          </div>
-        </div>
+        <p>
+          This architectural separation is an important compliance principle for the platform.
+        </p>
+
+        <h2>4. User Responsibilities</h2>
+        <p>Users are expected to:</p>
+        <ul>
+          <li>Provide accurate information when submitting requests, content, or account details</li>
+          <li>Submit only content they are authorized to share</li>
+          <li>Respect the privacy, dignity, and legal rights of other individuals</li>
+          <li>Refrain from uploading unlawful, deceptive, abusive, or infringing materials</li>
+          <li>Use the platform in a way that is consistent with applicable laws and platform policies</li>
+        </ul>
+
+        <h2>5. Regulatory Awareness</h2>
+        <p>
+          As Tomb of Light grows, we intend to continue evaluating applicable privacy, consumer
+          protection, data governance, digital asset, and online service requirements that may apply
+          to our operations depending on where users are located and what platform features are active.
+        </p>
+
+        <p>
+          This may include review of state privacy laws, data rights frameworks, record-handling
+          obligations, contract standards, and future digital asset compliance considerations.
+        </p>
+
+        <h2>6. Security and Operational Controls</h2>
+        <p>
+          Compliance depends in part on sound security and operational discipline. Tomb of Light
+          uses and plans to continue improving measures such as encrypted connections, controlled
+          access practices, monitoring, and internal review of privacy and security risks.
+        </p>
+
+        <p>
+          More details are available on our <a href="security.html">Security</a> page.
+        </p>
+
+        <h2>7. Data Rights and Requests</h2>
+        <p>
+          Depending on applicable law, users may have rights to request access to, correction of,
+          deletion of, or information about certain personal data. Tomb of Light provides a
+          <a href="data-request.html">Data Request</a> page for submitting applicable requests.
+        </p>
+
+        <p>
+          Additional notices for certain jurisdictions may be posted on our
+          <a href="privacy-state-notices.html">State Privacy Notices</a> page.
+        </p>
+
+        <h2>8. Platform Development and Evolving Standards</h2>
+        <p>
+          Tomb of Light is an evolving platform. Our compliance practices, review procedures,
+          consent workflows, and technical controls may change over time as we expand features,
+          improve governance, and respond to legal or operational developments.
+        </p>
+
+        <p>
+          We may update this page as our systems mature or as new compliance obligations become relevant.
+        </p>
+
+        <h2>9. No Guarantee of Universal Availability</h2>
+        <p>
+          Certain future platform features, including blockchain-backed ownership functions, account
+          features, or advanced lineage services, may not be available in all jurisdictions or for all
+          users. Availability may depend on legal, technical, operational, or eligibility considerations.
+        </p>
+
+        <h2>10. Related Policies</h2>
+        <p>
+          Please also review our
+          <a href="privacy.html">Privacy Policy</a>,
+          <a href="terms.html">Terms of Service</a>, and
+          <a href="security.html">Security</a> pages for related standards and requirements.
+        </p>
+
+        <h2>11. Contact Information</h2>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+
+        <p>
+          Email:
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -2,308 +2,244 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FAQ | Tomb of Light</title>
   <meta
     name="description"
-    content="Frequently asked questions about Tomb of Light, including privacy, family consent, blockchain ownership, security, and future platform direction."
+    content="Frequently asked questions about Tomb of Light, including privacy, consent, family records, blockchain-backed ownership, and future platform access."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/faq.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html" aria-current="page">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
   <main>
-    <section class="page-hero">
-      <div class="container">
-        <span class="eyebrow">Frequently asked questions</span>
-        <h1>FAQ</h1>
-        <p>
-          These answers explain Tomb of Light’s current public position on privacy,
-          ownership, family participation, policy expectations, and future platform direction.
+    <section class="legal-page">
+      <div class="container legal-container">
+        <p class="section-kicker">Support</p>
+        <h1>Frequently Asked Questions</h1>
+        <p class="legal-date">
+          Effective Date: March 11, 2026<br />
+          Last Updated: March 11, 2026
         </p>
-      </div>
-    </section>
 
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <h2>What is Tomb of Light?</h2>
-          <p>
-            Tomb of Light is being built as a secure, privacy-first family legacy
-            platform. The long-term goal is to help families preserve portraits,
-            stories, relationships, and generational memory in protected systems
-            while enabling future ownership structures that do not expose private
-            family data to the public blockchain.
-          </p>
-        </article>
+        <p class="legal-intro">
+          These answers explain the current direction of Tomb of Light and how we approach privacy,
+          family participation, future ownership systems, and user requests.
+        </p>
 
-        <article class="card">
-          <h2>Is Tomb of Light a public social media platform?</h2>
-          <p>
-            No. The platform direction is not centered on public posting or public
-            social sharing. It is centered on controlled legacy preservation,
-            protected access, and respectful family participation.
-          </p>
-        </article>
+        <h2>1. What is Tomb of Light?</h2>
+        <p>
+          Tomb of Light is being developed as a privacy-first digital legacy platform designed to help
+          families preserve portraits, stories, lineage, and generational memory in a structured and
+          secure way.
+        </p>
 
-        <article class="card">
-          <h2>Will private family data be placed on-chain?</h2>
-          <p>
-            The platform direction is to keep private family data, stories, media,
-            and sensitive records off-chain. If an NFT or blockchain ownership layer
-            is used, it should represent ownership or reference status only and
-            should avoid revealing sensitive family details.
-          </p>
-        </article>
+        <h2>2. Is Tomb of Light live as a full platform?</h2>
+        <p>
+          Not yet. The public website is live, but certain platform features are still being developed,
+          refined, or prepared for future release.
+        </p>
 
-        <article class="card">
-          <h2>What does the NFT represent?</h2>
-          <p>
-            A future NFT layer is intended to represent ownership or reference rights
-            tied to a protected family vault or legacy experience. It is not intended
-            to serve as a public dump of family records or private personal data.
-          </p>
-        </article>
+        <h2>3. Is Tomb of Light an NFT project?</h2>
+        <p>
+          Tomb of Light may include future blockchain-backed ownership features, but the platform is not
+          intended to expose sensitive family information on a public blockchain. Any ownership layer is
+          intended to remain separate from private family records.
+        </p>
 
-        <article class="card">
-          <h2>Can I add living family members without their knowledge?</h2>
-          <p>
-            Tomb of Light’s public-facing policy direction is that living individuals
-            should not be included casually or without appropriate authority,
-            permission, or lawful basis where required. Family participation should
-            be handled carefully and respectfully.
-          </p>
-        </article>
+        <h2>4. Is family information stored on the blockchain?</h2>
+        <p>
+          Sensitive family information is not intended to be written directly to public blockchain networks.
+          Public ownership references and private family materials are intended to remain separate.
+        </p>
 
-        <article class="card">
-          <h2>What about children or minors?</h2>
-          <p>
-            If minors are ever included in a family experience, parental or guardian
-            permission should be required. Sensitive family information involving
-            minors should receive heightened protection and private-by-default treatment.
-          </p>
-        </article>
+        <h2>5. How is family information protected?</h2>
+        <p>
+          Tomb of Light is being designed with privacy-first architecture, controlled access, and secure
+          handling practices intended to help protect submitted records, account activity, and family legacy data.
+        </p>
 
-        <article class="card">
-          <h2>Is Tomb of Light live as a full vault and NFT platform yet?</h2>
-          <p>
-            Public-facing website materials may describe the platform vision and
-            planned direction, but some features may still be under development or
-            not yet fully launched. Pages like Sign In or Sign Up may currently act
-            as front-end shells until the full backend systems are connected.
-          </p>
-        </article>
+        <h2>6. Can living family members be included?</h2>
+        <p>
+          Yes, but users are responsible for making sure they have proper permission, authority, or another
+          lawful basis before submitting information about living individuals.
+        </p>
 
-        <article class="card">
-          <h2>How is the platform planning to protect family content?</h2>
-          <p>
-            The intended protection model includes controlled storage, privacy-first
-            design, access controls, policy-based handling, and future security
-            improvements for encrypted and permission-sensitive family materials.
-          </p>
-        </article>
+        <h2>7. What about children or minors?</h2>
+        <p>
+          If a submission includes information about a minor, the submitting user must have appropriate
+          parental or guardian authority to provide that information. Sensitive information regarding minors
+          should be handled with elevated caution.
+        </p>
 
-        <article class="card">
-          <h2>Can I request correction or removal of my information?</h2>
-          <p>
-            Yes. If you believe information is inaccurate, should be corrected, or
-            should be removed, use the Data Request page or contact Tomb of Light
-            through the listed policy contact channels.
-          </p>
-        </article>
+        <h2>8. Is the family tree public?</h2>
+        <p>
+          The goal of the platform is not to make private family records publicly visible. Public-facing
+          ownership or identity references, if introduced in the future, are intended to remain distinct
+          from sensitive family content.
+        </p>
 
-        <article class="card">
-          <h2>Does Tomb of Light sell personal information?</h2>
-          <p>
-            The site’s current policy direction states that Tomb of Light does not
-            sell personal information in the traditional sense and does not use
-            optional analytics cookies unless the user permits them where applicable.
-          </p>
-        </article>
+        <h2>9. Can I remove my data?</h2>
+        <p>
+          Depending on applicable law and the nature of the request, you may be able to request access,
+          correction, or deletion of certain personal information. Visit our
+          <a href="data-request.html">Data Request</a> page to submit a request.
+        </p>
 
-        <article class="card">
-          <h2>How do cookies work on the website?</h2>
-          <p>
-            The site uses essential technologies for core functionality and may offer
-            optional analytics controls. You can review or change those preferences
-            through the Privacy Choices page.
-          </p>
-        </article>
+        <h2>10. Can I update information I previously submitted?</h2>
+        <p>
+          Yes. If you need to correct or update information, contact us or submit a request through the
+          <a href="data-request.html">Data Request</a> page.
+        </p>
 
-        <article class="card">
-          <h2>What if a family member disputes inclusion in a legacy project?</h2>
-          <p>
-            Disputes should be handled through correction, review, or removal
-            pathways. Because family identity can be sensitive, Tomb of Light’s
-            policy direction supports respectful review rather than careless permanence.
-          </p>
-        </article>
+        <h2>11. Does Tomb of Light sell personal information?</h2>
+        <p>
+          Tomb of Light does not sell personal information for money. Limited sharing may occur with service
+          providers or where required by law, as described in our <a href="privacy.html">Privacy Policy</a>.
+        </p>
 
-        <article class="card">
-          <h2>Can Tomb of Light support inheritance or future transfer?</h2>
-          <p>
-            Future versions of the platform may support transfer, succession,
-            inheritance, or role-based access workflows, but those systems should
-            be implemented carefully and without compromising private family materials.
-          </p>
-        </article>
+        <h2>12. Do I need an account?</h2>
+        <p>
+          Some current website information may be publicly viewable, while certain present or future features
+          may require an account, verification steps, or approval processes.
+        </p>
 
-        <article class="card">
-          <h2>Where should I read more about privacy and legal terms?</h2>
-          <p>
-            Review the Privacy Policy, Terms of Service, Cookie Policy, Security
-            page, Compliance &amp; Legal page, and Data Request page for the current
-            public-facing framework.
-          </p>
-        </article>
-      </div>
-    </section>
+        <h2>13. Is pricing available now?</h2>
+        <p>
+          Public pricing may not yet be finalized for all future services or ownership-related features.
+          Tomb of Light may introduce pricing, packages, or membership options as the platform develops.
+        </p>
 
-    <section class="section-sm">
-      <div class="container">
-        <div class="cta-banner">
-          <h3>Need more than a quick answer?</h3>
-          <p>
-            Review the core trust and policy pages to understand how Tomb of Light
-            approaches privacy, security, family participation, and rights requests.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="security.html">Security</a>
-            <a class="btn btn-secondary" href="privacy.html">Privacy Policy</a>
-            <a class="btn btn-secondary" href="data-request.html">Data Request</a>
-          </div>
-        </div>
+        <h2>14. What happens if I join early?</h2>
+        <p>
+          Joining early may allow you to receive updates, announcements, and future access information as
+          Tomb of Light continues platform development.
+        </p>
+
+        <h2>15. What rights do I have over submitted content?</h2>
+        <p>
+          You retain your rights in content you submit, subject to the limited rights needed for Tomb of Light
+          to host, process, and manage that content for platform operation, support, protection, and legal compliance.
+          See our <a href="terms.html">Terms of Service</a> for more details.
+        </p>
+
+        <h2>16. Where can I learn about security?</h2>
+        <p>
+          You can review our <a href="security.html">Security</a> page for information about our current
+          security approach and responsible disclosure process.
+        </p>
+
+        <h2>17. Where can I learn about privacy and compliance?</h2>
+        <p>
+          Visit our <a href="privacy.html">Privacy Policy</a>,
+          <a href="compliance.html">Compliance</a>, and
+          <a href="privacy-state-notices.html">State Privacy Notices</a> pages for more information.
+        </p>
+
+        <h2>18. How do I contact Tomb of Light?</h2>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+
+        <p>
+          Email:
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -2,79 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tomb of Light | Secure NFT Family Legacy Platform</title>
   <meta
     name="description"
-    content="Tomb of Light is building a secure, privacy-first family legacy platform where stories, portraits, and generational history can be preserved with blockchain-backed ownership."
+    content="Tomb of Light is building a privacy-first family legacy platform for preserving portraits, stories, and generational memory with future blockchain-backed ownership."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
@@ -82,85 +43,117 @@
   <main>
     <section class="hero">
       <div class="container hero-grid">
-        <div>
-          <span class="eyebrow">Private legacy infrastructure</span>
+        <div class="hero-copy">
+          <p class="eyebrow">Private legacy infrastructure</p>
           <h1>Preserve family history with security, privacy, and lasting ownership.</h1>
-          <p>
-            Tomb of Light is building a secure digital family legacy platform where
-            portraits, stories, and generational memory can be organized, protected,
-            and later anchored with blockchain-backed ownership without exposing private
-            family data on a public chain.
+          <p class="hero-text">
+            Tomb of Light is building a secure digital family legacy platform where portraits,
+            stories, and generational memory can be organized, protected, and later anchored
+            with blockchain-backed ownership without exposing private family data on a public chain.
           </p>
 
           <div class="hero-actions">
-            <a class="btn btn-primary" href="signup.html">Join the Waitlist</a>
-            <a class="btn btn-secondary" href="how-it-works.html">See How It Works</a>
+            <a href="signup.html" class="btn btn-primary">Join the Waitlist</a>
+            <a href="how-it-works.html" class="btn btn-secondary">See How It Works</a>
           </div>
 
-          <div class="hero-badges">
-            <span class="badge">Privacy-first design</span>
-            <span class="badge">Off-chain family data protection</span>
-            <span class="badge">Built for generational continuity</span>
-          </div>
-        </div>
-
-        <div class="hero-visual" aria-hidden="true">
-          <div class="hero-lines"></div>
-          <div class="hero-orb"></div>
-          <div class="hero-caption">
-            <strong>From portrait to lineage</strong>
-            <span>
-              Create a secure legacy vault designed for family storytelling,
-              controlled access, and future NFT anchoring.
-            </span>
+          <div class="hero-points">
+            <span>Privacy-first design</span>
+            <span>Off-chain family data protection</span>
+            <span>Built for generational continuity</span>
           </div>
         </div>
       </div>
     </section>
 
-    <section class="section">
+    <section class="trust-section">
       <div class="container">
-        <span class="eyebrow">What Tomb of Light is building</span>
-        <h2 class="section-title">A digital family vault, not just a profile page.</h2>
-        <p class="section-subtitle">
-          Tomb of Light is designed to help families preserve identity, memory,
-          and lineage in a way that feels premium, secure, and future-ready.
+        <p class="section-kicker">Privacy and trust</p>
+        <h2>Privacy-first legacy technology</h2>
+        <p class="section-intro">
+          Tomb of Light was designed to preserve family history while protecting personal privacy,
+          consent, and long-term ownership.
         </p>
 
-        <div class="grid grid-3" style="margin-top: 28px;">
-          <article class="card">
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Sensitive data stays off-chain</h3>
+            <p>
+              Sensitive family information is not intended to be written directly to public blockchain
+              networks. Public ownership references and private family materials are kept separate.
+            </p>
+          </article>
+
+          <article class="feature-card">
+            <h3>Encrypted platform access</h3>
+            <p>
+              Secure connections and controlled account access are part of the platform’s core design
+              to help protect account activity and legacy records.
+            </p>
+          </article>
+
+          <article class="feature-card">
+            <h3>Consent-based family participation</h3>
+            <p>
+              Living individuals should only be included with proper permission, and minors require
+              parent or guardian involvement where applicable.
+            </p>
+          </article>
+
+          <article class="feature-card">
+            <h3>Built for long-term continuity</h3>
+            <p>
+              Tomb of Light is being developed to preserve portraits, stories, and lineage in a secure
+              structure that families can carry forward over generations.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="overview">
+      <div class="container">
+        <p class="section-kicker">What Tomb of Light is building</p>
+        <h2>A digital family vault, not just a profile page.</h2>
+        <p class="section-intro">
+          Tomb of Light is designed to help families preserve identity, memory, and lineage in a way
+          that feels premium, secure, and future-ready.
+        </p>
+
+        <div class="feature-grid">
+          <article class="feature-card">
             <h3>Private family vaults</h3>
             <p>
-              Family stories, portraits, records, and historical context are intended
-              to live in protected storage, not in public blockchain metadata.
+              Family stories, portraits, records, and historical context are intended to live in protected
+              storage, not in public blockchain metadata.
             </p>
-            <ul class="feature-list">
+            <ul>
               <li>Controlled family access</li>
               <li>Structured legacy records</li>
               <li>Privacy-first architecture</li>
             </ul>
           </article>
 
-          <article class="card">
+          <article class="feature-card">
             <h3>Blockchain-backed ownership</h3>
             <p>
-              The ownership layer is designed to anchor a family vault without placing
-              sensitive personal details directly on-chain.
+              The ownership layer is designed to anchor a family vault without placing sensitive personal
+              details directly on-chain.
             </p>
-            <ul class="feature-list">
+            <ul>
               <li>Non-identifying NFT references</li>
               <li>Future transfer and inheritance workflows</li>
               <li>Direct platform ownership experience</li>
             </ul>
           </article>
 
-          <article class="card">
+          <article class="feature-card">
             <h3>Immersive lineage experience</h3>
             <p>
-              Tomb of Light is evolving toward an interactive, cinematic family tree
-              experience that allows users to move through generations with meaning.
+              Tomb of Light is evolving toward an interactive, cinematic family tree experience that allows
+              users to move through generations with meaning.
             </p>
-            <ul class="feature-list">
+            <ul>
               <li>Portrait-centered storytelling</li>
               <li>Generational navigation</li>
               <li>Future immersive viewer expansion</li>
@@ -170,198 +163,205 @@
       </div>
     </section>
 
-    <section class="section">
+    <section class="how-it-works-preview">
       <div class="container">
-        <span class="eyebrow">How the platform works</span>
-        <h2 class="section-title">Built to respect privacy, consent, and legacy.</h2>
-        <p class="section-subtitle">
-          The platform is designed so that ownership, memory, and family access can
-          coexist without exposing private family records to the public internet.
+        <p class="section-kicker">How the platform works</p>
+        <h2>Built to respect privacy, consent, and legacy.</h2>
+        <p class="section-intro">
+          The platform is designed so that ownership, memory, and family access can coexist without
+          exposing private family records to the public internet.
         </p>
 
-        <div class="grid grid-3" style="margin-top: 28px;">
-          <article class="info-card">
-            <h3>1. Create a legacy profile</h3>
+        <div class="steps-grid">
+          <article class="step-card">
+            <span class="step-number">1</span>
+            <h3>Create a legacy profile</h3>
             <p>
-              Start with a family anchor portrait and core lineage information. Add
-              approved family members, stories, and memorial context over time.
+              Start with a family anchor portrait and core lineage information. Add approved family members,
+              stories, and memorial context over time.
             </p>
           </article>
 
-          <article class="info-card">
-            <h3>2. Secure the vault</h3>
+          <article class="step-card">
+            <span class="step-number">2</span>
+            <h3>Secure the vault</h3>
             <p>
-              Family content is meant to remain protected in controlled storage with
-              access permissions, consent rules, and future security monitoring.
+              Family content is meant to remain protected in controlled storage with access permissions,
+              consent rules, and future security monitoring.
             </p>
           </article>
 
-          <article class="info-card">
-            <h3>3. Anchor ownership</h3>
+          <article class="step-card">
+            <span class="step-number">3</span>
+            <h3>Anchor ownership</h3>
             <p>
-              When the ownership layer is active, a family vault can be linked to an
-              NFT record that represents ownership without publishing sensitive family data.
+              When the ownership layer is active, a family vault can be linked to an NFT record that
+              represents ownership without publishing sensitive family data.
             </p>
           </article>
         </div>
 
-        <div class="cta-banner" style="margin-top: 32px;">
-          <h3>Privacy and security come first.</h3>
-          <p>
-            Tomb of Light is building for families, not speculation. Our public-facing
-            policies are designed to make clear what stays private, what may be anchored
-            on-chain, and how consent matters.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="security.html">View Security Page</a>
-            <a class="btn btn-secondary" href="privacy.html">Read Privacy Policy</a>
-          </div>
+        <div class="section-actions">
+          <a href="security.html" class="btn btn-secondary">View Security Page</a>
+          <a href="privacy.html" class="btn btn-secondary">Read Privacy Policy</a>
         </div>
       </div>
     </section>
 
-    <section class="section">
+    <section class="trust-pillars">
       <div class="container">
-        <span class="eyebrow">Trust pillars</span>
-        <h2 class="section-title">Why families and partners should take this seriously.</h2>
+        <p class="section-kicker">Trust pillars</p>
+        <h2>Why families and partners should take this seriously.</h2>
 
-        <div class="grid grid-2" style="margin-top: 28px;">
-          <article class="card">
+        <div class="feature-grid">
+          <article class="feature-card">
             <h3>Consent-based family participation</h3>
             <p>
-              Living individuals should not be added to a family experience without
-              proper permission. Where minors are involved, parental or guardian consent
-              is required.
+              Living individuals should not be added to a family experience without proper permission.
+              Where minors are involved, parental or guardian consent is required.
             </p>
-            <ul class="policy-list">
-              <li>Consent-aware onboarding direction</li>
-              <li>Removal and correction pathways</li>
-              <li>Identity and family sensitivity built into policy design</li>
-            </ul>
           </article>
 
-          <article class="card">
+          <article class="feature-card">
             <h3>Private-by-default data treatment</h3>
             <p>
-              Sensitive family media, names, stories, and records should remain off-chain
-              and under controlled platform management rather than becoming publicly visible forever.
+              Sensitive family media, names, stories, and records should remain off-chain and under
+              controlled platform management rather than becoming publicly visible forever.
             </p>
-            <ul class="policy-list">
-              <li>Off-chain protected storage model</li>
-              <li>Limited public blockchain exposure</li>
-              <li>Clear separation of ownership and family content</li>
-            </ul>
+          </article>
+
+          <article class="feature-card">
+            <h3>Clear legal and privacy framework</h3>
+            <p>
+              Public-facing policy pages explain privacy, security direction, user requests, and responsible
+              platform development as Tomb of Light grows.
+            </p>
           </article>
         </div>
       </div>
     </section>
 
-    <section class="section">
+    <section class="foundation-links">
       <div class="container">
-        <span class="eyebrow">Explore the foundation</span>
-        <h2 class="section-title">Review the pages that matter most.</h2>
+        <p class="section-kicker">Explore the foundation</p>
+        <h2>Review the pages that matter most.</h2>
 
-        <div class="grid grid-4" style="margin-top: 28px;">
-          <a class="card" href="how-it-works.html">
+        <div class="feature-grid">
+          <article class="feature-card">
             <h3>How It Works</h3>
             <p>See the planned experience from family vault creation to future ownership anchoring.</p>
-          </a>
+            <a href="how-it-works.html" class="text-link">Open page</a>
+          </article>
 
-          <a class="card" href="security.html">
+          <article class="feature-card">
             <h3>Security</h3>
             <p>Review the company’s security posture, protection goals, and responsible disclosure path.</p>
-          </a>
+            <a href="security.html" class="text-link">Open page</a>
+          </article>
 
-          <a class="card" href="compliance.html">
-            <h3>Compliance &amp; Legal</h3>
+          <article class="feature-card">
+            <h3>Compliance</h3>
             <p>Understand consent rules, privacy expectations, and legal protection priorities.</p>
-          </a>
+            <a href="compliance.html" class="text-link">Open page</a>
+          </article>
 
-          <a class="card" href="faq.html">
+          <article class="feature-card">
             <h3>FAQ</h3>
             <p>Get quick answers about privacy, NFTs, family permissions, and platform direction.</p>
-          </a>
+            <a href="faq.html" class="text-link">Open page</a>
+          </article>
         </div>
       </div>
     </section>
 
-    <section class="section-sm">
+    <section class="final-cta">
       <div class="container">
-        <div class="cta-banner">
-          <h3>Build your family legacy with intention.</h3>
-          <p>
-            Join Tomb of Light as the platform develops its secure family vault,
-            trust infrastructure, and future immersive lineage experience.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="signup.html">Join Now</a>
-            <a class="btn btn-secondary" href="data-request.html">Data Rights &amp; Requests</a>
-          </div>
+        <h2>Build your family legacy with intention.</h2>
+        <p>
+          Join Tomb of Light as the platform develops its secure family vault, trust infrastructure,
+          and future immersive lineage experience.
+        </p>
+        <div class="section-actions">
+          <a href="signup.html" class="btn btn-primary">Join Now</a>
+          <a href="data-request.html" class="btn btn-secondary">Data Rights &amp; Requests</a>
         </div>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
+    </div>
+
+    <div class="cookie-banner" id="cookieBanner" role="dialog" aria-live="polite" aria-label="Cookie preferences">
+      <div class="container cookie-banner-inner">
+        <p>
+          We use essential site technologies and may use optional analytics tools only where permitted.
+          You can accept or decline optional analytics cookies and review your choices at any time.
+        </p>
+        <div class="cookie-actions">
+          <button type="button" id="acceptCookies" class="btn btn-primary">Accept</button>
+          <button type="button" id="declineCookies" class="btn btn-secondary">Decline</button>
+          <a href="privacy-choices.html" class="text-link">Privacy Choices</a>
+        </div>
       </div>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -2,387 +2,293 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | Tomb of Light</title>
   <meta
     name="description"
-    content="Read the Tomb of Light Privacy Policy covering data collection, use, retention, rights requests, consent expectations, and privacy-first treatment of family legacy information."
+    content="Read the Tomb of Light Privacy Policy, including how we collect, use, protect, and manage personal information and family legacy data."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/privacy.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html" aria-current="page">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
   <main>
-    <section class="page-hero">
-      <div class="container">
-        <span class="eyebrow">Privacy policy</span>
+    <section class="legal-page">
+      <div class="container legal-container">
+        <p class="section-kicker">Legal</p>
         <h1>Privacy Policy</h1>
-        <p>
-          Effective date: March 11, 2026. This Privacy Policy explains how Tomb of
-          Light LLC may collect, use, protect, retain, and review personal information
-          in connection with its website, policy pages, contact pathways, and future
-          family legacy platform services.
+        <p class="legal-date">
+          Effective Date: March 11, 2026<br />
+          Last Updated: March 11, 2026
         </p>
-      </div>
-    </section>
 
-    <section class="section">
-      <div class="container">
-        <div class="notice">
-          Tomb of Light is being built as a privacy-first family legacy platform.
-          Some described platform features may still be in development, but this
-          policy is intended to describe the company’s public-facing privacy direction
-          now and as services expand.
-        </div>
-      </div>
-    </section>
+        <p class="legal-intro">
+          Tomb of Light LLC (“Tomb of Light,” “we,” “our,” or “us”) is committed to protecting
+          personal information, family legacy content, and user trust. This Privacy Policy explains
+          how we collect, use, store, disclose, and protect information when you visit our website,
+          interact with our services, join our waitlist, create an account, submit requests, or
+          otherwise communicate with us.
+        </p>
 
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <h2>1. Who we are</h2>
-          <p>
-            Tomb of Light LLC is building a secure digital family legacy platform
-            designed to help preserve family portraits, lineage information, stories,
-            and related legacy materials in a controlled environment.
-          </p>
-          <p>
-            Contact email:
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>
-          </p>
-        </article>
+        <p class="legal-intro">
+          Tomb of Light is being developed as a privacy-first legacy platform. Our goal is to allow
+          families to preserve stories, portraits, and generational history without placing sensitive
+          personal information directly on public blockchain networks.
+        </p>
 
-        <article class="card">
-          <h2>2. Information we may collect</h2>
-          <p>Depending on how you interact with the site or future services, we may collect:</p>
-          <ul>
-            <li>Contact information such as your name and email address</li>
-            <li>Account information such as login credentials or profile details</li>
-            <li>Communications you send to us through forms or email</li>
-            <li>Preference information such as cookie or privacy choices</li>
-            <li>Technical and device information necessary for site operation and security</li>
-            <li>Family legacy content you choose to submit, where applicable</li>
-            <li>Rights request or correction request details</li>
-          </ul>
-        </article>
+        <h2>1. Information We Collect</h2>
+        <p>We may collect the following categories of information:</p>
 
-        <article class="card">
-          <h2>3. How we may use information</h2>
-          <p>We may use information for purposes such as:</p>
-          <ul>
-            <li>Operating, maintaining, and securing the website or platform</li>
-            <li>Providing account access, support, or request handling</li>
-            <li>Responding to policy, privacy, or security concerns</li>
-            <li>Reviewing correction, deletion, or access requests</li>
-            <li>Improving site performance, reliability, and user experience</li>
-            <li>Preventing misuse, fraud, abuse, or unauthorized activity</li>
-            <li>Complying with legal obligations or protecting rights and safety</li>
-          </ul>
-        </article>
+        <h3>a. Information You Provide Directly</h3>
+        <ul>
+          <li>Name, email address, mailing address, and contact information</li>
+          <li>Account credentials such as username and password</li>
+          <li>Waitlist submissions, contact form entries, and support inquiries</li>
+          <li>Family legacy content you voluntarily submit, upload, or describe</li>
+          <li>Identity or verification information when needed for legal, compliance, or support purposes</li>
+        </ul>
 
-        <article class="card">
-          <h2>4. Privacy-first treatment of family legacy content</h2>
-          <p>
-            Tomb of Light’s platform direction is to avoid placing sensitive family
-            information directly on public blockchains. Family stories, media, records,
-            and similar legacy materials are intended to remain in controlled systems
-            rather than being exposed as public on-chain content.
-          </p>
-          <ul class="check-list">
-            <li>Private family materials are intended to remain off-chain</li>
-            <li>Ownership records should avoid exposing sensitive personal details</li>
-            <li>Family legacy content may receive heightened protection due to its sensitive nature</li>
-          </ul>
-        </article>
+        <h3>b. Information Collected Automatically</h3>
+        <ul>
+          <li>IP address, browser type, device type, operating system, and general site usage data</li>
+          <li>Pages visited, referring URLs, session behavior, and approximate geolocation derived from IP address</li>
+          <li>Cookie and similar technology preferences, where applicable</li>
+        </ul>
 
-        <article class="card">
-          <h2>5. Family participation, consent, and accuracy</h2>
-          <p>
-            Family identity information can be sensitive. Where users submit or manage
-            family-related content, they are expected to do so responsibly and with
-            appropriate authority, permission, or lawful basis where required.
-          </p>
-          <p>
-            Living individuals should not be included in a misleading, deceptive,
-            harmful, or unauthorized way. Inaccurate, outdated, disputed, or improperly
-            submitted information may be subject to correction, review, or removal.
-          </p>
-        </article>
+        <h3>c. Information Related to Family Legacy Records</h3>
+        <ul>
+          <li>Portraits, family stories, names, dates, relationships, and lineage details you choose to provide</li>
+          <li>Consent-related information for living individuals where applicable</li>
+          <li>Administrative records needed to manage, protect, or respond to requests involving submitted family content</li>
+        </ul>
 
-        <article class="card">
-          <h2>6. Children and minor-related information</h2>
-          <p>
-            Tomb of Light does not intend for children to independently use the platform
-            in a way that bypasses appropriate adult oversight. If minor-related family
-            content is ever included, parent or guardian permission is expected, and
-            such material should receive heightened protection.
-          </p>
-        </article>
+        <h2>2. How We Use Information</h2>
+        <p>We may use collected information to:</p>
+        <ul>
+          <li>Provide, operate, maintain, and improve our website and future platform services</li>
+          <li>Create and manage user accounts, waitlist entries, and support records</li>
+          <li>Respond to inquiries, requests, complaints, and data rights submissions</li>
+          <li>Communicate about platform updates, security notices, legal changes, and service-related matters</li>
+          <li>Protect the security, integrity, and lawful use of the site and future services</li>
+          <li>Review compliance, consent, fraud prevention, and misuse prevention issues</li>
+          <li>Develop future family legacy features, ownership systems, and platform functionality</li>
+        </ul>
 
-        <article class="card">
-          <h2>7. Cookies and similar technologies</h2>
-          <p>
-            The site uses essential technologies required for core site operation and
-            may offer optional analytics or preference tools where permitted. Optional
-            analytics should not be enabled unless the user permits them where applicable.
-          </p>
-          <p>
-            For more information, see the
-            <a href="cookie-policy.html">Cookie Policy</a> and
-            <a href="privacy-choices.html">Your Privacy Choices</a> page.
-          </p>
-        </article>
+        <h2>3. Sensitive Family Information and Blockchain Design</h2>
+        <p>
+          Tomb of Light is designed with the intent that sensitive family information, private stories,
+          personal records, and similar legacy materials are not written directly to public blockchain
+          networks. Public blockchain systems may later be used for ownership references or non-identifying
+          records, while personal family content is intended to remain under controlled platform management.
+        </p>
 
-        <article class="card">
-          <h2>8. How we may share information</h2>
-          <p>We may share information only where reasonably necessary, including:</p>
-          <ul>
-            <li>With service providers supporting hosting, operations, security, or communications</li>
-            <li>To comply with law, regulation, legal process, or lawful requests</li>
-            <li>To protect rights, safety, platform integrity, or users from misuse</li>
-            <li>As part of a business transaction where permitted by law and policy</li>
-            <li>With your direction or consent where applicable</li>
-          </ul>
-          <p>
-            Tomb of Light does not state that it sells personal information in the
-            traditional sense described by many privacy laws.
-          </p>
-        </article>
+        <p>
+          Because the platform is evolving, some future features may change over time. We will update this
+          Privacy Policy if our data practices materially change.
+        </p>
 
-        <article class="card">
-          <h2>9. Data retention</h2>
-          <p>
-            We may retain information for as long as reasonably necessary for the
-            purposes described in this policy, including service operation, security,
-            legal compliance, dispute handling, and recordkeeping. Retention periods
-            may vary depending on the type of information, the sensitivity involved,
-            and whether the data is needed for active services or legal obligations.
-          </p>
-        </article>
+        <h2>4. Legal Bases and Consent</h2>
+        <p>
+          Depending on the nature of the interaction and applicable law, we may process information based on:
+        </p>
+        <ul>
+          <li>Your consent</li>
+          <li>Performance of a contract or pre-contractual steps</li>
+          <li>Our legitimate interests in operating and securing the platform</li>
+          <li>Compliance with legal obligations</li>
+        </ul>
 
-        <article class="card">
-          <h2>10. Security</h2>
-          <p>
-            Tomb of Light uses a privacy-first security direction intended to protect
-            sensitive information through controlled storage, transport protection,
-            restricted access, and operational safeguards appropriate to the stage of
-            service development.
-          </p>
-          <p>
-            No system can promise absolute security. Please review our
-            <a href="security.html">Security page</a> for more information.
-          </p>
-        </article>
+        <p>
+          Where living individuals are included in submitted family records, users are responsible for ensuring
+          they have appropriate authority, notice, or consent before sharing information with us.
+        </p>
 
-        <article class="card">
-          <h2>11. Your rights and choices</h2>
-          <p>
-            Depending on your location and relationship to the site or future services,
-            you may have rights to request access, correction, deletion, or review of
-            certain personal information. You may also be able to request limitations
-            on specific processing activities where applicable by law.
-          </p>
-          <p>
-            To submit a request, use the
-            <a href="data-request.html">Data Request</a> page or contact
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>.
-          </p>
-        </article>
+        <h2>5. Cookies and Similar Technologies</h2>
+        <p>
+          We use essential site technologies needed for the operation, security, and functionality of the website.
+          We may also use optional analytics or similar tools where permitted by law and where appropriate consent
+          has been obtained.
+        </p>
 
-        <article class="card">
-          <h2>12. Identity verification for requests</h2>
-          <p>
-            Before fulfilling certain privacy or rights requests, Tomb of Light may
-            need to verify your identity or confirm your authority to act on behalf
-            of another person. We may request enough information to reasonably verify
-            the request while trying to minimize unnecessary collection.
-          </p>
-        </article>
+        <p>
+          You can review and manage available cookie or privacy preference choices through our
+          <a href="privacy-choices.html">Privacy Choices</a> page.
+        </p>
 
-        <article class="card">
-          <h2>13. Appeals and follow-up</h2>
-          <p>
-            If a request cannot be fully honored, Tomb of Light may provide an
-            explanation where appropriate and may offer a follow-up path, appeal
-            path, or additional review depending on the nature of the request and
-            applicable law.
-          </p>
-        </article>
+        <h2>6. When We Share Information</h2>
+        <p>We do not sell personal information for money. We may share information in limited cases such as:</p>
+        <ul>
+          <li>With service providers who help operate the website, support systems, hosting, security, or communications</li>
+          <li>When required by law, subpoena, court order, or lawful government request</li>
+          <li>To protect rights, safety, security, property, users, or the public</li>
+          <li>As part of a merger, acquisition, financing, restructuring, or sale of company assets, subject to appropriate safeguards</li>
+          <li>With your direction or consent</li>
+        </ul>
 
-        <article class="card">
-          <h2>14. External links</h2>
-          <p>
-            The site may contain links to third-party sites or services. Tomb of Light
-            is not responsible for the privacy practices of third-party sites outside
-            its control. Review those services separately before sharing information.
-          </p>
-        </article>
+        <h2>7. Data Retention</h2>
+        <p>
+          We retain information for as long as reasonably necessary for the purposes described in this Privacy Policy,
+          including to provide services, maintain security, resolve disputes, enforce agreements, and comply with legal obligations.
+        </p>
 
-        <article class="card">
-          <h2>15. Changes to this policy</h2>
-          <p>
-            Tomb of Light may update this Privacy Policy from time to time as the
-            platform evolves, legal requirements change, or operational practices
-            mature. Updated versions will be posted on this page with a revised
-            effective date or last-updated date.
-          </p>
-        </article>
+        <p>
+          Retention periods may vary depending on the type of information, the sensitivity of the material, and whether
+          the information relates to active accounts, support requests, waitlist activity, compliance review, or future platform services.
+        </p>
 
-        <article class="card">
-          <h2>16. Contact</h2>
-          <p>
-            For privacy questions, requests, or concerns, contact:
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>
-          </p>
-        </article>
-      </div>
-    </section>
+        <h2>8. Data Security</h2>
+        <p>
+          We use administrative, technical, and organizational safeguards intended to protect information against unauthorized
+          access, loss, misuse, disclosure, or alteration. However, no method of transmission or storage is completely secure,
+          and we cannot guarantee absolute security.
+        </p>
 
-    <section class="section-sm">
-      <div class="container">
-        <div class="cta-banner">
-          <h3>Review the related policy pages.</h3>
-          <p>
-            This Privacy Policy works together with the Cookie Policy, Security page,
-            Compliance &amp; Legal page, and Data Request page.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="cookie-policy.html">Cookie Policy</a>
-            <a class="btn btn-secondary" href="security.html">Security</a>
-            <a class="btn btn-secondary" href="data-request.html">Data Request</a>
-          </div>
-        </div>
+        <p>
+          For more information about our approach to security, visit our <a href="security.html">Security</a> page.
+        </p>
+
+        <h2>9. Children’s Privacy</h2>
+        <p>
+          Tomb of Light is not intended for children to use independently without authorized adult involvement. Where family
+          legacy content includes minors, the submitting adult is responsible for ensuring appropriate parental or guardian
+          authority and consent before providing that information.
+        </p>
+
+        <h2>10. Your Privacy Rights</h2>
+        <p>
+          Depending on where you live, you may have rights to request access to, correction of, deletion of, or limitation of
+          certain personal information. You may also have rights related to consent withdrawal, appeal, or certain disclosures.
+        </p>
+
+        <p>
+          To submit a request, visit our <a href="data-request.html">Data Request</a> page. Additional state-specific details
+          may be available on our <a href="privacy-state-notices.html">State Privacy Notices</a> page.
+        </p>
+
+        <h2>11. Third-Party Links and Services</h2>
+        <p>
+          Our site may contain links to third-party websites, tools, or services. We are not responsible for the privacy,
+          security, or content practices of third parties. You should review their policies separately before submitting
+          information to them.
+        </p>
+
+        <h2>12. International Visitors</h2>
+        <p>
+          Tomb of Light is operated from the United States. If you access the site from outside the United States, you understand
+          that your information may be transferred to, stored in, and processed in the United States or other jurisdictions where
+          our service providers operate.
+        </p>
+
+        <h2>13. Changes to This Policy</h2>
+        <p>
+          We may update this Privacy Policy from time to time to reflect platform development, legal changes, security improvements,
+          or business operations. When we make material changes, we will update the effective or last updated date shown on this page.
+        </p>
+
+        <h2>14. Contact Information</h2>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+
+        <p>
+          Email:
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/security.html
+++ b/security.html
@@ -2,392 +2,245 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Security | Tomb of Light</title>
   <meta
     name="description"
-    content="Review Tomb of Light’s security approach, including privacy-first design, controlled storage, incident response direction, responsible disclosure, and protection of family legacy data."
+    content="Review Tomb of Light’s security approach, responsible disclosure path, platform safeguards, and privacy-first data protection principles."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/security.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html" aria-current="page">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
   <main>
-    <section class="page-hero">
-      <div class="container">
-        <span class="eyebrow">Security and infrastructure</span>
-        <h1>Security at Tomb of Light</h1>
+    <section class="legal-page">
+      <div class="container legal-container">
+        <p class="section-kicker">Trust & Protection</p>
+        <h1>Security</h1>
+        <p class="legal-date">
+          Effective Date: March 11, 2026<br />
+          Last Updated: March 11, 2026
+        </p>
+
+        <p class="legal-intro">
+          Tomb of Light is being built with security, privacy, and responsible data handling as core
+          operating principles. Because the platform is designed to preserve sensitive family legacy
+          information, we take the protection of accounts, records, and submitted content seriously.
+        </p>
+
+        <p class="legal-intro">
+          This page describes our current security posture, development direction, and how security
+          concerns can be reported to us.
+        </p>
+
+        <h2>1. Security Commitment</h2>
         <p>
-          Tomb of Light is being built with a privacy-first security direction
-          focused on protecting family legacy information, limiting public exposure
-          of sensitive records, and strengthening trust through controlled access,
-          policy discipline, and responsible operational safeguards.
-        </p>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <div class="notice">
-          This page describes Tomb of Light’s current public-facing security direction.
-          Some controls described here may be in staged development, planned rollout,
-          or operational hardening phases as the platform evolves.
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <span class="eyebrow">Core approach</span>
-        <h2 class="section-title">Private family data should not be treated like public blockchain content.</h2>
-        <p class="section-subtitle">
-          Tomb of Light is being designed so that family portraits, stories, records,
-          and identity-sensitive information remain protected in controlled systems,
-          while any future blockchain layer is limited to ownership or reference
-          functions that avoid unnecessary exposure of personal family data.
+          Tomb of Light is designed with security as a core principle. Our platform uses encrypted
+          connections, secure authentication practices, and privacy-first architecture to help protect
+          family legacy data, account activity, and submitted records.
         </p>
 
-        <div class="grid grid-3" style="margin-top: 28px;">
-          <article class="card">
-            <h3>Private-by-default design</h3>
-            <p>
-              Sensitive family content is intended to remain off-chain and under
-              controlled platform protection rather than being published openly.
-            </p>
-            <ul class="feature-list">
-              <li>Off-chain protection model</li>
-              <li>Limited public metadata exposure</li>
-              <li>Separation between ownership and content</li>
-            </ul>
-          </article>
-
-          <article class="card">
-            <h3>Access-aware systems</h3>
-            <p>
-              Family legacy material should be available only through appropriate
-              permissions, account protection, and role-based handling.
-            </p>
-            <ul class="feature-list">
-              <li>Controlled account access</li>
-              <li>Future role and permission layers</li>
-              <li>Restricted handling of sensitive records</li>
-            </ul>
-          </article>
-
-          <article class="card">
-            <h3>Security-minded operations</h3>
-            <p>
-              Operational direction includes secure hosting, transport protection,
-              monitoring, and practical response processes as the company grows.
-            </p>
-            <ul class="feature-list">
-              <li>Infrastructure hardening direction</li>
-              <li>Monitoring and review goals</li>
-              <li>Incident response planning</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <span class="eyebrow">Data protection</span>
-          <h2>Encryption and protected storage direction</h2>
-          <p>
-            Tomb of Light’s platform direction includes protecting data both in
-            transit and at rest using modern security practices appropriate to the
-            sensitivity of family legacy information. Family content is intended to
-            be stored in controlled systems rather than embedded directly in public
-            blockchain records.
-          </p>
-          <ul class="check-list">
-            <li>Transport protection for data moving between users and platform services</li>
-            <li>Protected storage direction for sensitive family media and records</li>
-            <li>Separation between private vault content and public ownership references</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">Account protection</span>
-          <h2>Identity and access safeguards</h2>
-          <p>
-            Tomb of Light expects account security to be a major part of trust.
-            As platform capabilities mature, access control direction includes
-            secure authentication flows, stronger admin protection, and limited
-            access based on user role or family relationship context.
-          </p>
-          <ul class="check-list">
-            <li>Password-based authentication with future stronger options</li>
-            <li>Multi-factor authentication direction for staff or privileged access</li>
-            <li>Role-based or permission-aware handling for sensitive operations</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">Infrastructure</span>
-          <h2>Hosting, continuity, and resilience</h2>
-          <p>
-            Secure platform operation depends on infrastructure choices as much as
-            page design. Tomb of Light’s operational direction includes secure
-            hosting, HTTPS enforcement, service hardening, backup planning, and
-            resilience measures intended to reduce risk and support continuity.
-          </p>
-          <ul class="check-list">
-            <li>HTTPS-first service delivery</li>
-            <li>Production hardening and controlled deployment practices</li>
-            <li>Backup and recovery planning for critical systems and records</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <span class="eyebrow">Monitoring</span>
-          <h2>Logging, review, and incident awareness</h2>
-          <p>
-            Security depends on the ability to detect and investigate problems.
-            Tomb of Light’s long-term direction includes service monitoring,
-            operational logging, and review pathways for security-relevant events
-            involving accounts, access, or protected records.
-          </p>
-          <ul class="check-list">
-            <li>Operational event logging direction</li>
-            <li>Review pathways for suspicious activity</li>
-            <li>Escalation planning for platform incidents</li>
-          </ul>
-        </article>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <span class="eyebrow">Responsible handling</span>
-        <h2 class="section-title">Security also includes consent, sensitivity, and family dignity.</h2>
-        <p class="section-subtitle">
-          Because Tomb of Light deals with family identity, memory, and lineage,
-          security is not only a technical issue. It is also about respectful
-          participation, careful handling of disputes, and limiting misuse of
-          sensitive family information.
+        <p>
+          Sensitive personal information is not intended to be written directly to public blockchain
+          networks. Where blockchain-related ownership features are developed in the future, those
+          systems are intended to remain separate from private family content and sensitive records.
         </p>
 
-        <div class="grid grid-2" style="margin-top: 28px;">
-          <article class="card">
-            <h3>Consent-sensitive participation</h3>
-            <p>
-              Living individuals should not be included carelessly. Sensitive family
-              inclusion decisions should be handled with respect, lawful basis where
-              required, and clear correction or removal pathways.
-            </p>
-            <ul class="policy-list">
-              <li>Respect for living family members</li>
-              <li>Correction and removal processes</li>
-              <li>Heightened care for sensitive family disputes</li>
-            </ul>
-          </article>
+        <h2>2. Current Security Measures</h2>
+        <p>Our website and evolving platform may use measures such as:</p>
+        <ul>
+          <li>HTTPS-encrypted connections for website traffic</li>
+          <li>Access controls for account-related functions and administrative operations</li>
+          <li>Hosting-level protections and infrastructure monitoring</li>
+          <li>Secure handling of support, request, and account-related submissions</li>
+          <li>Limited internal access to personal information based on operational need</li>
+          <li>Ongoing review of privacy, consent, and data exposure risks</li>
+        </ul>
 
-          <article class="card">
-            <h3>Minors and protected family material</h3>
-            <p>
-              Where minors or especially sensitive legacy content are involved,
-              parental or guardian permission and private-by-default treatment are
-              expected as part of the platform’s public trust direction.
-            </p>
-            <ul class="policy-list">
-              <li>Parental or guardian authorization expectations</li>
-              <li>Protected handling of minor-related content</li>
-              <li>Higher sensitivity for vulnerable family records</li>
-            </ul>
-          </article>
-        </div>
-      </div>
-    </section>
+        <h2>3. Authentication and Account Protection</h2>
+        <p>
+          Users are responsible for maintaining the confidentiality of their account credentials and for
+          protecting access to their devices and email accounts. If you believe your account has been
+          accessed without authorization, contact us immediately.
+        </p>
 
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <span class="eyebrow">Incident response</span>
-          <h2>Response direction for security issues</h2>
-          <p>
-            Tomb of Light intends to review credible security issues promptly and
-            take appropriate steps based on the nature of the issue, the systems
-            involved, and the potential impact on users or protected family material.
-          </p>
-          <ol>
-            <li>Review reported security concerns and validate whether the issue is credible.</li>
-            <li>Assess scope, severity, and whether protected user or family data may be affected.</li>
-            <li>Contain, remediate, and document the issue based on operational needs.</li>
-            <li>Improve controls, procedures, or infrastructure where needed.</li>
-          </ol>
-        </article>
+        <p>
+          Strong passwords should be used for all Tomb of Light accounts. Two-factor authentication may
+          be introduced in a future platform update to strengthen account protection.
+        </p>
 
-        <article class="card">
-          <span class="eyebrow">Responsible disclosure</span>
-          <h2>How to report a security concern</h2>
-          <p>
-            If you believe you have found a security issue affecting Tomb of Light,
-            please report it responsibly and in good faith. Do not attempt to access
-            data that does not belong to you, disrupt services, or expose private
-            information publicly.
-          </p>
-          <ul class="check-list">
-            <li>Provide a clear description of the issue</li>
-            <li>Include the affected page, feature, or workflow</li>
-            <li>Share reproduction details where possible</li>
-            <li>Do not exploit, exfiltrate, or publish sensitive data</li>
-          </ul>
-          <p style="margin-top: 18px;">
-            Security contact:
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>
-          </p>
-        </article>
-      </div>
-    </section>
+        <h2>4. Privacy-First Architecture</h2>
+        <p>
+          Tomb of Light is being developed so that private family details, sensitive records, and legacy
+          narratives can remain under controlled platform management instead of being placed openly on
+          public blockchain systems.
+        </p>
 
-    <section class="section-sm">
-      <div class="container">
-        <div class="cta-banner">
-          <h3>Review the rest of the trust framework.</h3>
-          <p>
-            Security at Tomb of Light works together with privacy, compliance,
-            consent, and user rights handling. Review the related pages below.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="privacy.html">Privacy Policy</a>
-            <a class="btn btn-secondary" href="compliance.html">Compliance &amp; Legal</a>
-            <a class="btn btn-secondary" href="data-request.html">Data Request</a>
-          </div>
-        </div>
+        <p>
+          This separation is an important part of our security and privacy design approach. The goal is
+          to reduce unnecessary public exposure of personal family information while still allowing future
+          digital ownership structures where appropriate.
+        </p>
+
+        <h2>5. Security Limitations</h2>
+        <p>
+          No website, server environment, application, or data transmission method can be guaranteed to
+          be completely secure. Although we use safeguards designed to reduce risk, we cannot guarantee
+          absolute protection against all threats, attacks, failures, or unauthorized actions.
+        </p>
+
+        <p>
+          Users should also take reasonable steps to protect their own accounts, devices, networks, and
+          email systems.
+        </p>
+
+        <h2>6. Responsible Disclosure</h2>
+        <p>
+          If you discover a security issue, vulnerability, or suspected weakness involving Tomb of Light,
+          please report it to us responsibly so we can investigate.
+        </p>
+
+        <p>Please include:</p>
+        <ul>
+          <li>A clear description of the issue</li>
+          <li>The affected page, feature, or workflow</li>
+          <li>Steps to reproduce the issue, if known</li>
+          <li>Screenshots or supporting details, if available</li>
+          <li>Your contact information for follow-up, if you want a response</li>
+        </ul>
+
+        <p>
+          Please do not exploit vulnerabilities, access data you are not authorized to access, disrupt
+          services, or test the site in a way that could harm users, infrastructure, or data.
+        </p>
+
+        <h2>7. Security Updates and Platform Evolution</h2>
+        <p>
+          Tomb of Light is an evolving platform. Our security controls, authentication features,
+          infrastructure design, and internal procedures may change over time as the platform grows.
+        </p>
+
+        <p>
+          We may update this page as security practices mature, new features are introduced, or risk
+          management standards are revised.
+        </p>
+
+        <h2>8. Related Policies</h2>
+        <p>
+          Additional information about how we handle data and user rights can be found in our
+          <a href="privacy.html">Privacy Policy</a>,
+          <a href="terms.html">Terms of Service</a>, and
+          <a href="data-request.html">Data Request</a> pages.
+        </p>
+
+        <h2>9. Contact Information</h2>
+        <p>
+          To report a security concern or contact us about account protection:
+        </p>
+
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+
+        <p>
+          Email:
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/signin.html
+++ b/signin.html
@@ -2,195 +2,183 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sign In | Tomb of Light</title>
   <meta
     name="description"
-    content="Sign in to Tomb of Light to access future account, vault, and legacy platform features."
+    content="Sign in to Tomb of Light to access your account, manage your legacy profile, and review protected platform features."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/signin.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary" aria-current="page">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
-  <main class="auth-shell">
-    <div class="container">
-      <div class="auth-card">
-        <span class="eyebrow">Account access</span>
-        <h1>Sign In</h1>
-        <p>
-          Access future Tomb of Light account tools, family vault features, and legacy
-          platform services. This page currently provides front-end validation and layout
-          structure while backend authentication is connected separately.
-        </p>
+  <main>
+    <section class="auth-page">
+      <div class="container auth-container">
+        <div class="auth-card">
+          <p class="section-kicker">Account Access</p>
+          <h1>Sign In</h1>
+          <p class="auth-intro">
+            Access your Tomb of Light account to review protected features, submitted records,
+            and future legacy platform tools as they become available.
+          </p>
 
-        <form id="signin-form" class="form-grid" novalidate>
-          <div class="form-row">
-            <label for="signin-email">Email address</label>
-            <input
-              type="email"
-              id="signin-email"
-              name="signin-email"
-              placeholder="you@example.com"
-              required
-            />
+          <form class="auth-form" action="#" method="post">
+            <div class="form-group">
+              <label for="email">Email Address</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                autocomplete="email"
+                placeholder="you@example.com"
+                required
+              />
+            </div>
+
+            <div class="form-group">
+              <label for="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                autocomplete="current-password"
+                placeholder="Enter your password"
+                required
+              />
+            </div>
+
+            <div class="form-row form-row-between">
+              <label class="checkbox-inline">
+                <input type="checkbox" name="remember" />
+                <span>Remember me</span>
+              </label>
+
+              <a href="data-request.html" class="text-link">Need account help?</a>
+            </div>
+
+            <button type="submit" class="btn btn-primary btn-full">Sign In</button>
+          </form>
+
+          <div class="security-note">
+            <p>
+              🔒 Your information is protected using encrypted connections and secure account access practices.
+            </p>
+            <p>
+              Use a strong password and do not share your login details with anyone.
+            </p>
+            <p>
+              Need help accessing your account?
+              <a href="mailto:support@tomboflight.com">Contact support</a>.
+            </p>
           </div>
 
-          <div class="form-row">
-            <label for="signin-password">Password</label>
-            <input
-              type="password"
-              id="signin-password"
-              name="signin-password"
-              placeholder="Enter your password"
-              required
-            />
+          <div class="auth-links">
+            <p>
+              Don’t have an account yet?
+              <a href="signup.html">Create one here</a>.
+            </p>
+            <p>
+              By signing in, you agree to our
+              <a href="terms.html">Terms of Service</a>
+              and acknowledge our
+              <a href="privacy.html">Privacy Policy</a>.
+            </p>
           </div>
-
-          <div class="cta-actions">
-            <button class="btn btn-primary" type="submit">Sign In</button>
-            <a class="btn btn-secondary" href="signup.html">Create Account</a>
-          </div>
-
-          <p id="signin-message" class="form-help" style="margin: 0;"></p>
-        </form>
-
-        <div class="inline-links">
-          <a href="privacy.html">Privacy Policy</a>
-          <a href="terms.html">Terms of Service</a>
-          <a href="security.html">Security</a>
         </div>
       </div>
-    </div>
+    </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>
 </html>
+

--- a/signup.html
+++ b/signup.html
@@ -1,228 +1,222 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
-  <title>Join Now | Tomb of Light</title>
-  <meta
-    name="description"
-    content="Create a Tomb of Light account to join the platform waitlist and prepare for future family vault and legacy features."
-  />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Create Account | Tomb of Light</title>
+
+<meta name="description" content="Create a Tomb of Light account to begin building your secure digital family legacy." />
+
+<link rel="canonical" href="https://tomboflight.com/signup.html">
+
+<link rel="stylesheet" href="styles.css">
 </head>
+
 <body>
-  <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
-          <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
-      </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-      </nav>
+<header class="site-header">
+<div class="container nav-wrap">
 
-      <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
+<a href="index.html" class="logo">
+<span class="logo-mark">TL</span>
+<span class="logo-text">
+<strong>Tomb of Light</strong>
+<small>Secure digital family legacy infrastructure</small>
+</span>
+</a>
 
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
+<nav class="main-nav">
+<a href="index.html">Home</a>
+<a href="how-it-works.html">How It Works</a>
+<a href="faq.html">FAQ</a>
+<a href="security.html">Security</a>
+<a href="compliance.html">Compliance</a>
+<a href="privacy.html">Privacy Policy</a>
+<a href="terms.html">Terms</a>
+<a href="data-request.html">Data Request</a>
+</nav>
 
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
-      </div>
-    </div>
-  </header>
+<div class="nav-actions">
+<a href="signin.html" class="btn btn-secondary">Sign In</a>
+<a href="signup.html" class="btn btn-primary" aria-current="page">Join Now</a>
+</div>
 
-  <main class="auth-shell">
-    <div class="container">
-      <div class="auth-card">
-        <span class="eyebrow">Account creation</span>
-        <h1>Join Now</h1>
-        <p>
-          Create your Tomb of Light account to prepare for future family vault,
-          legacy preservation, and ownership features. This page currently provides
-          front-end validation and structure while full backend registration is connected separately.
-        </p>
+</div>
+</header>
 
-        <form id="signup-form" class="form-grid" novalidate>
-          <div class="form-row">
-            <label for="signup-name">Full name</label>
-            <input
-              type="text"
-              id="signup-name"
-              name="signup-name"
-              placeholder="Your full name"
-              required
-            />
-          </div>
+<main>
 
-          <div class="form-row">
-            <label for="signup-email">Email address</label>
-            <input
-              type="email"
-              id="signup-email"
-              name="signup-email"
-              placeholder="you@example.com"
-              required
-            />
-          </div>
+<section class="auth-page">
+<div class="container auth-container">
 
-          <div class="form-row">
-            <label for="signup-password">Password</label>
-            <input
-              type="password"
-              id="signup-password"
-              name="signup-password"
-              placeholder="Create a password"
-              required
-            />
-            <div class="form-help">
-              Password must be at least 8 characters long.
-            </div>
-          </div>
+<div class="auth-card">
 
-          <div class="form-row">
-            <label for="signup-confirm-password">Confirm password</label>
-            <input
-              type="password"
-              id="signup-confirm-password"
-              name="signup-confirm-password"
-              placeholder="Confirm your password"
-              required
-            />
-          </div>
+<p class="section-kicker">Create Account</p>
 
-          <div class="form-row">
-            <label>
-              <input type="checkbox" id="signup-consent" required />
-              I confirm that I have read the Privacy Policy and Terms of Service and understand that some platform features may still be in development.
-            </label>
-          </div>
+<h1>Join Tomb of Light</h1>
 
-          <div class="cta-actions">
-            <button class="btn btn-primary" type="submit">Create Account</button>
-            <a class="btn btn-secondary" href="signin.html">Already have an account?</a>
-          </div>
+<p class="auth-intro">
+Create an account to begin accessing the Tomb of Light platform and future legacy tools as they become available.
+</p>
 
-          <p id="signup-message" class="form-help" style="margin: 0;"></p>
-        </form>
+<form class="auth-form" action="#" method="post">
 
-        <div class="inline-links">
-          <a href="privacy.html">Privacy Policy</a>
-          <a href="terms.html">Terms of Service</a>
-          <a href="security.html">Security</a>
-        </div>
-      </div>
-    </div>
-  </main>
+<div class="form-group">
+<label for="name">Full Name</label>
+<input type="text" id="name" name="name" placeholder="Your full name" required>
+</div>
 
-  <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
+<div class="form-group">
+<label for="email">Email Address</label>
+<input type="email" id="email" name="email" placeholder="you@example.com" required>
+</div>
 
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
-      </div>
+<div class="form-group">
+<label for="password">Create Password</label>
+<input type="password" id="password" name="password" placeholder="Create a password" required>
+</div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
-      </div>
-    </div>
-  </footer>
+<div class="password-requirements">
 
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
+<p>Password must contain:</p>
 
-  <script src="app.js"></script>
+<ul>
+<li>At least 8 characters</li>
+<li>One uppercase letter</li>
+<li>One number</li>
+<li>One special character</li>
+</ul>
+
+</div>
+
+<div class="form-group">
+<label class="checkbox-inline">
+<input type="checkbox" required>
+<span>I agree to the <a href="terms.html">Terms of Service</a> and <a href="privacy.html">Privacy Policy</a></span>
+</label>
+</div>
+
+<button type="submit" class="btn btn-primary btn-full">
+Create Account
+</button>
+
+</form>
+
+<div class="security-note">
+
+<p>
+🔒 Your information is protected using encrypted connections and responsible data handling practices.
+</p>
+
+<p>
+Sensitive family information is not intended to be written directly to public blockchain networks.
+</p>
+
+</div>
+
+<div class="auth-links">
+
+<p>
+Already have an account?
+<a href="signin.html">Sign in here</a>
+</p>
+
+<p>
+Need help?
+<a href="mailto:support@tomboflight.com">Contact support</a>
+</p>
+
+</div>
+
+</div>
+
+</div>
+</section>
+
+</main>
+
+<footer class="site-footer">
+
+<div class="container footer-grid">
+
+<div class="footer-brand">
+
+<a href="index.html" class="logo footer-logo">
+
+<span class="logo-mark">TL</span>
+
+<span class="logo-text">
+<strong>Tomb of Light</strong>
+<small>Secure digital family legacy infrastructure</small>
+</span>
+
+</a>
+
+<p>
+Tomb of Light is building a privacy-first platform for preserving family history, protecting sensitive legacy records, and enabling future ownership systems without exposing personal family data on public blockchains.
+</p>
+
+</div>
+
+<div>
+
+<h3>Platform</h3>
+
+<ul>
+<li><a href="how-it-works.html">How It Works</a></li>
+<li><a href="faq.html">FAQ</a></li>
+<li><a href="security.html">Security</a></li>
+<li><a href="compliance.html">Compliance</a></li>
+</ul>
+
+</div>
+
+<div>
+
+<h3>Policies</h3>
+
+<ul>
+<li><a href="privacy.html">Privacy Policy</a></li>
+<li><a href="terms.html">Terms</a></li>
+<li><a href="cookie-policy.html">Cookie Policy</a></li>
+<li><a href="data-request.html">Data Request</a></li>
+<li><a href="privacy-choices.html">Privacy Choices</a></li>
+<li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+<li><a href="accessibility.html">Accessibility</a></li>
+</ul>
+
+</div>
+
+<div>
+
+<h3>Contact</h3>
+
+<p>
+Tomb of Light LLC<br>
+3007 Woodland Hills Dr<br>
+PMB 176<br>
+Kingwood, TX 77339<br>
+United States
+</p>
+
+<p>
+<a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+</p>
+
+</div>
+
+</div>
+
+<div class="container footer-bottom">
+
+<p>© 2026 Tomb of Light LLC. All rights reserved.</p>
+
+</div>
+
+</footer>
+
+<script src="app.js"></script>
+
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -2,392 +2,339 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms of Service | Tomb of Light</title>
   <meta
     name="description"
-    content="Read the Tomb of Light Terms of Service covering platform use, eligibility, account responsibility, acceptable conduct, intellectual property, and legal limitations."
+    content="Read the Tomb of Light Terms of Service for use of the website, accounts, legacy submissions, intellectual property, and platform rules."
   />
-  <meta
-    name="theme-color"
-    content="#07090f"
-  />
-  <link
-    rel="manifest"
-    href="site.webmanifest"
-  />
-  <link
-    rel="stylesheet"
-    href="styles.css"
-  />
+  <link rel="canonical" href="https://tomboflight.com/terms.html" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <div class="container navbar">
-      <a class="brand" href="index.html" aria-label="Tomb of Light home">
-        <div class="brand-mark">TL</div>
-        <div class="brand-text">
+    <div class="container nav-wrap">
+      <a href="index.html" class="logo" aria-label="Tomb of Light home">
+        <span class="logo-mark">TL</span>
+        <span class="logo-text">
           <strong>Tomb of Light</strong>
-          <span>Generational legacy, secured</span>
-        </div>
+          <small>Secure digital family legacy infrastructure</small>
+        </span>
       </a>
 
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="how-it-works.html" data-nav-link>How It Works</a>
-        <a href="faq.html" data-nav-link>FAQ</a>
-        <a href="security.html" data-nav-link>Security</a>
-        <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+        <a href="how-it-works.html">How It Works</a>
+        <a href="faq.html">FAQ</a>
+        <a href="security.html">Security</a>
+        <a href="compliance.html">Compliance</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html" aria-current="page">Terms of Service</a>
+        <a href="data-request.html">Data Request</a>
       </nav>
 
       <div class="nav-actions">
-        <a class="btn btn-secondary" href="signin.html">Sign In</a>
-        <a class="btn btn-primary" href="signup.html">Join Now</a>
-        <button
-          class="menu-toggle"
-          id="menu-toggle"
-          type="button"
-          aria-label="Open menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-        >
-          <span></span>
-        </button>
-      </div>
-    </div>
-
-    <div class="container mobile-menu" id="mobile-menu">
-      <div class="mobile-menu-inner">
-        <nav aria-label="Mobile navigation">
-          <a href="index.html" data-nav-link>Home</a>
-          <a href="how-it-works.html" data-nav-link>How It Works</a>
-          <a href="faq.html" data-nav-link>FAQ</a>
-          <a href="security.html" data-nav-link>Security</a>
-          <a href="compliance.html" data-nav-link>Compliance &amp; Legal</a>
-          <a href="privacy.html" data-nav-link>Privacy Policy</a>
-          <a href="terms.html" data-nav-link>Terms of Service</a>
-          <a href="data-request.html" data-nav-link>Data Request</a>
-        </nav>
-
-        <div class="mobile-actions">
-          <a class="btn btn-secondary" href="signin.html">Sign In</a>
-          <a class="btn btn-primary" href="signup.html">Join Now</a>
-        </div>
+        <a href="signin.html" class="btn btn-secondary">Sign In</a>
+        <a href="signup.html" class="btn btn-primary">Join Now</a>
       </div>
     </div>
   </header>
 
   <main>
-    <section class="page-hero">
-      <div class="container">
-        <span class="eyebrow">Terms of service</span>
+    <section class="legal-page">
+      <div class="container legal-container">
+        <p class="section-kicker">Legal</p>
         <h1>Terms of Service</h1>
-        <p>
-          Effective date: March 11, 2026. These Terms of Service govern your access to
-          and use of the Tomb of Light website and any current or future services,
-          features, pages, tools, or account systems made available by Tomb of Light LLC.
+        <p class="legal-date">
+          Effective Date: March 11, 2026<br />
+          Last Updated: March 11, 2026
         </p>
-      </div>
-    </section>
 
-    <section class="section">
-      <div class="container">
-        <div class="notice">
-          Some platform features described on this website may still be in development
-          or staged release. These terms apply to current website use as well as future
-          services made available by Tomb of Light unless replaced by more specific terms.
-        </div>
-      </div>
-    </section>
+        <p class="legal-intro">
+          These Terms of Service (“Terms”) govern your access to and use of the Tomb of Light website,
+          services, future platform features, communications, accounts, and related materials provided by
+          Tomb of Light LLC (“Tomb of Light,” “we,” “our,” or “us”).
+        </p>
 
-    <section class="section">
-      <div class="container content-wrap">
-        <article class="card">
-          <h2>1. Acceptance of these terms</h2>
-          <p>
-            By accessing or using the Tomb of Light website or services, you agree to
-            be bound by these Terms of Service and any policies incorporated by reference,
-            including the Privacy Policy, Cookie Policy, and other applicable legal pages.
-            If you do not agree, do not use the site or services.
-          </p>
-        </article>
+        <p class="legal-intro">
+          By accessing or using our website or services, you agree to be bound by these Terms. If you do
+          not agree, do not use the site or services.
+        </p>
 
-        <article class="card">
-          <h2>2. Who may use the services</h2>
-          <p>
-            You may use the site or services only if you can form a binding agreement
-            under applicable law and are not prohibited from using the services under
-            any applicable laws or regulations.
-          </p>
-          <p>
-            If you use the services on behalf of another person, family, organization,
-            or entity, you represent that you have authority to do so.
-          </p>
-        </article>
+        <h2>1. Eligibility</h2>
+        <p>
+          You may use the website only if you can form a binding agreement under applicable law and are not
+          prohibited from using the services under any applicable laws or regulations.
+        </p>
 
-        <article class="card">
-          <h2>3. Accounts and registration</h2>
-          <p>
-            Some features may require an account. You agree to provide accurate, current,
-            and complete information and to keep your account information updated.
-          </p>
-          <ul>
-            <li>You are responsible for safeguarding your login credentials.</li>
-            <li>You are responsible for activity occurring under your account.</li>
-            <li>You must notify Tomb of Light promptly of suspected unauthorized use.</li>
-          </ul>
-        </article>
+        <p>
+          If you use the website or services on behalf of a business, family office, organization, or another
+          person, you represent that you have authority to bind that party to these Terms.
+        </p>
 
-        <article class="card">
-          <h2>4. Family content, authority, and responsibility</h2>
-          <p>
-            If you submit, manage, or request inclusion of family-related content,
-            you are responsible for ensuring that you have the right, permission,
-            authority, or lawful basis to do so where required.
-          </p>
-          <p>
-            You must not submit content in a way that is deceptive, harmful, unlawful,
-            defamatory, invasive of privacy, or otherwise abusive of another person’s identity,
-            likeness, memory, or family relationship.
-          </p>
-        </article>
+        <h2>2. Scope of Services</h2>
+        <p>
+          Tomb of Light currently provides a public-facing website, informational materials, request pages,
+          account-related pages, waitlist features, and related communications. Certain features described on
+          the site may be planned, limited, evolving, or not yet publicly available.
+        </p>
 
-        <article class="card">
-          <h2>5. Minors and sensitive family information</h2>
-          <p>
-            If content involves minors, you represent that you have the appropriate
-            parent or guardian authorization where required. You agree not to misuse
-            the services in ways that expose, exploit, or mishandle sensitive information
-            relating to children or vulnerable individuals.
-          </p>
-        </article>
+        <p>
+          We may modify, suspend, limit, or discontinue any part of the website or services at any time,
+          with or without notice, as permitted by law.
+        </p>
 
-        <article class="card">
-          <h2>6. Acceptable use</h2>
-          <p>You agree not to:</p>
-          <ul>
-            <li>Use the services for unlawful, fraudulent, deceptive, or abusive purposes</li>
-            <li>Impersonate another person or misrepresent your authority or identity</li>
-            <li>Upload malicious code or interfere with site security or operations</li>
-            <li>Attempt unauthorized access to accounts, systems, or data</li>
-            <li>Use the services to harass, threaten, defame, or invade privacy</li>
-            <li>Scrape, reverse engineer, or exploit the services beyond permitted use</li>
-            <li>Upload family material you do not have the right to submit</li>
-          </ul>
-        </article>
+        <h2>3. Accounts and Credentials</h2>
+        <p>
+          If you create an account or submit account-related information, you are responsible for maintaining
+          the confidentiality of your credentials and for all activity that occurs under your account.
+        </p>
 
-        <article class="card">
-          <h2>7. Privacy and protected information</h2>
-          <p>
-            Your use of the services is also governed by the
-            <a href="privacy.html">Privacy Policy</a>.
-            Tomb of Light’s platform direction is privacy-first, including a design goal
-            of avoiding public exposure of sensitive family data on blockchain systems.
-          </p>
-        </article>
+        <ul>
+          <li>Provide accurate, current, and complete information</li>
+          <li>Keep login credentials secure</li>
+          <li>Notify us promptly of suspected unauthorized access or misuse</li>
+          <li>Use only accounts that belong to you or that you are authorized to use</li>
+        </ul>
 
-        <article class="card">
-          <h2>8. Ownership and intellectual property</h2>
-          <p>
-            The website, design, branding, text, graphics, software, and related materials
-            provided by Tomb of Light are owned by Tomb of Light LLC or its licensors and
-            are protected by applicable intellectual property laws.
-          </p>
-          <p>
-            Except where explicitly allowed, you may not copy, reproduce, republish,
-            distribute, modify, or create derivative works from Tomb of Light materials
-            without permission.
-          </p>
-        </article>
+        <p>
+          We may suspend or terminate accounts that appear to involve fraud, abuse, unauthorized access, or
+          violations of these Terms.
+        </p>
 
-        <article class="card">
-          <h2>9. Your content</h2>
-          <p>
-            You retain rights you may have in content you lawfully submit, subject to
-            any permissions needed for Tomb of Light to host, process, review, secure,
-            and display that content as required to operate the services.
-          </p>
-          <p>
-            You represent that your submitted content does not violate the rights of
-            others and that you have the authority needed to provide it.
-          </p>
-        </article>
+        <h2>4. Family Legacy Content and User Submissions</h2>
+        <p>
+          You may submit information, messages, requests, images, lineage details, stories, or other content
+          (“User Content”) through the website or future services. You are responsible for the content you
+          submit and for ensuring that you have the necessary rights, permissions, and authority to provide it.
+        </p>
 
-        <article class="card">
-          <h2>10. Future blockchain or NFT features</h2>
-          <p>
-            If Tomb of Light introduces blockchain, NFT, ownership, transfer, or
-            inheritance-related features in the future, additional terms may apply.
-            Public descriptions of future functionality are for informational purposes
-            and do not guarantee immediate availability.
-          </p>
-          <p>
-            Unless explicitly stated otherwise, Tomb of Light does not represent that
-            digital assets offered through future services are investment products,
-            securities, or guarantees of profit.
-          </p>
-        </article>
+        <p>You agree that you will not submit content that:</p>
+        <ul>
+          <li>Violates the rights of another person or entity</li>
+          <li>Includes unlawful, defamatory, fraudulent, abusive, or misleading material</li>
+          <li>Infringes intellectual property, privacy, publicity, or contract rights</li>
+          <li>Contains malware, malicious code, or harmful files</li>
+          <li>Includes personal data that you are not authorized to share</li>
+        </ul>
 
-        <article class="card">
-          <h2>11. Service availability and changes</h2>
-          <p>
-            Tomb of Light may modify, suspend, discontinue, or update any part of the
-            site or services at any time, with or without notice, to the extent allowed
-            by law. We are not obligated to maintain any specific feature indefinitely.
-          </p>
-        </article>
+        <p>
+          Where living individuals are included in family legacy submissions, you are responsible for ensuring
+          proper consent, notice, or authority before providing that information.
+        </p>
 
-        <article class="card">
-          <h2>12. Suspension or termination</h2>
-          <p>
-            Tomb of Light may suspend or terminate access to the site or services if
-            we believe you violated these terms, created legal or security risk,
-            misused the services, or acted in a way that could harm the platform,
-            users, or affected individuals.
-          </p>
-        </article>
+        <h2>5. License You Grant to Tomb of Light</h2>
+        <p>
+          To operate the website and future platform services, you grant Tomb of Light a non-exclusive,
+          revocable, limited license to host, store, process, display internally, reproduce, and use User Content
+          solely as reasonably necessary to provide services, maintain operations, respond to requests, improve
+          platform functionality, and protect the integrity of the system.
+        </p>
 
-        <article class="card">
-          <h2>13. Disclaimers</h2>
-          <p>
-            The website and services are provided on an “as is” and “as available” basis,
-            to the fullest extent permitted by law. Tomb of Light disclaims warranties
-            of any kind, whether express or implied, including implied warranties of
-            merchantability, fitness for a particular purpose, and non-infringement.
-          </p>
-        </article>
+        <p>
+          This license does not transfer ownership of your User Content to Tomb of Light, except to the limited
+          extent necessary for service operation and legal compliance.
+        </p>
 
-        <article class="card">
-          <h2>14. Limitation of liability</h2>
-          <p>
-            To the fullest extent permitted by law, Tomb of Light LLC and its officers,
-            owners, employees, contractors, affiliates, and service providers will not
-            be liable for indirect, incidental, special, consequential, exemplary, or
-            punitive damages, or for loss of profits, data, goodwill, or business opportunities,
-            arising out of or related to your use of the site or services.
-          </p>
-        </article>
+        <h2>6. Privacy and Data Practices</h2>
+        <p>
+          Your use of the website and services is also governed by our <a href="privacy.html">Privacy Policy</a>,
+          which describes how we collect, use, disclose, and protect information.
+        </p>
 
-        <article class="card">
-          <h2>15. Indemnification</h2>
-          <p>
-            You agree to defend, indemnify, and hold harmless Tomb of Light LLC and its
-            affiliates, officers, employees, contractors, and representatives from and
-            against claims, liabilities, damages, losses, and expenses arising out of
-            or related to your content, your misuse of the services, or your violation
-            of these terms or applicable law.
-          </p>
-        </article>
+        <h2>7. Intellectual Property Rights</h2>
+        <p>
+          The website, branding, design, text, graphics, logos, layouts, platform concepts, software, and
+          related materials provided by Tomb of Light are owned by or licensed to Tomb of Light and are protected
+          by applicable intellectual property and proprietary rights laws.
+        </p>
 
-        <article class="card">
-          <h2>16. Governing law</h2>
-          <p>
-            These Terms of Service are governed by the laws of the State of Texas,
-            without regard to conflict of law principles, except where applicable law
-            requires otherwise.
-          </p>
-        </article>
+        <p>
+          Except as expressly permitted in writing, you may not copy, reproduce, republish, distribute, modify,
+          reverse engineer, scrape, frame, create derivative works from, or exploit any part of the website or
+          services.
+        </p>
 
-        <article class="card">
-          <h2>17. Changes to these terms</h2>
-          <p>
-            Tomb of Light may update these Terms of Service from time to time.
-            Updated versions will be posted on this page with a revised effective
-            date or last-updated date. Continued use after changes become effective
-            constitutes acceptance of the updated terms to the extent permitted by law.
-          </p>
-        </article>
+        <h2>8. Acceptable Use</h2>
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use the website in violation of any law, regulation, or third-party right</li>
+          <li>Attempt to gain unauthorized access to accounts, systems, servers, or data</li>
+          <li>Interfere with the website’s security, performance, or functionality</li>
+          <li>Use automated tools to scrape, harvest, or extract data without written permission</li>
+          <li>Impersonate another person or misrepresent your affiliation</li>
+          <li>Use the site to distribute spam, malware, scams, or deceptive materials</li>
+        </ul>
 
-        <article class="card">
-          <h2>18. Contact</h2>
-          <p>
-            For questions about these terms, contact:
-            <a href="mailto:admin@tomboflight.com">admin@tomboflight.com</a>
-          </p>
-        </article>
-      </div>
-    </section>
+        <h2>9. Future Blockchain and Ownership Features</h2>
+        <p>
+          Tomb of Light may develop future ownership, tokenization, blockchain, authentication, inheritance,
+          or digital asset features. Any such features may be subject to additional terms, eligibility rules,
+          compliance requirements, technical limitations, or jurisdictional restrictions.
+        </p>
 
-    <section class="section-sm">
-      <div class="container">
-        <div class="cta-banner">
-          <h3>Review the related policy pages.</h3>
-          <p>
-            These terms work together with Tomb of Light’s privacy, security,
-            cookie, and compliance framework.
-          </p>
-          <div class="cta-actions">
-            <a class="btn btn-primary" href="privacy.html">Privacy Policy</a>
-            <a class="btn btn-secondary" href="security.html">Security</a>
-            <a class="btn btn-secondary" href="cookie-policy.html">Cookie Policy</a>
-          </div>
-        </div>
+        <p>
+          Unless expressly stated otherwise, references on the website to future blockchain-backed ownership or
+          related functionality are informational and do not constitute a guarantee that any specific feature,
+          token, marketplace function, or transfer mechanism is currently available.
+        </p>
+
+        <h2>10. Disclaimers</h2>
+        <p>
+          The website and services are provided on an “as is” and “as available” basis to the fullest extent
+          permitted by law. Tomb of Light disclaims all warranties, express or implied, including warranties of
+          merchantability, fitness for a particular purpose, non-infringement, and uninterrupted availability.
+        </p>
+
+        <p>
+          We do not guarantee that the website will always be available, secure, error-free, complete, or suitable
+          for your intended purpose.
+        </p>
+
+        <h2>11. Limitation of Liability</h2>
+        <p>
+          To the fullest extent permitted by law, Tomb of Light LLC and its officers, directors, owners, members,
+          employees, contractors, affiliates, licensors, and service providers will not be liable for indirect,
+          incidental, consequential, special, exemplary, or punitive damages, or for loss of data, revenue,
+          profits, goodwill, or business opportunity arising out of or related to your use of the website or services.
+        </p>
+
+        <p>
+          To the fullest extent permitted by law, the total liability of Tomb of Light for any claim arising out of
+          or relating to the website or services will not exceed the greater of one hundred U.S. dollars (US $100)
+          or the amount you paid to Tomb of Light, if any, for the specific service giving rise to the claim in the
+          twelve months preceding the event.
+        </p>
+
+        <h2>12. Indemnification</h2>
+        <p>
+          You agree to defend, indemnify, and hold harmless Tomb of Light LLC and its officers, directors, owners,
+          members, employees, contractors, affiliates, licensors, and service providers from and against claims,
+          damages, liabilities, losses, costs, and expenses, including reasonable attorneys’ fees, arising out of
+          or related to:
+        </p>
+        <ul>
+          <li>Your use of the website or services</li>
+          <li>Your User Content</li>
+          <li>Your violation of these Terms</li>
+          <li>Your violation of any law or third-party right</li>
+        </ul>
+
+        <h2>13. Termination</h2>
+        <p>
+          We may suspend, restrict, or terminate your access to the website or services at any time if we believe
+          you have violated these Terms, created risk, misused the platform, or if termination is necessary for
+          security, legal, or operational reasons.
+        </p>
+
+        <p>
+          Provisions that by their nature should survive termination will survive, including provisions related to
+          intellectual property, disclaimers, limitation of liability, indemnification, and dispute-related terms.
+        </p>
+
+        <h2>14. Governing Law</h2>
+        <p>
+          These Terms are governed by the laws of the State of Texas, without regard to its conflict of law principles,
+          except to the extent superseded by applicable federal law.
+        </p>
+
+        <h2>15. Dispute Resolution</h2>
+        <p>
+          Before filing a formal legal claim, you agree to first contact Tomb of Light and attempt to resolve the issue
+          informally by writing to us with sufficient detail about the dispute.
+        </p>
+
+        <p>
+          If a dispute cannot be resolved informally, any legal action shall be brought in a court of competent
+          jurisdiction located in Texas, unless applicable law requires otherwise.
+        </p>
+
+        <h2>16. Changes to These Terms</h2>
+        <p>
+          We may update these Terms from time to time to reflect changes in services, legal requirements, or business
+          operations. When we do, we will update the effective or last updated date shown on this page.
+        </p>
+
+        <p>
+          Your continued use of the website after updated Terms become effective constitutes acceptance of the revised Terms.
+        </p>
+
+        <h2>17. Contact Information</h2>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+
+        <p>
+          Email:
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="container footer-container">
-      <div class="footer-top">
-        <div class="footer-copy">
-          <a class="brand" href="index.html" aria-label="Tomb of Light home">
-            <div class="brand-mark">TL</div>
-            <div class="brand-text">
-              <strong>Tomb of Light</strong>
-              <span>Secure digital family legacy infrastructure</span>
-            </div>
-          </a>
-          <p>
-            Tomb of Light is building a privacy-first platform for preserving family
-            history, protecting sensitive legacy records, and enabling future ownership
-            systems without exposing personal family data on public blockchains.
-          </p>
-        </div>
-
-        <div class="footer-links">
-          <div>
-            <h4>Platform</h4>
-            <a href="how-it-works.html">How It Works</a>
-            <a href="faq.html">FAQ</a>
-            <a href="security.html">Security</a>
-            <a href="compliance.html">Compliance &amp; Legal</a>
-          </div>
-          <div>
-            <h4>Policies</h4>
-            <a href="privacy.html">Privacy Policy</a>
-            <a href="terms.html">Terms of Service</a>
-            <a href="cookie-policy.html">Cookie Policy</a>
-            <a href="data-request.html">Data Request</a>
-            <a href="privacy-choices.html">Your Privacy Choices</a>
-            <a href="privacy-state-notices.html">State Privacy Notices</a>
-            <a href="accessibility.html">Accessibility</a>
-          </div>
-        </div>
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a href="index.html" class="logo footer-logo" aria-label="Tomb of Light home">
+          <span class="logo-mark">TL</span>
+          <span class="logo-text">
+            <strong>Tomb of Light</strong>
+            <small>Secure digital family legacy infrastructure</small>
+          </span>
+        </a>
+        <p>
+          Tomb of Light is building a privacy-first platform for preserving family history,
+          protecting sensitive legacy records, and enabling future ownership systems without
+          exposing personal family data on public blockchains.
+        </p>
       </div>
 
-      <div class="footer-bottom">
-        <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-        <span data-cookie-status>Your cookie preference has not been set yet.</span>
+      <div>
+        <h3>Platform</h3>
+        <ul>
+          <li><a href="how-it-works.html">How It Works</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="compliance.html">Compliance</a></li>
+        </ul>
       </div>
+
+      <div>
+        <h3>Policies</h3>
+        <ul>
+          <li><a href="privacy.html">Privacy Policy</a></li>
+          <li><a href="terms.html">Terms of Service</a></li>
+          <li><a href="cookie-policy.html">Cookie Policy</a></li>
+          <li><a href="data-request.html">Data Request</a></li>
+          <li><a href="privacy-choices.html">Your Privacy Choices</a></li>
+          <li><a href="privacy-state-notices.html">State Privacy Notices</a></li>
+          <li><a href="accessibility.html">Accessibility</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Contact</h3>
+        <p>
+          Tomb of Light LLC<br />
+          3007 Woodland Hills Dr<br />
+          PMB 176<br />
+          Kingwood, TX 77339<br />
+          United States
+        </p>
+        <p>
+          <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="container footer-bottom">
+      <p>© 2026 Tomb of Light LLC. All rights reserved.</p>
     </div>
   </footer>
-
-  <div class="cookie-banner" id="cookie-banner" hidden>
-    <div class="cookie-inner">
-      <p>
-        We use essential site technologies and may use optional analytics tools only
-        where permitted. You can accept or decline optional analytics cookies and
-        review your choices at any time.
-      </p>
-      <div class="cookie-actions">
-        <button class="btn btn-primary" id="accept-cookies" type="button">Accept</button>
-        <button class="btn btn-secondary" id="decline-cookies" type="button">Decline</button>
-        <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
-      </div>
-    </div>
-  </div>
 
   <script src="app.js"></script>
 </body>


### PR DESCRIPTION
Standardized metadata and page titles across multiple pages including compliance, FAQ, privacy, security, sign-in, sign-up, and terms.

Changes include:
- Simplified viewport meta tag formatting
- Updated page titles for consistency with Tomb of Light branding
- Removed duplicate or outdated meta description and theme metadata
- Cleaned up head section structure for better consistency

This improves maintainability and ensures consistent metadata across the site.