### PR TITLE
Wire intake draft flow and fix onboarding step order

### DIFF
--- a/intake-consent.html
+++ b/intake-consent.html
@@ -40,7 +40,7 @@
         <section class="page-hero">
           <div class="container">
             <div class="page-hero-panel">
-              <span class="eyebrow">Step 5 of 5</span>
+              <span class="eyebrow">Step 4 of 5</span>
               <h1>Consent</h1>
               <p class="card-copy">
                 Confirm visibility preferences and authorize Tomb of Light to
@@ -122,9 +122,9 @@
                   >
                     Save Consent
                   </button>
-                  <a class="btn btn-secondary" href="intake-review.html"
-                    >Go to Review</a
-                  >
+                  <a class="btn btn-secondary" href="intake-review.html">
+                    Continue to Review
+                  </a>
                 </div>
               </form>
             </div>
@@ -158,12 +158,12 @@
               </div>
 
               <div class="inline-actions" style="margin-top: 1.25rem">
-                <a class="btn btn-secondary" href="intake-welcome.html"
-                  >Back to Welcome</a
-                >
-                <a class="btn btn-secondary" href="dashboard.html"
-                  >Return to Dashboard</a
-                >
+                <a class="btn btn-secondary" href="intake-welcome.html">
+                  Back to Welcome
+                </a>
+                <a class="btn btn-secondary" href="dashboard.html">
+                  Return to Dashboard
+                </a>
               </div>
             </div>
           </div>
@@ -184,5 +184,6 @@
     <script src="config.js"></script>
     <script src="app.js"></script>
     <script src="auth.js"></script>
+    <script src="intake.js"></script>
   </body>
 </html>

--- a/intake-family-map.html
+++ b/intake-family-map.html
@@ -1,216 +1,233 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Family Map | Tomb of Light</title>
-  <meta
-    name="description"
-    content="Outline your household family structure for Tomb of Light onboarding."
-  />
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <div class="page-wrap">
-    <header class="site-header">
-      <div class="container site-header-inner">
-        <a class="brand" href="index.html" aria-label="Tomb of Light home">
-          <span>Tomb of Light<span class="brand-symbol">™</span></span>
-        </a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Family Map | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Outline your household family structure for Tomb of Light onboarding."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
 
-        <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
-          <a href="dashboard.html">Dashboard</a>
-          <a href="intake-welcome.html">Intake Welcome</a>
-          <a href="intake-household.html">Household Setup</a>
-          <a href="faq.html">FAQ</a>
-        </nav>
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="intake-welcome.html">Intake Welcome</a>
+            <a href="intake-household.html">Household Setup</a>
+            <a href="intake-uploads.html">Uploads</a>
+            <a href="intake-consent.html">Consent</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
 
-        <div class="header-actions">
-          <a class="btn btn-secondary" href="intake-household.html">Back to Household Setup</a>
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="intake-household.html"
+              >Back to Household Setup</a
+            >
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
 
