### PR TITLE
Restrict lineage graph access to owner or shared users

### DIFF
--- a/backend/app/routes/lineage_graph.py
+++ b/backend/app/routes/lineage_graph.py
@@ -1,12 +1,139 @@
-from fastapi import APIRouter
+from typing import Any
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.database import get_database
+from app.dependencies.auth import get_current_user
 from app.services.lineage_graph_service import build_lineage_graph
 
 router = APIRouter(
     prefix="/lineage",
-    tags=["lineage"]
+    tags=["lineage"],
 )
 
 
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return str(raw_email).strip().lower()
+
+
+def _current_user_display_name(user: dict[str, Any]) -> str:
+    raw_name = user.get("full_name") or user.get("name") or ""
+    return str(raw_name).strip()
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    return str(user.get("role", "")).strip().lower() == "admin"
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = str(family.get("owner_user_id") or "").strip()
+    owner_email = str(family.get("owner_email") or "").strip().lower()
+
+    shared_with_user_ids = [
+        str(value).strip()
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        str(value).strip().lower()
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    # Backward-compatible fallback for older family records
+    if not owner_user_id and not owner_email:
+        created_by = str(family.get("created_by") or "").strip()
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_family_access(
+    family_id: str,
+    current_user: dict[str, Any],
+) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database is not connected.",
+        )
+
+    if not ObjectId.is_valid(family_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid family id.",
+        )
+
+    family = db["families"].find_one({"_id": ObjectId(family_id)})
+    if not family:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Family not found.",
+        )
+
+    if _is_admin(current_user):
+        return family
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_display_name(current_user)
+
+    if not _family_is_visible_to_user(
+        family=family,
+        current_user_id=current_user_id,
+        current_user_email=current_user_email,
+        current_user_name=current_user_name,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this lineage graph.",
+        )
+
+    return family
+
+
 @router.get("/{family_id}")
-def get_lineage_graph(family_id: str):
+def get_lineage_graph(
+    family_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _require_family_access(family_id, current_user)
     return build_lineage_graph(family_id)


### PR DESCRIPTION
- added authorization checks to lineage graph route
- restricted lineage graph access to the owner, shared users, or admin only
- blocked direct access to other household lineage graphs by family id
- added family ownership visibility checks before building lineage graph data
- included backward-compatible access fallback for older family records without owner metadata