### PR TITLE
Fix viewer embed + stabilize interaction surface

### DIFF
--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -152,6 +152,7 @@ a { color: inherit; text-decoration: none; }
   white-space: nowrap;
 }
 
+/* IMPORTANT: stage is interaction surface */
 .viewer-stage-shell {
   position: relative;
   border-radius: 26px;
@@ -165,6 +166,7 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: none; /* enables custom pinch */
 }
 
 .viewer-stage-glow {
@@ -195,12 +197,30 @@ a { color: inherit; text-decoration: none; }
   object-fit: contain;
   object-position: center;
   transform-origin: center;
-  will-change: transform;
+  will-change: transform, opacity;
   transition: opacity 0.25s ease;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
-.zoom-in { transform: scale(1.08); }
-.zoom-out { transform: scale(0.68); }
+/* Eye hint rings: only show when holding C */
+.eye-hint {
+  position: absolute;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 176, 102, 0.35);
+  box-shadow: 0 0 0 4px rgba(214, 176, 102, 0.08);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+}
+
+.show-eyes .eye-hint { opacity: 0.85; }
+
+/* If you want: place these using JS later. For now, hide if not used */
+.eye-hint { display: none; }
 
 .viewer-line {
   width: 100%;
@@ -259,7 +279,7 @@ a { color: inherit; text-decoration: none; }
   pointer-events: none;
 }
 
-/* FIX: display:flex so gap/wrap/justify work */
+/* Branch options */
 .branch-options {
   position: absolute;
   bottom: 34px;
@@ -296,25 +316,15 @@ a { color: inherit; text-decoration: none; }
   letter-spacing: -0.02em;
 }
 
-/* -----------------------
-   EMBED MODE (homepage preview) — WATCH ONLY
-   ----------------------- */
-.embed-mode .viewer-page {
-  max-width: 100%;
-  padding: 12px;
-}
-
+/* EMBED MODE (homepage preview) — watch-only by default */
+.embed-mode .viewer-page { max-width: 100%; padding: 12px; }
 .embed-mode #backLink { display: none !important; }
 .embed-mode #viewerHeader { display: none !important; }
 .embed-mode #sidePanel { display: none !important; }
 .embed-mode #controls { display: none !important; }
-
-/* Stage becomes the only focus */
 .embed-mode .viewer-main { grid-template-columns: 1fr; }
 .embed-mode .viewer-stage-panel { padding: 14px; }
 .embed-mode .viewer-line { display: none; }
