### PR TITLE
Make homepage prototype preview watch-only; fix embed-mode layout and…

### DIFF
--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -1,249 +1,351 @@
-:root{
-  --bg:#03060d;
-  --bg-soft:#07101d;
-  --panel:rgba(10,16,28,.84);
-  --panel-2:rgba(7,12,22,.94);
-  --panel-3:rgba(255,255,255,.025);
-  --border:rgba(255,255,255,.1);
-  --border-soft:rgba(255,255,255,.06);
-  --text:#f4f7fb;
-  --muted:#b9c4d4;
-  --muted-2:#8d9aae;
-  --gold:#d6b066;
-  --shadow:0 24px 70px rgba(0,0,0,.44);
-  --transition:220ms ease;
+:root {
+  --bg: #03060d;
+  --bg-soft: #07101d;
+  --panel: rgba(10, 16, 28, 0.84);
+  --panel-2: rgba(7, 12, 22, 0.94);
+  --panel-3: rgba(255, 255, 255, 0.025);
+  --border: rgba(255, 255, 255, 0.1);
+  --border-soft: rgba(255, 255, 255, 0.06);
+  --text: #f4f7fb;
+  --muted: #b9c4d4;
+  --muted-2: #8d9aae;
+  --gold: #d6b066;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.44);
+  --transition: 220ms ease;
 }
 
-*,*::before,*::after{box-sizing:border-box;min-width:0;}
-html{scroll-behavior:smooth;}
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  min-width: 0;
+}
 
