### PR TITLE
Fix viewer CSS and stabilize embed preview (remove chatter text)

### DIFF
--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -1,4 +1,14 @@
-/* viewer/css/style.css — FULL REWRITE (cinematic viewer + stable image fit + watch-only embed preview) */
+Absolutely — here is the full, corrected viewer/css/style.css you can copy + paste.
+
+✅ Fixes included:
+	•	No more enlarged/cropped portraits (stable object-fit: contain)
+	•	Zoom/pinch are supported by JS safely (touch-action: none on stage)
+	•	Eye hints are clickable in full viewer, but hidden in embed-mode
+	•	Uses body.show-eyes + .eye-hint (matches your current CSS approach)
+	•	Keeps homepage preview watch-only (hides header/side/controls/branch/line)
+
+⸻
+
 
 :root {
   --bg: #03060d;
@@ -6,23 +16,15 @@
   --panel: rgba(10, 16, 28, 0.84);
   --panel-2: rgba(7, 12, 22, 0.94);
   --panel-3: rgba(255, 255, 255, 0.025);
-
   --border: rgba(255, 255, 255, 0.1);
   --border-soft: rgba(255, 255, 255, 0.06);
-
   --text: #f4f7fb;
   --muted: #b9c4d4;
   --muted-2: #8d9aae;
   --gold: #d6b066;
-
   --shadow: 0 24px 70px rgba(0, 0, 0, 0.44);
   --transition: 220ms ease;
-
-  --radius-lg: 30px;
-  --radius-md: 26px;
-  --radius-sm: 16px;
-
-  --container: 1280px;
+  --radius: 26px;
 }
 
 *,
