### PR TITLE
Align family and tree services with private ownership model

### DIFF
--- a/backend/app/services/family_member_service.py
+++ b/backend/app/services/family_member_service.py
@@ -1,21 +1,46 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from app.database import get_database
 from app.schemas.family_member import FamilyMemberCreate
 
 
-def list_family_members() -> list[dict]:
+def list_family_members(
+    *,
+    family_ids: list[str] | None = None,
+    is_admin: bool = False,
+) -> list[dict]:
     db = get_database()
     if db is None:
         return []
 
-    return list(db.family_members.find().sort("generation", 1))
+    if is_admin:
+        return list(
+            db.family_members.find().sort(
+                [("generation", 1), ("created_at", 1)]
+            )
+        )
+
+    if not family_ids:
+        return []
+
+    return list(
+        db.family_members.find({"family_id": {"$in": family_ids}}).sort(
+            [("generation", 1), ("created_at", 1)]
+        )
+    )
 
 
-def create_family_member(payload: FamilyMemberCreate) -> dict:
+def create_family_member(
+    payload: FamilyMemberCreate,
+    *,
+    created_by_user_id: str | None = None,
+) -> dict:
     db = get_database()
     data = payload.model_dump()
-    data["created_at"] = datetime.now(UTC).isoformat()
+
+    data["created_at"] = datetime.now(UTC)
+    if created_by_user_id:
+        data["created_by_user_id"] = created_by_user_id
 
     if db is None:
         data["_id"] = "local-family-member-preview"

--- a/backend/app/services/family_service.py
+++ b/backend/app/services/family_service.py
@@ -1,21 +1,72 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
+from typing import Optional
 
 from app.database import get_database
 from app.schemas.family import FamilyCreate
 
 