-    <main data-intake-family-map>
-      <section class="page-hero">
+      <main data-intake-family-map>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Step 2 of 5</span>
+              <h1>Family Map</h1>
+              <p data-family-map-status>
+                Begin outlining the family structure that belongs in this Tomb
+                of Light build.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Family Structure</span>
+
+              <form class="form-grid" data-family-map-form novalidate>
+                <div class="form-grid two-col">
+                  <label>
+                    Family / Branch Name
+                    <input
+                      type="text"
+                      name="family_branch_name"
+                      placeholder="Example: Robinson Household Branch"
+                      required
+                    />
+                  </label>
+
+                  <label>
+                    Approximate Number of People in Scope
+                    <input
+                      type="number"
+                      name="people_in_scope"
+                      min="1"
+                      placeholder="Example: 14"
+                      required
+                    />
+                  </label>
+                </div>
+
+                <div class="form-grid two-col">
+                  <label>
+                    Parent Figure One
+                    <input
+                      type="text"
+                      name="parent_one"
+                      placeholder="Full name"
+                      required
+                    />
+                  </label>
+
+                  <label>
+                    Parent Figure Two
+                    <input
+                      type="text"
+                      name="parent_two"
+                      placeholder="Full name"
+                    />
+                  </label>
+                </div>
+
+                <div class="form-grid two-col">
+                  <label>
+                    Spouse / Partner in Scope
+                    <input
+                      type="text"
+                      name="spouse_partner"
+                      placeholder="Optional"
+                    />
+                  </label>
+
+                  <label>
+                    Children in Scope
+                    <input
+                      type="text"
+                      name="children_names"
+                      placeholder="Example: Nasir Robinson, Faith Robinson, ..."
+                      required
+                    />
+                  </label>
+                </div>
+
+                <label>
+                  Family Structure Summary
+                  <textarea
+                    name="family_structure_summary"
+                    rows="5"
+                    placeholder="Describe how this family is structured, who belongs in this branch, and how the first generation should be understood."
+                    required
+                  ></textarea>
+                </label>
+
+                <label>
+                  Branch Notes
+                  <textarea
+                    name="branch_notes"
+                    rows="4"
+                    placeholder="Optional notes about step-parents, adopted members, branch separation, household differences, or special mapping instructions."
+                  ></textarea>
+                </label>
+
+                <div
+                  class="helper"
+                  data-family-map-form-status
+                  aria-live="polite"
+                  style="display: none"
+                ></div>
+
+                <div class="inline-actions" style="margin-top: 1.5rem">
+                  <button
+                    class="btn btn-primary"
+                    type="submit"
+                    data-family-map-submit-btn
+                  >
+                    Save Family Map
+                  </button>
+                  <a class="btn btn-secondary" href="intake-uploads.html">
+                    Continue to Uploads
+                  </a>
+                </div>
+              </form>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">What This Step Defines</span>
+              <div class="grid-3">
+                <div>
+                  <div class="card-number">1</div>
+                  <h3>Core Household Branch</h3>
+                  <p class="card-copy">
+                    This identifies which branch or family group belongs in the
+                    current build.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">2</div>
+                  <h3>Relationship Starting Point</h3>
+                  <p class="card-copy">
+                    This gives Tomb of Light the first parent, spouse, and child
+                    structure to follow.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">3</div>
+                  <h3>Package Scope Control</h3>
+                  <p class="card-copy">
+                    This helps keep the onboarding within the purchased package
+                    size and branch limits.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Next Step</span>
+              <h2>Uploads</h2>
+              <p class="card-copy">
+                After saving your family map, continue to upload planning and
+                consent before the final review step.
+              </p>
+
+              <div class="inline-actions" style="margin-top: 1.5rem">
+                <a class="btn btn-primary" href="intake-uploads.html"
+                  >Go to Uploads</a
+                >
+                <a class="btn btn-secondary" href="intake-household.html"
+                  >Back to Household Setup</a
+                >
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
         <div class="container">
-          <div class="page-hero-panel">
-            <span class="eyebrow">Step 2 of 5</span>
-            <h1>Family Map</h1>
-            <p data-family-map-status>
-              Begin outlining the family structure that belongs in this Tomb of Light build.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section class="page-sections">
-        <div class="container form-shell">
-          <div class="form-panel">
-            <span class="eyebrow">Family Structure</span>
-
-            <form class="form-grid" data-family-map-form novalidate>
-              <div class="form-grid two-col">
-                <label>
-                  Family / Branch Name
-                  <input
-                    type="text"
-                    name="family_branch_name"
-                    placeholder="Example: Moreland Main Branch"
-                    required
-                  />
-                </label>
-
-                <label>
-                  Approximate Number of People in Scope
-                  <input
-                    type="number"
-                    name="people_in_scope"
-                    min="1"
-                    placeholder="Example: 6"
-                    required
-                  />
-                </label>
-              </div>
-
-              <div class="form-grid two-col">
-                <label>
-                  Parent Figure One
-                  <input
-                    type="text"
-                    name="parent_one"
-                    placeholder="Full name"
-                    required
-                  />
-                </label>
-
-                <label>
-                  Parent Figure Two
-                  <input
-                    type="text"
-                    name="parent_two"
-                    placeholder="Full name"
-                  />
-                </label>
-              </div>
-
-              <div class="form-grid two-col">
-                <label>
-                  Spouse / Partner in Scope
-                  <input
-                    type="text"
-                    name="spouse_partner"
-                    placeholder="Optional"
-                  />
-                </label>
-
-                <label>
-                  Children in Scope
-                  <input
-                    type="text"
-                    name="children_names"
-                    placeholder="Example: Malik, Selah, Julian"
-                    required
-                  />
-                </label>
-              </div>
-
-              <label>
-                Family Structure Summary
-                <textarea
-                  name="family_structure_summary"
-                  rows="5"
-                  placeholder="Describe how this family is structured, who belongs in this branch, and how the first generation should be understood."
-                  required
-                ></textarea>
-              </label>
-
-              <label>
-                Branch Notes
-                <textarea
-                  name="branch_notes"
-                  rows="4"
-                  placeholder="Optional notes about step-parents, adopted members, branch separation, household differences, or special mapping instructions."
-                ></textarea>
-              </label>
-
-              <div
-                class="helper"
-                data-family-map-form-status
-                aria-live="polite"
-                style="display: none;"
-              ></div>
-
-              <div class="inline-actions" style="margin-top: 1.5rem;">
-                <button class="btn btn-primary" type="submit" data-family-map-submit-btn>
-                  Save Family Map
-                </button>
-                <a class="btn btn-secondary" href="intake-review.html">
-                  Continue to Review
-                </a>
-              </div>
-            </form>
-          </div>
-
-          <div class="form-panel">
-            <span class="eyebrow">What This Step Defines</span>
-            <div class="grid-3">
-              <div>
-                <div class="card-number">1</div>
-                <h3>Core Household Branch</h3>
-                <p class="card-copy">
-                  This identifies which branch or family group belongs in the current build.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">2</div>
-                <h3>Relationship Starting Point</h3>
-                <p class="card-copy">
-                  This gives Tomb of Light the first parent, spouse, and child structure to follow.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">3</div>
-                <h3>Package Scope Control</h3>
-                <p class="card-copy">
-                  This helps keep the onboarding within the purchased package size and branch limits.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div class="form-panel">
-            <span class="eyebrow">Next Step</span>
-            <h2>Review &amp; Submit</h2>
-            <p class="card-copy">
-              After saving your family map, you will review the household and structure details
-              before the next onboarding stages are added.
-            </p>
-
-            <div class="inline-actions" style="margin-top: 1.5rem;">
-              <a class="btn btn-primary" href="intake-review.html">Go to Review</a>
-              <a class="btn btn-secondary" href="intake-household.html">Back to Household Setup</a>
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
             </div>
           </div>
         </div>
