### PR TITLE
restrict issued certificate access to owner or shared users and certi…

### DIFF
--- a/backend/app/routes/certificate_versions.py
+++ b/backend/app/routes/certificate_versions.py
@@ -1,5 +1,10 @@
-from fastapi import APIRouter, HTTPException, status
+from typing import Any
 
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.database import get_database
+from app.dependencies.auth import get_current_user
 from app.services.issued_certificate_service import IssuedCertificateService
 
 router = APIRouter(
@@ -10,8 +15,136 @@ router = APIRouter(
 service = IssuedCertificateService()
 
 
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return str(raw_email).strip().lower()
+
+
+def _current_user_display_name(user: dict[str, Any]) -> str:
+    raw_name = user.get("full_name") or user.get("name") or ""
+    return str(raw_name).strip()
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    return str(user.get("role", "")).strip().lower() == "admin"
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = str(family.get("owner_user_id") or "").strip()
+    owner_email = str(family.get("owner_email") or "").strip().lower()
+
+    shared_with_user_ids = [
+        str(value).strip()
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        str(value).strip().lower()
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    # Backward-compatible fallback for older family records
+    if not owner_user_id and not owner_email:
+        created_by = str(family.get("created_by") or "").strip()
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_family_access(
+    family_id: str,
+    current_user: dict[str, Any],
+) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database is not connected.",
+        )
+
+    if not family_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="family_id is required.",
+        )
+
+    if not ObjectId.is_valid(family_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid family id.",
+        )
+
+    family = db["families"].find_one({"_id": ObjectId(family_id)})
+    if not family:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Family not found.",
+        )
+
+    if _is_admin(current_user):
+        return family
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_display_name(current_user)
+
+    if not _family_is_visible_to_user(
+        family=family,
+        current_user_id=current_user_id,
+        current_user_email=current_user_email,
+        current_user_name=current_user_name,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access these certificate versions.",
+        )
+
+    return family
+
+
 @router.get("/family/{family_id}")