-body{
-  margin:0;min-height:100vh;color:var(--text);
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
   background:
-    radial-gradient(circle at top left, rgba(21,48,108,.12), transparent 28%),
-    radial-gradient(circle at top right, rgba(7,20,58,.14), transparent 30%),
-    linear-gradient(180deg,#010309 0%,#04070e 44%,#02050b 100%);
-  font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
-  line-height:1.6;
+    radial-gradient(circle at top left, rgba(21, 48, 108, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(7, 20, 58, 0.14), transparent 30%),
+    linear-gradient(180deg, #010309 0%, #04070e 44%, #02050b 100%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
 }
 
-a{color:inherit;text-decoration:none;}
+a { color: inherit; text-decoration: none; }
 
-.viewer-page{width:100%;max-width:1280px;margin:0 auto;padding:20px 20px 32px;}
-
-.viewer-header{
-  display:grid;
-  grid-template-columns:minmax(0,.72fr) minmax(0,1.28fr);
-  gap:24px;margin-bottom:24px;
+.viewer-page {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 20px 20px 32px;
 }
 
-.viewer-brand-wrap,.viewer-header-copy,.viewer-stage-panel,.viewer-side-panel .side-card{
-  background:linear-gradient(180deg,rgba(10,16,28,.82),rgba(6,10,18,.92));
-  border:1px solid var(--border);
-  border-radius:30px;
-  box-shadow:var(--shadow);
-  backdrop-filter:blur(12px);
+.viewer-header {
+  display: grid;
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1.28fr);
+  gap: 24px;
+  margin-bottom: 24px;
 }
 
-.viewer-brand-wrap{
-  padding:24px;
-  display:flex;
-  flex-direction:column;
-  justify-content:space-between;
-  gap:18px;
+.viewer-brand-wrap,
+.viewer-header-copy,
+.viewer-stage-panel,
+.viewer-side-panel .side-card {
+  background: linear-gradient(180deg, rgba(10, 16, 28, 0.82), rgba(6, 10, 18, 0.92));
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
 }
 
-.back-link{
-  display:inline-flex;
-  align-items:center;
-  width:fit-content;
-  color:var(--muted);
-  font-weight:700;
-  transition:color var(--transition);
-}
-.back-link:hover{color:var(--text);}
-
-.viewer-brand{
-  font-size:clamp(2rem,4vw,3.1rem);
-  font-weight:800;line-height:1;letter-spacing:-.055em;
+.viewer-brand-wrap {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 18px;
 }
 
-.brand-symbol{font-size:.46em;vertical-align:super;}
-.viewer-header-copy{padding:24px 28px;}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: var(--muted);
+  font-weight: 700;
+  transition: color var(--transition);
+}
+.back-link:hover { color: var(--text); }
 
-.viewer-kicker,.panel-kicker{
-  display:inline-block;margin-bottom:14px;color:var(--gold);
-  font-size:.82rem;font-weight:800;letter-spacing:.22em;text-transform:uppercase;
+.viewer-brand {
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.055em;
 }
 
-.viewer-header-copy h1{
-  margin:0 0 14px;
-  font-size:clamp(2.2rem,4vw,4.2rem);
-  line-height:.96;letter-spacing:-.06em;max-width:12ch;
-}
-.viewer-header-copy p{margin:0;max-width:62ch;color:var(--muted);font-size:1.04rem;}
+.brand-symbol { font-size: 0.46em; vertical-align: super; }
 
-.viewer-main{
-  display:grid;
-  grid-template-columns:minmax(0,1.35fr) minmax(300px,.65fr);
-  gap:24px;align-items:start;
-}
+.viewer-header-copy { padding: 24px 28px; }
 
-.viewer-stage-panel{padding:24px;}
-
-.viewer-stage-top{
-  display:flex;justify-content:space-between;align-items:flex-start;
-  gap:18px;margin-bottom:18px;
-}
-.viewer-stage-top h2{
-  margin:0;font-size:clamp(1.6rem,2.5vw,2.4rem);
-  line-height:1.02;letter-spacing:-.05em;
-}
-.viewer-status{
-  padding:10px 14px;border-radius:999px;color:var(--muted);
-  border:1px solid var(--border);background:rgba(255,255,255,.02);
-  font-size:.92rem;font-weight:600;white-space:nowrap;
+.viewer-kicker,
+.panel-kicker {
+  display: inline-block;
+  margin-bottom: 14px;
+  color: var(--gold);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
 }
 
-.viewer-stage-shell{
-  position:relative;
-  border-radius:26px;overflow:hidden;
-  border:1px solid var(--border-soft);
+.viewer-header-copy h1 {
+  margin: 0 0 14px;
+  font-size: clamp(2.2rem, 4vw, 4.2rem);
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+  max-width: 12ch;
+}
+
+.viewer-header-copy p {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--muted);
+  font-size: 1.04rem;
+}
+
+.viewer-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.viewer-stage-panel { padding: 24px; }
+
+.viewer-stage-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.viewer-stage-top h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.5vw, 2.4rem);
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+}
+
+.viewer-status {
+  padding: 10px 14px;
+  border-radius: 999px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.92rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.viewer-stage-shell {
+  position: relative;
+  border-radius: 26px;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
   background:
-    radial-gradient(circle at center, rgba(214,176,102,.06), transparent 55%),
-    linear-gradient(180deg, rgba(3,7,15,.96), rgba(2,5,11,1));
-  aspect-ratio:16/10;
-  display:flex;align-items:center;justify-content:center;
-  min-height:0;
-  touch-action:none;
+    radial-gradient(circle at center, rgba(214, 176, 102, 0.06), transparent 55%),
+    linear-gradient(180deg, rgba(3, 7, 15, 0.96), rgba(2, 5, 11, 1));
+  aspect-ratio: 16 / 10;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.viewer-stage-glow{
-  position:absolute;width:680px;height:680px;border-radius:50%;
-  background:radial-gradient(circle, rgba(214,176,102,.14), transparent 68%);
-  filter:blur(58px);opacity:.8;pointer-events:none;
+.viewer-stage-glow {
+  position: absolute;
+  width: 680px;
+  height: 680px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(214, 176, 102, 0.14), transparent 68%);
+  filter: blur(58px);
+  opacity: 0.8;
+  pointer-events: none;
 }
 
-.slideshow{
-  position:relative;
-  z-index:1;
-  width:100%;height:100%;
-  overflow:hidden;
-  display:flex;align-items:center;justify-content:center;
+.slideshow {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-/* IMPORTANT: transform is managed by JS for smooth continuous zoom */
-.slideshow img{
-  width:100%;height:100%;
-  object-fit:contain;
-  object-position:center;
-  transform-origin:50% 50%;
-  will-change:transform;
-  transition:opacity .22s ease;
-  user-select:none;
-  -webkit-user-drag:none;
+.slideshow img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  transform-origin: center;
+  will-change: transform;
+  transition: opacity 0.25s ease;
 }
 
-.eye-hint{
-  position:absolute;
-  width:42px;height:42px;border-radius:999px;
-  border:1px solid rgba(214,176,102,.35);
-  box-shadow:0 0 0 4px rgba(214,176,102,.08);
-  opacity:0;
-  pointer-events:none;
-  transform:translate(-50%,-50%);
-  z-index:4;
-}
-.viewer-stage-shell:hover .eye-hint{opacity:.7;}
-.embed-mode .eye-hint{opacity:0;}
+.zoom-in { transform: scale(1.08); }
+.zoom-out { transform: scale(0.68); }
 
-.viewer-line{
-  width:100%;height:1px;margin:24px 0 22px;
-  background:linear-gradient(90deg,transparent,rgba(214,176,102,.72),transparent);
+.viewer-line {
+  width: 100%;
+  height: 1px;
+  margin: 24px 0 22px;
+  background: linear-gradient(90deg, transparent, rgba(214, 176, 102, 0.72), transparent);
 }
 
-.controls{
-  display:flex;flex-wrap:wrap;gap:12px;justify-content:center;
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
 }
 
-.controls button,.branch-options button{
-  appearance:none;border:1px solid var(--border);
-  background:rgba(255,255,255,.04);color:var(--text);
-  min-height:52px;padding:0 22px;border-radius:999px;
-  font-size:.98rem;font-weight:700;cursor:pointer;
-  transition:transform var(--transition), border-color var(--transition), background var(--transition), box-shadow var(--transition);
+.controls button,
+.branch-options button {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  min-height: 52px;
+  padding: 0 22px;
+  border-radius: 999px;
+  font-size: 0.98rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), background var(--transition), box-shadow var(--transition);
 }
 
-.controls button:hover,.branch-options button:hover{
-  transform:translateY(-1px);
-  border-color:rgba(214,176,102,.42);
-  background:rgba(214,176,102,.08);
-  box-shadow:0 10px 24px rgba(0,0,0,.18);
+.controls button:hover,
+.branch-options button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(214, 176, 102, 0.42);
+  background: rgba(214, 176, 102, 0.08);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
 }
 
-.narration-text{
-  position:absolute;bottom:24px;left:24px;right:24px;z-index:6;
-  padding:16px 20px;border-radius:16px;
-  background:rgba(3,6,13,.82);
-  border:1px solid rgba(214,176,102,.18);
-  backdrop-filter:blur(8px);
-  color:var(--text);
-  font-size:.96rem;line-height:1.6;text-align:center;
-  opacity:0;transition:opacity .35s ease;
-  pointer-events:none;
+.narration-text {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  right: 24px;
+  z-index: 6;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(3, 6, 13, 0.82);
+  border: 1px solid rgba(214, 176, 102, 0.18);
+  backdrop-filter: blur(8px);
+  color: var(--text);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  pointer-events: none;
 }
 
-/* Branch selector (parents) */
-.branch-options{
-  position:absolute;bottom:34px;left:50%;
-  transform:translateX(-50%);
-  z-index:5;
-  display:flex;
-  gap:12px;flex-wrap:wrap;justify-content:center;
-  padding:12px 14px;
-  border:1px solid var(--border);
-  border-radius:999px;
-  background:rgba(4,8,15,.82);
-  backdrop-filter:blur(12px);
-  box-shadow:var(--shadow);
+/* FIX: display:flex so gap/wrap/justify work */
+.branch-options {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(4, 8, 15, 0.82);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
 }
 
-.viewer-side-panel{display:grid;gap:20px;}
-.viewer-side-panel .side-card{padding:24px;}
-.viewer-side-panel h3{margin:0 0 8px;font-size:1.4rem;line-height:1.05;letter-spacing:-.04em;}
-.viewer-side-panel p{margin:0;color:var(--muted);}
+.viewer-side-panel { display: grid; gap: 20px; }
+.viewer-side-panel .side-card { padding: 24px; }
+.viewer-side-panel h3 { margin: 0 0 8px; font-size: 1.4rem; line-height: 1.05; letter-spacing: -0.04em; }
+.viewer-side-panel p { margin: 0; color: var(--muted); }
 
-.path-list{display:grid;gap:12px;margin-top:4px;}
-.path-item{
-  padding:14px 16px;border-radius:18px;border:1px solid var(--border-soft);
-  background:var(--panel-3);
-  color:var(--text);
-  font-weight:700;letter-spacing:-.02em;
+.path-list { display: grid; gap: 12px; margin-top: 4px; }
+.path-item {
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid var(--border-soft);
+  background: var(--panel-3);
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
-/* EMBED MODE: homepage preview */
-.embed-mode .viewer-page{max-width:100%;padding:12px;}
-.embed-mode #backLink{display:none!important;}
-.embed-mode #viewerHeader{display:none!important;}
-.embed-mode #sidePanel{display:none!important;}
-.embed-mode #controls{display:none!important;}
-.embed-mode .viewer-main{grid-template-columns:1fr;}
-.embed-mode .viewer-stage-panel{padding:14px;}
-.embed-mode .viewer-line{display:none;}
-
-@media (max-width:1180px){
-  .viewer-header,.viewer-main{grid-template-columns:1fr;}
-  .viewer-header-copy h1{max-width:none;}
+/* -----------------------
+   EMBED MODE (homepage preview) — WATCH ONLY
+   ----------------------- */
+.embed-mode .viewer-page {
+  max-width: 100%;
+  padding: 12px;
 }
-@media (max-width:760px){
-  .viewer-page{padding:14px 12px 24px;}
-  .viewer-brand-wrap,.viewer-header-copy,.viewer-stage-panel,.viewer-side-panel .side-card{
-    border-radius:24px;padding:20px;
+
+.embed-mode #backLink { display: none !important; }
+.embed-mode #viewerHeader { display: none !important; }
+.embed-mode #sidePanel { display: none !important; }
+.embed-mode #controls { display: none !important; }
+
+/* Stage becomes the only focus */
+.embed-mode .viewer-main { grid-template-columns: 1fr; }
+.embed-mode .viewer-stage-panel { padding: 14px; }
+.embed-mode .viewer-line { display: none; }
+
+/* Also ensure branch picker never appears in preview */
+.embed-mode #branchOptions { display: none !important; }
+
+@media (max-width: 1180px) {
+  .viewer-header,
+  .viewer-main { grid-template-columns: 1fr; }
+  .viewer-header-copy h1 { max-width: none; }
+}
+
+@media (max-width: 760px) {
+  .viewer-page { padding: 14px 12px 24px; }
+
+  .viewer-brand-wrap,
+  .viewer-header-copy,
+  .viewer-stage-panel,
+  .viewer-side-panel .side-card {
+    border-radius: 24px;
+    padding: 20px;
   }
-  .viewer-stage-top{flex-direction:column;align-items:flex-start;}
-  .viewer-status{white-space:normal;}
-  .viewer-stage-shell,.slideshow{aspect-ratio:16/10;height:auto;}
-  .branch-options{bottom:18px;width:calc(100% - 24px);border-radius:24px;}
-  .controls{flex-direction:column;}
-  .controls button{width:100%;}
+
+  .viewer-stage-top { flex-direction: column; align-items: flex-start; }
+  .viewer-status { white-space: normal; }
+
+  .viewer-stage-shell,
+  .slideshow { aspect-ratio: 16 / 10; min-height: 0; height: auto; }
+
+  .branch-options {
+    bottom: 18px;
+    width: calc(100% - 24px);
+    border-radius: 24px;
+  }
+
+  .controls { flex-direction: column; }
+  .controls button { width: 100%; }
 }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -11,6 +11,7 @@
     <header class="viewer-header" id="viewerHeader">
       <div class="viewer-brand-wrap">
         <a href="../index.html" class="back-link" id="backLink">← Back to Tomb of Light</a>
+
         <div class="viewer-brand">
           Tomb of Light<span class="brand-symbol">™</span>
         </div>
@@ -27,28 +28,26 @@
     </header>
 
     <main class="viewer-main">
-      <section class="viewer-stage-panel">
+      <section class="viewer-stage-panel" id="viewerStagePanel">
         <div class="viewer-stage-top">
           <div>
-            <span class="panel-kicker">Cinematic Viewer</span>
+            <span class="panel-kicker">Lineage Viewer</span>
             <h2 id="viewerTitle">Malik Moreland</h2>
           </div>
 
-          <div class="viewer-status" id="viewerStatus">Anchor Portrait</div>
+          <div class="viewer-status" id="viewerStatus">
+            Anchor Portrait
+          </div>
         </div>
 
-        <div class="viewer-stage-shell" id="viewerStage">
+        <div class="viewer-stage-shell" id="viewerStageShell">
           <div class="viewer-stage-glow"></div>
 
-          <div class="slideshow" id="slideshow">
+          <div class="slideshow">
             <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
           </div>
 
           <div id="narrationDisplay" class="narration-text"></div>
-
-          <!-- optional eye hints (positioned by JS) -->
-          <div class="eye-hint" id="eyeHintLeft" aria-hidden="true"></div>
-          <div class="eye-hint" id="eyeHintRight" aria-hidden="true"></div>
 
           <div class="branch-options" id="branchOptions">
             <button type="button" onclick="selectBranch('julian')">Julian</button>
@@ -71,7 +70,9 @@
         <div class="side-card">
           <span class="panel-kicker">Current Node</span>
           <h3 id="currentNode">Malik Moreland</h3>
-          <p id="currentDescription">Starting at the anchor portrait for the Genesis family line.</p>
+          <p id="currentDescription">
+            Starting at the anchor portrait for the Genesis family line.
+          </p>
         </div>
 
         <div class="side-card">
@@ -88,19 +89,17 @@
     </main>
   </div>
 
-  <!-- Embed mode -->
+  <!-- Embed mode flag: watch-only when ?embed=1 OR when inside an iframe -->
   <script>
     (function () {
       const params = new URLSearchParams(window.location.search);
-      if (params.get("embed") === "1") document.body.classList.add("embed-mode");
+      const embedParam = params.get("embed") === "1";
+      const isEmbedded = window.self !== window.top;
+      if (embedParam || isEmbedded) {
+        document.body.classList.add("embed-mode");
+      }
     })();
   </script>
-
-  <!-- MediaPipe FaceMesh (CDN) -->
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/control_utils/control_utils.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/face_mesh.js"></script>
 
   <script src="js/script.js"></script>
 </body>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -1,8 +1,4 @@
-/* Tomb of Light Viewer — FaceMesh eye targeting + smooth zoom */
-
 const viewerImage = document.getElementById("viewerImage");
-const viewerStage = document.getElementById("viewerStage");
-const slideshow = document.getElementById("slideshow");
 const branchOptions = document.getElementById("branchOptions");
 const viewerTitle = document.getElementById("viewerTitle");
 const viewerStatus = document.getElementById("viewerStatus");
@@ -11,12 +7,10 @@ const currentDescription = document.getElementById("currentDescription");
 const narrationDisplay = document.getElementById("narrationDisplay");
 const narrationToggleBtn = document.getElementById("narrationToggleBtn");
 
-const eyeHintLeft = document.getElementById("eyeHintLeft");
-const eyeHintRight = document.getElementById("eyeHintRight");
+const EMBED_MODE =
+  new URLSearchParams(window.location.search).get("embed") === "1" ||
+  window.self !== window.top;
 
-// ---------------------
-// State machine
-// ---------------------
 const states = {
   malik: {
     image: "images/malik.jpg",
@@ -24,9 +18,8 @@ const states = {
     status: "Anchor Portrait",
     node: "Malik Moreland",
     description: "Starting at the anchor portrait for the Genesis family line.",
-    narration: "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations.",
-    parents: "parents",
-    descendants: "malik_descendants"
+    narration:
+      "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations."
   },
   parents: {
     image: "images/parents.jpg",
@@ -34,10 +27,8 @@ const states = {
     status: "Parent Structure",
     node: "Parent Layer",
     description: "Choose a family branch from the shared parent structure.",
-    narration: "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge.",
-    parents: "malik",
-    descendants: "malik",
-    showBranches: true
+    narration:
+      "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge."
   },
   malik_descendants: {
     image: "images/malik_descendants.jpg",
@@ -45,9 +36,8 @@ const states = {
     status: "Descendant Layer",
     node: "Malik Descendants",
     description: "Malik's line expands into the next generation.",
-    narration: "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree.",
-    parents: "malik",
-    descendants: "imani"
+    narration:
+      "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree."
   },
   imani: {
     image: "images/imani.jpg",
@@ -55,9 +45,8 @@ const states = {
     status: "Next Generation Anchor",
     node: "Imani Moreland",
     description: "Imani becomes the next generation anchor portrait.",
-    narration: "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters.",
-    parents: "malik_descendants",
-    descendants: "imani_descendants"
+    narration:
+      "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters."
   },
   imani_descendants: {
     image: "images/imani_descendants.jpg",
@@ -65,9 +54,8 @@ const states = {
     status: "Future Legacy Layer",
     node: "Imani Descendants",
     description: "Imani's descendants extend the family line forward.",
-    narration: "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time.",
-    parents: "imani",
-    descendants: "imani"
+    narration:
+      "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time."
   },
   julian: {
     image: "images/julian.jpg",
@@ -75,9 +63,8 @@ const states = {
     status: "Sibling Branch",
     node: "Julian Moreland",
     description: "Julian is a sibling branch with no descendant layer.",
-    narration: "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer.",
-    parents: "parents",
-    descendants: "parents"
+    narration:
+      "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer."
   },
   selah: {
     image: "images/selah.jpg",
@@ -85,9 +72,8 @@ const states = {
     status: "Sibling Branch",
     node: "Selah Carter",
     description: "Selah is a sibling branch with her own descendants.",
-    narration: "Selah Carter branches from the parent structure with her own distinct lineage and family tree.",
-    parents: "parents",
-    descendants: "selah_descendants"
+    narration:
+      "Selah Carter branches from the parent structure with her own distinct lineage and family tree."
   },
   selah_descendants: {
     image: "images/selah_descendants.jpg",
@@ -95,38 +81,40 @@ const states = {
     status: "Descendant Layer",
     node: "Selah Descendants",
     description: "Selah's line expands into her descendant branch.",
-    narration: "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure.",
-    parents: "selah",
-    descendants: "selah"
+    narration:
+      "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure."
   }
 };
 
-const stateOrder = ["malik","parents","malik_descendants","imani","imani_descendants","julian","selah","selah_descendants"];
+const stateOrder = [
+  "malik",
+  "parents",
+  "malik_descendants",
+  "imani",
+  "imani_descendants",
+  "julian",
+  "selah",
+  "selah_descendants"
+];
 
-let state = "malik";
-
-// ---------------------
-// Narration mode (no fighting user)
-// ---------------------
 const NARRATION_DISPLAY_DURATION_MS = 4500;
 const AUTO_ADVANCE_INTERVAL_MS = 5000;
 
+let state = "malik";
 let isPlaying = true;
 let narrationInterval = null;
 let narrationFadeTimeout = null;
-let userInteractingUntil = 0;
+let transitionLock = false;
 
-function nowMs(){ return Date.now(); }
-
-function pauseAutoAdvanceFor(ms){
-  userInteractingUntil = Math.max(userInteractingUntil, nowMs() + ms);
-}
-
-function showNarration(text){
+function showNarration(text) {
   if (!narrationDisplay) return;
-  if (narrationFadeTimeout) clearTimeout(narrationFadeTimeout);
 
-  if (!isPlaying || !text){
+  if (narrationFadeTimeout) {
+    clearTimeout(narrationFadeTimeout);
+    narrationFadeTimeout = null;
+  }
+
+  if (!isPlaying || !text) {
     narrationDisplay.style.opacity = "0";
     return;
   }
@@ -139,33 +127,40 @@ function showNarration(text){
   }, NARRATION_DISPLAY_DURATION_MS);
 }
 
-function startNarrationAutoAdvance(){
+function startNarrationAutoAdvance() {
   if (narrationInterval) clearInterval(narrationInterval);
 
   narrationInterval = setInterval(() => {
-    if (!isPlaying) return;
-    if (nowMs() < userInteractingUntil) return;
-
     const currentIndex = stateOrder.indexOf(state);
     const nextIndex = (currentIndex + 1) % stateOrder.length;
-    applyState(stateOrder[nextIndex], { cinematic: true });
+    applyState(stateOrder[nextIndex]);
   }, AUTO_ADVANCE_INTERVAL_MS);
 }
 
-function stopNarrationAutoAdvance(){
-  if (narrationInterval) clearInterval(narrationInterval);
-  narrationInterval = null;
-  if (narrationFadeTimeout) clearTimeout(narrationFadeTimeout);
-  narrationFadeTimeout = null;
+function stopNarrationAutoAdvance() {
+  if (narrationInterval) {
+    clearInterval(narrationInterval);
+    narrationInterval = null;
+  }
+
+  if (narrationFadeTimeout) {
+    clearTimeout(narrationFadeTimeout);
+    narrationFadeTimeout = null;
+  }
+
   if (narrationDisplay) narrationDisplay.style.opacity = "0";
 }
 
-function toggleNarration(){
+function toggleNarration() {
+  if (EMBED_MODE) return; // watch-only on homepage preview
+
   isPlaying = !isPlaying;
-  if (narrationToggleBtn){
+
+  if (narrationToggleBtn) {
     narrationToggleBtn.textContent = isPlaying ? "Narration: ON" : "Narration: OFF";
   }
-  if (isPlaying){
+
+  if (isPlaying) {
     showNarration(states[state].narration);
     startNarrationAutoAdvance();
   } else {
@@ -173,302 +168,22 @@ function toggleNarration(){
   }
 }
 
-// ---------------------
-// Smooth zoom engine (continuous)
-// ---------------------
-let scale = 1;
-let targetScale = 1;
-let tx = 0;
-let ty = 0;
-let targetTx = 0;
-let targetTy = 0;
-
-const MIN_SCALE = 1;
-const MAX_SCALE = 2.2;
-const SMOOTHING = 0.18;
-
-function clamp(v, min, max){ return Math.min(max, Math.max(min, v)); }
-
-function applyTransform(){
-  if (!viewerImage) return;
-  scale += (targetScale - scale) * SMOOTHING;
-  tx += (targetTx - tx) * SMOOTHING;
-  ty += (targetTy - ty) * SMOOTHING;
-
-  viewerImage.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
-  requestAnimationFrame(applyTransform);
-}
-
-function resetTransform(){
-  scale = 1; targetScale = 1;
-  tx = 0; ty = 0;
-  targetTx = 0; targetTy = 0;
-}
-
-// Convert normalized (0..1) coords to transform offsets so the point becomes centered
-function focusOnPoint(nx, ny, zoom){
-  if (!viewerStage) return;
-
-  const rect = viewerStage.getBoundingClientRect();
-  const cx = rect.width / 2;
-  const cy = rect.height / 2;
-
-  // point in stage pixels
-  const px = nx * rect.width;
-  const py = ny * rect.height;
-
-  const z = clamp(zoom, MIN_SCALE, MAX_SCALE);
-  targetScale = z;
-
-  // When scaling around center, translation should bring px/py to center.
-  // translate = center - point
-  targetTx = (cx - px) * z;
-  targetTy = (cy - py) * z;
-}
-
-function zoomBy(delta, anchorX, anchorY){
-  // anchorX/Y are in stage pixels
-  if (!viewerStage) return;
-  const rect = viewerStage.getBoundingClientRect();
-
-  const nx = clamp(anchorX / rect.width, 0, 1);
-  const ny = clamp(anchorY / rect.height, 0, 1);
-
-  const next = clamp(targetScale + delta, MIN_SCALE, MAX_SCALE);
-  focusOnPoint(nx, ny, next);
-}
-
-function zoomIn(){
-  pauseAutoAdvanceFor(3000);
-  const cfg = states[state];
-  const next = cfg?.descendants || state;
-  applyState(next, { cinematic: true, direction: "in" });
-}
-
-function zoomOut(){
-  pauseAutoAdvanceFor(3000);
-  const cfg = states[state];
-  const next = cfg?.parents || state;
-  applyState(next, { cinematic: true, direction: "out" });
-}
-
-function resetViewer(){
-  pauseAutoAdvanceFor(3000);
-  resetTransform();
-  applyState("malik", { cinematic: false });
-  if (isPlaying) startNarrationAutoAdvance();
-}
-
-// ---------------------
-// Eye detection (FaceMesh)
-// ---------------------
-// Fallback eye points per image (normalized).
-// Fill these once and it becomes perfect forever.
-const EYE_FALLBACK = {
-  "images/malik.jpg": { left: {x:0.42,y:0.40}, right:{x:0.58,y:0.40} },
-  "images/imani.jpg": { left: {x:0.44,y:0.41}, right:{x:0.56,y:0.41} },
-  "images/selah.jpg": { left: {x:0.44,y:0.41}, right:{x:0.56,y:0.41} },
-  "images/julian.jpg": { left: {x:0.44,y:0.41}, right:{x:0.56,y:0.41} }
-};
-
-let lastEye = null; // {left:{x,y}, right:{x,y}} normalized
-
-function setEyeHints(eyes){
-  if (!eyes) {
-    if (eyeHintLeft) eyeHintLeft.style.opacity = "0";
-    if (eyeHintRight) eyeHintRight.style.opacity = "0";
-    return;
-  }
-  if (!viewerStage) return;
-  const rect = viewerStage.getBoundingClientRect();
-
-  if (eyeHintLeft && eyes.left){
-    eyeHintLeft.style.left = `${eyes.left.x * rect.width}px`;
-    eyeHintLeft.style.top = `${eyes.left.y * rect.height}px`;
-  }
-  if (eyeHintRight && eyes.right){
-    eyeHintRight.style.left = `${eyes.right.x * rect.width}px`;
-    eyeHintRight.style.top = `${eyes.right.y * rect.height}px`;
-  }
-}
-
-function dist(a,b){ const dx=a.x-b.x, dy=a.y-b.y; return Math.sqrt(dx*dx+dy*dy); }
-
-async function detectEyesFromImage(imgEl){
-  // If FaceMesh isn't available, fall back.
-  if (!window.FaceMesh) return null;
-
-  // Use fallback if embed-mode or performance concern? (you can keep it on)
-  return new Promise((resolve) => {
-    const mesh = new FaceMesh({
-      locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/${file}`
-    });
-
-    mesh.setOptions({
-      maxNumFaces: 1,
-      refineLandmarks: true,
-      minDetectionConfidence: 0.5,
-      minTrackingConfidence: 0.5
-    });
-
-    mesh.onResults((results) => {
-      try{
-        const faces = results.multiFaceLandmarks || [];
-        if (!faces.length) return resolve(null);
-
-        const lm = faces[0];
-
-        // Approx eye centers using a few landmark indices
-        // Left eye region (viewer’s left): 33 (outer), 133 (inner)
-        // Right eye region: 263 (outer), 362 (inner)
-        const leftOuter = lm[33], leftInner = lm[133];
-        const rightOuter = lm[263], rightInner = lm[362];
-
-        if (!leftOuter || !leftInner || !rightOuter || !rightInner) return resolve(null);
-
-        const left = { x: (leftOuter.x + leftInner.x)/2, y: (leftOuter.y + leftInner.y)/2 };
-        const right = { x: (rightOuter.x + rightInner.x)/2, y: (rightOuter.y + rightInner.y)/2 };
-
-        resolve({ left, right });
-      } catch(e){
-        resolve(null);
-      }
-    });
-
-    // Send the still image through FaceMesh
-    mesh.send({ image: imgEl });
-  });
-}
-
-async function resolveEyesForCurrentImage(){
-  if (!viewerImage) return null;
-
-  const src = viewerImage.getAttribute("src") || "";
-  const fallback = EYE_FALLBACK[src] || null;
-
-  // Always try mesh first; fallback if none.
-  const detected = await detectEyesFromImage(viewerImage);
-  const eyes = detected || fallback;
-
-  lastEye = eyes;
-  setEyeHints(eyes);
-  return eyes;
-}
-
-// ---------------------
-// Click/tap eye logic
-// ---------------------
-function whichEyeHit(eyes, clientX, clientY){
-  if (!viewerStage || !eyes) return null;
-  const rect = viewerStage.getBoundingClientRect();
-  const p = { x: (clientX - rect.left)/rect.width, y: (clientY - rect.top)/rect.height };
-
-  const dl = dist(p, eyes.left);
-  const dr = dist(p, eyes.right);
-
-  // within radius threshold
-  const TH = 0.08; // tune
-  if (dl < TH && dl < dr) return "left";
-  if (dr < TH && dr < dl) return "right";
-  return null;
-}
-
-function onTapOrClick(e){
-  pauseAutoAdvanceFor(4000);
-  if (!lastEye) return;
-
-  const eye = whichEyeHit(lastEye, e.clientX, e.clientY);
-  if (eye === "left"){
-    // left eye => parents
-    focusOnPoint(lastEye.left.x, lastEye.left.y, 1.9);
-    setTimeout(() => zoomOut(), 260);
-  } else if (eye === "right"){
-    // right eye => descendants
-    focusOnPoint(lastEye.right.x, lastEye.right.y, 1.9);
-    setTimeout(() => zoomIn(), 260);
-  }
-}
-
-// ---------------------
-// Input: wheel + pinch
-// ---------------------
-function setupWheelZoom(){
-  if (!viewerStage) return;
-  viewerStage.addEventListener("wheel", (e) => {
-    e.preventDefault();
-    pauseAutoAdvanceFor(2500);
-
-    const delta = e.deltaY > 0 ? -0.08 : 0.08;
-    const rect = viewerStage.getBoundingClientRect();
-    zoomBy(delta, e.clientX - rect.left, e.clientY - rect.top);
-  }, { passive: false });
-}
-
-let pinchStartDist = 0;
-let pinchStartScale = 1;
-
-function getTouchDist(t1, t2){
-  const dx = t1.clientX - t2.clientX;
-  const dy = t1.clientY - t2.clientY;
-  return Math.sqrt(dx*dx + dy*dy);
-}
-
-function setupPinchZoom(){
-  if (!viewerStage) return;
-
-  viewerStage.addEventListener("touchstart", (e) => {
-    if (e.touches.length === 2){
-      pauseAutoAdvanceFor(3000);
-      pinchStartDist = getTouchDist(e.touches[0], e.touches[1]);
-      pinchStartScale = targetScale;
-    }
-  }, { passive: true });
-
-  viewerStage.addEventListener("touchmove", (e) => {
-    if (e.touches.length === 2){
-      e.preventDefault();
-      pauseAutoAdvanceFor(3000);
-
-      const distNow = getTouchDist(e.touches[0], e.touches[1]);
-      const ratio = distNow / (pinchStartDist || distNow);
-
-      const next = clamp(pinchStartScale * ratio, MIN_SCALE, MAX_SCALE);
-
-      // anchor at midpoint
-      const midX = (e.touches[0].clientX + e.touches[1].clientX)/2;
-      const midY = (e.touches[0].clientY + e.touches[1].clientY)/2;
-
-      if (viewerStage){
-        const rect = viewerStage.getBoundingClientRect();
-        const ax = midX - rect.left;
-        const ay = midY - rect.top;
-
-        const nx = clamp(ax / rect.width, 0, 1);
-        const ny = clamp(ay / rect.height, 0, 1);
-        focusOnPoint(nx, ny, next);
-      }
-    }
-  }, { passive: false });
-}
-
-// ---------------------
-// Apply state
-// ---------------------
-async function applyState(nextState, opts = {}){
+function applyState(nextState) {
   const config = states[nextState];
   if (!config) return;
+  if (transitionLock) return;
 
+  transitionLock = true;
   state = nextState;
 
-  if (viewerImage) viewerImage.style.opacity = "0.35";
+  // Simple crossfade (no zoom transforms in embed-mode)
+  if (viewerImage) viewerImage.style.opacity = "0.25";
 
-  // stop fighting transforms during swap
-  resetTransform();
-
-  setTimeout(async () => {
-    if (viewerImage){
+  setTimeout(() => {
+    if (viewerImage) {
       viewerImage.src = config.image;
       viewerImage.alt = config.node;
+      viewerImage.classList.remove("zoom-in", "zoom-out");
       viewerImage.style.opacity = "1";
     }
 
@@ -477,43 +192,107 @@ async function applyState(nextState, opts = {}){
     if (currentNode) currentNode.textContent = config.node;
     if (currentDescription) currentDescription.textContent = config.description;
 
-    if (branchOptions){
-      branchOptions.style.display = config.showBranches ? "flex" : "none";
-    }
-
     showNarration(config.narration);
 
-    // wait a tick so image is ready, then detect eyes
-    setTimeout(() => {
-      resolveEyesForCurrentImage();
-    }, 250);
+    // Branch buttons only make sense on full viewer
+    if (branchOptions) {
+      if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
+      else branchOptions.style.display = "none";
+    }
 
+    // Unlock after paint
+    setTimeout(() => {
+      transitionLock = false;
+    }, 120);
   }, 160);
 }
 
-function selectBranch(branch){
-  pauseAutoAdvanceFor(3000);
-  if (branch === "julian") applyState("julian", { cinematic: true });
-  if (branch === "malik") applyState("malik", { cinematic: true });
-  if (branch === "selah") applyState("selah", { cinematic: true });
+function animateZoom(className) {
+  if (EMBED_MODE) return; // prevent “shake” in preview
+  if (!viewerImage) return;
+
+  viewerImage.classList.remove("zoom-in", "zoom-out");
+  void viewerImage.offsetWidth;
+  viewerImage.classList.add(className);
+
+  setTimeout(() => {
+    viewerImage.classList.remove(className);
+  }, 700);
 }
 
-// ---------------------
-// Init
-// ---------------------
-function init(){
-  if (branchOptions) branchOptions.style.display = "none";
+function zoomIn() {
+  if (EMBED_MODE) return;
 
-  setupWheelZoom();
-  setupPinchZoom();
-
-  if (viewerStage){
-    viewerStage.addEventListener("click", onTapOrClick);
+  if (state === "malik") {
+    animateZoom("zoom-in");
+    applyState("malik_descendants");
+  } else if (state === "malik_descendants") {
+    animateZoom("zoom-in");
+    applyState("imani");
+  } else if (state === "imani") {
+    animateZoom("zoom-in");
+    applyState("imani_descendants");
+  } else if (state === "selah") {
+    animateZoom("zoom-in");
+    applyState("selah_descendants");
+  } else if (state === "parents") {
+    if (branchOptions) branchOptions.style.display = "flex";
   }
-
-  applyTransform();            // start render loop
-  applyState("malik");         // initial
-  startNarrationAutoAdvance(); // narration
 }
 
-init();
+function zoomOut() {
+  if (EMBED_MODE) return;
+
+  if (state === "malik") {
+    animateZoom("zoom-out");
+    applyState("parents");
+  } else if (state === "malik_descendants") {
+    animateZoom("zoom-out");
+    applyState("malik");
+  } else if (state === "imani") {
+    animateZoom("zoom-out");
+    applyState("malik_descendants");
+  } else if (state === "imani_descendants") {
+    animateZoom("zoom-out");
+    applyState("imani");
+  } else if (state === "julian") {
+    animateZoom("zoom-out");
+    applyState("parents");
+  } else if (state === "selah") {
+    animateZoom("zoom-out");
+    applyState("parents");
+  } else if (state === "selah_descendants") {
+    animateZoom("zoom-out");
+    applyState("selah");
+  } else if (state === "parents") {
+    animateZoom("zoom-in");
+    applyState("malik");
+  }
+}
+
+function selectBranch(branch) {
+  if (EMBED_MODE) return;
+
+  if (branch === "julian") {
+    animateZoom("zoom-in");
+    applyState("julian");
+  } else if (branch === "malik") {
+    animateZoom("zoom-in");
+    applyState("malik");
+  } else if (branch === "selah") {
+    animateZoom("zoom-in");
+    applyState("selah");
+  }
+}
+
+function resetViewer() {
+  if (EMBED_MODE) return;
+
+  if (viewerImage) viewerImage.classList.remove("zoom-in", "zoom-out");
+  applyState("malik");
+  if (isPlaying) startNarrationAutoAdvance();
+}
+
+// Boot
+applyState("malik");
+startNarrationAutoAdvance();


### PR DESCRIPTION
… reduce viewer shaking

	•	Added reliable embed detection (?embed=1 or iframe) and applied embed-mode class
	•	Fixed embed-mode CSS by adding missing element IDs and hiding header/side panel/controls inside preview
	•	Made preview watch-only (no branch picker, no zoom controls, no back link)
	•	Reduced “shake” by disabling zoom transform animations in embed mode and adding a transition lock
	•	Kept full viewer fully interactive while homepage preview remains clean and cinematic