### PR TITLE
Fix prototype iframe path to viewer folder

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
 
         <div class="prototype-frame">
           <iframe
-            src="viewer-demo/index.html"
+            src="viewer/index.html"
             title="Tomb of Light Prototype Viewer"
             loading="lazy"
           ></iframe>


### PR DESCRIPTION
Updated index.html to point the homepage prototype iframe to viewer/index.html instead of viewer-demo/index.html so the embedded Tomb of Light prototype loads correctly on the live site.