-def list_family_certificate_versions(family_id: str):
+def list_family_certificate_versions(
+    family_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _require_family_access(family_id, current_user)
+
     try:
         return service.list_family_certificate_versions(family_id)
     except Exception as exc:
@@ -22,7 +155,12 @@ def list_family_certificate_versions(family_id: str):
 
 
 @router.get("/family/{family_id}/latest")
-def get_latest_family_certificate(family_id: str):
+def get_latest_family_certificate(
+    family_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _require_family_access(family_id, current_user)
+
     try:
         return service.get_latest_family_certificate(family_id)
     except ValueError as exc:
@@ -38,7 +176,15 @@ def get_latest_family_certificate(family_id: str):
 
 
 @router.post("/ensure-indexes")
-def ensure_certificate_indexes():
+def ensure_certificate_indexes(
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    if not _is_admin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required.",
+        )
+
     try:
         return service.ensure_indexes()
     except Exception as exc:

--- a/backend/app/routes/issued_certificates.py
+++ b/backend/app/routes/issued_certificates.py
@@ -1,5 +1,10 @@
-from fastapi import APIRouter, HTTPException, Query, status
+from typing import Any
 
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.database import get_database
+from app.dependencies.auth import get_current_user
 from app.services.issued_certificate_service import IssuedCertificateService
 
 router = APIRouter(
@@ -10,16 +15,165 @@ router = APIRouter(
 service = IssuedCertificateService()
 
 
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return str(raw_email).strip().lower()
+
+
+def _current_user_display_name(user: dict[str, Any]) -> str:
+    raw_name = user.get("full_name") or user.get("name") or ""
+    return str(raw_name).strip()
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    return str(user.get("role", "")).strip().lower() == "admin"
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = str(family.get("owner_user_id") or "").strip()
+    owner_email = str(family.get("owner_email") or "").strip().lower()
+
+    shared_with_user_ids = [
+        str(value).strip()
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        str(value).strip().lower()
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    # Backward-compatible fallback for older family records
+    if not owner_user_id and not owner_email:
+        created_by = str(family.get("created_by") or "").strip()
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_family_access(
+    family_id: str,
+    current_user: dict[str, Any],
+) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database is not connected.",
+        )
+
+    if not family_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="family_id is required.",
+        )
+
+    if not ObjectId.is_valid(family_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid family id.",
+        )
+
+    family = db["families"].find_one({"_id": ObjectId(family_id)})
+    if not family:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Family not found.",
+        )
+
+    if _is_admin(current_user):
+        return family
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_display_name(current_user)
+
+    if not _family_is_visible_to_user(
+        family=family,
+        current_user_id=current_user_id,
+        current_user_email=current_user_email,
+        current_user_name=current_user_name,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this family certificate.",
+        )
+
+    return family
+
+
+def _extract_family_id_from_record(record: dict[str, Any]) -> str | None:
+    direct = record.get("family_id")
+    if direct:
+        return str(direct)
+
+    certificate = record.get("certificate") or {}
+    family = certificate.get("family") or {}
+
+    nested_id = family.get("id") or family.get("family_id")
+    if nested_id:
+        return str(nested_id)
+
+    return None
+
+
 @router.post("/issue/{family_id}")
 def issue_certificate(
     family_id: str,
-    issued_by: str = Query(default="system"),
     notes: str | None = Query(default=None),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _require_family_access(family_id, current_user)
+
+    issued_by = (
+        current_user.get("email")
+        or current_user.get("username")
+        or current_user.get("full_name")
+        or current_user.get("name")
+        or current_user.get("id")
+        or "system"
+    )
+
     try:
         return service.issue_certificate(
             family_id=family_id,
-            issued_by=issued_by,
+            issued_by=str(issued_by),
             notes=notes,
         )
     except ValueError as exc:
@@ -35,9 +189,29 @@ def issue_certificate(
 
 
 @router.get("/")
-def list_issued_certificates(limit: int = Query(default=50, ge=1, le=200)):
+def list_issued_certificates(
+    limit: int = Query(default=50, ge=1, le=200),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     try:
-        return service.list_certificates(limit=limit)
+        records = service.list_certificates(limit=limit)
+
+        if _is_admin(current_user):
+            return records
+
+        visible_records = []
+        for record in records:
+            family_id = _extract_family_id_from_record(record)
+            if not family_id:
+                continue
+
+            try:
+                _require_family_access(family_id, current_user)
+                visible_records.append(record)
+            except HTTPException:
+                continue
+
+        return visible_records
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -46,14 +220,28 @@ def list_issued_certificates(limit: int = Query(default=50, ge=1, le=200)):
 
 
 @router.get("/by-certificate-id/{certificate_id}")
-def get_issued_certificate_by_certificate_id(certificate_id: str):
+def get_issued_certificate_by_certificate_id(
+    certificate_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     try:
-        return service.get_certificate_by_certificate_id(certificate_id)
+        record = service.get_certificate_by_certificate_id(certificate_id)
+        family_id = _extract_family_id_from_record(record)
+        if not family_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificate family could not be resolved.",
+            )
+
+        _require_family_access(family_id, current_user)
+        return record
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(exc),
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -62,14 +250,28 @@ def get_issued_certificate_by_certificate_id(certificate_id: str):
 
 
 @router.get("/{record_id}")
-def get_issued_certificate(record_id: str):
+def get_issued_certificate(
+    record_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     try:
-        return service.get_certificate_by_record_id(record_id)
+        record = service.get_certificate_by_record_id(record_id)
+        family_id = _extract_family_id_from_record(record)
+        if not family_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Certificate family could not be resolved.",
+            )
+
+        _require_family_access(family_id, current_user)
+        return record
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(exc),
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
…ficate version access and admin-only index action

- added authorization checks to certificate version routes
- restricted family certificate version access to the owner, shared users, or admin only
- blocked direct access to other household certificate version history by family id
- restricted ensure-indexes to admin users only
- aligned certificate version security with family, graph, tree, certificate, member, and relationship routes,- added authorization checks to issued certificate routes
- restricted certificate issuance and retrieval to the owner, shared users, or admin only
- filtered issued certificate listing for non-admin users to visible families only
- blocked direct access to other household certificate records by family id, record id, or certificate id
- derived issued_by from the authenticated user instead of trusting a public query value