-def list_families() -> list[dict]:
+def _normalize_email(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    return str(value).strip().lower()
+
+
+def list_families(
+    *,
+    owner_user_id: str | None = None,
+    owner_email: str | None = None,
+    include_shared: bool = True,
+    is_admin: bool = False,
+) -> list[dict]:
     db = get_database()
     if db is None:
         return []
 
-    return list(db.families.find().sort("created_at", -1))
+    if is_admin:
+        return list(db.families.find().sort("created_at", -1))
+
+    owner_email = _normalize_email(owner_email)
+
+    filters = []
+    if owner_user_id:
+        filters.append({"owner_user_id": owner_user_id})
+    if owner_email:
+        filters.append({"owner_email": owner_email})
+
+    if include_shared:
+        if owner_user_id:
+            filters.append({"shared_with_user_ids": owner_user_id})
+        if owner_email:
+            filters.append({"shared_with_emails": owner_email})
+
+    if not filters:
+        return []
+
+    return list(
+        db.families.find({"$or": filters}).sort("created_at", -1)
+    )
 
 
-def create_family(payload: FamilyCreate) -> dict:
+def create_family(
+    payload: FamilyCreate,
+    *,
+    owner_user_id: str | None = None,
+    owner_email: str | None = None,
+    visibility: str = "private",
+    shared_with_user_ids: list[str] | None = None,
+    shared_with_emails: list[str] | None = None,
+) -> dict:
     db = get_database()
     data = payload.model_dump()
-    data["created_at"] = datetime.now(UTC).isoformat()
+
+    data["created_at"] = datetime.now(UTC)
+    data["owner_user_id"] = owner_user_id
+    data["owner_email"] = _normalize_email(owner_email)
+    data["visibility"] = visibility
+    data["shared_with_user_ids"] = shared_with_user_ids or []
+    data["shared_with_emails"] = [
+        email for email in (_normalize_email(x) for x in (shared_with_emails or [])) if email
+    ]
 
     if db is None:
         data["_id"] = "local-family-preview"

--- a/backend/app/services/tree_service.py
+++ b/backend/app/services/tree_service.py
@@ -1,4 +1,15 @@
+from typing import Any
+
+from bson import ObjectId
+
 from app.database import get_database
+
+
+def _family_id_candidates(family_id: str) -> list[Any]:
+    values: list[Any] = [family_id]
+    if ObjectId.is_valid(family_id):
+        values.append(ObjectId(family_id))
+    return values
 
 
 def _serialize_member(member: dict) -> dict:
@@ -38,6 +49,7 @@ def _serialize_node(node: dict) -> dict:
 def _serialize_relationship(rel: dict) -> dict:
     return {
         "id": str(rel["_id"]),
+        "family_id": rel.get("family_id"),
         "source_member_id": rel.get("source_member_id"),
         "target_member_id": rel.get("target_member_id"),
         "relationship_type": rel.get("relationship_type"),
@@ -63,6 +75,52 @@ def _build_edges(relationships: list[dict]) -> list[dict]:
     return edges
 
 
+def _find_family(db, family_id: str):
+    if ObjectId.is_valid(family_id):
+        family = db.families.find_one({"_id": ObjectId(family_id)})
+        if family is not None:
+            return family
+
+    family = db.families.find_one({"family_id": family_id})
+    if family is not None:
+        return family
+
+    family = db.families.find_one({"family_name": family_id})
+    return family
+
+
+def _find_members(db, family_id: str) -> list[dict]:
+    candidates = _family_id_candidates(family_id)
+    return list(db.family_members.find({"family_id": {"$in": candidates}}))
+
+
+def _find_nodes(db, family_id: str) -> list[dict]:
+    candidates = _family_id_candidates(family_id)
+    return list(db.lineage_nodes.find({"family_id": {"$in": candidates}}))
+
+
+def _find_relationships(db, family_id: str, member_ids: set[str]) -> list[dict]:
+    candidates = _family_id_candidates(family_id)
+
+    relationships = list(db.relationships.find({"family_id": {"$in": candidates}}))
+    if relationships:
+        return relationships
+
+    if not member_ids:
+        return []
+
+    return list(
+        db.relationships.find(
+            {
+                "$or": [
+                    {"source_member_id": {"$in": list(member_ids)}},
+                    {"target_member_id": {"$in": list(member_ids)}},
+                ]
+            }
+        )
+    )
+
+
 def get_family_tree(family_id: str) -> dict:
     db = get_database()
     if db is None:
@@ -76,19 +134,20 @@ def get_family_tree(family_id: str) -> dict:
             "edges": [],
         }
 
-    family = db.families.find_one({"_id": family_id})
-    if family is None:
-        family = db.families.find_one({"family_name": family_id})
-
-    members = list(db.family_members.find({"family_id": family_id}))
-    nodes = list(db.lineage_nodes.find({"family_id": family_id}))
-    relationships = list(db.relationships.find())
+    family = _find_family(db, family_id)
+    members = _find_members(db, family_id)
+    nodes = _find_nodes(db, family_id)
 
     member_ids = {str(member["_id"]) for member in members}
+    relationships = _find_relationships(db, family_id, member_ids)
+
     filtered_relationships = [
         rel
         for rel in relationships
-        if rel.get("source_member_id") in member_ids or rel.get("target_member_id") in member_ids
+        if (
+            rel.get("source_member_id") in member_ids
+            or rel.get("target_member_id") in member_ids
+        )
     ]
 
     return {
@@ -115,19 +174,20 @@ def get_filtered_family_tree(family_id: str, mode: str) -> dict:
             "edges": [],
         }
 
-    family = db.families.find_one({"_id": family_id})
-    if family is None:
-        family = db.families.find_one({"family_name": family_id})
-
-    members = list(db.family_members.find({"family_id": family_id}))
-    nodes = list(db.lineage_nodes.find({"family_id": family_id}))
-    relationships = list(db.relationships.find())
+    family = _find_family(db, family_id)
+    members = _find_members(db, family_id)
+    nodes = _find_nodes(db, family_id)
 
     member_ids = {str(member["_id"]) for member in members}
+    relationships = _find_relationships(db, family_id, member_ids)
+
     relationships = [
         rel
         for rel in relationships
-        if rel.get("source_member_id") in member_ids or rel.get("target_member_id") in member_ids
+        if (
+            rel.get("source_member_id") in member_ids
+            or rel.get("target_member_id") in member_ids
+        )
     ]
 
     if mode == "verified":


### PR DESCRIPTION
- updated family_service to support owner/shared family scoping and private family metadata
- updated family_member_service to avoid returning all family members without an authorized family scope
- restored and corrected tree_service so tree routes use real family tree logic again
- updated tree_service to query family-specific relationships instead of scanning all relationships globally
- improved family lookup handling for string and ObjectId-based family references