-      </section>
-    </main>
+      </footer>
+    </div>
 
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-card">
-          <div class="footer-bottom">
-            <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-          </div>
-        </div>
-      </div>
-    </footer>
-  </div>
-
-  <script src="config.js"></script>
-  <script src="app.js"></script>
-  <script src="auth.js"></script>
-</body>
+    <script src="config.js"></script>
+    <script src="app.js"></script>
+    <script src="auth.js"></script>
+    <script src="intake.js"></script>
+  </body>
 </html>

--- a/intake-household.html
+++ b/intake-household.html
@@ -227,5 +227,6 @@
     <script src="config.js"></script>
     <script src="app.js"></script>
     <script src="auth.js"></script>
+    <script src="intake.js"></script>
   </body>
 </html>

--- a/intake-review.html
+++ b/intake-review.html
@@ -203,5 +203,6 @@
     <script src="config.js"></script>
     <script src="app.js"></script>
     <script src="auth.js"></script>
+    <script src="intake.js"></script>
   </body>
 </html>

--- a/intake-uploads.html
+++ b/intake-uploads.html
@@ -23,13 +23,13 @@
             <a href="intake-welcome.html">Intake Welcome</a>
             <a href="intake-household.html">Household Setup</a>
             <a href="intake-family-map.html">Family Map</a>
-            <a href="intake-review.html">Review</a>
             <a href="intake-consent.html">Consent</a>
+            <a href="intake-review.html">Review</a>
           </nav>
 
           <div class="header-actions">
-            <a class="btn btn-secondary" href="intake-review.html"
-              >Back to Review</a
+            <a class="btn btn-secondary" href="intake-family-map.html"
+              >Back to Family Map</a
             >
           </div>
         </div>
@@ -39,7 +39,7 @@
         <section class="page-hero">
           <div class="container">
             <div class="page-hero-panel">
-              <span class="eyebrow">Step 4 of 5</span>
+              <span class="eyebrow">Step 3 of 5</span>
               <h1>Uploads</h1>
               <p class="card-copy">
                 List the assets you will provide for this package. Upload
@@ -83,7 +83,7 @@
                   <textarea
                     name="key_portraits"
                     rows="5"
-                    placeholder="Example: Malik Moreland (adult portrait), Elias + Clara (parents), Imani (adult), etc."
+                    placeholder="Example: Larry Robinson portrait, Lanisha Robinson portrait, mother portrait, children portraits, household family group photos, supporting family images."
                   ></textarea>
                 </label>
 
@@ -102,7 +102,7 @@
                   <textarea
                     name="quality_notes"
                     rows="4"
-                    placeholder="Example: need scan cleanup, missing one sibling portrait, phone photos need sharpening, etc."
+                    placeholder="Example: need scan cleanup, missing one portrait, phone photos need sharpening, etc."
                   ></textarea>
                 </label>
 