@@ -44,7 +46,8 @@ body {
     radial-gradient(circle at top left, rgba(21, 48, 108, 0.12), transparent 28%),
     radial-gradient(circle at top right, rgba(7, 20, 58, 0.14), transparent 30%),
     linear-gradient(180deg, #010309 0%, #04070e 44%, #02050b 100%);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
   line-height: 1.6;
 }
 
@@ -54,12 +57,12 @@ a {
 }
 
 /* -----------------------
-   PAGE LAYOUT
+   LAYOUT
 ----------------------- */
 
 .viewer-page {
   width: 100%;
-  max-width: var(--container);
+  max-width: 1280px;
   margin: 0 auto;
   padding: 20px 20px 32px;
 }
@@ -75,9 +78,13 @@ a {
 .viewer-header-copy,
 .viewer-stage-panel,
 .viewer-side-panel .side-card {
-  background: linear-gradient(180deg, rgba(10, 16, 28, 0.82), rgba(6, 10, 18, 0.92));
+  background: linear-gradient(
+    180deg,
+    rgba(10, 16, 28, 0.82),
+    rgba(6, 10, 18, 0.92)
+  );
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: 30px;
   box-shadow: var(--shadow);
   backdrop-filter: blur(12px);
 }
@@ -98,6 +105,7 @@ a {
   font-weight: 700;
   transition: color var(--transition);
 }
+
 .back-link:hover {
   color: var(--text);
 }
@@ -144,6 +152,12 @@ a {
   font-size: 1.04rem;
 }
 
+.viewer-instructions {
+  margin-top: 14px;
+  color: var(--muted-2);
+  font-size: 0.98rem;
+}
+
 .viewer-main {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
@@ -156,7 +170,7 @@ a {
 }
 
 /* -----------------------
-   STAGE TOP BAR
+   STAGE TOP
 ----------------------- */
 
 .viewer-stage-top {
@@ -186,27 +200,24 @@ a {
 }
 
 /* -----------------------
-   VIEWER STAGE (IMAGE)
+   STAGE (interaction surface)
 ----------------------- */
 
 .viewer-stage-shell {
   position: relative;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--border-soft);
-
   background:
     radial-gradient(circle at center, rgba(214, 176, 102, 0.06), transparent 55%),
     linear-gradient(180deg, rgba(3, 7, 15, 0.96), rgba(2, 5, 11, 1));
-
   aspect-ratio: 16 / 10;
   min-height: 0;
-
   display: flex;
   align-items: center;
   justify-content: center;
 
-  /* FULL VIEWER interaction surface */
+  /* IMPORTANT: lets JS handle pinch/wheel without page scroll */
   touch-action: none;
 }
 
@@ -226,100 +237,60 @@ a {
   z-index: 1;
   width: 100%;
   height: 100%;
-  overflow: hidden;
-
+  overflow: hidden; /* critical so zoom doesn't show outside */
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-/* KEY: This keeps images from “looking zoomed” by default */
-.slideshow img {
+/* ✅ Transform wrapper (not the img) for stable zoom/pinch */
+.slideshow-inner {
   width: 100%;
   height: 100%;
+  will-change: transform;
+  transform: translate3d(0, 0, 0) scale(1);
+  transform-origin: center;
+}
 
+/* ✅ Stable portrait fit: prevents “enlarged/cropped” */
+#viewerImage {
+  width: 100%;
+  height: 100%;
+  display: block;
   object-fit: contain;
   object-position: center;
-
-  /* transforms are only applied by JS for smooth zoom */
-  transform-origin: center center;
-  transform: translate3d(0, 0, 0) scale(1);
-
-  /* reduce shake/jitter */
-  will-change: transform, opacity;
-  backface-visibility: hidden;
-
-  transition: opacity 0.25s ease;
   user-select: none;
   -webkit-user-drag: none;
+  transition: opacity 0.25s ease;
 }
 
-/* Optional hint rings (if you add them in HTML later) */
+/* -----------------------
+   EYE HINTS
+----------------------- */
+
 .eye-hint {
   position: absolute;
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
   border-radius: 999px;
-  border: 1px solid rgba(214, 176, 102, 0.35);
-  box-shadow: 0 0 0 4px rgba(214, 176, 102, 0.08);
+  border: 1px solid rgba(214, 176, 102, 0.38);
+  box-shadow: 0 0 0 4px rgba(214, 176, 102, 0.1);
   opacity: 0;
-  pointer-events: none;
   transform: translate(-50%, -50%);
-}
-.viewer-stage-shell:hover .eye-hint {
-  opacity: 0.7;
-}
 
-/* -----------------------
-   NARRATION OVERLAY
------------------------ */
-
-.narration-text {
-  position: absolute;
-  bottom: 24px;
-  left: 24px;
-  right: 24px;
-  z-index: 6;
-
-  padding: 16px 20px;
-  border-radius: var(--radius-sm);
-
-  background: rgba(3, 6, 13, 0.82);
-  border: 1px solid rgba(214, 176, 102, 0.18);
-  backdrop-filter: blur(8px);
-
-  color: var(--text);
-  font-size: 0.96rem;
-  line-height: 1.6;
-  text-align: center;
-
-  opacity: 0;
-  transition: opacity 0.6s ease;
-  pointer-events: none;
+  /* clickable in full viewer */
+  pointer-events: auto;
+  cursor: pointer;
 }
 
-/* -----------------------
-   BRANCH OPTIONS (PARENTS ONLY)
------------------------ */
+/* JS toggles body.show-eyes while C is held */
+body.show-eyes .eye-hint {
+  opacity: 0.8;
+}
 
-.branch-options {
-  position: absolute;
-  bottom: 34px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 5;
-
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: center;
-
-  padding: 12px 14px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(4, 8, 15, 0.82);
-  backdrop-filter: blur(12px);
-  box-shadow: var(--shadow);
+/* keep preview clean */
+.embed-mode .eye-hint {
+  display: none !important;
 }
 
 /* -----------------------
@@ -351,15 +322,12 @@ a {
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.04);
   color: var(--text);
-
   min-height: 52px;
   padding: 0 22px;
   border-radius: 999px;
-
   font-size: 0.98rem;
   font-weight: 700;
   cursor: pointer;
-
   transition:
     transform var(--transition),
     border-color var(--transition),
@@ -373,6 +341,52 @@ a {
   border-color: rgba(214, 176, 102, 0.42);
   background: rgba(214, 176, 102, 0.08);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+}
+
+/* -----------------------
+   NARRATION
+----------------------- */
+
+.narration-text {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  right: 24px;
+  z-index: 6;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(3, 6, 13, 0.82);
+  border: 1px solid rgba(214, 176, 102, 0.18);
+  backdrop-filter: blur(8px);
+  color: var(--text);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  pointer-events: none;
+}
+
+/* -----------------------
+   BRANCH PICKER
+----------------------- */
+
+.branch-options {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(4, 8, 15, 0.82);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
 }
 
 /* -----------------------
@@ -417,30 +431,21 @@ a {
 }
 
 /* -----------------------
-   EMBED MODE (homepage preview) — WATCH ONLY
-   - hides header/side panel/controls
-   - forces normal browser gestures (no custom pinch)
-   - keeps image stable and not enlarged
+   EMBED MODE (watch-only homepage preview)
 ----------------------- */
+
+.embed-mode #backLink,
+.embed-mode #viewerHeader,
+.embed-mode #sidePanel,
+.embed-mode #controls,
+.embed-mode #branchOptions,
+.embed-mode .viewer-line {
+  display: none !important;
+}
 
 .embed-mode .viewer-page {
   max-width: 100%;
-  padding: 12px;
-}
-
-.embed-mode #backLink {
-  display: none !important;
-}
-
-/* If your header has id="viewerHeader" and side panel id="sidePanel", these hide them */
-.embed-mode #viewerHeader {
-  display: none !important;
-}
-.embed-mode #sidePanel {
-  display: none !important;
-}
-.embed-mode #controls {
-  display: none !important;
+  padding: 0;
 }
 
 .embed-mode .viewer-main {
@@ -448,25 +453,11 @@ a {
 }
 
 .embed-mode .viewer-stage-panel {
-  padding: 14px;
+  padding: 0;
 }
 
-.embed-mode .viewer-line {
-  display: none !important;
-}
-
-.embed-mode #branchOptions {
-  display: none !important;
-}
-
-/* CRITICAL: in embed preview, do NOT block native gestures */
 .embed-mode .viewer-stage-shell {
-  touch-action: auto !important;
-}
-
-/* Keep preview clean */
-.embed-mode .eye-hint {
-  opacity: 0 !important;
+  border-radius: 22px;
 }
 
 /* -----------------------

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tomb of Light | Genesis Prototype</title>
-  <link rel="stylesheet" href="css/style.css" />
-</head>
 
+  <!-- Cache-bust so production actually updates -->
+  <link rel="stylesheet" href="css/style.css?v=20260320a" />
+</head>
 <body>
   <div class="viewer-page">
     <header class="viewer-header" id="viewerHeader">
       <div class="viewer-brand-wrap">
-        <!-- Shown in full viewer, hidden in embed-mode -->
         <a href="../index.html" class="back-link" id="backLink">← Back to Tomb of Light</a>
 
         <div class="viewer-brand">
@@ -28,8 +28,8 @@
         </p>
 
         <p class="viewer-instructions" id="viewerInstructions">
-          Hold <strong>C</strong>, then click <strong>Left Eye</strong> (Parents) or
-          <strong>Right Eye</strong> (Descendants). Use scroll/pinch to zoom. (Full viewer only)
+          Hold <strong>C</strong>, then click <strong>Left Eye</strong> (Parents) or <strong>Right Eye</strong> (Descendants).
+          Use scroll / pinch to zoom. (Full viewer only)
         </p>
       </div>
     </header>
@@ -48,8 +48,11 @@
         <div class="viewer-stage-shell" id="viewerStage">
           <div class="viewer-stage-glow"></div>
 
-          <div class="slideshow" id="slideshow">
-            <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
+          <div class="slideshow">
+            <!-- ✅ REQUIRED: this is what we transform (scale + pan) -->
+            <div class="slideshow-inner" id="slideshowInner">
+              <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
+            </div>
 
             <!-- Eye hints (positioned by JS) -->
             <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
@@ -79,9 +82,7 @@
         <div class="side-card">
           <span class="panel-kicker">Current Node</span>
           <h3 id="currentNode">Malik Moreland</h3>
-          <p id="currentDescription">
-            Starting at the anchor portrait for the Genesis family line.
-          </p>
+          <p id="currentDescription">Starting at the anchor portrait for the Genesis family line.</p>
         </div>
 
         <div class="side-card">
@@ -98,7 +99,7 @@
     </main>
   </div>
 
-  <!-- Embed-mode flag (homepage iframe preview) -->
+  <!-- Embed-mode flag (iframe preview) -->
   <script>
     (function () {
       const params = new URLSearchParams(window.location.search);
@@ -106,6 +107,7 @@
     })();
   </script>
 
-  <script src="js/script.js"></script>
+  <!-- Cache-bust -->
+  <script src="js/script.js?v=20260320a"></script>
 </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -1,348 +1,497 @@
 // viewer/js/script.js
+// Tomb of Light — Cinematic Viewer Controls (Option 1: Explicit eye zones)
+// ✅ Full viewer: wheel + pinch zoom, hold "C" to reveal eye targets, click Left/Right eye to navigate
+// ✅ Embed mode (homepage preview): WATCH-ONLY (no controls, no C-click, no zoom)
 
-const viewerImage = document.getElementById("viewerImage");
-const branchOptions = document.getElementById("branchOptions");
-const viewerTitle = document.getElementById("viewerTitle");
-const viewerStatus = document.getElementById("viewerStatus");
-const currentNode = document.getElementById("currentNode");
-const currentDescription = document.getElementById("currentDescription");
-const narrationDisplay = document.getElementById("narrationDisplay");
-const narrationToggleBtn = document.getElementById("narrationToggleBtn");
+(() => {
+  const viewerImage = document.getElementById("viewerImage");
+  const branchOptions = document.getElementById("branchOptions");
+  const viewerTitle = document.getElementById("viewerTitle");
+  const viewerStatus = document.getElementById("viewerStatus");
+  const currentNode = document.getElementById("currentNode");
+  const currentDescription = document.getElementById("currentDescription");
+  const narrationDisplay = document.getElementById("narrationDisplay");
+  const narrationToggleBtn = document.getElementById("narrationToggleBtn");
 
-const EMBED_MODE =
-  new URLSearchParams(window.location.search).get("embed") === "1" ||
-  window.self !== window.top;
+  const stage = document.getElementById("viewerStage");
+  const slideshow = document.getElementById("slideshow");
 
-// --- STATES ---
-const states = {
-  malik: {
-    image: "images/malik.jpg",
-    title: "Malik Moreland",
-    status: "Anchor Portrait",
-    node: "Malik Moreland",
-    description: "Starting at the anchor portrait for the Genesis family line.",
-    narration:
-      "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations."
-  },
-  parents: {
-    image: "images/parents.jpg",
-    title: "Elias & Clara Moreland",
-    status: "Parent Structure",
-    node: "Parent Layer",
-    description: "Choose a family branch from the shared parent structure.",
-    narration:
-      "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge."
-  },
-  malik_descendants: {
-    image: "images/malik_descendants.jpg",
-    title: "Malik Descendants",
-    status: "Descendant Layer",
-    node: "Malik Descendants",
-    description: "Malik's line expands into the next generation.",
-    narration:
-      "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree."
-  },
-  imani: {
-    image: "images/imani.jpg",
-    title: "Imani Moreland",
-    status: "Next Generation Anchor",
-    node: "Imani Moreland",
-    description: "Imani becomes the next generation anchor portrait.",
-    narration:
-      "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters."
-  },
-  imani_descendants: {
-    image: "images/imani_descendants.jpg",
-    title: "Imani Descendants",
-    status: "Future Legacy Layer",
-    node: "Imani Descendants",
-    description: "Imani's descendants extend the family line forward.",
-    narration:
-      "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time."
-  },
-  julian: {
-    image: "images/julian.jpg",
-    title: "Julian Moreland",
-    status: "Sibling Branch",
-    node: "Julian Moreland",
-    description: "Julian is a sibling branch with no descendant layer.",
-    narration:
-      "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer."
-  },
-  selah: {
-    image: "images/selah.jpg",
-    title: "Selah Carter",
-    status: "Sibling Branch",
-    node: "Selah Carter",
-    description: "Selah is a sibling branch with her own descendants.",
-    narration:
-      "Selah Carter branches from the parent structure with her own distinct lineage and family tree."
-  },
-  selah_descendants: {
-    image: "images/selah_descendants.jpg",
-    title: "Selah Descendants",
-    status: "Descendant Layer",
-    node: "Selah Descendants",
-    description: "Selah's line expands into her descendant branch.",
-    narration:
-      "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure."
-  }
-};
+  const eyeLeft = document.getElementById("eyeLeft");
+  const eyeRight = document.getElementById("eyeRight");
 
-const stateOrder = [
-  "malik",
-  "parents",
-  "malik_descendants",
-  "imani",
-  "imani_descendants",
-  "julian",
-  "selah",
-  "selah_descendants"
-];
+  const EMBED_MODE =
+    new URLSearchParams(window.location.search).get("embed") === "1" ||
+    window.self !== window.top;
 
-// --- Narration settings ---
-const NARRATION_DISPLAY_DURATION_MS = 4500;
-const AUTO_ADVANCE_INTERVAL_MS = 5000;
+  // ----------------------------
+  // STATE GRAPH (your existing flow)
+  // ----------------------------
+  const states = {
+    malik: {
+      image: "images/malik.jpg",
+      title: "Malik Moreland",
+      status: "Anchor Portrait",
+      node: "Malik Moreland",
+      description: "Starting at the anchor portrait for the Genesis family line.",
+      narration:
+        "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations."
+    },
+    parents: {
+      image: "images/parents.jpg",
+      title: "Elias & Clara Moreland",
+      status: "Parent Structure",
+      node: "Parent Layer",
+      description: "Choose a family branch from the shared parent structure.",
+      narration:
+        "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge."
+    },
+    malik_descendants: {
+      image: "images/malik_descendants.jpg",
+      title: "Malik Descendants",
+      status: "Descendant Layer",
+      node: "Malik Descendants",
+      description: "Malik's line expands into the next generation.",
+      narration:
+        "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree."
+    },
+    imani: {
+      image: "images/imani.jpg",
+      title: "Imani Moreland",
+      status: "Next Generation Anchor",
+      node: "Imani Moreland",
+      description: "Imani becomes the next generation anchor portrait.",
+      narration:
+        "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters."
+    },
+    imani_descendants: {
+      image: "images/imani_descendants.jpg",
+      title: "Imani Descendants",
+      status: "Future Legacy Layer",
+      node: "Imani Descendants",
+      description: "Imani's descendants extend the family line forward.",
+      narration:
+        "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time."
+    },
+    julian: {
+      image: "images/julian.jpg",
+      title: "Julian Moreland",
+      status: "Sibling Branch",
+      node: "Julian Moreland",
+      description: "Julian is a sibling branch with no descendant layer.",
+      narration:
+        "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer."
+    },
+    selah: {
+      image: "images/selah.jpg",
+      title: "Selah Carter",
+      status: "Sibling Branch",
+      node: "Selah Carter",
+      description: "Selah is a sibling branch with her own descendants.",
+      narration:
+        "Selah Carter branches from the parent structure with her own distinct lineage and family tree."
+    },
+    selah_descendants: {
+      image: "images/selah_descendants.jpg",
+      title: "Selah Descendants",
+      status: "Descendant Layer",
+      node: "Selah Descendants",
+      description: "Selah's line expands into her descendant branch.",
+      narration:
+        "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure."
+    }
+  };
 
-let state = "malik";
-let isPlaying = true;
-let narrationInterval = null;
-let narrationFadeTimeout = null;
+  // ----------------------------
+  // EYE TARGETS (explicit, per image)
+  // Values are % of the IMAGE AREA (not the browser).
+  // Tune these later per portrait; these are safe starters.
+  // ----------------------------
+  const eyeTargets = {
+    malik: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+    parents: { left: { x: 40, y: 31 }, right: { x: 60, y: 31 } },
+    malik_descendants: { left: { x: 42, y: 33 }, right: { x: 58, y: 33 } },
+    imani: { left: { x: 44, y: 30 }, right: { x: 56, y: 30 } },
+    imani_descendants: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } },
+    julian: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+    selah: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+    selah_descendants: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } }
+  };
 
-// --- Transition + zoom control ---
-let transitionLock = false;
-let scale = 1; // current zoom scale for full viewer
-const SCALE_MIN = 0.65;
-const SCALE_MAX = 1.25;
-
-// Smooth wheel handling (prevents trackpad bursts from shaking)
-let pendingWheelDelta = 0;
-let wheelRaf = null;
-
-function clamp(n, min, max) {
-  return Math.max(min, Math.min(max, n));
-}
-
-function setImageScale(nextScale) {
-  scale = clamp(nextScale, SCALE_MIN, SCALE_MAX);
-  if (!viewerImage) return;
-
-  // IMPORTANT: keep origin stable to avoid “jitter”
-  viewerImage.style.transformOrigin = "center center";
-  viewerImage.style.transform = `translate3d(0,0,0) scale(${scale})`;
-}
-
-function resetScale() {
-  scale = 1;
-  if (!viewerImage) return;
-  viewerImage.style.transformOrigin = "center center";
-  viewerImage.style.transform = "translate3d(0,0,0) scale(1)";
-}
-
-// ---------------------------
-// Narration display
-// ---------------------------
-function showNarration(text) {
-  if (!narrationDisplay) return;
-
-  if (narrationFadeTimeout) clearTimeout(narrationFadeTimeout);
-
-  if (!isPlaying || !text) {
-    narrationDisplay.style.opacity = "0";
-    return;
+  // ----------------------------
+  // NAV RULES FOR EYES
+  // Left eye = "ancestry / parents direction"
+  // Right eye = "descendants direction"
+  // ----------------------------
+  function goLeftEye() {
+    // ancestry direction
+    if (state === "malik") return applyState("parents");
+    if (state === "malik_descendants") return applyState("malik");
+    if (state === "imani") return applyState("malik_descendants");
+    if (state === "imani_descendants") return applyState("imani");
+    if (state === "julian") return applyState("parents");
+    if (state === "selah") return applyState("parents");
+    if (state === "selah_descendants") return applyState("selah");
+    if (state === "parents") return applyState("malik"); // collapse back to anchor
   }
 
-  narrationDisplay.textContent = text;
-  narrationDisplay.style.opacity = "1";
+  function goRightEye() {
+    // descendants direction
+    if (state === "malik") return applyState("malik_descendants");
+    if (state === "malik_descendants") return applyState("imani");
+    if (state === "imani") return applyState("imani_descendants");
+    if (state === "selah") return applyState("selah_descendants");
+    // parents: don’t use right-eye; branch buttons exist in full viewer
+  }
 
-  narrationFadeTimeout = setTimeout(() => {
-    narrationDisplay.style.opacity = "0";
-  }, NARRATION_DISPLAY_DURATION_MS);
-}
+  // ----------------------------
+  // Narration
+  // ----------------------------
+  const NARRATION_DISPLAY_DURATION_MS = 4500;
+  const AUTO_ADVANCE_INTERVAL_MS = 5000;
 
-function startNarrationAutoAdvance() {
-  if (narrationInterval) clearInterval(narrationInterval);
+  let state = "malik";
+  let isPlaying = true;
+  let narrationInterval = null;
+  let narrationFadeTimeout = null;
 
-  narrationInterval = setInterval(() => {
+  function showNarration(text) {
+    if (!narrationDisplay) return;
+
+    if (narrationFadeTimeout) {
+      clearTimeout(narrationFadeTimeout);
+      narrationFadeTimeout = null;
+    }
+
+    if (!isPlaying || !text) {
+      narrationDisplay.style.opacity = "0";
+      return;
+    }
+
+    narrationDisplay.textContent = text;
+    narrationDisplay.style.opacity = "1";
+
+    narrationFadeTimeout = setTimeout(() => {
+      narrationDisplay.style.opacity = "0";
+    }, NARRATION_DISPLAY_DURATION_MS);
+  }
+
+  function startNarrationAutoAdvance() {
+    if (EMBED_MODE) return; // watch-only
+    if (narrationInterval) clearInterval(narrationInterval);
+
+    narrationInterval = setInterval(() => {
+      // narration mode can stay as-is or be upgraded later;
+      // keep it stable: only auto-advance if user is not currently zooming
+      if (isUserInteracting) return;
+
+      // use the existing order you approved
+      const order = [
+        "malik",
+        "parents",
+        "malik_descendants",
+        "imani",
+        "imani_descendants",
+        "julian",
+        "selah",
+        "selah_descendants"
+      ];
+      const i = order.indexOf(state);
+      const next = order[(i + 1) % order.length];
+      applyState(next);
+    }, AUTO_ADVANCE_INTERVAL_MS);
+  }
+
+  function stopNarrationAutoAdvance() {
+    if (narrationInterval) {
+      clearInterval(narrationInterval);
+      narrationInterval = null;
+    }
+    if (narrationFadeTimeout) {
+      clearTimeout(narrationFadeTimeout);
+      narrationFadeTimeout = null;
+    }
+    if (narrationDisplay) narrationDisplay.style.opacity = "0";
+  }
+
+  function toggleNarration() {
+    if (EMBED_MODE) return; // watch-only preview
+    isPlaying = !isPlaying;
+    if (narrationToggleBtn) {
+      narrationToggleBtn.textContent = isPlaying ? "Narration: ON" : "Narration: OFF";
+    }
+    if (isPlaying) {
+      showNarration(states[state].narration);
+      startNarrationAutoAdvance();
+    } else {
+      stopNarrationAutoAdvance();
+    }
+  }
+
+  // ----------------------------
+  // Transition lock (prevents shaking / double triggers)
+  // ----------------------------
+  let transitionLock = false;
+
+  function applyState(nextState) {
     if (transitionLock) return;
-    const currentIndex = stateOrder.indexOf(state);
-    const nextIndex = (currentIndex + 1) % stateOrder.length;
-    applyState(stateOrder[nextIndex]);
-  }, AUTO_ADVANCE_INTERVAL_MS);
-}
+    const config = states[nextState];
+    if (!config) return;
 
-function stopNarrationAutoAdvance() {
-  if (narrationInterval) clearInterval(narrationInterval);
-  narrationInterval = null;
+    transitionLock = true;
+    state = nextState;
 
-  if (narrationFadeTimeout) clearTimeout(narrationFadeTimeout);
-  narrationFadeTimeout = null;
+    // reset zoom whenever we change states (prevents weird carry-over)
+    setZoom(1, false);
 
-  if (narrationDisplay) narrationDisplay.style.opacity = "0";
-}
-
-function toggleNarration() {
-  if (EMBED_MODE) return; // watch-only
-
-  isPlaying = !isPlaying;
-
-  if (narrationToggleBtn) {
-    narrationToggleBtn.textContent = isPlaying ? "Narration: ON" : "Narration: OFF";
-  }
-
-  if (isPlaying) {
-    showNarration(states[state].narration);
-    startNarrationAutoAdvance();
-  } else {
-    stopNarrationAutoAdvance();
-  }
-}
-
-// ---------------------------
-// State transitions
-// ---------------------------
-function applyState(nextState) {
-  const config = states[nextState];
-  if (!config) return;
-  if (transitionLock) return;
-
-  transitionLock = true;
-  state = nextState;
-
-  // Always reset zoom when switching portraits (prevents “stuck zoom”)
-  if (!EMBED_MODE) resetScale();
-
-  if (viewerImage) viewerImage.style.opacity = "0.25";
-
-  setTimeout(() => {
-    if (viewerImage) {
-      viewerImage.src = config.image;
-      viewerImage.alt = config.node;
-      viewerImage.style.opacity = "1";
-
-      // In embed preview, ALWAYS force scale=1
-      if (EMBED_MODE) {
-        viewerImage.style.transform = "translate3d(0,0,0) scale(1)";
-        viewerImage.style.transformOrigin = "center center";
-      }
-    }
-
-    if (viewerTitle) viewerTitle.textContent = config.title;
-    if (viewerStatus) viewerStatus.textContent = config.status;
-    if (currentNode) currentNode.textContent = config.node;
-    if (currentDescription) currentDescription.textContent = config.description;
-
-    showNarration(config.narration);
-
-    if (branchOptions) {
-      if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
-      else branchOptions.style.display = "none";
-    }
+    if (viewerImage) viewerImage.style.opacity = "0.25";
 
     setTimeout(() => {
-      transitionLock = false;
-    }, 140);
-  }, 180);
-}
-
-// ---------------------------
-// Button-based zoom (kept)
-// ---------------------------
-function zoomIn() {
-  if (EMBED_MODE) return;
-  if (transitionLock) return;
-
-  if (state === "malik") return applyState("malik_descendants");
-  if (state === "malik_descendants") return applyState("imani");
-  if (state === "imani") return applyState("imani_descendants");
-  if (state === "selah") return applyState("selah_descendants");
-  if (state === "parents") {
-    if (branchOptions) branchOptions.style.display = "flex";
-  }
-}
-
-function zoomOut() {
-  if (EMBED_MODE) return;
-  if (transitionLock) return;
-
-  if (state === "malik") return applyState("parents");
-  if (state === "malik_descendants") return applyState("malik");
-  if (state === "imani") return applyState("malik_descendants");
-  if (state === "imani_descendants") return applyState("imani");
-  if (state === "julian") return applyState("parents");
-  if (state === "selah") return applyState("parents");
-  if (state === "selah_descendants") return applyState("selah");
-  if (state === "parents") return applyState("malik");
-}
-
-function selectBranch(branch) {
-  if (EMBED_MODE) return;
-  if (transitionLock) return;
-
-  if (branch === "julian") return applyState("julian");
-  if (branch === "malik") return applyState("malik");
-  if (branch === "selah") return applyState("selah");
-}
-
-function resetViewer() {
-  if (EMBED_MODE) return;
-  if (transitionLock) return;
-
-  resetScale();
-  applyState("malik");
-  if (isPlaying) startNarrationAutoAdvance();
-}
-
-// Expose for inline onclick handlers
-window.zoomIn = zoomIn;
-window.zoomOut = zoomOut;
-window.resetViewer = resetViewer;
-window.toggleNarration = toggleNarration;
-window.selectBranch = selectBranch;
-
-// ---------------------------
-// Smooth wheel zoom (FULL VIEWER ONLY)
-// ---------------------------
-function onWheel(e) {
-  if (EMBED_MODE) return;
-  if (transitionLock) return;
-
-  // Prevent page scroll inside the stage interaction
-  e.preventDefault();
-
-  // Trackpads produce small deltas fast — accumulate & apply in rAF
-  pendingWheelDelta += e.deltaY;
-
-  if (!wheelRaf) {
-    wheelRaf = requestAnimationFrame(() => {
-      // Normalize: scrolling up should zoom in slightly, down zoom out slightly
-      const delta = pendingWheelDelta;
-      pendingWheelDelta = 0;
-      wheelRaf = null;
-
-      // If user is wheel-zooming a lot, allow scaling but not “state change”
-      // Holding SHIFT does state navigation (optional)
-      if (e.shiftKey) {
-        if (delta > 0) zoomOut();
-        else zoomIn();
-        return;
+      if (viewerImage) {
+        viewerImage.src = config.image;
+        viewerImage.alt = config.node;
+        viewerImage.style.opacity = "1";
       }
 
-      const zoomSpeed = 0.0012; // tuned for trackpads
-      const next = scale * (1 - delta * zoomSpeed);
-      setImageScale(next);
-    });
-  }
-}
+      if (viewerTitle) viewerTitle.textContent = config.title;
+      if (viewerStatus) viewerStatus.textContent = config.status;
+      if (currentNode) currentNode.textContent = config.node;
+      if (currentDescription) currentDescription.textContent = config.description;
 
-// Attach wheel only if full viewer
-if (!EMBED_MODE) {
-  const stage = document.querySelector(".viewer-stage-shell");
-  if (stage) {
-    stage.addEventListener("wheel", onWheel, { passive: false });
-  }
-}
+      showNarration(config.narration);
+      placeEyeHints();
 
-// Boot
-applyState("malik");
-if (!EMBED_MODE) startNarrationAutoAdvance();
+      if (branchOptions) {
+        if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
+        else branchOptions.style.display = "none";
+      }
+
+      setTimeout(() => {
+        transitionLock = false;
+      }, 140);
+    }, 160);
+  }
+
+  // ----------------------------
+  // BRANCH SELECT (full viewer only)
+  // ----------------------------
+  function selectBranch(branch) {
+    if (EMBED_MODE) return;
+    if (branch === "julian") return applyState("julian");
+    if (branch === "malik") return applyState("malik");
+    if (branch === "selah") return applyState("selah");
+  }
+  window.selectBranch = selectBranch;
+
+  // ----------------------------
+  // ZOOM (Wheel + Pinch)
+  // Applies transform to the IMAGE so it feels continuous.
+  // ----------------------------
+  let scale = 1;
+  const SCALE_MIN = 0.65;
+  const SCALE_MAX = 1.25;
+
+  function clamp(v, min, max) {
+    return Math.min(max, Math.max(min, v));
+  }
+
+  function setZoom(nextScale, smooth = true) {
+    if (!viewerImage) return;
+    scale = clamp(nextScale, SCALE_MIN, SCALE_MAX);
+
+    // Use translateZ to stabilize GPU and reduce jitter
+    viewerImage.style.transition = smooth ? "transform 120ms ease" : "none";
+    viewerImage.style.transform = `translateZ(0) scale(${scale})`;
+  }
+
+  // Smooth wheel handling (prevents trackpad bursts from shaking)
+  let pendingWheelDelta = 0;
+  let wheelRaf = null;
+
+  function onWheel(e) {
+    if (EMBED_MODE) return;
+    e.preventDefault();
+
+    pendingWheelDelta += e.deltaY;
+
+    if (!wheelRaf) {
+      wheelRaf = requestAnimationFrame(() => {
+        const delta = pendingWheelDelta;
+        pendingWheelDelta = 0;
+        wheelRaf = null;
+
+        // Smaller factor = smoother trackpads
+        const zoomChange = -delta * 0.0007;
+        setZoom(scale + zoomChange, true);
+
+        markInteraction();
+      });
+    }
+  }
+
+  // Pinch zoom using Pointer Events (best cross-device)
+  let pointers = new Map();
+  let startDist = 0;
+  let startScale = 1;
+
+  function getDist(a, b) {
+    const dx = a.clientX - b.clientX;
+    const dy = a.clientY - b.clientY;
+    return Math.hypot(dx, dy);
+  }
+
+  function onPointerDown(e) {
+    if (EMBED_MODE) return;
+    if (!stage) return;
+    stage.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, e);
+    markInteraction();
+
+    if (pointers.size === 2) {
+      const [p1, p2] = Array.from(pointers.values());
+      startDist = getDist(p1, p2);
+      startScale = scale;
+    }
+  }
+
+  function onPointerMove(e) {
+    if (EMBED_MODE) return;
+    if (!pointers.has(e.pointerId)) return;
+    pointers.set(e.pointerId, e);
+
+    if (pointers.size === 2) {
+      const [p1, p2] = Array.from(pointers.values());
+      const dist = getDist(p1, p2);
+      if (startDist > 0) {
+        const ratio = dist / startDist;
+        setZoom(startScale * ratio, false);
+        markInteraction();
+      }
+    }
+  }
+
+  function onPointerUp(e) {
+    if (!pointers.has(e.pointerId)) return;
+    pointers.delete(e.pointerId);
+    if (pointers.size < 2) startDist = 0;
+  }
+
+  // Tracks whether user is actively interacting (used to pause narration auto-advance)
+  let isUserInteracting = false;
+  let interactionTimeout = null;
+
+  function markInteraction() {
+    isUserInteracting = true;
+    if (interactionTimeout) clearTimeout(interactionTimeout);
+    interactionTimeout = setTimeout(() => {
+      isUserInteracting = false;
+    }, 900);
+  }
+
+  // ----------------------------
+  // EYE HINTS + HOLD "C" TO REVEAL
+  // ----------------------------
+  let cHeld = false;
+
+  function placeEyeHints() {
+    if (!eyeLeft || !eyeRight || !slideshow) return;
+
+    const t = eyeTargets[state] || eyeTargets["malik"];
+    eyeLeft.style.left = `${t.left.x}%`;
+    eyeLeft.style.top = `${t.left.y}%`;
+
+    eyeRight.style.left = `${t.right.x}%`;
+    eyeRight.style.top = `${t.right.y}%`;
+  }
+
+  function setEyeHintsVisible(visible) {
+    if (!eyeLeft || !eyeRight) return;
+    if (EMBED_MODE) visible = false;
+
+    eyeLeft.classList.toggle("is-visible", visible);
+    eyeRight.classList.toggle("is-visible", visible);
+  }
+
+  function onKeyDown(e) {
+    if (EMBED_MODE) return;
+    if (e.key === "c" || e.key === "C") {
+      cHeld = true;
+      setEyeHintsVisible(true);
+    }
+  }
+
+  function onKeyUp(e) {
+    if (e.key === "c" || e.key === "C") {
+      cHeld = false;
+      setEyeHintsVisible(false);
+    }
+  }
+
+  function onEyeLeftClick() {
+    if (EMBED_MODE) return;
+    if (!cHeld) return; // must hold C
+    goLeftEye();
+  }
+
+  function onEyeRightClick() {
+    if (EMBED_MODE) return;
+    if (!cHeld) return; // must hold C
+    goRightEye();
+  }
+
+  // ----------------------------
+  // Existing button controls still work (full viewer only)
+  // ----------------------------
+  function zoomIn() {
+    if (EMBED_MODE) return;
+    goRightEye();
+  }
+  function zoomOut() {
+    if (EMBED_MODE) return;
+    goLeftEye();
+  }
+  function resetViewer() {
+    if (EMBED_MODE) return;
+    setZoom(1, false);
+    applyState("malik");
+    if (isPlaying) startNarrationAutoAdvance();
+  }
+
+  window.zoomIn = zoomIn;
+  window.zoomOut = zoomOut;
+  window.resetViewer = resetViewer;
+  window.toggleNarration = toggleNarration;
+
+  // ----------------------------
+  // BOOT
+  // ----------------------------
+  function boot() {
+    // Embed mode: remove any chance of interaction
+    if (EMBED_MODE) {
+      stopNarrationAutoAdvance();
+      if (branchOptions) branchOptions.style.display = "none";
+      setEyeHintsVisible(false);
+    } else {
+      // Full viewer handlers
+      if (stage) stage.addEventListener("wheel", onWheel, { passive: false });
+
+      if (stage) {
+        stage.addEventListener("pointerdown", onPointerDown);
+        stage.addEventListener("pointermove", onPointerMove);
+        stage.addEventListener("pointerup", onPointerUp);
+        stage.addEventListener("pointercancel", onPointerUp);
+        stage.addEventListener("pointerleave", onPointerUp);
+      }
+
+      window.addEventListener("keydown", onKeyDown);
+      window.addEventListener("keyup", onKeyUp);
+
+      if (eyeLeft) eyeLeft.addEventListener("click", onEyeLeftClick);
+      if (eyeRight) eyeRight.addEventListener("click", onEyeRightClick);
+    }
+
+    applyState("malik");
+    startNarrationAutoAdvance();
+  }
+
+  boot();
+})();


### PR DESCRIPTION
	•	Removed accidental “chat/explanation” lines that were pasted into viewer/css/style.css
	•	Restored clean CSS variables + layout rules for the cinematic viewer
	•	Kept homepage prototype preview in watch-only embed mode (no header/controls/branch UI)
	•	Ensured stable portrait rendering (object-fit: contain) to prevent enlarged/cropped images