### PR TITLE
Add lineage certificate page and dashboard access

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -27,10 +27,8 @@
 
         <div class="header-actions">
           <a class="btn btn-primary" href="create-family.html">Create Family</a>
-          <a class="btn btn-secondary" href="add-member.html">Add Member</a>
-          <a class="btn btn-secondary" href="create-relationship.html">Add Relationship</a>
-          <a class="btn btn-secondary" href="family-graph.html">View Graph</a>
-          <a class="btn btn-secondary" href="tree-view.html">View Tree</a>
+          <a class="btn btn-secondary" href="tree-view.html">Family Tree</a>
+          <a class="btn btn-secondary" href="lineage-certificate.html">Lineage Certificate</a>
           <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
         </div>
       </div>
@@ -74,7 +72,7 @@
           </div>
 
           <div class="form-panel">
-            <span class="eyebrow">Lineage Build Steps</span>
+            <span class="eyebrow">Your First Family Step</span>
 
             <div class="grid-3">
               <div>
@@ -87,56 +85,26 @@
 
               <div>
                 <div class="card-number">2</div>
-                <h3>Add family members</h3>
+                <h3>Add members</h3>
                 <p class="card-copy">
-                  Create the people who belong inside the family line.
+                  After your family exists, connect parents, children, spouses, and branches.
                 </p>
               </div>
 
               <div>
                 <div class="card-number">3</div>
-                <h3>Map relationships</h3>
+                <h3>Build the living tree</h3>
                 <p class="card-copy">
-                  Connect members as parents, children, spouses, siblings, guardians, or step-family.
+                  The family record becomes the foundation of the Tomb of Light lineage engine.
                 </p>
               </div>
             </div>
 
             <div class="inline-actions" style="margin-top: 1.5rem;">
-              <a class="btn btn-primary" href="create-family.html">Create Family</a>
-              <a class="btn btn-secondary" href="add-member.html">Add Family Member</a>
-              <a class="btn btn-secondary" href="create-relationship.html">Create Relationship</a>
-              <a class="btn btn-secondary" href="family-graph.html">View Family Graph</a>
-              <a class="btn btn-secondary" href="tree-view.html">View Family Tree</a>
+              <a class="btn btn-primary" href="create-family.html">Create Your First Family</a>
+              <a class="btn btn-secondary" href="tree-view.html">Open Family Tree</a>
+              <a class="btn btn-secondary" href="lineage-certificate.html">Open Lineage Certificate</a>
             </div>
-          </div>
-
-          <div class="form-panel">
-            <div style="display: flex; justify-content: space-between; gap: 1rem; align-items: center; flex-wrap: wrap;">
-              <span class="eyebrow">Your Family Records</span>
-              <span class="helper" data-families-count>Loading...</span>
-            </div>
-
-            <div
-              class="helper"
-              data-families-error
-              aria-live="polite"
-              style="display: none; color: #ffb3b3; margin-top: 1rem;"
-            ></div>
-
-            <div
-              class="helper"
-              data-families-empty
-              style="display: none; margin-top: 1rem;"
-            >
-              No family records have been created yet. Start by creating your first family.
-            </div>
-
-            <div
-              data-families-list
-              class="grid-3"
-              style="margin-top: 1.5rem;"
-            ></div>
           </div>
 
           <div class="form-panel">
@@ -163,7 +131,7 @@
                 <div class="card-number">C</div>
                 <h3>Next Build Phase</h3>
                 <p class="card-copy">
-                  The next step after graph viewing is visual lineage rendering and advanced relationship logic.
+                  The next step after tree rendering is lineage certification and verified record presentation.
                 </p>
               </div>
             </div>
@@ -186,6 +154,5 @@
   <script src="config.js"></script>
   <script src="app.js"></script>
   <script src="auth.js"></script>
-  <script src="families-list.js"></script>
 </body>
 </html>

