### PR TITLE
Stabilize cinematic viewer autoplay and embed-mode behavior (reduce s…

### DIFF
--- a/viewer/css/viewer-preview.css
+++ b/viewer/css/viewer-preview.css
@@ -19,6 +19,7 @@ body {
   height: 100%;
   background: var(--bg-dark);
   color: var(--text-main);
+  overflow: hidden;
 }
 
 .viewer-preview-body {
@@ -33,8 +34,10 @@ body {
   height: 100vh;
   padding: 0;
   background: var(--bg-dark);
+  overflow: hidden;
 }
 
+/* The frame container */
 .viewer-preview-stage {
   width: 100%;
   height: 100%;
@@ -43,9 +46,13 @@ body {
   border: 1px solid var(--border-soft);
   background: linear-gradient(180deg, rgba(10, 16, 28, 0.95), rgba(6, 10, 18, 0.98));
   position: relative;
+
+  /* Prevent scroll chaining + touch gestures from bubbling */
+  overscroll-behavior: contain;
+  touch-action: none;
 }
 
-/* overlay BEHIND the iframe */
+/* overlay (visual only) */
 .viewer-preview-stage::before {
   content: "";
   position: absolute;
@@ -55,7 +62,7 @@ body {
   z-index: 0;
 }
 
-/* iframe ABOVE the overlay */
+/* iframe above overlay */
 .viewer-preview-stage iframe {
   width: 100%;
   height: 100%;
@@ -64,4 +71,7 @@ body {
   position: relative;
   z-index: 1;
   background: transparent;
+
+  /* KEY: preview should not be clickable/scrollable */
+  pointer-events: none;
 }

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -7,9 +7,16 @@ const currentDescription = document.getElementById("currentDescription");
 const narrationDisplay = document.getElementById("narrationDisplay");
 const narrationToggleBtn = document.getElementById("narrationToggleBtn");
 
+// Safer embed detection (works for ?embed=1 and iframe embeds)
 const EMBED_MODE =
   new URLSearchParams(window.location.search).get("embed") === "1" ||
-  window.self !== window.top;
+  (() => {
+    try {
+      return window.self !== window.top;
+    } catch {
+      return true;
+    }
+  })();
 
 const states = {
   malik: {
@@ -131,6 +138,9 @@ function startNarrationAutoAdvance() {
   if (narrationInterval) clearInterval(narrationInterval);
 
   narrationInterval = setInterval(() => {
+    // Don’t advance if the tab isn’t visible (prevents “jump/shake” on return)
+    if (document.hidden) return;
+
     const currentIndex = stateOrder.indexOf(state);
     const nextIndex = (currentIndex + 1) % stateOrder.length;
     applyState(stateOrder[nextIndex]);
@@ -176,7 +186,6 @@ function applyState(nextState) {
   transitionLock = true;
   state = nextState;
 
-  // Simple crossfade (no zoom transforms in embed-mode)
   if (viewerImage) viewerImage.style.opacity = "0.25";
 
   setTimeout(() => {
@@ -194,16 +203,14 @@ function applyState(nextState) {
 
     showNarration(config.narration);
 
-    // Branch buttons only make sense on full viewer
     if (branchOptions) {
       if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
       else branchOptions.style.display = "none";
     }
 
-    // Unlock after paint
     setTimeout(() => {
       transitionLock = false;
-    }, 120);
+    }, 140);
   }, 160);
 }
 
@@ -292,6 +299,12 @@ function resetViewer() {
   applyState("malik");
   if (isPlaying) startNarrationAutoAdvance();
 }
+
+// Pause/resume auto-advance when tab visibility changes (extra stability)
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) return;
+  if (isPlaying && !EMBED_MODE) startNarrationAutoAdvance();
+});
 
 // Boot
 applyState("malik");


### PR DESCRIPTION
…hake)

	•	Hardened embed detection (?embed=1 or iframe)
	•	Prevented autoplay jumps by skipping auto-advance when tab is hidden
	•	Added small transition lock timing tweak to prevent rapid re-entry
	•	Kept homepage preview watch-only while full viewer remains interactive