### PR TITLE
Restrict relationship access to owner or shared users

### DIFF
--- a/backend/app/routes/relationships.py
+++ b/backend/app/routes/relationships.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
@@ -5,22 +7,167 @@ from app.dependencies.auth import get_current_user
 from app.schemas.relationship import RelationshipCreate, RelationshipResponse
 from app.services.relationship_guardrails import RelationshipGuardrailService
 
-
 router = APIRouter(prefix="/relationships", tags=["Relationships"])
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return str(raw_email).strip().lower()
+
+
+def _current_user_display_name(user: dict[str, Any]) -> str:
+    raw_name = user.get("full_name") or user.get("name") or ""
+    return str(raw_name).strip()
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    return str(user.get("role", "")).strip().lower() == "admin"
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = str(family.get("owner_user_id") or "").strip()
+    owner_email = str(family.get("owner_email") or "").strip().lower()
+
+    shared_with_user_ids = [
+        str(value).strip()
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        str(value).strip().lower()
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    # Backward-compatible fallback for older family records
+    if not owner_user_id and not owner_email:
+        created_by = str(family.get("created_by") or "").strip()
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_family_access_by_family_id(
+    family_id: str,
+    db,
+    current_user: dict[str, Any],
+) -> dict[str, Any]:
+    if not family_id:
+        raise HTTPException(status_code=400, detail="family_id is required.")
+
+    if not ObjectId.is_valid(family_id):
+        raise HTTPException(status_code=400, detail="Invalid family id.")
+
+    family = db["families"].find_one({"_id": ObjectId(family_id)})
+    if not family:
+        raise HTTPException(status_code=404, detail="Family not found.")
+
+    if _is_admin(current_user):
+        return family
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_display_name(current_user)
+
+    if not _family_is_visible_to_user(
+        family=family,
+        current_user_id=current_user_id,
+        current_user_email=current_user_email,
+        current_user_name=current_user_name,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this family.",
+        )
+
+    return family
+
+
+def _require_member_access(
+    member_id: str,
+    db,
+    current_user: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not ObjectId.is_valid(member_id):
+        raise HTTPException(status_code=400, detail="Invalid member id.")
+
+    member = db["family_members"].find_one({"_id": ObjectId(member_id)})
+    if not member:
+        raise HTTPException(status_code=404, detail="Family member not found.")
+
+    family_id = str(member.get("family_id") or "").strip()
+    family = _require_family_access_by_family_id(family_id, db, current_user)
+    return member, family
+
+
+def _require_relationship_access(
+    relationship_id: str,
+    db,
+    current_user: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not ObjectId.is_valid(relationship_id):
+        raise HTTPException(status_code=400, detail="Invalid relationship_id format")
+
+    relationship = db["relationships"].find_one({"_id": ObjectId(relationship_id)})
+    if not relationship:
+        raise HTTPException(status_code=404, detail="Relationship not found")
+
+    family_id = str(relationship.get("family_id") or "").strip()
+    family = _require_family_access_by_family_id(family_id, db, current_user)
+    return relationship, family
 
 
 @router.post("", response_model=RelationshipResponse, status_code=status.HTTP_201_CREATED)
 async def create_relationship(
     payload: RelationshipCreate,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = request.app.state.db
     service = RelationshipGuardrailService(db)
 
+    _require_family_access_by_family_id(payload.family_id, db, current_user)
+
     created_by = (
         current_user.get("email")
         or current_user.get("username")
+        or current_user.get("full_name")
+        or current_user.get("name")
         or current_user.get("id")
         or payload.created_by
     )
@@ -49,7 +196,7 @@ async def create_relationship(
     )
 
     return RelationshipResponse(
-        id=created["_id"],
+        id=str(created["_id"]),
         family_id=created["family_id"],
         source_member_id=created["source_member_id"],
         target_member_id=created["target_member_id"],
@@ -64,16 +211,28 @@ async def create_relationship(
 async def get_family_relationships(
     family_id: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = request.app.state.db
+
+    _require_family_access_by_family_id(family_id, db, current_user)
 
     relationships = []
     cursor = db["relationships"].find({"family_id": family_id})
 
     for rel in cursor:
-        rel["_id"] = str(rel["_id"])
-        relationships.append(rel)
+        relationships.append(
+            {
+                "id": str(rel.get("_id")),
+                "family_id": rel.get("family_id"),
+                "source_member_id": rel.get("source_member_id"),
+                "target_member_id": rel.get("target_member_id"),
+                "relationship_type": rel.get("relationship_type"),
+                "notes": rel.get("notes"),
+                "created_by": rel.get("created_by"),
+                "created_at": rel.get("created_at"),
+            }
+        )
 
     return {
         "family_id": family_id,
@@ -86,9 +245,11 @@ async def get_family_relationships(
 async def get_member_relationships(
     member_id: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = request.app.state.db
+
+    _member, _family = _require_member_access(member_id, db, current_user)
 
     relationships = []
     cursor = db["relationships"].find(
@@ -101,8 +262,18 @@ async def get_member_relationships(
     )
 
     for rel in cursor:
-        rel["_id"] = str(rel["_id"])
-        relationships.append(rel)
+        relationships.append(
+            {
+                "id": str(rel.get("_id")),
+                "family_id": rel.get("family_id"),
+                "source_member_id": rel.get("source_member_id"),
+                "target_member_id": rel.get("target_member_id"),
+                "relationship_type": rel.get("relationship_type"),
+                "notes": rel.get("notes"),
+                "created_by": rel.get("created_by"),
+                "created_at": rel.get("created_at"),
+            }
+        )
 
     return {
         "member_id": member_id,
@@ -115,30 +286,28 @@ async def get_member_relationships(
 async def delete_relationship(
     relationship_id: str,
     request: Request,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = request.app.state.db
 
-    try:
-        object_id = ObjectId(relationship_id)
-    except Exception:
-        raise HTTPException(status_code=400, detail="Invalid relationship_id format")
+    relationship, _family = _require_relationship_access(relationship_id, db, current_user)
 
-    relationship = db["relationships"].find_one({"_id": object_id})
+    db["relationships"].delete_one({"_id": ObjectId(relationship_id)})
 
-    if not relationship:
-        raise HTTPException(status_code=404, detail="Relationship not found")
-
-    db["relationships"].delete_one({"_id": object_id})
+    deleted_by = (
+        current_user.get("email")
+        or current_user.get("username")
+        or current_user.get("full_name")
+        or current_user.get("name")
+        or current_user.get("id")
+    )
 
     db["audit_logs"].insert_one(
         {
             "event": "relationship_deleted",
             "relationship_id": relationship_id,
             "family_id": relationship.get("family_id"),
-            "deleted_by": current_user.get("email")
-            or current_user.get("username")
-            or current_user.get("id"),
+            "deleted_by": deleted_by,
             "created_at": relationship.get("created_at"),
         }
     )


### PR DESCRIPTION
- added authorization checks to relationship routes
- restricted family relationship queries to owners, shared users, or admin only
- blocked creating relationships under unauthorized family ids
- blocked reading member relationships outside authorized family scope
- blocked deleting relationships outside authorized family scope
- normalized relationship response ids and aligned access rules with family, graph, tree, certificate, and member routes