--- a/lineage-certificate.html
+++ b/lineage-certificate.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lineage Certificate | Tomb of Light</title>
+  <meta
+    name="description"
+    content="Generate and view lineage certificates for Tomb of Light family records."
+  />
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .certificate-shell {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .certificate-card {
+      background: rgba(10, 16, 28, 0.96);
+      border: 1px solid rgba(214, 176, 102, 0.18);
+      border-radius: 24px;
+      padding: 1.5rem;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.22);
+    }
+
+    .certificate-paper {
+      position: relative;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.02)),
+        rgba(9, 14, 24, 0.98);
+      border: 1px solid rgba(214, 176, 102, 0.22);
+      border-radius: 28px;
+      padding: 2rem;
+      overflow: hidden;
+    }
+
+    .certificate-paper::before {
+      content: "";
+      position: absolute;
+      inset: 14px;
+      border: 1px solid rgba(214, 176, 102, 0.14);
+      border-radius: 20px;
+      pointer-events: none;
+    }
+
+    .certificate-title {
+      text-align: center;
+      margin-bottom: 1.5rem;
+    }
+
+    .certificate-title .eyebrow {
+      margin-bottom: 0.75rem;
+    }
+
+    .certificate-title h2 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 3rem);
+      line-height: 1.05;
+      letter-spacing: -0.05em;
+    }
+
+    .certificate-subtitle {
+      margin: 0.65rem auto 0;
+      max-width: 60ch;
+      text-align: center;
+      color: var(--muted);
+    }
+
+    .certificate-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .certificate-item {
+      padding: 1rem 1rem 0.95rem;
+      border-radius: 18px;
+      background: rgba(255,255,255,0.025);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .certificate-label {
+      display: block;
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--gold);
+      margin-bottom: 0.35rem;
+    }
+
+    .certificate-value {
+      color: var(--text);
+      word-break: break-word;
+    }
+
+    .certificate-list {
+      margin: 0;
+      padding-left: 1.1rem;
+      color: var(--muted);
+    }
+
+    .certificate-list li + li {
+      margin-top: 0.35rem;
+    }
+
+    .certificate-summary {
+      margin-top: 1.5rem;
+      padding: 1.1rem 1.15rem;
+      border-radius: 18px;
+      background: rgba(214, 176, 102, 0.06);
+      border: 1px solid rgba(214, 176, 102, 0.14);
+      color: var(--muted);
+    }
+
+    .certificate-id {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92rem;
+    }
+
+    .certificate-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem;
+      margin-top: 1.5rem;
+    }
+
+    @media (max-width: 860px) {
+      .certificate-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-wrap">
+    <header class="site-header">
+      <div class="container site-header-inner">
+        <a class="brand" href="index.html" aria-label="Tomb of Light home">
+          <span>Tomb of Light<span class="brand-symbol">™</span></span>
+        </a>
+
+        <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+          <a href="platform.html">Platform</a>
+          <a href="how-it-works.html">How It Works</a>
+          <a href="security.html">Security</a>
+          <a href="faq.html">FAQ</a>
+        </nav>
+
+        <div class="header-actions">
+          <a class="btn btn-secondary" href="dashboard.html">Dashboard</a>
+          <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
+        </div>
+      </div>
+    </header>
+
+    <main data-dashboard data-lineage-certificate-page>
+      <section class="page-hero">
+        <div class="container">
+          <div class="page-hero-panel">
+            <span class="eyebrow">Verification Layer</span>
+            <h1>Lineage Certificate</h1>
+            <p>
+              Generate and review lineage certificate data for a Tomb of Light family record.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-sections">
+        <div class="container form-shell" data-auth-required style="display: none;">
+          <div class="certificate-shell">
+            <div class="form-panel">
+              <div class="form-grid">
+                <label>
+                  Select Family
+                  <select data-certificate-family-select>
+                    <option value="">Select a family</option>
+                  </select>
+                </label>
+
+                <div
+                  class="helper"
+                  data-certificate-status
+                  aria-live="polite"
+                  style="display: none;"
+                ></div>
+
+                <div class="inline-actions">
+                  <button class="btn btn-primary" type="button" data-load-certificate-btn>
+                    Load Certificate
+                  </button>
+                  <a class="btn btn-secondary" href="tree-view.html">Back to Family Tree</a>
+                </div>
+              </div>
+            </div>
+
+            <div class="certificate-card">
+              <div data-certificate-empty class="helper">
+                Select a family to generate its lineage certificate view.
+              </div>
+              <div data-certificate-output style="display: none;"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <div class="footer-card">
+          <div class="footer-bottom">
+            <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+
+  <script src="config.js"></script>
+  <script src="app.js"></script>
+  <script src="auth.js"></script>
+  <script src="lineage-certificate.js"></script>
+</body>
+</html>

--- a/lineage-certificate.js
+++ b/lineage-certificate.js
@@ -1,0 +1,326 @@
+(function () {
+  'use strict';
+
+  async function setupLineageCertificatePage() {
+    if (!window.TOLAuth) return;
+
+    const page = document.querySelector('[data-lineage-certificate-page]');
+    if (!page) return;
+
+    const familySelect = document.querySelector('[data-certificate-family-select]');
+    const statusNode = document.querySelector('[data-certificate-status]');
+    const outputNode = document.querySelector('[data-certificate-output]');
+    const emptyNode = document.querySelector('[data-certificate-empty]');
+    const loadBtn = document.querySelector('[data-load-certificate-btn]');
+
+    const token = window.TOLAuth.getToken();
+    if (!token) {
+      window.location.href = 'signin.html';
+      return;
+    }
+
+    try {
+      await window.TOLAuth.apiRequest('/auth/me', { method: 'GET' });
+    } catch (error) {
+      window.TOLAuth.clearToken();
+      window.location.href = 'signin.html';
+      return;
+    }
+
+    await loadFamilyOptions(familySelect, statusNode);
+
+    if (loadBtn) {
+      loadBtn.addEventListener('click', async function () {
+        const familyId = familySelect ? familySelect.value : '';
+        if (!familyId) {
+          showStatus(statusNode, 'Please select a family first.', 'error');
+          return;
+        }
+
+        await loadCertificate(familyId, outputNode, emptyNode, statusNode);
+      });
+    }
+  }
+
+  async function loadFamilyOptions(selectNode, statusNode) {
+    if (!selectNode || !window.TOLAuth) return;
+
+    selectNode.innerHTML = '<option value="">Select a family</option>';
+
+    try {
+      const families = await window.TOLAuth.apiRequest('/families/', { method: 'GET' });
+
+      families.forEach(function (family) {
+        const option = document.createElement('option');
+        option.value = family.id;
+        option.textContent = `${family.family_name} (${family.created_by})`;
+        selectNode.appendChild(option);
+      });
+
+      hideStatus(statusNode);
+    } catch (error) {
+      showStatus(statusNode, error.message || 'Unable to load families.', 'error');
+    }
+  }
+
+  async function loadCertificate(familyId, outputNode, emptyNode, statusNode) {
+    if (!outputNode || !window.TOLAuth) return;
+
+    showStatus(statusNode, 'Loading lineage certificate...', 'info');
+    outputNode.style.display = 'none';
+    outputNode.innerHTML = '';
+
+    try {
+      const certificate = await window.TOLAuth.apiRequest(`/lineage-certificate/${familyId}`, {
+        method: 'GET'
+      });
+
+      renderCertificate(certificate, outputNode);
+      outputNode.style.display = 'block';
+
+      if (emptyNode) {
+        emptyNode.style.display = 'none';
+      }
+
+      showStatus(statusNode, 'Lineage certificate loaded successfully.', 'success');
+    } catch (error) {
+      if (emptyNode) {
+        emptyNode.style.display = 'block';
+      }
+      showStatus(statusNode, error.message || 'Failed to load lineage certificate.', 'error');
+    }
+  }
+
+  function renderCertificate(certificate, outputNode) {
+    const certificateId =
+      certificate.certificate_id ||
+      certificate.id ||
+      certificate.record_id ||
+      'Pending';
+
+    const familyName =
+      certificate.family_name ||
+      certificate.family?.family_name ||
+      certificate.family ||
+      'Unknown Family';
+
+    const createdBy =
+      certificate.created_by ||
+      certificate.family?.created_by ||
+      'Unknown';
+
+    const issuedAt =
+      certificate.issued_at ||
+      certificate.created_at ||
+      certificate.generated_at ||
+      'Not provided';
+
+    const summary =
+      certificate.summary ||
+      certificate.statement ||
+      certificate.description ||
+      'This lineage certificate summarizes the current family lineage record stored within Tomb of Light.';
+
+    const lineageProof = normalizeList(
+      certificate.lineage_proof ||
+      certificate.ancestors ||
+      certificate.proof ||
+      certificate.lineage ||
+      []
+    );
+
+    const descendants = normalizeList(
+      certificate.descendants ||
+      certificate.children ||
+      certificate.branch_members ||
+      []
+    );
+
+    const metadataEntries = collectMetadataEntries(certificate);
+
+    outputNode.innerHTML = `
+      <div class="certificate-paper">
+        <div class="certificate-title">
+          <span class="eyebrow">Certified Lineage Record</span>
+          <h2>Lineage Certificate</h2>
+          <p class="certificate-subtitle">
+            Tomb of Light lineage verification record for the selected family structure.
+          </p>
+        </div>
+
+        <div class="certificate-grid">
+          <div class="certificate-item">
+            <span class="certificate-label">Certificate ID</span>
+            <div class="certificate-value certificate-id">${escapeHtml(String(certificateId))}</div>
+          </div>
+
+          <div class="certificate-item">
+            <span class="certificate-label">Family Name</span>
+            <div class="certificate-value">${escapeHtml(String(familyName))}</div>
+          </div>
+
+          <div class="certificate-item">
+            <span class="certificate-label">Created By</span>
+            <div class="certificate-value">${escapeHtml(String(createdBy))}</div>
+          </div>
+
+          <div class="certificate-item">
+            <span class="certificate-label">Issued At</span>
+            <div class="certificate-value">${escapeHtml(String(issuedAt))}</div>
+          </div>
+
+          <div class="certificate-item">
+            <span class="certificate-label">Lineage Proof</span>
+            ${renderList(lineageProof)}
+          </div>
+
+          <div class="certificate-item">
+            <span class="certificate-label">Descendant Records</span>
+            ${renderList(descendants)}
+          </div>
+        </div>
+
+        ${metadataEntries.length ? `
+          <div class="certificate-grid" style="margin-top: 1rem;">
+            ${metadataEntries.map(function (entry) {
+              return `
+                <div class="certificate-item">
+                  <span class="certificate-label">${escapeHtml(entry.label)}</span>
+                  <div class="certificate-value">${escapeHtml(entry.value)}</div>
+                </div>
+              `;
+            }).join('')}
+          </div>
+        ` : ''}
+
+        <div class="certificate-summary">
+          ${escapeHtml(String(summary))}
+        </div>
+
+        <div class="certificate-actions">
+          <button class="btn btn-secondary" type="button" onclick="window.print()">Print Certificate</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function collectMetadataEntries(certificate) {
+    const ignoredKeys = new Set([
+      'certificate_id',
+      'id',
+      'record_id',
+      'family_name',
+      'family',
+      'created_by',
+      'issued_at',
+      'created_at',
+      'generated_at',
+      'summary',
+      'statement',
+      'description',
+      'lineage_proof',
+      'ancestors',
+      'proof',
+      'lineage',
+      'descendants',
+      'children',
+      'branch_members'
+    ]);
+
+    const entries = [];
+
+    Object.keys(certificate || {}).forEach(function (key) {
+      if (ignoredKeys.has(key)) return;
+
+      const value = certificate[key];
+      if (value == null) return;
+      if (typeof value === 'object') return;
+
+      entries.push({
+        label: formatLabel(key),
+        value: String(value)
+      });
+    });
+
+    return entries.slice(0, 6);
+  }
+
+  function normalizeList(value) {
+    if (!Array.isArray(value)) return [];
+
+    return value.map(function (item) {
+      if (item == null) return '';
+
+      if (typeof item === 'string' || typeof item === 'number') {
+        return String(item);
+      }
+
+      if (typeof item === 'object') {
+        return (
+          item.display_name ||
+          item.name ||
+          item.full_name ||
+          item.label ||
+          item.id ||
+          JSON.stringify(item)
+        );
+      }
+
+      return String(item);
+    }).filter(Boolean);
+  }
+
+  function renderList(items) {
+    if (!items.length) {
+      return '<div class="certificate-value">None recorded.</div>';
+    }
+
+    return `
+      <ul class="certificate-list">
+        ${items.map(function (item) {
+          return `<li>${escapeHtml(String(item))}</li>`;
+        }).join('')}
+      </ul>
+    `;
+  }
+
+  function formatLabel(key) {
+    return String(key)
+      .replaceAll('_', ' ')
+      .replace(/\b\w/g, function (char) {
+        return char.toUpperCase();
+      });
+  }
+
+  function showStatus(node, message, type) {
+    if (!node) return;
+
+    node.style.display = 'block';
+    node.textContent = message;
+    node.style.color =
+      type === 'error'
+        ? '#ffb3b3'
+        : type === 'success'
+          ? '#cfe8cf'
+          : '#d6e6ff';
+  }
+
+  function hideStatus(node) {
+    if (!node) return;
+    node.style.display = 'none';
+    node.textContent = '';
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    setupLineageCertificatePage();
+  });
+})();


### PR DESCRIPTION
This commit adds the first Tomb of Light lineage certificate view and connects it into the dashboard workflow.

Changes included:
• Added lineage-certificate.html
• Added lineage-certificate.js
• Added dashboard access links for the lineage certificate page • Connected certificate page to authenticated family selection • Connected certificate page to the backend lineage certificate route • Rendered certificate-style output for lineage verification records • Added print-ready certificate action

This update advances Tomb of Light from family graph visualization into lineage verification and certificate presentation, bringing the platform closer to formal digital legacy documentation.