-
-/* Also ensure branch picker never appears in preview */
 .embed-mode #branchOptions { display: none !important; }
 
 @media (max-width: 1180px) {
@@ -336,9 +346,6 @@ a { color: inherit; text-decoration: none; }
 
   .viewer-stage-top { flex-direction: column; align-items: flex-start; }
   .viewer-status { white-space: normal; }
-
-  .viewer-stage-shell,
-  .slideshow { aspect-ratio: 16 / 10; min-height: 0; height: auto; }
 
   .branch-options {
     bottom: 18px;

--- a/viewer/css/viewer-preview.css
+++ b/viewer/css/viewer-preview.css
@@ -19,7 +19,6 @@ body {
   height: 100%;
   background: var(--bg-dark);
   color: var(--text-main);
-  overflow: hidden;
 }
 
 .viewer-preview-body {
@@ -34,35 +33,32 @@ body {
   height: 100vh;
   padding: 0;
   background: var(--bg-dark);
-  overflow: hidden;
 }
 
-/* The frame container */
 .viewer-preview-stage {
   width: 100%;
   height: 100%;
   overflow: hidden;
   border-radius: 22px;
   border: 1px solid var(--border-soft);
-  background: linear-gradient(180deg, rgba(10, 16, 28, 0.95), rgba(6, 10, 18, 0.98));
+  background: linear-gradient(
+    180deg,
+    rgba(10, 16, 28, 0.95),
+    rgba(6, 10, 18, 0.98)
+  );
   position: relative;
-
-  /* Prevent scroll chaining + touch gestures from bubbling */
-  overscroll-behavior: contain;
-  touch-action: none;
 }
 
-/* overlay (visual only) */
+/* Optional: subtle glass overlay (behind iframe) */
 .viewer-preview-stage::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(3, 6, 13, 0.55);
+  background: rgba(3, 6, 13, 0.28);
   pointer-events: none;
   z-index: 0;
 }
 
-/* iframe above overlay */
 .viewer-preview-stage iframe {
   width: 100%;
   height: 100%;
@@ -71,7 +67,4 @@ body {
   position: relative;
   z-index: 1;
   background: transparent;
-
-  /* KEY: preview should not be clickable/scrollable */
-  pointer-events: none;
 }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -10,6 +10,7 @@
   <div class="viewer-page">
     <header class="viewer-header" id="viewerHeader">
       <div class="viewer-brand-wrap">
+        <!-- Shown in full viewer, hidden in embed-mode -->
         <a href="../index.html" class="back-link" id="backLink">← Back to Tomb of Light</a>
 
         <div class="viewer-brand">
@@ -24,27 +25,36 @@
           Navigate through generations of the Moreland lineage and explore
           family branches through the Tomb of Light viewer.
         </p>
+
+        <p class="viewer-instructions" id="viewerInstructions">
+          Hold <strong>C</strong>, then click <strong>Left Eye</strong> (Parents) or <strong>Right Eye</strong> (Descendants).
+          Use scroll/pinch to zoom. (Full viewer only)
+        </p>
       </div>
     </header>
 
     <main class="viewer-main">
-      <section class="viewer-stage-panel" id="viewerStagePanel">
+      <section class="viewer-stage-panel">
         <div class="viewer-stage-top">
           <div>
-            <span class="panel-kicker">Lineage Viewer</span>
+            <span class="panel-kicker">Cinematic Viewer</span>
             <h2 id="viewerTitle">Malik Moreland</h2>
           </div>
 
-          <div class="viewer-status" id="viewerStatus">
-            Anchor Portrait
-          </div>
+          <div class="viewer-status" id="viewerStatus">Anchor Portrait</div>
         </div>
 
-        <div class="viewer-stage-shell" id="viewerStageShell">
+        <div class="viewer-stage-shell" id="viewerStage">
           <div class="viewer-stage-glow"></div>
 
           <div class="slideshow">
-            <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
+            <div class="slideshow-inner" id="slideshowInner">
+              <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
+            </div>
+
+            <!-- Eye hints (positioned by JS) -->
+            <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
+            <div class="eye-hint" id="eyeRight" aria-hidden="true"></div>
           </div>
 
           <div id="narrationDisplay" class="narration-text"></div>
@@ -70,9 +80,7 @@
         <div class="side-card">
           <span class="panel-kicker">Current Node</span>
           <h3 id="currentNode">Malik Moreland</h3>
-          <p id="currentDescription">
-            Starting at the anchor portrait for the Genesis family line.
-          </p>
+          <p id="currentDescription">Starting at the anchor portrait for the Genesis family line.</p>
         </div>
 
         <div class="side-card">
@@ -89,15 +97,11 @@
     </main>
   </div>
 
-  <!-- Embed mode flag: watch-only when ?embed=1 OR when inside an iframe -->
+  <!-- Embed-mode flag (iframe preview) -->
   <script>
     (function () {
       const params = new URLSearchParams(window.location.search);
-      const embedParam = params.get("embed") === "1";
-      const isEmbedded = window.self !== window.top;
-      if (embedParam || isEmbedded) {
-        document.body.classList.add("embed-mode");
-      }
+      if (params.get("embed") === "1") document.body.classList.add("embed-mode");
     })();
   </script>
 

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -1,5 +1,12 @@
+/* viewer/js/script.js
+   Tomb of Light — Cinematic Viewer Controls (Option 1: Explicit eye zones)
+   - Scroll/trackpad wheel zoom
+   - Pinch zoom (mobile)
+   - Click left/right eye hotspots (optional hold "C" to reveal)
+   - Prevents shake by using a single transform pipeline
+*/
+
 const viewerImage = document.getElementById("viewerImage");
-const branchOptions = document.getElementById("branchOptions");
 const viewerTitle = document.getElementById("viewerTitle");
 const viewerStatus = document.getElementById("viewerStatus");
 const currentNode = document.getElementById("currentNode");
@@ -7,17 +14,20 @@ const currentDescription = document.getElementById("currentDescription");
 const narrationDisplay = document.getElementById("narrationDisplay");
 const narrationToggleBtn = document.getElementById("narrationToggleBtn");
 
-// Safer embed detection (works for ?embed=1 and iframe embeds)
+const branchOptions = document.getElementById("branchOptions"); // shown on parents state in full viewer
+const stageShell = document.querySelector(".viewer-stage-shell");
+
+// EMBED MODE rules:
+// - If you want homepage preview to be interactive, set WATCH_ONLY_EMBED = false
 const EMBED_MODE =
   new URLSearchParams(window.location.search).get("embed") === "1" ||
-  (() => {
-    try {
-      return window.self !== window.top;
-    } catch {
-      return true;
-    }
-  })();
+  window.self !== window.top;
 
+const WATCH_ONLY_EMBED = true; // <-- change to false if you want preview interactive
+
+// ---------------------------
+// States
+// ---------------------------
 const states = {
   malik: {
     image: "images/malik.jpg",
@@ -26,8 +36,18 @@ const states = {
     node: "Malik Moreland",
     description: "Starting at the anchor portrait for the Genesis family line.",
     narration:
-      "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations."
+      "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations.",
+    // Eye zones are normalized coordinates relative to the image box (0..1)
+    eyes: {
+      left: { x: 0.46, y: 0.22 },  // Malik left eye
+      right: { x: 0.54, y: 0.22 }  // Malik right eye
+    },
+    nav: {
+      leftEye: "parents",           // left eye -> parents
+      rightEye: "malik_descendants" // right eye -> descendants
+    }
   },
+
   parents: {
     image: "images/parents.jpg",
     title: "Elias & Clara Moreland",
@@ -35,8 +55,19 @@ const states = {
     node: "Parent Layer",
     description: "Choose a family branch from the shared parent structure.",
     narration:
-      "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge."
+      "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge.",
+    // Parents image is special: you can use face regions for sibling selection later.
+    // For now, eye clicks return to Malik by default.
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "malik",
+      rightEye: "malik"
+    }
   },
+
   malik_descendants: {
     image: "images/malik_descendants.jpg",
     title: "Malik Descendants",
@@ -44,8 +75,17 @@ const states = {
     node: "Malik Descendants",
     description: "Malik's line expands into the next generation.",
     narration:
-      "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree."
+      "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree.",
+    eyes: {
+      left: { x: 0.42, y: 0.26 },
+      right: { x: 0.58, y: 0.26 }
+    },
+    nav: {
+      leftEye: "malik",
+      rightEye: "imani"
+    }
   },
+
   imani: {
     image: "images/imani.jpg",
     title: "Imani Moreland",
@@ -53,8 +93,17 @@ const states = {
     node: "Imani Moreland",
     description: "Imani becomes the next generation anchor portrait.",
     narration:
-      "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters."
+      "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters.",
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "malik_descendants",
+      rightEye: "imani_descendants"
+    }
   },
+
   imani_descendants: {
     image: "images/imani_descendants.jpg",
     title: "Imani Descendants",
@@ -62,8 +111,17 @@ const states = {
     node: "Imani Descendants",
     description: "Imani's descendants extend the family line forward.",
     narration:
-      "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time."
+      "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time.",
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "imani",
+      rightEye: "imani"
+    }
   },
+
   julian: {
     image: "images/julian.jpg",
     title: "Julian Moreland",
@@ -71,8 +129,17 @@ const states = {
     node: "Julian Moreland",
     description: "Julian is a sibling branch with no descendant layer.",
     narration:
-      "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer."
+      "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer.",
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "parents",
+      rightEye: "parents"
+    }
   },
+
   selah: {
     image: "images/selah.jpg",
     title: "Selah Carter",
@@ -80,8 +147,17 @@ const states = {
     node: "Selah Carter",
     description: "Selah is a sibling branch with her own descendants.",
     narration:
-      "Selah Carter branches from the parent structure with her own distinct lineage and family tree."
+      "Selah Carter branches from the parent structure with her own distinct lineage and family tree.",
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "parents",
+      rightEye: "selah_descendants"
+    }
   },
+
   selah_descendants: {
     image: "images/selah_descendants.jpg",
     title: "Selah Descendants",
@@ -89,10 +165,19 @@ const states = {
     node: "Selah Descendants",
     description: "Selah's line expands into her descendant branch.",
     narration:
-      "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure."
+      "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure.",
+    eyes: {
+      left: { x: 0.46, y: 0.22 },
+      right: { x: 0.54, y: 0.22 }
+    },
+    nav: {
+      leftEye: "selah",
+      rightEye: "selah"
+    }
   }
 };
 
+// The narration autoplay order (unchanged)
 const stateOrder = [
   "malik",
   "parents",
@@ -104,15 +189,85 @@ const stateOrder = [
   "selah_descendants"
 ];
 
+// ---------------------------
+// Cinematic Transform Engine (NO SHAKE)
+// ---------------------------
+let state = "malik";
+let isPlaying = true;
+
 const NARRATION_DISPLAY_DURATION_MS = 4500;
 const AUTO_ADVANCE_INTERVAL_MS = 5000;
 
-let state = "malik";
-let isPlaying = true;
 let narrationInterval = null;
 let narrationFadeTimeout = null;
 let transitionLock = false;
 
+// Single transform pipeline
+let zoom = 1; // 1..3
+let tx = 0;   // px
+let ty = 0;   // px
+
+const ZOOM_MIN = 1;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 0.18;
+const ZOOM_THRESHOLD_IN = 1.35;
+const ZOOM_THRESHOLD_OUT = 0.95;
+
+// Eye overlay (optional)
+let showEyes = false;
+
+// Helpers
+function clamp(n, min, max) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function getImageRect() {
+  if (!viewerImage) return null;
+  return viewerImage.getBoundingClientRect();
+}
+
+function applyTransform() {
+  if (!viewerImage) return;
+  viewerImage.style.transform = `translate3d(${tx}px, ${ty}px, 0) scale(${zoom})`;
+}
+
+function resetTransform() {
+  zoom = 1;
+  tx = 0;
+  ty = 0;
+  applyTransform();
+}
+
+function focusOnNormalizedPoint(nx, ny, targetZoom = 2.2) {
+  const rect = getImageRect();
+  if (!rect) return;
+
+  zoom = clamp(targetZoom, ZOOM_MIN, ZOOM_MAX);
+
+  // Convert normalized point inside the image rect into pixel coords
+  const px = rect.left + rect.width * nx;
+  const py = rect.top + rect.height * ny;
+
+  // Center that point in the stage
+  const stageRect = stageShell ? stageShell.getBoundingClientRect() : rect;
+  const cx = stageRect.left + stageRect.width / 2;
+  const cy = stageRect.top + stageRect.height / 2;
+
+  // Translate image so point moves toward center
+  // Since we scale the image, translate amount should be scaled too
+  tx += (cx - px);
+  ty += (cy - py);
+
+  // damp translation to avoid extreme jump
+  tx = clamp(tx, -rect.width * 0.4, rect.width * 0.4);
+  ty = clamp(ty, -rect.height * 0.4, rect.height * 0.4);
+
+  applyTransform();
+}
+
+// ---------------------------
+// Narration
+// ---------------------------
 function showNarration(text) {
   if (!narrationDisplay) return;
 
@@ -136,14 +291,10 @@ function showNarration(text) {
 
 function startNarrationAutoAdvance() {
   if (narrationInterval) clearInterval(narrationInterval);
-
   narrationInterval = setInterval(() => {
-    // Don’t advance if the tab isn’t visible (prevents “jump/shake” on return)
-    if (document.hidden) return;
-
     const currentIndex = stateOrder.indexOf(state);
     const nextIndex = (currentIndex + 1) % stateOrder.length;
-    applyState(stateOrder[nextIndex]);
+    applyState(stateOrder[nextIndex], { cinematic: false }); // narration is "watch mode"
   }, AUTO_ADVANCE_INTERVAL_MS);
 }
 
@@ -152,20 +303,17 @@ function stopNarrationAutoAdvance() {
     clearInterval(narrationInterval);
     narrationInterval = null;
   }
-
   if (narrationFadeTimeout) {
     clearTimeout(narrationFadeTimeout);
     narrationFadeTimeout = null;
   }
-
   if (narrationDisplay) narrationDisplay.style.opacity = "0";
 }
 
 function toggleNarration() {
-  if (EMBED_MODE) return; // watch-only on homepage preview
+  if (EMBED_MODE && WATCH_ONLY_EMBED) return;
 
   isPlaying = !isPlaying;
-
   if (narrationToggleBtn) {
     narrationToggleBtn.textContent = isPlaying ? "Narration: ON" : "Narration: OFF";
   }
@@ -178,7 +326,10 @@ function toggleNarration() {
   }
 }
 
-function applyState(nextState) {
+// ---------------------------
+// State transitions
+// ---------------------------
+function applyState(nextState, opts = { cinematic: true }) {
   const config = states[nextState];
   if (!config) return;
   if (transitionLock) return;
@@ -186,14 +337,15 @@ function applyState(nextState) {
   transitionLock = true;
   state = nextState;
 
-  if (viewerImage) viewerImage.style.opacity = "0.25";
+  // Fade out image
+  if (viewerImage) viewerImage.style.opacity = "0.15";
 
   setTimeout(() => {
     if (viewerImage) {
       viewerImage.src = config.image;
       viewerImage.alt = config.node;
-      viewerImage.classList.remove("zoom-in", "zoom-out");
       viewerImage.style.opacity = "1";
+      resetTransform();
     }
 
     if (viewerTitle) viewerTitle.textContent = config.title;
@@ -203,109 +355,210 @@ function applyState(nextState) {
 
     showNarration(config.narration);
 
+    // Parent branch buttons only in full viewer
     if (branchOptions) {
-      if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
-      else branchOptions.style.display = "none";
+      if (!EMBED_MODE || !WATCH_ONLY_EMBED) {
+        branchOptions.style.display = nextState === "parents" ? "flex" : "none";
+      } else {
+        branchOptions.style.display = "none";
+      }
     }
 
+    // Unlock
     setTimeout(() => {
       transitionLock = false;
-    }, 140);
-  }, 160);
+    }, 180);
+  }, 180);
 }
 
-function animateZoom(className) {
-  if (EMBED_MODE) return; // prevent “shake” in preview
-  if (!viewerImage) return;
+// ---------------------------
+// Eye click navigation (Option 1)
+// ---------------------------
+function getEyeHitSide(clientX, clientY) {
+  const rect = getImageRect();
+  if (!rect) return null;
 
-  viewerImage.classList.remove("zoom-in", "zoom-out");
-  void viewerImage.offsetWidth;
-  viewerImage.classList.add(className);
+  const xNorm = (clientX - rect.left) / rect.width;
+  const yNorm = (clientY - rect.top) / rect.height;
 
-  setTimeout(() => {
-    viewerImage.classList.remove(className);
-  }, 700);
+  // Simple split by centerline for "left vs right" eye choice
+  if (xNorm < 0 || xNorm > 1 || yNorm < 0 || yNorm > 1) return null;
+  return xNorm < 0.5 ? "left" : "right";
 }
 
-function zoomIn() {
-  if (EMBED_MODE) return;
+function handleEyeClick(clientX, clientY) {
+  const cfg = states[state];
+  if (!cfg || !cfg.nav) return;
 
-  if (state === "malik") {
-    animateZoom("zoom-in");
-    applyState("malik_descendants");
-  } else if (state === "malik_descendants") {
-    animateZoom("zoom-in");
-    applyState("imani");
-  } else if (state === "imani") {
-    animateZoom("zoom-in");
-    applyState("imani_descendants");
-  } else if (state === "selah") {
-    animateZoom("zoom-in");
-    applyState("selah_descendants");
-  } else if (state === "parents") {
-    if (branchOptions) branchOptions.style.display = "flex";
+  const side = getEyeHitSide(clientX, clientY);
+  if (!side) return;
+
+  // Cinematic focus first
+  const eye = cfg.eyes?.[side];
+  if (eye) focusOnNormalizedPoint(eye.x, eye.y, 2.2);
+
+  // Then transition to next state
+  const next = side === "left" ? cfg.nav.leftEye : cfg.nav.rightEye;
+  if (next) {
+    setTimeout(() => applyState(next, { cinematic: true }), 260);
   }
 }
 
-function zoomOut() {
-  if (EMBED_MODE) return;
+// ---------------------------
+// Scroll + pinch zoom (cross-device)
+// ---------------------------
+function zoomBy(delta, anchorX, anchorY) {
+  const rect = getImageRect();
+  if (!rect) return;
 
-  if (state === "malik") {
-    animateZoom("zoom-out");
-    applyState("parents");
-  } else if (state === "malik_descendants") {
-    animateZoom("zoom-out");
-    applyState("malik");
-  } else if (state === "imani") {
-    animateZoom("zoom-out");
-    applyState("malik_descendants");
-  } else if (state === "imani_descendants") {
-    animateZoom("zoom-out");
-    applyState("imani");
-  } else if (state === "julian") {
-    animateZoom("zoom-out");
-    applyState("parents");
-  } else if (state === "selah") {
-    animateZoom("zoom-out");
-    applyState("parents");
-  } else if (state === "selah_descendants") {
-    animateZoom("zoom-out");
-    applyState("selah");
-  } else if (state === "parents") {
-    animateZoom("zoom-in");
-    applyState("malik");
+  // Normalize anchor
+  const nx = (anchorX - rect.left) / rect.width;
+  const ny = (anchorY - rect.top) / rect.height;
+
+  const prevZoom = zoom;
+  zoom = clamp(zoom + delta, ZOOM_MIN, ZOOM_MAX);
+
+  // Adjust translation to keep anchor stable
+  // Basic approach: scale translation relative to zoom change
+  const scale = zoom / prevZoom;
+  tx *= scale;
+  ty *= scale;
+
+  applyTransform();
+
+  // If user zooms far enough, trigger state transitions (only full viewer or interactive embed)
+  if (EMBED_MODE && WATCH_ONLY_EMBED) return;
+
+  if (zoom >= ZOOM_THRESHOLD_IN) {
+    // treat as zoom-in intent => go right-eye path (descendants)
+    const cfg = states[state];
+    const next = cfg?.nav?.rightEye;
+    if (next) {
+      resetTransform();
+      applyState(next, { cinematic: true });
+    }
+  } else if (zoom <= ZOOM_THRESHOLD_OUT) {
+    // treat as zoom-out intent => go left-eye path (parents)
+    const cfg = states[state];
+    const next = cfg?.nav?.leftEye;
+    if (next) {
+      resetTransform();
+      applyState(next, { cinematic: true });
+    }
   }
 }
 
-function selectBranch(branch) {
-  if (EMBED_MODE) return;
+let pinchStartDist = null;
 
-  if (branch === "julian") {
-    animateZoom("zoom-in");
-    applyState("julian");
-  } else if (branch === "malik") {
-    animateZoom("zoom-in");
-    applyState("malik");
-  } else if (branch === "selah") {
-    animateZoom("zoom-in");
-    applyState("selah");
-  }
+function distance(t1, t2) {
+  const dx = t1.clientX - t2.clientX;
+  const dy = t1.clientY - t2.clientY;
+  return Math.sqrt(dx * dx + dy * dy);
 }
 
-function resetViewer() {
-  if (EMBED_MODE) return;
+// ---------------------------
+// Event wiring
+// ---------------------------
+function bindEvents() {
+  if (!stageShell) return;
 
-  if (viewerImage) viewerImage.classList.remove("zoom-in", "zoom-out");
+  // Wheel / trackpad
+  stageShell.addEventListener(
+    "wheel",
+    (e) => {
+      e.preventDefault();
+      if (transitionLock) return;
+
+      const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+      zoomBy(delta, e.clientX, e.clientY);
+    },
+    { passive: false }
+  );
+
+  // Click eye navigation
+  stageShell.addEventListener("click", (e) => {
+    if (transitionLock) return;
+    if (EMBED_MODE && WATCH_ONLY_EMBED) return;
+    // If holding C, we allow eye click; if not holding C, still allow.
+    handleEyeClick(e.clientX, e.clientY);
+  });
+
+  // Touch pinch
+  stageShell.addEventListener(
+    "touchstart",
+    (e) => {
+      if (transitionLock) return;
+      if (e.touches.length === 2) {
+        pinchStartDist = distance(e.touches[0], e.touches[1]);
+      }
+    },
+    { passive: true }
+  );
+
+  stageShell.addEventListener(
+    "touchmove",
+    (e) => {
+      if (transitionLock) return;
+      if (e.touches.length === 2 && pinchStartDist) {
+        e.preventDefault();
+        const d = distance(e.touches[0], e.touches[1]);
+        const diff = d - pinchStartDist;
+        pinchStartDist = d;
+
+        const centerX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const centerY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+
+        const delta = diff > 0 ? ZOOM_STEP * 0.6 : -ZOOM_STEP * 0.6;
+        zoomBy(delta, centerX, centerY);
+      }
+    },
+    { passive: false }
+  );
+
+  stageShell.addEventListener(
+    "touchend",
+    () => {
+      pinchStartDist = null;
+    },
+    { passive: true }
+  );
+
+  // Hold C to show eye hints (optional – uses CSS .show-eyes)
+  window.addEventListener("keydown", (e) => {
+    if (e.key.toLowerCase() === "c") {
+      showEyes = true;
+      document.body.classList.add("show-eyes");
+    }
+  });
+
+  window.addEventListener("keyup", (e) => {
+    if (e.key.toLowerCase() === "c") {
+      showEyes = false;
+      document.body.classList.remove("show-eyes");
+    }
+  });
+}
+
+// Branch buttons (only used on parents)
+window.selectBranch = function selectBranch(branch) {
+  if (EMBED_MODE && WATCH_ONLY_EMBED) return;
+  if (transitionLock) return;
+
+  if (branch === "julian") applyState("julian");
+  if (branch === "malik") applyState("malik");
+  if (branch === "selah") applyState("selah");
+};
+
+window.toggleNarration = toggleNarration;
+
+window.resetViewer = function resetViewer() {
+  if (EMBED_MODE && WATCH_ONLY_EMBED) return;
+  resetTransform();
   applyState("malik");
   if (isPlaying) startNarrationAutoAdvance();
-}
-
-// Pause/resume auto-advance when tab visibility changes (extra stability)
-document.addEventListener("visibilitychange", () => {
-  if (document.hidden) return;
-  if (isPlaying && !EMBED_MODE) startNarrationAutoAdvance();
-});
+};
 
 // Boot
 applyState("malik");
+bindEvents();
 startNarrationAutoAdvance();


### PR DESCRIPTION
	•	Make homepage preview watch-only (embed mode) so it doesn’t hijack navigation or show the Back link
	•	Stabilize the viewer stage as the interaction surface (touch-action: none) and improve rendering (will-change: transform, opacity)
	•	Reduce visual jitter during transitions and ensure the preview iframe stays clean/readable
	•	Updates across: viewer/index.html, viewer/js/script.js, viewer/css/style.css, viewer/css/viewer-preview.css