### PR TITLE
Updated fixed background logo watermark

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ body.menu-open {
   z-index: 0;
   pointer-events: none;
 
-  background-image: url('/images/tol-watermark.png');
+  background-image: url('/images/tol-watermark-clean.png');
   background-repeat: no-repeat;
   background-position: center center;
   background-size: min(58vw, 760px);


### PR DESCRIPTION
Updated the homepage watermark to use the Tomb of Light logo as a fixed background image that remains stationary while scrolling.