### PR TITLE
 full updated index.html for this section and a full updated styles.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,12 +96,14 @@
               </div>
 
               <div class="hero-demo-embed">
-                <iframe
-                  src="viewer/"
-                  title="Tomb of Light Prototype Viewer - Interactive family lineage experience"
-                  loading="lazy"
-                  allowfullscreen>
-                </iframe>
+                <div class="hero-demo-stage">
+                  <iframe
+                    src="viewer/"
+                    title="Tomb of Light Prototype Viewer - Interactive family lineage experience"
+                    loading="lazy"
+                    allowfullscreen>
+                  </iframe>
+                </div>
               </div>
             </div>
 

--- a/styles.css
+++ b/styles.css
@@ -48,8 +48,6 @@ body.menu-open {
   overflow: hidden;
 }
 
-/* ================= PREFERS REDUCED MOTION ================= */
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -60,8 +58,6 @@ body.menu-open {
     scroll-behavior: auto !important;
   }
 }
-
-/* ================= SKIP TO CONTENT ================= */
 
 .skip-to-content {
   position: absolute;
@@ -89,8 +85,6 @@ body.menu-open {
   text-decoration: none;
 }
 
-/* ================= SITE WATERMARK ================= */
-
 .site-watermark {
   position: fixed;
   inset: 0;
@@ -103,8 +97,6 @@ body.menu-open {
   opacity: 0.18;
   filter: brightness(1.32) contrast(1.08);
 }
-
-/* ================= BASE ELEMENTS ================= */
 
 img {
   max-width: 100%;
@@ -151,8 +143,6 @@ a {
   position: relative;
   z-index: 1;
 }
-
-/* ================= HEADER ================= */
 
 .site-header {
   position: sticky;
@@ -253,8 +243,6 @@ a {
   border-color: var(--border);
 }
 
-/* ================= BUTTONS ================= */
-
 .btn {
   display: inline-flex;
   align-items: center;
@@ -323,6 +311,7 @@ a {
   font-size: 0.94rem;
   text-decoration: none;
   transition: color var(--transition);
+  align-self: flex-start;
 }
 
 .mini-link:hover {
@@ -335,8 +324,6 @@ a {
   border-radius: 4px;
 }
 
-/* ================= HERO ================= */
-
 .hero {
   padding: 48px 0 28px;
 }
@@ -345,7 +332,7 @@ a {
   display: grid;
   grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
   gap: 22px;
-  align-items: stretch;
+  align-items: start;
 }
 
 .hero-shell-tech {
@@ -386,7 +373,9 @@ a {
 
 .hero-copy-premium {
   padding: 36px;
-  min-height: 100%;
+  min-height: auto;
+  height: fit-content;
+  align-self: start;
 }
 
 .hero-copy-tech {
@@ -447,6 +436,16 @@ a {
   font-weight: 600;
 }
 
+.signal-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  margin-top: 18px;
+  color: var(--muted);
+  font-size: 0.97rem;
+  font-weight: 600;
+}
+
 .hero-visual {
   display: grid;
   gap: 20px;
@@ -499,39 +498,25 @@ a {
 }
 
 .hero-demo-card-top h2 {
-  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-size: clamp(1.8rem, 2.7vw, 3.3rem);
   margin-bottom: 0;
-}
-
-.hero-demo-card-top h3 {
-  margin: 0;
-  font-size: 1.15rem;
-  line-height: 1.15;
-  letter-spacing: -0.03em;
+  max-width: 12ch;
 }
 
 .hero-demo-embed {
   width: 100%;
-  min-height: 520px;
-  overflow: hidden;
   border-radius: 26px;
   border: 1px solid var(--border-soft);
   background: rgba(255, 255, 255, 0.025);
-}
-
-.hero-demo-embed-centered {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 14px;
+  overflow: hidden;
+  padding: 0;
+  min-height: unset;
 }
 
 .hero-demo-stage {
   width: 100%;
-  max-width: none;
-  height: 100%;
-  min-height: 430px;
-  aspect-ratio: auto;
+  aspect-ratio: 16 / 10;
+  min-height: 0;
   border-radius: 22px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -545,14 +530,6 @@ a {
   border: 0;
   display: block;
   background: #02050b;
-}
-
-.hero-demo-stage iframe,
-.hero-demo-stage img,
-.hero-demo-stage .viewer-preview {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
 }
 
 .hero-visual-main p {
@@ -637,8 +614,6 @@ a {
   color: var(--muted);
 }
 
-/* ================= SECTIONS ================= */
-
 .section {
   padding: 28px 0 10px;
 }
@@ -693,6 +668,7 @@ a {
   background: linear-gradient(180deg, rgba(10, 15, 25, 0.76), rgba(5, 9, 17, 0.86));
 }
 
+.package-list,
 .section-list,
 .policy-list {
   margin: 16px 0 0;
@@ -700,7 +676,18 @@ a {
   color: var(--muted);
 }
 
-/* ================= ARCHITECTURE ================= */
+.section-note {
+  margin-top: 18px;
+  color: var(--muted-2);
+  font-size: 0.96rem;
+}
+
+.pricing-card-featured {
+  border-color: rgba(214, 176, 102, 0.34);
+  box-shadow:
+    var(--shadow),
+    0 0 0 1px rgba(214, 176, 102, 0.18);
+}
 
 .architecture-panel {
   padding: 34px;
@@ -758,8 +745,6 @@ a {
   padding-left: 8px;
 }
 
-/* ================= VIEWER ================= */
-
 .viewer-panel {
   padding: 34px;
 }
@@ -811,15 +796,11 @@ a {
   color: var(--muted);
 }
 
-/* ================= TRUST ================= */
-
 .trust-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 20px;
 }
-
-/* ================= CTA ================= */
 
 .cta-panel {
   padding: 40px;
@@ -830,7 +811,16 @@ a {
   text-align: left;
 }
 
-/* ================= PAGE HERO / FORMS ================= */
+.founder-copy + .founder-copy {
+  margin-top: 12px;
+}
+
+.founder-signoff {
+  margin-top: 20px;
+  color: var(--text);
+  font-weight: 700;
+  line-height: 1.6;
+}
 
 .page-hero {
   padding: 72px 0 20px;
@@ -941,8 +931,6 @@ textarea {
   outline-offset: 2px;
   border-radius: 4px;
 }
-
-/* ================= CERTIFICATE ================= */
 
 .exec-certificate {
   position: relative;
@@ -1118,8 +1106,6 @@ textarea {
   margin-top: 16px;
 }
 
-/* ================= FOOTER ================= */
-
 .footer {
   padding: 24px 0 44px;
 }
@@ -1176,8 +1162,6 @@ textarea {
   color: var(--muted-2);
   font-size: 0.96rem;
 }
-
-/* ================= COOKIE ================= */
 
 .cookie-banner {
   position: fixed;
@@ -1246,8 +1230,6 @@ textarea {
   margin-top: 8px;
 }
 
-/* ================= THANK YOU ================= */
-
 .thank-you-hero {
   padding: 96px 0 64px;
 }
@@ -1312,16 +1294,12 @@ textarea {
   line-height: 1.7;
 }
 
-/* ================= STATUS ================= */
-
 [data-signin-status],
 [data-signup-status],
 [data-dashboard-status],
 [data-certificate-status] {
   min-height: 24px;
 }
-
-/* ================= RESPONSIVE ================= */
 
 @media (max-width: 1180px) {
   .hero-shell,
@@ -1348,6 +1326,10 @@ textarea {
   .hero-demo-card-top {
     align-items: start;
     flex-direction: column;
+  }
+
+  .hero-demo-card-top h2 {
+    max-width: none;
   }
 }
 
@@ -1437,17 +1419,13 @@ textarea {
   }
 
   .hero-demo-embed {
-    min-height: auto;
-  }
-
-  .hero-demo-embed-centered {
-    padding: 16px;
+    min-height: unset;
   }
 
   .hero-demo-stage {
     width: 100%;
-    min-height: 280px;
-    aspect-ratio: auto;
+    aspect-ratio: 16 / 10;
+    min-height: 0;
   }
 
   .btn {


### PR DESCRIPTION
	left hero card no longer stretches to fake full height
	•	viewer embed now uses a proper internal stage
	•	oversized min-heights were removed
	•	iframe now fills a controlled 16 / 10 area
	•	the “Open Full Viewer” link stays aligned better
	•	the large empty bubble effect is reduced on both sides