@@ -126,8 +126,8 @@
                     Continue to Consent
                   </a>
 
-                  <a class="btn btn-secondary" href="intake-review.html">
-                    Back to Review
+                  <a class="btn btn-secondary" href="intake-family-map.html">
+                    Back to Family Map
                   </a>
                 </div>
               </form>
@@ -160,12 +160,12 @@
               </div>
 
               <div class="inline-actions" style="margin-top: 1.25rem">
-                <a class="btn btn-secondary" href="intake-welcome.html"
-                  >Back to Welcome</a
-                >
-                <a class="btn btn-secondary" href="dashboard.html"
-                  >Return to Dashboard</a
-                >
+                <a class="btn btn-secondary" href="intake-welcome.html">
+                  Back to Welcome
+                </a>
+                <a class="btn btn-secondary" href="dashboard.html">
+                  Return to Dashboard
+                </a>
               </div>
             </div>
           </div>
@@ -186,5 +186,6 @@
     <script src="config.js"></script>
     <script src="app.js"></script>
     <script src="auth.js"></script>
+    <script src="intake.js"></script>
   </body>
 </html>

--- a/intake-welcome.html
+++ b/intake-welcome.html
@@ -1,153 +1,166 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Intake Welcome | Tomb of Light</title>
-  <meta
-    name="description"
-    content="Welcome to Tomb of Light intake. Begin your family legacy onboarding."
-  />
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <div class="page-wrap">
-    <header class="site-header">
-      <div class="container site-header-inner">
-        <a class="brand" href="index.html" aria-label="Tomb of Light home">
-          <span>Tomb of Light<span class="brand-symbol">™</span></span>
-        </a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Intake Welcome | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Welcome to Tomb of Light intake. Begin your family legacy onboarding."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
 
-        <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
-          <a href="dashboard.html">Dashboard</a>
-          <a href="platform.html">Platform</a>
-          <a href="how-it-works.html">How It Works</a>
-          <a href="security.html">Security</a>
-          <a href="faq.html">FAQ</a>
-        </nav>
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="platform.html">Platform</a>
+            <a href="how-it-works.html">How It Works</a>
+            <a href="security.html">Security</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
 
-        <div class="header-actions">
-          <a class="btn btn-secondary" href="dashboard.html">Back to Dashboard</a>
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="dashboard.html"
+              >Back to Dashboard</a
+            >
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
 
-    <main data-intake-welcome>
-      <section class="page-hero">
+      <main data-intake-welcome>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Intake Welcome</span>
+              <h1>Begin Your Tomb of Light Onboarding</h1>
+              <p data-intake-status>
+                Loading your package and onboarding path...
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Purchased Package</span>
+              <h2 data-package-name>Checking package...</h2>
+              <p class="card-copy" data-package-summary>
+                We are reviewing your account access and purchase record now.
+              </p>
+
+              <div class="grid-3">
+                <div>
+                  <div class="card-number">1</div>
+                  <h3>Household Setup</h3>
+                  <p class="card-copy">
+                    Confirm the main household owner, household name, and
+                    contact details.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">2</div>
+                  <h3>Family Structure</h3>
+                  <p class="card-copy">
+                    Begin outlining the family map that will guide your lineage
+                    build.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">3</div>
+                  <h3>Review & Submit</h3>
+                  <p class="card-copy">
+                    Review your intake details before moving into the production
+                    process.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Your Onboarding Path</span>
+              <div class="grid-3" data-package-path>
+                <div>
+                  <div class="card-number">A</div>
+                  <h3>Checking access</h3>
+                  <p class="card-copy">
+                    Your package-specific onboarding sequence will appear here.
+                  </p>
+                </div>
+              </div>
+
+              <div class="inline-actions" style="margin-top: 1.5rem">
+                <a
+                  class="btn btn-primary"
+                  href="intake-household.html"
+                  data-intake-start
+                >
+                  Start Intake
+                </a>
+                <a class="btn btn-secondary" href="dashboard.html">
+                  Return to Dashboard
+                </a>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Important Preparation</span>
+              <div class="grid-3">
+                <div>
+                  <div class="card-number">I</div>
+                  <h3>Gather family information</h3>
+                  <p class="card-copy">
+                    Prepare names, relationships, and your first branch
+                    structure before continuing.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">II</div>
+                  <h3>Prepare uploads</h3>
+                  <p class="card-copy">
+                    Collect the photos, videos, and records that belong in this
+                    project scope.
+                  </p>
+                </div>
+
+                <div>
+                  <div class="card-number">III</div>
+                  <h3>Expect package limits</h3>
+                  <p class="card-copy">
+                    Your upload count, family scope, and onboarding depth depend
+                    on your purchased package.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
         <div class="container">
