### PR TITLE
Add paid-access gating, auth-aware homepage CTAs, and payment-link su…

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,10 @@
       : DEFAULT_LIVE_API_BASE_URL;
   }
 
+  function getPaymentLinks() {
+    return (window.TOL_CONFIG && window.TOL_CONFIG.PAYMENT_LINKS) || {};
+  }
+
   function saveToken(token) {
     if (typeof token === "string" && token.trim()) {
       localStorage.setItem(TOKEN_KEY, token);
@@ -308,16 +312,51 @@
     });
   }
 
+  function applyPaymentLinks() {
+    const paymentLinks = getPaymentLinks();
+
+    document.querySelectorAll("[data-payment-link]").forEach(function (link) {
+      const slug = link.dataset.paymentLink;
+      const resolved = paymentLinks[slug];
+
+      if (resolved) {
+        link.href = resolved;
+      }
+    });
+  }
+
+  async function syncPublicAuthCtas() {
+    const ctas = document.querySelectorAll("[data-auth-cta]");
+    if (!ctas.length) return;
+
+    const token = getToken();
+    if (!token) return;
+
+    try {
+      await fetchCurrentUser();
+
+      ctas.forEach(function (cta) {
+        cta.textContent = cta.dataset.loggedInLabel || "Dashboard";
+        cta.setAttribute("href", cta.dataset.loggedInHref || "dashboard.html");
+      });
+    } catch (error) {
+      clearSession();
+    }
+  }
+
   document.addEventListener("DOMContentLoaded", function () {
     setupMobileMenu();
     markActiveNavLink();
     updateCookieStatus();
     setupCookieBanner();
+    applyPaymentLinks();
+    syncPublicAuthCtas();
   });
 
   const sharedApi = {
     isLocalApp,
     getApiBaseUrl,
+    getPaymentLinks,
     saveToken,
     getToken,
     clearToken,

--- a/auth.js
+++ b/auth.js
@@ -18,6 +18,77 @@
     );
   }
 
