### PR TITLE
Add executive one-page lineage certificate styling + print rules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,7 @@ body.menu-open {
   overflow: hidden;
 }
 
+/* ================= PREFERS REDUCED MOTION ================= */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -58,6 +59,7 @@ body.menu-open {
   }
 }
 
+/* ================= SKIP TO CONTENT ================= */
 .skip-to-content {
   position: absolute;
   left: -9999px;
@@ -84,6 +86,7 @@ body.menu-open {
   text-decoration: none;
 }
 
+/* ================= SITE WATERMARK ================= */
 .site-watermark {
   position: fixed;
   inset: 0;
@@ -97,6 +100,7 @@ body.menu-open {
   filter: brightness(1.32) contrast(1.08);
 }
 
+/* ================= BASE ELEMENTS ================= */
 img {
   max-width: 100%;
   display: block;
@@ -125,6 +129,7 @@ select {
   z-index: 1;
 }
 
+/* ================= HEADER ================= */
 .site-header {
   position: sticky;
   top: 0;
@@ -223,6 +228,7 @@ select {
   border-color: var(--border);
 }
 
+/* ================= BUTTONS ================= */
 .btn {
   display: inline-flex;
   align-items: center;
@@ -301,22 +307,7 @@ select {
   border-radius: 4px;
 }
 
-.hero {
-  padding: 72px 0 42px;
-}
-
-.hero-shell {
-  display: grid;
-  grid-template-columns: minmax(0, 1.04fr) minmax(0, 0.96fr);
-  gap: 26px;
-  align-items: stretch;
-}
-
-.hero-shell-tech {
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-  align-items: start;
-}
-
+/* ================= PANELS / SHARED CARDS ================= */
 .eyebrow {
   display: inline-block;
   margin-bottom: 16px;
@@ -389,455 +380,7 @@ select {
   z-index: 1;
 }
 
-.hero-copy-premium {
-  padding: 42px;
-  min-height: 100%;
-}
-
-.hero-copy-tech {
-  position: sticky;
-  top: 112px;
-}
-
-.hero-copy h1,
-.page-hero h1 {
-  margin: 0 0 18px;
-  font-size: clamp(2.9rem, 5vw, 5rem);
-  line-height: 0.98;
-  letter-spacing: -0.06em;
-  max-width: 11.5ch;
-}
-
-.hero-gold {
-  color: var(--text);
-}
-
-.hero-lead,
-.hero-copy p,
-.page-hero p,
-.section-lead,
-.card-copy,
-.footer-copy {
-  color: var(--muted);
-  font-size: 1.04rem;
-}
-
-.hero-lead {
-  max-width: 58ch;
-}
-
-.hero-actions,
-.cta-actions,
-.inline-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 28px;
-}
-
-.hero-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 24px;
-}
-
-.meta-pill {
-  padding: 10px 14px;
-  border-radius: 999px;
-  color: var(--muted);
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.02);
-  font-size: 0.94rem;
-  font-weight: 600;
-}
-
-.signal-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 18px;
-  margin-top: 20px;
-  color: var(--muted-2);
-  font-size: 0.92rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-}
-
-.signal-row span {
-  position: relative;
-  padding-left: 14px;
-}
-
-.signal-row span::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.52em;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--gold);
-  box-shadow: 0 0 12px rgba(214, 176, 102, 0.6);
-}
-
-.hero-visual {
-  display: grid;
-  gap: 20px;
-}
-
-.hero-visual-tech {
-  gap: 20px;
-}
-
-.hero-visual-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-  gap: 20px;
-}
-
-.hero-visual-card {
-  padding: 28px;
-}
-
-.hero-visual-card:focus {
-  outline: 2px solid var(--gold);
-  outline-offset: 4px;
-}
-
-.hero-demo-card {
-  padding: 24px;
-}
-
-.hero-demo-card-top {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  align-items: flex-start;
-  margin-bottom: 16px;
-}
-
-.hero-demo-card-top .eyebrow {
-  margin-bottom: 10px;
-}
-
-.hero-demo-card-top h2,
-.hero-visual-main h2,
-.section-head h2,
-.cta-panel h2,
-.viewer-panel-top h2 {
-  margin: 0 0 12px;
-  font-size: clamp(2rem, 3vw, 3.1rem);
-  line-height: 1.05;
-  letter-spacing: -0.05em;
-}
-
-.hero-demo-card-top h2 {
-  font-size: clamp(1.4rem, 2vw, 2rem);
-  margin-bottom: 0;
-}
-
-.hero-copy h1,
-.section-head h2,
-.cta-panel h2,
-.viewer-panel-top h2,
-.hero-demo-card-top h2,
-.hero-visual-main h2 {
-  text-wrap: balance;
-}
-
-.hero-demo-embed {
-  height: 280px;
-  overflow: hidden;
-  border-radius: 22px;
-  border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.3);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 18px 40px rgba(0, 0, 0, 0.28);
-}
-
-.hero-demo-embed iframe {
-  width: 100%;
-  height: 100%;
-  border: 0;
-  display: block;
-  background: #000;
-}
-
-.hero-visual-main p {
-  color: var(--muted);
-  margin: 0;
-}
-
-.lineage-track {
-  display: grid;
-  gap: 14px;
-  margin-top: 24px;
-}
-
-.lineage-node {
-  padding: 16px 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(214, 176, 102, 0.14);
-  background: rgba(255, 255, 255, 0.025);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.lineage-line {
-  width: 1px;
-  height: 18px;
-  margin-left: 16px;
-  background: linear-gradient(180deg, rgba(214, 176, 102, 0.58), rgba(255, 255, 255, 0.08));
-}
-
-.mini-stack {
-  display: grid;
-  gap: 14px;
-}
-
-.mini-stack-item {
-  display: grid;
-  grid-template-columns: 56px 1fr;
-  gap: 16px;
-  align-items: start;
-  padding: 18px;
-  border-radius: 22px;
-  border: 1px solid var(--border-soft);
-  background: var(--panel-3);
-  transition: all var(--transition);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.mini-stack-item:focus-within {
-  border-color: var(--gold);
-  background: rgba(214, 176, 102, 0.06);
-}
-
-.stack-num,
-.card-number {
-  display: inline-flex;
-  width: 42px;
-  height: 42px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  color: var(--gold);
-  background: rgba(214, 176, 102, 0.1);
-  border: 1px solid rgba(214, 176, 102, 0.2);
-  font-weight: 800;
-}
-
-.mini-stack-item h3,
-.feature-card h3,
-.section-card h3,
-.trust-card h3,
-.policy-card h3,
-.arch-box h3 {
-  margin: 0 0 8px;
-  font-size: 1.2rem;
-  line-height: 1.15;
-  letter-spacing: -0.04em;
-}
-
-.mini-stack-item p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.section {
-  padding: 28px 0 10px;
-}
-
-.section-tight {
-  padding-top: 12px;
-}
-
-.section-head {
-  margin-bottom: 22px;
-}
-
-.section-head-wide {
-  max-width: 820px;
-}
-
-.feature-strip {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 22px;
-}
-
-.pricing-row-two {
-  margin-top: 22px;
-}
-
-.feature-card,
-.section-card,
-.trust-card,
-.policy-card {
-  padding: 28px;
-  transition: all var(--transition);
-}
-
-.feature-card:hover,
-.section-card:hover,
-.trust-card:hover,
-.policy-card:hover {
-  border-color: rgba(214, 176, 102, 0.3);
-}
-
-.feature-card:focus-within,
-.section-card:focus-within,
-.trust-card:focus-within,
-.policy-card:focus-within {
-  border-color: var(--gold);
-  box-shadow: 0 0 0 2px rgba(214, 176, 102, 0.2);
-}
-
-.feature-card-clean,
-.trust-grid-clean .trust-card {
-  background: linear-gradient(180deg, rgba(10, 15, 25, 0.76), rgba(5, 9, 17, 0.86));
-}
-
-.feature-card,
-.trust-card {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.section-list,
-.policy-list {
-  margin: 16px 0 0;
-  padding-left: 20px;
-  color: var(--muted);
-}
-
-.architecture-panel {
-  padding: 34px;
-}
-
-.architecture-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 22px;
-  margin-top: 24px;
-}
-
-.architecture-column {
-  display: grid;
-  gap: 12px;
-}
-
-.arch-box {
-  padding: 24px;
-  border-radius: 24px;
-  border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.025);
-  transition: all var(--transition);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.arch-box:hover {
-  border-color: rgba(214, 176, 102, 0.2);
-}
-
-.arch-box:focus-within {
-  border-color: var(--gold);
-  background: rgba(214, 176, 102, 0.04);
-}
-
-.flow-label {
-  display: block;
-  color: var(--gold);
-  font-size: 0.82rem;
-  font-weight: 800;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  margin-bottom: 10px;
-}
-
-.arch-box p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.arch-arrow {
-  color: rgba(214, 176, 102, 0.8);
-  font-size: 1.6rem;
-  line-height: 1;
-  padding-left: 8px;
-}
-
-.architecture-actions {
-  margin-top: 24px;
-}
-
-.viewer-panel {
-  padding: 34px;
-}
-
-.viewer-panel-top {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  align-items: end;
-  margin-bottom: 10px;
-}
-
-.viewer-steps {
-  display: grid;
-  gap: 18px;
-  margin-top: 22px;
-}
-
-.viewer-steps-premium {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.viewer-step {
-  padding: 22px;
-  border-radius: 24px;
-  border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.03);
-  transition: all var(--transition);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.viewer-step:hover {
-  border-color: rgba(214, 176, 102, 0.2);
-}
-
-.viewer-step:focus-within {
-  border-color: var(--gold);
-  background: rgba(214, 176, 102, 0.06);
-}
-
-.viewer-step h3 {
-  margin: 0 0 8px;
-  font-size: 1.12rem;
-  letter-spacing: -0.03em;
-}
-
-.viewer-step p {
-  margin: 0;
-  color: var(--muted);
-}
-
-.trust-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 20px;
-}
-
-.cta-panel {
-  padding: 40px;
-  margin: 22px 0 44px;
-}
-
-.cta-panel-premium {
-  text-align: left;
-}
-
+/* ================= PAGE HERO / FORMS ================= */
 .page-hero {
   padding: 72px 0 20px;
 }
@@ -848,6 +391,15 @@ select {
 
 .page-hero h1 {
   font-size: clamp(2.3rem, 4vw, 4rem);
+  margin: 0 0 14px;
+  letter-spacing: -0.06em;
+  line-height: 1.05;
+}
+
+.page-hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.04rem;
 }
 
 .page-sections {
@@ -912,38 +464,14 @@ textarea {
   font-size: 0.94rem;
 }
 
-.notice {
-  padding: 16px 18px;
-  border-radius: 18px;
-  color: var(--muted);
-  border: 1px solid rgba(214, 176, 102, 0.2);
-  background: rgba(214, 176, 102, 0.06);
-}
-
-.small-link-row {
+.inline-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  margin-top: 14px;
+  gap: 14px;
+  margin-top: 12px;
 }
 
-.small-link-row a {
-  color: var(--muted);
-  font-weight: 600;
-  transition: color var(--transition);
-  text-decoration: none;
-}
-
-.small-link-row a:hover {
-  color: var(--text);
-}
-
-.small-link-row a:focus {
-  outline: 2px solid var(--gold);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
+/* ================= FOOTER ================= */
 .footer {
   padding: 24px 0 44px;
 }
@@ -952,527 +480,273 @@ textarea {
   padding: 34px;
 }
 
-.footer-top {
-  display: grid;
-  grid-template-columns: 1.15fr 0.85fr;
-  gap: 28px;
-  align-items: start;
-}
-
-.footer-brand {
-  font-size: 2rem;
-  font-weight: 800;
-  letter-spacing: -0.045em;
-  margin-bottom: 12px;
-}
-
-.footer-links {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px 30px;
-}
-
-.footer-links a {
-  color: var(--muted);
-  font-weight: 600;
-  text-decoration: none;
-  transition: color var(--transition);
-}
-
-.footer-links a:hover {
-  color: var(--text);
-}
-
-.footer-links a:focus {
-  outline: 2px solid var(--gold);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
 .footer-bottom {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 12px 20px;
-  margin-top: 28px;
-  padding-top: 24px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 10px;
+  padding-top: 0;
   color: var(--muted-2);
   font-size: 0.96rem;
 }
 
-.cookie-banner {
-  position: fixed;
-  left: 20px;
-  right: 20px;
-  bottom: 20px;
-  z-index: 1100;
-  display: none;
-}
+/* =========================================================
+   LINEAGE CERTIFICATE — EXECUTIVE (ONE PAGE) STYLES
+   Use with your lineage-certificate.js output.
+   (This keeps it “certified” looking while staying compact.)
+   ========================================================= */
 
-.cookie-banner.visible {
-  display: block;
-  animation: slideUp 300ms ease;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.cookie-inner {
-  width: min(1100px, 100%);
-  margin: 0 auto;
-  padding: 18px 20px;
-  border-radius: 22px;
-  border: 1px solid var(--border);
-  background: rgba(7, 11, 21, 0.95);
-  backdrop-filter: blur(18px);
-  box-shadow: var(--shadow);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px 22px;
-}
-
-.cookie-copy {
-  flex: 1 1 620px;
-  color: var(--muted);
-  font-size: 0.96rem;
-}
-
-.cookie-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.cookie-actions .btn {
-  min-width: 140px;
-}
-
-.cookie-status {
-  color: var(--muted-2);
-  font-size: 0.94rem;
-  margin-top: 8px;
-}
-
-.thank-you-hero {
-  padding: 96px 0 64px;
-}
-
-.thank-you-card {
-  max-width: 860px;
-  margin: 0 auto;
-  padding: 2.25rem;
-}
-
-.thank-you-card h1 {
-  margin: 0 0 1rem;
-  font-size: clamp(2rem, 4vw, 3.4rem);
-  line-height: 1.08;
-}
-
-.thank-you-copy {
-  margin: 0 0 2rem;
-  max-width: 62ch;
-  color: var(--muted);
-  font-size: 1.05rem;
-  line-height: 1.75;
-}
-
-.thank-you-status {
-  display: grid;
-  gap: 1rem;
-  margin: 0 0 2rem;
-}
-
-.thank-you-status-item {
-  padding: 1.15rem 1.15rem 1rem;
-  border: 1px solid var(--border-soft);
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.02);
-}
-
-.thank-you-status-item strong {
-  display: block;
-  margin-bottom: 0.45rem;
-  color: var(--text);
-  font-size: 1rem;
-}
-
-.thank-you-status-item p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
-.thank-you-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem;
-  margin: 0 0 1.25rem;
-}
-
-.thank-you-note {
-  margin: 0;
-  color: var(--muted-2);
-  font-size: 0.95rem;
-  line-height: 1.7;
-}
-
-.package-list {
-  margin: 18px 0 0;
-  padding-left: 18px;
-  color: var(--muted);
-}
-
-.package-list li {
-  margin-bottom: 8px;
-}
-
-.pricing-card {
-  display: flex;
-  flex-direction: column;
-}
-
-.pricing-card .inline-actions {
-  margin-top: auto;
-  padding-top: 18px;
-}
-
-.pricing-card-featured {
-  border-color: rgba(214, 176, 102, 0.34);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.03),
-    0 0 0 1px rgba(214, 176, 102, 0.08);
-}
-
-.section-note {
-  margin-top: 22px;
-  padding: 16px 18px;
-  border-radius: 18px;
-  color: var(--muted);
-  border: 1px solid rgba(214, 176, 102, 0.18);
-  background: rgba(214, 176, 102, 0.05);
-}
-
-.founder-panel {
-  max-width: 980px;
-  margin: 0 auto;
-}
-
-.founder-copy {
-  max-width: 70ch;
-}
-
-.founder-signoff {
-  margin-top: 24px;
-  color: var(--gold);
-  font-weight: 700;
-  line-height: 1.7;
-}
-
-/* ==========================================
-   EXECUTIVE LINEAGE CERTIFICATE
-========================================== */
-
-.certificate-shell {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.certificate-card {
-  background: rgba(10, 16, 28, 0.96);
-  border: 1px solid rgba(214, 176, 102, 0.18);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.22);
-}
-
-.certificate-print-stack {
+/* Optional wrapper you can use around the certificate output container */
+.certificate-print-stack,
+.certificate-exec-print-stack {
   display: block;
 }
 
-.certificate-paper {
+/* White paper inside dark UI */
+.exec-certificate-paper,
+.certificate-exec-paper,
+.certificate-paper-exec {
   background: #ffffff;
   color: #111111;
+  border-radius: 26px;
+  border: 1px solid rgba(0,0,0,0.12);
+  box-shadow: 0 18px 50px rgba(0,0,0,0.22);
+  padding: 34px 38px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* subtle inner border */
+.exec-certificate-paper::before,
+.certificate-exec-paper::before,
+.certificate-paper-exec::before {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border: 1px solid rgba(0,0,0,0.12);
   border-radius: 18px;
-  padding: 30px;
-  max-width: 1000px;
-  margin: auto;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
 }
 
-.certificate-executive-topbar {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: center;
-  margin-bottom: 1rem;
+/* title area */
+.exec-certificate-title,
+.certificate-exec-title {
+  text-align: center;
+  margin-bottom: 18px;
+  position: relative;
+  z-index: 1;
 }
 
-.certificate-mark {
+.exec-certificate-title h2,
+.certificate-exec-title h2 {
+  margin: 0;
+  font-size: 42px;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.exec-certificate-subtitle,
+.certificate-exec-subtitle {
+  margin: 10px auto 0;
+  max-width: 72ch;
+  color: rgba(0,0,0,0.68);
+  font-size: 16px;
+}
+
+.exec-certificate-eyebrow,
+.certificate-exec-eyebrow {
+  display: inline-block;
+  margin-bottom: 10px;
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-weight: 800;
   color: #8a6a2f;
+}
+
+/* compact grid that fits one page */
+.exec-certificate-grid,
+.certificate-exec-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+/* field cards */
+.exec-certificate-field,
+.certificate-exec-field {
+  border: 1px solid rgba(0,0,0,0.14);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: #ffffff;
+}
+
+.exec-certificate-label,
+.certificate-exec-label {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: rgba(0,0,0,0.55);
+  margin-bottom: 6px;
+}
+
+.exec-certificate-value,
+.certificate-exec-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111111;
+  word-break: break-word;
+}
+
+/* long blocks go full width */
+.exec-certificate-block,
+.certificate-exec-block {
+  grid-column: 1 / -1;
+  border: 1px solid rgba(0,0,0,0.14);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: #ffffff;
+}
+
+/* compact list text */
+.exec-certificate-block p,
+.certificate-exec-block p,
+.exec-certificate-block ul,
+.certificate-exec-block ul {
+  margin: 0;
+  color: rgba(0,0,0,0.72);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.exec-certificate-block ul,
+.certificate-exec-block ul {
+  padding-left: 18px;
+}
+
+.exec-certificate-block li + li,
+.certificate-exec-block li + li {
+  margin-top: 4px;
+}
+
+/* signature row — keeps it official */
+.exec-certificate-signatures,
+.certificate-exec-signatures {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+  margin-top: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.exec-certificate-signature,
+.certificate-exec-signature {
+  border-top: 1px solid rgba(0,0,0,0.6);
+  padding-top: 8px;
+  color: rgba(0,0,0,0.78);
+  font-size: 15px;
+}
+
+/* small badge right (like your screenshot) */
+.exec-certificate-badge,
+.certificate-exec-badge {
+  position: absolute;
+  right: 22px;
+  top: 22px;
+  border: 1px solid rgba(0,0,0,0.16);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.84rem;
+  color: rgba(0,0,0,0.7);
+  background: rgba(255,255,255,0.95);
 }
 
-.certificate-badge {
-  padding: 0.45rem 0.8rem;
-  border-radius: 999px;
-  border: 1px solid rgba(138, 106, 47, 0.22);
-  background: rgba(214, 176, 102, 0.08);
-  color: #111111;
-  font-size: 0.82rem;
-  font-weight: 700;
-}
-
-.certificate-title {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
-.certificate-title h2 {
-  margin: 0;
-  font-size: 32px;
-  letter-spacing: -1px;
-  color: #111111;
-}
-
-.certificate-subtitle {
-  margin-top: 6px;
-  color: #555555;
-  font-size: 14px;
-}
-
-.certificate-executive-grid,
-.certificate-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  margin-top: 20px;
-}
-
-.certificate-executive-grid-secondary {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  margin-top: 12px;
-}
-
-.certificate-executive-proof {
-  display: grid;
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.certificate-item {
-  border: 1px solid #e3e3e3;
-  padding: 12px 14px;
-  border-radius: 10px;
-  background: #ffffff;
-}
-
-.certificate-item-full {
-  width: 100%;
-}
-
-.certificate-label {
-  display: block;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: #777777;
-  margin-bottom: 3px;
-  font-weight: 700;
-}
-
-.certificate-value {
-  font-weight: 600;
-  color: #111111;
-}
-
-.certificate-id {
-  font-family: monospace;
-  font-size: 13px;
-}
-
-.certificate-summary {
-  margin-top: 20px;
-  padding: 14px;
-  border: 1px solid #e3e3e3;
-  border-radius: 10px;
-  font-size: 14px;
-  line-height: 1.6;
-  background: #ffffff;
-  color: #111111;
-}
-
-.certificate-signature-row {
-  margin-top: 16px;
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-}
-
-.certificate-signature-block {
-  flex: 1;
-}
-
-.certificate-signature-line {
-  border-top: 1px solid #333333;
-  padding-top: 6px;
-  width: 100%;
-}
-
-.certificate-signature-label {
-  font-size: 0.9rem;
-  color: #444444;
-}
-
-.certificate-actions {
-  margin-top: 22px;
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-/* ==========================================
-   LINEAGE INTELLIGENCE DASHBOARD
-========================================== */
-
-.intelligence-cards {
-  margin-top: 30px;
-}
-
-.intelligence-cards .feature-card {
-  text-align: center;
-}
-
-.intelligence-cards .feature-card h3 {
-  margin-bottom: 12px;
-}
-
-.intelligence-cards .feature-card div {
-  font-size: 2rem;
-  font-weight: 800;
-  line-height: 1;
-  color: var(--text);
-}
-
-.intelligence-report {
-  margin-top: 30px;
-}
-
-.intelligence-report h3 {
-  margin-bottom: 14px;
-}
-
-.intelligence-report .helper,
-.intelligence-report p {
-  color: var(--muted);
-}
-
+/* =========================================================
+   PRINT — EXECUTIVE CERTIFICATE (ONE PAGE)
+   ========================================================= */
 @media print {
   @page {
     size: letter portrait;
     margin: 0.45in;
   }
 
+  html,
+  body {
+    background: #ffffff !important;
+    color: #111111 !important;
+  }
+
+  /* hide everything by default */
   body * {
     visibility: hidden !important;
   }
 
+  /* show only certificate stack */
   .certificate-print-stack,
-  .certificate-print-stack * {
+  .certificate-print-stack *,
+  .certificate-exec-print-stack,
+  .certificate-exec-print-stack * {
     visibility: visible !important;
   }
 
-  .certificate-print-stack {
+  .certificate-print-stack,
+  .certificate-exec-print-stack {
     position: absolute !important;
-    top: 0;
-    left: 0;
-    width: 100%;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
     display: block !important;
   }
 
-  .certificate-paper {
-    position: static !important;
-    width: 100% !important;
-    max-width: 100% !important;
-    margin: 0 !important;
-    padding: 20px !important;
-    background: #ffffff !important;
-    color: #111111 !important;
-    border: 1px solid #cccccc !important;
-    border-radius: 0 !important;
+  /* print paper should be flat + clean */
+  .exec-certificate-paper,
+  .certificate-exec-paper,
+  .certificate-paper-exec {
     box-shadow: none !important;
-    min-height: auto !important;
-    break-after: auto !important;
-    page-break-after: auto !important;
-    break-before: auto !important;
-    page-break-before: auto !important;
+    border: 1px solid #d9d9d9 !important;
+    border-radius: 0 !important;
+    padding: 0.32in !important;
+    overflow: visible !important;
   }
 
-  .certificate-executive-topbar,
-  .certificate-title,
-  .certificate-executive-grid,
-  .certificate-executive-grid-secondary,
-  .certificate-executive-proof,
-  .certificate-summary,
-  .certificate-signature-row {
+  .exec-certificate-paper::before,
+  .certificate-exec-paper::before,
+  .certificate-paper-exec::before {
+    display: none !important;
+  }
+
+  /* keep it on ONE page */
+  .exec-certificate-title,
+  .certificate-exec-title,
+  .exec-certificate-grid,
+  .certificate-exec-grid,
+  .exec-certificate-signatures,
+  .certificate-exec-signatures {
     break-inside: avoid !important;
     page-break-inside: avoid !important;
   }
 
-  .certificate-executive-grid,
-  .certificate-grid,
-  .certificate-executive-grid-secondary {
-    grid-template-columns: 1fr 1fr !important;
-    gap: 8px !important;
-    margin-top: 10px !important;
-  }
-
-  .certificate-executive-proof {
-    gap: 8px !important;
-    margin-top: 10px !important;
-  }
-
-  .certificate-item {
-    padding: 8px 10px !important;
-    border: 1px solid #d9d9d9 !important;
-  }
-
-  .certificate-summary {
-    margin-top: 10px !important;
-    padding: 10px !important;
-    border: 1px solid #d9d9d9 !important;
-  }
-
-  .certificate-signature-row {
-    margin-top: 10px !important;
-    gap: 14px !important;
-  }
-
-  .certificate-actions,
+  /* ensure no UI prints */
   .site-header,
   .footer,
+  nav,
+  .header-actions,
   .page-hero,
-  .form-panel,
+  .form-panel:first-child,
   [data-certificate-status],
   [data-certificate-empty],
-  nav,
-  .header-actions {
+  .certificate-actions,
+  button,
+  .btn {
     display: none !important;
   }
 
@@ -1482,31 +756,10 @@ textarea {
   }
 }
 
+/* ================= RESPONSIVE ================= */
 @media (max-width: 1180px) {
-  .hero-shell,
-  .hero-shell-tech,
-  .feature-strip,
-  .architecture-grid,
-  .viewer-steps-premium,
-  .trust-grid,
-  .footer-top,
-  .form-grid.two-col,
-  .hero-visual-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-copy-tech {
-    position: static;
-  }
-
   .site-nav {
     gap: 18px;
-  }
-
-  .viewer-panel-top,
-  .hero-demo-card-top {
-    align-items: start;
-    flex-direction: column;
   }
 }
 
@@ -1537,52 +790,13 @@ textarea {
     display: none;
   }
 
-  .site-header.open .site-nav,
-  .site-header.open .header-actions {
-    display: flex;
-    width: 100%;
-  }
-
-  .site-header.open .site-header-inner {
-    flex-wrap: wrap;
-    align-items: flex-start;
-  }
-
-  .site-nav {
-    order: 3;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 14px;
-    padding: 14px 0 6px;
-    margin-left: 0;
-  }
-
-  .header-actions {
-    order: 4;
-    justify-content: flex-start;
-    padding-bottom: 10px;
-  }
-
-  .hero,
-  .page-hero,
-  .thank-you-hero {
+  .page-hero {
     padding-top: 42px;
   }
 
-  .hero-copy-premium,
-  .hero-visual-card,
-  .viewer-panel,
-  .feature-card,
-  .section-card,
-  .trust-card,
-  .policy-card,
   .page-hero-panel,
-  .footer-card,
-  .cta-panel,
   .form-panel,
-  .architecture-panel,
-  .thank-you-card,
-  .certificate-card {
+  .footer-card {
     padding: 24px;
     border-radius: 26px;
   }
@@ -1591,82 +805,19 @@ textarea {
     font-size: 1.5rem;
   }
 
-  .hero-copy h1,
   .page-hero h1 {
     max-width: none;
     font-size: clamp(2.3rem, 8vw, 3.6rem);
-  }
-
-  .hero-demo-embed {
-    height: 220px;
   }
 
   .btn {
     width: 100%;
   }
 
-  .cookie-inner {
-    padding: 16px;
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .cookie-copy {
-    flex: 1 1 100%;
-    order: 1;
-  }
-
-  .cookie-actions {
-    width: 100%;
-    order: 2;
-  }
-
-  .cookie-actions .btn {
-    flex: 1 1 0;
-    width: auto;
-  }
-
-  .thank-you-actions {
-    flex-direction: column;
-  }
-
-  .thank-you-actions .btn-primary,
-  .thank-you-actions .btn-secondary {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .signal-row {
-    gap: 10px 14px;
-    font-size: 0.88rem;
-  }
-
-  .package-list {
-    padding-left: 18px;
-  }
-
-  .certificate-executive-topbar {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .certificate-executive-grid,
-  .certificate-grid,
-  .certificate-executive-grid-secondary,
-  .certificate-signature-row {
+  .exec-certificate-grid,
+  .certificate-exec-grid,
+  .exec-certificate-signatures,
+  .certificate-exec-signatures {
     grid-template-columns: 1fr;
-    display: grid;
-  }
-
-  .certificate-signature-row {
-    gap: 12px;
-  }
-
-  .certificate-paper {
-    padding: 22px;
-  }
-
-  .certificate-title h2 {
-    font-size: 28px;
   }
 }


### PR DESCRIPTION
Updates styles.css with executive certificate “paper” layout and optimized print output (Letter). Hides site chrome during print and keeps certificate content compact for single-page certification.