### PR TITLE
Fixed Tomb of Light background watermark visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ body.menu-open {
 .site-watermark {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   pointer-events: none;
 
   background-image: url("/images/tol-watermark-clean.png");
@@ -58,8 +58,7 @@ body.menu-open {
   background-position: center center;
   background-size: 700px;
 
-  opacity: 0.15;
-  mix-blend-mode: screen;
+  opacity: 0.14;
   filter: brightness(1.15) contrast(1.05);
 }
 
@@ -844,7 +843,7 @@ select:focus {
   .site-watermark {
     background-size: min(84vw, 500px);
     background-position: center 38%;
-    opacity: 0.028;
+    opacity: 0.10;
   }
 
   .site-header-inner {


### PR DESCRIPTION
Updated the homepage watermark layering and opacity so the Tomb of Light background logo displays correctly behind the site content without disappearing behind the page background.