-          <div class="page-hero-panel">
-            <span class="eyebrow">Intake Welcome</span>
-            <h1>Begin Your Tomb of Light Onboarding</h1>
-            <p data-intake-status>
-              Loading your package and onboarding path...
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section class="page-sections">
-        <div class="container form-shell">
-          <div class="form-panel">
-            <span class="eyebrow">Purchased Package</span>
-            <h2 data-package-name>Checking package...</h2>
-            <p class="card-copy" data-package-summary>
-              We are reviewing your account access and purchase record now.
-            </p>
-
-            <div class="grid-3">
-              <div>
-                <div class="card-number">1</div>
-                <h3>Household Setup</h3>
-                <p class="card-copy">
-                  Confirm the main household owner, household name, and contact details.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">2</div>
-                <h3>Family Structure</h3>
-                <p class="card-copy">
-                  Begin outlining the family map that will guide your lineage build.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">3</div>
-                <h3>Review & Submit</h3>
-                <p class="card-copy">
-                  Review your intake details before moving into the production process.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div class="form-panel">
-            <span class="eyebrow">Your Onboarding Path</span>
-            <div class="grid-3" data-package-path>
-              <div>
-                <div class="card-number">A</div>
-                <h3>Checking access</h3>
-                <p class="card-copy">
-                  Your package-specific onboarding sequence will appear here.
-                </p>
-              </div>
-            </div>
-
-            <div class="inline-actions" style="margin-top: 1.5rem;">
-              <a class="btn btn-primary" href="intake-household.html" data-intake-start>
-                Start Intake
-              </a>
-              <a class="btn btn-secondary" href="dashboard.html">
-                Return to Dashboard
-              </a>
-            </div>
-          </div>
-
-          <div class="form-panel">
-            <span class="eyebrow">Important Preparation</span>
-            <div class="grid-3">
-              <div>
-                <div class="card-number">I</div>
-                <h3>Gather family information</h3>
-                <p class="card-copy">
-                  Prepare names, relationships, and your first branch structure before continuing.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">II</div>
-                <h3>Prepare uploads</h3>
-                <p class="card-copy">
-                  Collect the photos, videos, and records that belong in this project scope.
-                </p>
-              </div>
-
-              <div>
-                <div class="card-number">III</div>
-                <h3>Expect package limits</h3>
-                <p class="card-copy">
-                  Your upload count, family scope, and onboarding depth depend on your purchased package.
-                </p>
-              </div>
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
             </div>
           </div>
         </div>
-      </section>
-    </main>
+      </footer>
+    </div>
 
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-card">
-          <div class="footer-bottom">
-            <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-          </div>
-        </div>
-      </div>
-    </footer>
-  </div>
-
-  <script src="config.js"></script>
-  <script src="app.js"></script>
-  <script src="auth.js"></script>
-</body>
+    <script src="config.js"></script>
+    <script src="app.js"></script>
+    <script src="auth.js"></script>
+    <script src="intake.js"></script>
+  </body>
 </html>