+  function toArray(payload) {
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload?.items)) return payload.items;
+    if (Array.isArray(payload?.orders)) return payload.orders;
+    if (Array.isArray(payload?.data)) return payload.data;
+    if (Array.isArray(payload?.submissions)) return payload.submissions;
+    return [];
+  }
+
+  function getPaidOrder(orders) {
+    return (
+      orders.find(function (order) {
+        const status = String(order?.status || "").toLowerCase();
+        return (
+          status === "paid" || status === "complete" || status === "succeeded"
+        );
+      }) || null
+    );
+  }
+
+  function formatDate(value) {
+    if (!value) return "—";
+
+    try {
+      return new Date(value).toLocaleString();
+    } catch (error) {
+      return String(value);
+    }
+  }
+
+  function setLinkEnabled(element, enabled) {
+    if (!element) return;
+
+    if (!element.dataset.originalHref && element.getAttribute("href")) {
+      element.dataset.originalHref = element.getAttribute("href");
+    }
+
+    if (enabled) {
+      element.style.pointerEvents = "";
+      element.style.opacity = "";
+      element.removeAttribute("aria-disabled");
+
+      if (element.dataset.originalHref) {
+        element.setAttribute("href", element.dataset.originalHref);
+      }
+    } else {
+      element.style.pointerEvents = "none";
+      element.style.opacity = "0.45";
+      element.setAttribute("aria-disabled", "true");
+    }
+  }
+
+  function setButtonEnabled(element, enabled) {
+    if (!element) return;
+
+    element.disabled = !enabled;
+    element.style.opacity = enabled ? "" : "0.45";
+    element.style.pointerEvents = enabled ? "" : "none";
+    element.setAttribute("aria-disabled", enabled ? "false" : "true");
+  }
+
+  function setActionEnabled(element, enabled) {
+    if (!element) return;
+
+    if (element.tagName === "A") {
+      setLinkEnabled(element, enabled);
+    } else {
+      setButtonEnabled(element, enabled);
+    }
+  }
+
   async function handleLogin(email, password) {
     const loginData = await app.apiRequest("/auth/login", {
       method: "POST",
@@ -45,20 +116,231 @@
   function populateUserFields(user, refs) {
     if (!user || !refs) return;
 
-    if (refs.userName) {
-      refs.userName.textContent = user.full_name || "User";
-    }
+    if (refs.userName) refs.userName.textContent = user.full_name || "User";
+    if (refs.userEmail) refs.userEmail.textContent = user.email || "";
+    if (refs.userRole) refs.userRole.textContent = user.role || "user";
+  }
 
-    if (refs.userEmail) {
-      refs.userEmail.textContent = user.email || "";
-    }
+  async function fetchOrders() {
+    const payload = await app.apiRequest("/orders/my-orders", {
+      method: "GET",
+    });
+    return toArray(payload);
+  }
 
-    if (refs.userRole) {
-      refs.userRole.textContent = user.role || "user";
+  async function fetchLatestIntake() {
+    try {
+      return await app.apiRequest("/intake-submissions/my-latest", {
+        method: "GET",
+      });
+    } catch (error) {
+      if ((error.message || "").includes("404")) return null;
+      throw error;
     }
   }
 
-  function setupSignupForm() {
+  async function fetchIntakeHistory() {
+    try {
+      const payload = await app.apiRequest(
+        "/intake-submissions/my-list?limit=10",
+        {
+          method: "GET",
+        },
+      );
+      return toArray(payload);
+    } catch (error) {
+      if ((error.message || "").includes("404")) return [];
+      throw error;
+    }
+  }
+
+  function renderOrders(orders) {
+    const statusNode = document.querySelector("[data-orders-status]");
+    const listNode = document.querySelector("[data-orders-list]");
+    if (!statusNode || !listNode) return;
+
+    listNode.innerHTML = "";
+
+    if (!orders.length) {
+      statusNode.textContent = "No purchases have been recorded yet.";
+      return;
+    }
+
+    statusNode.textContent = "Your recorded purchases are listed below.";
+
+    orders.forEach(function (order, index) {
+      const card = document.createElement("div");
+      card.className = "feature-card feature-card-clean";
+      card.innerHTML = `
+        <div class="card-number">${index + 1}</div>
+        <h3>${order.package_name || order.package_slug || "Package"}</h3>
+        <p class="card-copy">Status: ${order.status || "unknown"}</p>
+        <p class="card-copy">Price: ${order.price_label || "—"}</p>
+        <p class="card-copy">Created: ${formatDate(order.created_at)}</p>
+      `;
+      listNode.appendChild(card);
+    });
+  }
+
+  function updateAccessState(paidOrder) {
+    const accessStatus = document.querySelector("[data-access-status]");
+    const paidActions = document.querySelectorAll("[data-paid-action]");
+    const intakeOpenAction = document.querySelector(
+      "[data-intake-open-action]",
+    );
+    const upgradeAction = document.querySelector("[data-upgrade-action]");
+
+    const hasPaidOrder = !!paidOrder;
+
+    paidActions.forEach(function (element) {
+      setActionEnabled(element, hasPaidOrder);
+    });
+
+    if (intakeOpenAction) {
+      setActionEnabled(intakeOpenAction, hasPaidOrder);
+      intakeOpenAction.style.display = hasPaidOrder ? "" : "none";
+    }
+
+    if (upgradeAction) {
+      upgradeAction.style.display = hasPaidOrder ? "none" : "";
+    }
+
+    if (!accessStatus) return;
+
+    if (hasPaidOrder) {
+      accessStatus.textContent = `Access unlocked through ${paidOrder.package_name || paidOrder.package_slug || "your paid package"}.`;
+    } else {
+      accessStatus.textContent =
+        "Purchase required. Buy a Tomb of Light package to unlock platform tools.";
+    }
+  }
+
+  function renderNoIntakeBecauseNoPurchase() {
+    const intakeStatus = document.querySelector("[data-intake-card-status]");
+    const currentPackage = document.querySelector(
+      "[data-intake-current-package]",
+    );
+    const submissionStatus = document.querySelector(
+      "[data-intake-status-badge]",
+    );
+    const submissionId = document.querySelector("[data-intake-submission-id]");
+    const submittedAt = document.querySelector("[data-intake-submitted-at]");
+    const nextStep = document.querySelector("[data-intake-next-step]");
+    const lockNote = document.querySelector("[data-intake-lock-note]");
+    const intakeHistoryStatus = document.querySelector(
+      "[data-intake-history-status]",
+    );
+    const intakeHistoryList = document.querySelector(
+      "[data-intake-history-list]",
+    );
+
+    if (intakeStatus)
+      intakeStatus.textContent = "Purchase required before intake opens.";
+    if (currentPackage) currentPackage.textContent = "No package detected";
+    if (submissionStatus) submissionStatus.textContent = "Not submitted";
+    if (submissionId) submissionId.textContent = "—";
+    if (submittedAt) submittedAt.textContent = "—";
+    if (nextStep)
+      nextStep.textContent = "Purchase a package first to unlock intake.";
+    if (lockNote)
+      lockNote.textContent = "Intake is locked until a paid order exists.";
+    if (intakeHistoryStatus)
+      intakeHistoryStatus.textContent = "No intake submissions found yet.";
+    if (intakeHistoryList) intakeHistoryList.innerHTML = "";
+  }
+
+  function renderIntake(latest, history, paidOrder) {
+    const intakeStatus = document.querySelector("[data-intake-card-status]");
+    const currentPackage = document.querySelector(
+      "[data-intake-current-package]",
+    );
+    const submissionStatus = document.querySelector(
+      "[data-intake-status-badge]",
+    );
+    const submissionId = document.querySelector("[data-intake-submission-id]");
+    const submittedAt = document.querySelector("[data-intake-submitted-at]");
+    const nextStep = document.querySelector("[data-intake-next-step]");
+    const lockNote = document.querySelector("[data-intake-lock-note]");
+    const intakeHistoryStatus = document.querySelector(
+      "[data-intake-history-status]",
+    );
+    const intakeHistoryList = document.querySelector(
+      "[data-intake-history-list]",
+    );
+
+    if (!latest) {
+      if (intakeStatus)
+        intakeStatus.textContent = "No intake submission found yet.";
+      if (currentPackage)
+        currentPackage.textContent =
+          paidOrder?.package_name || "Paid package detected";
+      if (submissionStatus) submissionStatus.textContent = "Not submitted";
+      if (submissionId) submissionId.textContent = "—";
+      if (submittedAt) submittedAt.textContent = "—";
+      if (nextStep)
+        nextStep.textContent =
+          "Open your intake flow and submit the review step.";
+      if (lockNote)
+        lockNote.textContent =
+          "Editing is open because no final submission exists yet.";
+    } else {
+      const latestStatus =
+        latest.status || latest.submission_status || "submitted";
+      const locked =
+        String(latestStatus).toLowerCase() === "submitted" ||
+        String(latestStatus).toLowerCase() === "final";
+
+      if (intakeStatus)
+        intakeStatus.textContent =
+          "Your most recent intake submission is shown below.";
+      if (currentPackage)
+        currentPackage.textContent =
+          latest.package_name ||
+          paidOrder?.package_name ||
+          "Paid package detected";
+      if (submissionStatus) submissionStatus.textContent = latestStatus;
+      if (submissionId)
+        submissionId.textContent = latest.id || latest._id || "—";
+      if (submittedAt)
+        submittedAt.textContent = formatDate(
+          latest.submitted_at || latest.created_at,
+        );
+      if (nextStep)
+        nextStep.textContent = locked
+          ? "Your submission is on file for review."
+          : "Continue and finalize your intake.";
+      if (lockNote)
+        lockNote.textContent = locked
+          ? "Editing is locked after final submission."
+          : "Editing is still open until final submission.";
+    }
+
+    if (!intakeHistoryStatus || !intakeHistoryList) return;
+
+    intakeHistoryList.innerHTML = "";
+
+    if (!history.length) {
+      intakeHistoryStatus.textContent = "No intake submissions found yet.";
+      return;
+    }
+
+    intakeHistoryStatus.textContent =
+      "Your recent intake submissions are listed below.";
+
+    history.forEach(function (item, index) {
+      const card = document.createElement("div");
+      card.className = "feature-card feature-card-clean";
+      card.innerHTML = `
+        <div class="card-number">${index + 1}</div>
+        <h3>${item.package_name || "Intake Submission"}</h3>
+        <p class="card-copy">Status: ${item.status || item.submission_status || "submitted"}</p>
+        <p class="card-copy">Created: ${formatDate(item.created_at || item.submitted_at)}</p>
+      `;
+      intakeHistoryList.appendChild(card);
+    });
+  }
+
+  async function setupSignupForm() {
     const form = document.querySelector("[data-signup-form]");
     if (!form) return;
 
@@ -196,11 +478,7 @@
     const userRole = document.querySelector("[data-user-role]");
     const statusNode = document.querySelector("[data-dashboard-status]");
 
-    const refs = {
-      userName,
-      userEmail,
-      userRole,
-    };
+    const refs = { userName, userEmail, userRole };
 
     const token = app.getToken();
     if (!token) {
@@ -217,15 +495,31 @@
       const me = await app.fetchCurrentUser();
       populateUserFields(me, refs);
 
-      if (authRequired) {
-        authRequired.style.display = "block";
-      }
+      if (authRequired) authRequired.style.display = "block";
 
       app.setStatus(
         statusNode,
         "You are signed in and connected to the Tomb of Light platform.",
         "success",
       );
+
+      const orders = await fetchOrders();
+      renderOrders(orders);
+
+      const paidOrder = getPaidOrder(orders);
+      updateAccessState(paidOrder);
+
+      if (!paidOrder) {
+        renderNoIntakeBecauseNoPurchase();
+        return;
+      }
+
+      const [latest, history] = await Promise.all([
+        fetchLatestIntake(),
+        fetchIntakeHistory(),
+      ]);
+
+      renderIntake(latest, history, paidOrder);
     } catch (error) {
       app.clearSession();
       app.setStatus(
@@ -236,6 +530,34 @@
       setTimeout(function () {
         window.location.href = "signin.html";
       }, 1200);
+    }
+  }
+
+  async function gatePurchaseRequiredPages() {
+    const page = window.location.pathname.split("/").pop() || "";
+    const intakePages = new Set([
+      "intake-welcome.html",
+      "intake-household.html",
+      "intake-family-map.html",
+      "intake-uploads.html",
+      "intake-consent.html",
+      "intake-review.html",
+    ]);
+
+    if (!intakePages.has(page)) return;
+
+    const user = await app.requireSession("signin.html");
+    if (!user) return;
+
+    try {
+      const orders = await fetchOrders();
+      const paidOrder = getPaidOrder(orders);
+
+      if (!paidOrder) {
+        window.location.href = "dashboard.html?purchase_required=1";
+      }
+    } catch (error) {
+      window.location.href = "dashboard.html?purchase_required=1";
     }
   }
 
@@ -273,6 +595,7 @@
     setupSigninForm();
     setupDashboard();
     bindLogoutButtons();
+    gatePurchaseRequiredPages();
   });
 
   window.TOLAuthPages = {

--- a/config.js
+++ b/config.js
@@ -10,5 +10,22 @@
     API_BASE_URL: isLocal
       ? "http://127.0.0.1:8000"
       : "https://tomboflight-api.onrender.com",
+
+    PAYMENT_LINKS: isLocal
+      ? {
+          "digital-legacy-portrait": "REPLACE_WITH_STRIPE_TEST_LINK_1",
+          "starter-family-tree": "REPLACE_WITH_STRIPE_TEST_LINK_2",
+          "heirloom-legacy-tree": "REPLACE_WITH_STRIPE_TEST_LINK_3",
+          "legacy-plus": "REPLACE_WITH_STRIPE_TEST_LINK_4",
+        }
+      : {
+          "digital-legacy-portrait":
+            "https://buy.stripe.com/28EeVdeMK4g74mW3d3bEA01",
+          "starter-family-tree":
+            "https://buy.stripe.com/5kQdR99sq3c32eOdRHbEA02",
+          "heirloom-legacy-tree":
+            "https://buy.stripe.com/7sY6oHbAybIzf1A6pfbEA00",
+          "legacy-plus": "https://buy.stripe.com/9B6aEX7ki8wndXwaFvbEA03",
+        },
   };
 })();

--- a/index.html
+++ b/index.html
@@ -48,7 +48,15 @@
           </nav>
 
           <div class="header-actions">
-            <a class="btn btn-primary" href="signup.html">Create Account</a>
+            <a
+              class="btn btn-primary"
+              href="signup.html"
+              data-auth-cta
+              data-logged-in-href="dashboard.html"
+              data-logged-in-label="Dashboard"
+            >
+              Create Account
+            </a>
           </div>
         </div>
       </header>
@@ -188,9 +196,9 @@
             </div>
 
             <div class="inline-actions architecture-actions">
-              <a class="btn btn-secondary" href="platform.html"
-                >Explore the Platform</a
-              >
+              <a class="btn btn-secondary" href="platform.html">
+                Explore the Platform
+              </a>
             </div>
           </div>
         </section>
@@ -279,7 +287,8 @@
                 <div class="inline-actions">
                   <a
                     class="btn btn-primary"
-                    href="https://buy.stripe.com/28EeVdeMK4g74mW3d3bEA01"
+                    href="#pricing"
+                    data-payment-link="digital-legacy-portrait"
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Begin Legacy - opens payment page in new window"
@@ -311,7 +320,8 @@
                 <div class="inline-actions">
                   <a
                     class="btn btn-primary"
-                    href="https://buy.stripe.com/5kQdR99sq3c32eOdRHbEA02"
+                    href="#pricing"
+                    data-payment-link="starter-family-tree"
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Start My Tree - opens payment page in new window"
@@ -346,7 +356,8 @@
                 <div class="inline-actions">
                   <a
                     class="btn btn-primary"
-                    href="https://buy.stripe.com/7sY6oHbAybIzf1A6pfbEA00"
+                    href="#pricing"
+                    data-payment-link="heirloom-legacy-tree"
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Build My Legacy - opens payment page in new window"
@@ -381,7 +392,8 @@
                 <div class="inline-actions">
                   <a
                     class="btn btn-primary"
-                    href="https://buy.stripe.com/9B6aEX7ki8wndXwaFvbEA03"
+                    href="#pricing"
+                    data-payment-link="legacy-plus"
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Create My Dynasty - opens payment page in new window"
@@ -411,7 +423,13 @@
                   <li>Dedicated production support</li>
                 </ul>
                 <div class="inline-actions">
-                  <a class="btn btn-secondary" href="signup.html">
+                  <a
+                    class="btn btn-secondary"
+                    href="signup.html"
+                    data-auth-cta
+                    data-logged-in-href="dashboard.html"
+                    data-logged-in-label="Dashboard"
+                  >
                     Create Account
                   </a>
                 </div>
@@ -515,10 +533,18 @@
               </p>
 
               <div class="cta-actions">
-                <a class="btn btn-primary" href="signup.html">Create Account</a>
-                <a class="btn btn-secondary" href="platform.html"
-                  >Explore the Platform</a
+                <a
+                  class="btn btn-primary"
+                  href="signup.html"
+                  data-auth-cta
+                  data-logged-in-href="dashboard.html"
+                  data-logged-in-label="Dashboard"
                 >
+                  Create Account
+                </a>
+                <a class="btn btn-secondary" href="platform.html">
+                  Explore the Platform
+                </a>
               </div>
             </div>
           </div>
@@ -557,10 +583,9 @@
 
             <div class="footer-bottom">
               <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-              <span
-                >Tomb of Light technology and platform design are
-                proprietary.</span
-              >
+              <span>
+                Tomb of Light technology and platform design are proprietary.
+              </span>
             </div>
           </div>
         </div>
@@ -586,9 +611,9 @@
           <button class="btn btn-secondary" type="button" data-cookie-decline>
             Decline
           </button>
-          <a class="btn btn-ghost" href="privacy-choices.html"
-            >Privacy Choices</a
-          >
+          <a class="btn btn-ghost" href="privacy-choices.html">
+            Privacy Choices
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
…pport

- updated homepage CTAs to switch from Create Account to Dashboard when a user is already signed in
- added payment-link hooks on pricing buttons for local/live payment routing
- updated shared app runtime to support auth-aware public CTAs and payment links
- updated dashboard auth logic to gate premium actions behind a paid order
- changed intake flow to Option A: purchase required before intake opens
- disabled or hid Create Family, Family Tree, Lineage Certificate, and Open Intake until a paid order exists
- added intake-page purchase gate redirect back to dashboard when access is locked
- improved dashboard order and intake state handling for empty and unlocked states
- kept local and live API routing separated through config.js