--- a/intake.js
+++ b/intake.js
@@ -1,0 +1,537 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  const DRAFT_KEY = "tol_intake_draft_v1";
+
+  if (!app) {
+    console.error("intake.js requires app.js/auth.js to be loaded first.");
+    return;
+  }
+
+  function getErrorMessage(error) {
+    if (!error) return "Unknown error";
+    if (typeof error === "string") return error;
+    if (error.message) return String(error.message);
+    return String(error);
+  }
+
+  function loadDraft() {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function saveDraft(nextDraft) {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(nextDraft || {}));
+  }
+
+  function mergeDraft(sectionKey, values) {
+    const draft = loadDraft();
+    draft[sectionKey] = {
+      ...(draft[sectionKey] || {}),
+      ...(values || {}),
+    };
+    saveDraft(draft);
+    return draft;
+  }
+
+  function setStatus(node, message, type) {
+    if (!node) return;
+    node.style.display = "block";
+    node.textContent = message;
+    node.dataset.state = type || "info";
+
+    if (type === "error") {
+      node.style.color = "#ffb3b3";
+    } else if (type === "success") {
+      node.style.color = "#cfe8cf";
+    } else {
+      node.style.color = "#d6e6ff";
+    }
+  }
+
+  function clearStatus(node) {
+    if (!node) return;
+    node.style.display = "none";
+    node.textContent = "";
+    node.dataset.state = "";
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function hydrateForm(form, values) {
+    if (!form || !values) return;
+
+    Object.entries(values).forEach(function ([key, value]) {
+      const field = form.querySelector(`[name="${key}"]`);
+      if (!field) return;
+
+      if (field.type === "checkbox") {
+        field.checked = Boolean(value);
+      } else {
+        field.value = value ?? "";
+      }
+    });
+  }
+
+  function formToObject(form) {
+    const data = {};
+
+    form.querySelectorAll("input, textarea, select").forEach(function (field) {
+      if (!field.name) return;
+
+      if (field.type === "checkbox") {
+        data[field.name] = field.checked;
+      } else {
+        data[field.name] = field.value;
+      }
+    });
+
+    return data;
+  }
+
+  function getPaidOrder(orders) {
+    return (
+      orders.find(function (order) {
+        const status = String(order?.status || "").toLowerCase();
+        return (
+          status === "paid" ||
+          status === "complete" ||
+          status === "completed" ||
+          status === "succeeded"
+        );
+      }) || null
+    );
+  }
+
+  async function fetchPaidOrder() {
+    const payload = await app.apiRequest("/orders/my-orders", {
+      method: "GET",
+    });
+    const orders = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.orders)
+        ? payload.orders
+        : Array.isArray(payload?.data)
+          ? payload.data
+          : [];
+    return getPaidOrder(orders);
+  }
+
+  function formatReviewBlock(title, lines, number) {
+    const safeLines = (lines || []).filter(Boolean);
+
+    return `
+      <div>
+        <div class="card-number">${escapeHtml(number)}</div>
+        <h3>${escapeHtml(title)}</h3>
+        <p class="card-copy">${safeLines.map(escapeHtml).join("<br />")}</p>
+      </div>
+    `;
+  }
+
+  async function setupIntakeWelcome() {
+    const page = document.querySelector("[data-intake-welcome]");
+    if (!page) return;
+
+    const intakeStatus = document.querySelector("[data-intake-status]");
+    const packageName = document.querySelector("[data-package-name]");
+    const packageSummary = document.querySelector("[data-package-summary]");
+    const packagePath = document.querySelector("[data-package-path]");
+
+    try {
+      const paidOrder = await fetchPaidOrder();
+      const draft = loadDraft();
+
+      if (paidOrder) {
+        draft.package_name =
+          paidOrder.package_name || draft.package_name || "Active Package";
+        draft.package_slug = paidOrder.package_slug || draft.package_slug || "";
+        saveDraft(draft);
+
+        if (packageName) {
+          packageName.textContent = paidOrder.package_name || "Active Package";
+        }
+
+        if (packageSummary) {
+          packageSummary.textContent = `Your package is active and ready for onboarding. Current unlocked package: ${paidOrder.package_name || "Active Package"}.`;
+        }
+
+        if (intakeStatus) {
+          intakeStatus.textContent = `Your package is active: ${paidOrder.package_name || "Active Package"}. Begin your household onboarding below.`;
+        }
+
+        if (packagePath) {
+          packagePath.innerHTML = `
+            ${formatReviewBlock("Household Setup", ["Confirm household ownership and household details."], "A")}
+            ${formatReviewBlock("Family Map", ["Outline parents, spouse, children, and branch structure."], "B")}
+            ${formatReviewBlock("Uploads", ["Plan photos, records, and supporting files for this build."], "C")}
+            ${formatReviewBlock("Consent", ["Confirm privacy, processing, and storage permissions."], "D")}
+            ${formatReviewBlock("Review & Submit", ["Review the saved onboarding data before final submission."], "E")}
+          `;
+        }
+      } else {
+        if (packageName) packageName.textContent = "No active package detected";
+        if (packageSummary) {
+          packageSummary.textContent =
+            "We could not confirm a paid package for this account yet.";
+        }
+        if (intakeStatus) {
+          intakeStatus.textContent =
+            "Purchase is required before onboarding can continue.";
+        }
+      }
+    } catch (error) {
+      if (intakeStatus) {
+        intakeStatus.textContent =
+          "Your onboarding path could not be loaded right now.";
+      }
+    }
+  }
+
+  function setupHouseholdForm() {
+    const page = document.querySelector("[data-intake-household]");
+    if (!page) return;
+
+    const form = document.querySelector("[data-household-form]");
+    const statusNode = document.querySelector("[data-household-form-status]");
+    const headlineStatus = document.querySelector("[data-household-status]");
+    const submitBtn = document.querySelector("[data-household-submit-btn]");
+
+    if (!form) return;
+
+    const draft = loadDraft();
+    hydrateForm(form, draft.household || {});
+
+    const savedUser = app.getSavedUser();
+    if (savedUser) {
+      const current = formToObject(form);
+
+      if (!current.primary_contact_name) {
+        const field = form.querySelector('[name="primary_contact_name"]');
+        if (field) field.value = savedUser.full_name || "";
+      }
+
+      if (!current.primary_contact_email) {
+        const field = form.querySelector('[name="primary_contact_email"]');
+        if (field) field.value = savedUser.email || "";
+      }
+    }
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      clearStatus(statusNode);
+
+      if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+        return;
+      }
+
+      const values = formToObject(form);
+      mergeDraft("household", values);
+
+      if (headlineStatus) {
+        headlineStatus.textContent =
+          "Household setup has been saved for this onboarding draft.";
+      }
+
+      setStatus(statusNode, "Household setup saved successfully.", "success");
+
+      if (submitBtn) {
+        submitBtn.blur();
+      }
+    });
+  }
+
+  function setupFamilyMapForm() {
+    const page = document.querySelector("[data-intake-family-map]");
+    if (!page) return;
+
+    const form = document.querySelector("[data-family-map-form]");
+    const statusNode = document.querySelector("[data-family-map-form-status]");
+    const headlineStatus = document.querySelector("[data-family-map-status]");
+    const submitBtn = document.querySelector("[data-family-map-submit-btn]");
+
+    if (!form) return;
+
+    const draft = loadDraft();
+    hydrateForm(form, draft.family_map || {});
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      clearStatus(statusNode);
+
+      if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+        return;
+      }
+
+      const values = formToObject(form);
+      mergeDraft("family_map", values);
+
+      if (headlineStatus) {
+        headlineStatus.textContent =
+          "Family map has been saved for this onboarding draft.";
+      }
+
+      setStatus(statusNode, "Family map saved successfully.", "success");
+
+      if (submitBtn) {
+        submitBtn.blur();
+      }
+    });
+  }
+
+  function setupUploadsForm() {
+    const page = document.querySelector("[data-intake-uploads]");
+    if (!page) return;
+
+    const form = document.querySelector("[data-intake-uploads-form]");
+    const statusNode = document.querySelector(
+      "[data-intake-uploads-form-status]",
+    );
+    const submitBtn = document.querySelector(
+      "[data-intake-uploads-submit-btn]",
+    );
+
+    if (!form) return;
+
+    const draft = loadDraft();
+    hydrateForm(form, draft.uploads || {});
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      clearStatus(statusNode);
+
+      const values = formToObject(form);
+      mergeDraft("uploads", values);
+
+      setStatus(statusNode, "Upload plan saved successfully.", "success");
+
+      if (submitBtn) {
+        submitBtn.blur();
+      }
+    });
+  }
+
+  function setupConsentForm() {
+    const page = document.querySelector("[data-intake-consent]");
+    if (!page) return;
+
+    const form = document.querySelector("[data-intake-consent-form]");
+    const statusNode = document.querySelector(
+      "[data-intake-consent-form-status]",
+    );
+    const submitBtn = document.querySelector(
+      "[data-intake-consent-submit-btn]",
+    );
+
+    if (!form) return;
+
+    const draft = loadDraft();
+    hydrateForm(form, draft.consent || {});
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      clearStatus(statusNode);
+
+      if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+        return;
+      }
+
+      const values = formToObject(form);
+      mergeDraft("consent", values);
+
+      setStatus(statusNode, "Consent saved successfully.", "success");
+
+      if (submitBtn) {
+        submitBtn.blur();
+      }
+    });
+  }
+
+  function renderReviewSummaryBlocks() {
+    const page = document.querySelector("[data-intake-review]");
+    if (!page) return;
+
+    const draft = loadDraft();
+
+    const householdNode = document.querySelector(
+      "[data-review-household-summary]",
+    );
+    const familyMapNode = document.querySelector(
+      "[data-review-family-map-summary]",
+    );
+    const uploadsNode = document.querySelector("[data-review-uploads-summary]");
+    const consentNode = document.querySelector("[data-review-consent-summary]");
+
+    if (householdNode) {
+      const h = draft.household || {};
+      householdNode.innerHTML = formatReviewBlock(
+        h.household_name || "Household Setup",
+        [
+          `Primary Contact: ${h.primary_contact_name || "—"}`,
+          `Email: ${h.primary_contact_email || "—"}`,
+          `Role: ${h.household_role || "—"}`,
+        ],
+        "1",
+      );
+    }
+
+    if (familyMapNode) {
+      const f = draft.family_map || {};
+      familyMapNode.innerHTML = formatReviewBlock(
+        f.family_branch_name || "Family Map",
+        [
+          `People in Scope: ${f.people_in_scope || "—"}`,
+          `Parent One: ${f.parent_one || "—"}`,
+          `Parent Two: ${f.parent_two || "—"}`,
+          `Children: ${f.children_names || "—"}`,
+        ],
+        "2",
+      );
+    }
+
+    if (uploadsNode) {
+      const u = draft.uploads || {};
+      uploadsNode.innerHTML = formatReviewBlock(
+        "Uploads",
+        [
+          `Approx. Uploads: ${u.approx_upload_count || "—"}`,
+          `Primary Asset Type: ${u.primary_asset_type || "—"}`,
+          `Key Portraits: ${u.key_portraits || "—"}`,
+        ],
+        "3",
+      );
+    }
+
+    if (consentNode) {
+      const c = draft.consent || {};
+      consentNode.innerHTML = formatReviewBlock(
+        "Consent",
+        [
+          `Process Consent: ${c.consent_process ? "Yes" : "No"}`,
+          `Store Consent: ${c.consent_store ? "Yes" : "No"}`,
+          `Visibility: ${c.visibility_preference || "—"}`,
+        ],
+        "4",
+      );
+    }
+  }
+
+  function setupReviewForm() {
+    const page = document.querySelector("[data-intake-review]");
+    if (!page) return;
+
+    const form = document.querySelector("[data-intake-review-form]");
+    const statusNode = document.querySelector(
+      "[data-intake-review-form-status]",
+    );
+    const reviewHeadline = document.querySelector(
+      "[data-intake-review-status]",
+    );
+    const submitBtn = document.querySelector("[data-intake-review-submit-btn]");
+
+    if (!form) return;
+
+    renderReviewSummaryBlocks();
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      clearStatus(statusNode);
+
+      if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+        return;
+      }
+
+      const draft = loadDraft();
+
+      if (!draft.household || !draft.family_map) {
+        setStatus(
+          statusNode,
+          "Household Setup and Family Map must be saved before submission.",
+          "error",
+        );
+        return;
+      }
+
+      const formValues = formToObject(form);
+      mergeDraft("review", formValues);
+
+      const submissionPayload = {
+        package_name: draft.package_name || "",
+        package_slug: draft.package_slug || "",
+        household: draft.household || {},
+        family_map: draft.family_map || {},
+        uploads: draft.uploads || {},
+        consent: draft.consent || {},
+        review: {
+          final_intake_notes: formValues.final_intake_notes || "",
+          confirm_accuracy: Boolean(formValues.confirm_accuracy),
+        },
+        status: "submitted",
+        source: "web",
+        submitted_at: new Date().toISOString(),
+      };
+
+      try {
+        if (submitBtn) {
+          submitBtn.disabled = true;
+          submitBtn.textContent = "Submitting Intake...";
+        }
+
+        const response = await app.apiRequest("/intake-submissions", {
+          method: "POST",
+          body: JSON.stringify(submissionPayload),
+        });
+
+        saveDraft({
+          ...draft,
+          submitted: true,
+          submission_id:
+            response?.id || response?.submission_id || response?._id || null,
+        });
+
+        if (reviewHeadline) {
+          reviewHeadline.textContent =
+            "Your intake review has been submitted successfully.";
+        }
+
+        setStatus(statusNode, "Intake submitted successfully.", "success");
+
+        setTimeout(function () {
+          window.location.href = "dashboard.html";
+        }, 1200);
+      } catch (error) {
+        setStatus(
+          statusNode,
+          `Submission failed: ${getErrorMessage(error)}`,
+          "error",
+        );
+      } finally {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = "Submit Intake Review";
+        }
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupIntakeWelcome();
+    setupHouseholdForm();
+    setupFamilyMapForm();
+    setupUploadsForm();
+    setupConsentForm();
+    setupReviewForm();
+  });
+})();


### PR DESCRIPTION
- added intake.js to save and reload onboarding draft data across intake pages
- connected household, family map, uploads, consent, and review pages to the shared intake draft flow
- fixed family map navigation so the flow now continues to uploads instead of jumping straight to review
- corrected onboarding step numbering for uploads and consent
- updated review page support so saved intake sections can be summarized before final submission
- improved package-aware intake welcome behavior for active paid users
- fixed intake page script loading so intake.js runs alongside config.js, app.js, and auth.js
- aligned the founder onboarding path to the real sequence: welcome -> household -> family map -> uploads -> consent -> review