### PR TITLE
Add intake review states, lock behavior, and approval metadata

### DIFF
--- a/backend/app/schemas/intake_submission.py
+++ b/backend/app/schemas/intake_submission.py
@@ -52,12 +52,16 @@ class IntakeSubmissionCreate(BaseModel):
 
     household: IntakeHouseholdPayload
     family_map: IntakeFamilyMapPayload
-
-    # ✅ NEW
     uploads: IntakeUploadsPayload
     consent: IntakeConsentPayload
-
     review: IntakeReviewPayload
+
+
+class IntakeSubmissionStatusUpdate(BaseModel):
+    status: str = Field(..., min_length=1)
+    review_notes: str = Field(default="")
+    approval_notes: str = Field(default="")
+    rejection_reason: str = Field(default="")
 
 
 class IntakeSubmissionResponse(BaseModel):
@@ -67,15 +71,21 @@ class IntakeSubmissionResponse(BaseModel):
     package_slug: str
     package_name: str
     status: str
+    review_locked: bool
 
     household: dict[str, Any]
     family_map: dict[str, Any]
-
-    # ✅ NEW
     uploads: dict[str, Any]
     consent: dict[str, Any]
-
     review: dict[str, Any]
+
+    submitted_at: Optional[datetime] = None
+    review_started_at: Optional[datetime] = None
+    reviewed_at: Optional[datetime] = None
+    reviewed_by: Optional[str] = None
+    review_notes: Optional[str] = None
+    approval_notes: Optional[str] = None
+    rejection_reason: Optional[str] = None
 
     created_at: datetime
     updated_at: datetime
@@ -83,7 +93,13 @@ class IntakeSubmissionResponse(BaseModel):
 
 class IntakeSubmissionListItem(BaseModel):
     id: str
+    user_id: str
+    email: str
     package_slug: str
     package_name: str
     status: str
+    review_locked: bool
+    submitted_at: Optional[datetime] = None
+    reviewed_at: Optional[datetime] = None
+    reviewed_by: Optional[str] = None
     created_at: datetime

--- a/backend/app/services/intake_submission_service.py
+++ b/backend/app/services/intake_submission_service.py
@@ -1,9 +1,7 @@
-# app/services/intake_submission_service.py
-
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional, Any
+from typing import Any, Optional
 
 from bson import ObjectId
 from pymongo.collection import Collection
@@ -11,6 +9,9 @@ from pymongo.collection import Collection
 from app.database import get_database
 
 COLLECTION = "intake_submissions"
+
+LOCKED_STATUSES = {"submitted", "in_review", "approved"}
+REVIEWABLE_STATUSES = {"submitted", "in_review", "approved", "rejected"}
 
 
 def _now() -> datetime:
@@ -22,13 +23,18 @@ def _oid(value: str) -> ObjectId:
 
 
 def _serialize(doc: dict[str, Any]) -> dict[str, Any]:
-    """Mongo -> JSON-safe"""
     out = dict(doc)
     out["id"] = str(out.pop("_id"))
-    # normalize common ids
+
     if "user_id" in out and isinstance(out["user_id"], ObjectId):
         out["user_id"] = str(out["user_id"])
+
     return out
+
+
+def _collection() -> Collection:
+    db = get_database()
+    return db[COLLECTION]
 
 
 def create_intake_submission(
@@ -40,50 +46,60 @@ def create_intake_submission(
     """
     Create a submitted intake record.
 
-    payload expected keys:
-      - package_slug (str)
-      - package_name (str)
-      - household (dict)
-      - family_map (dict)
-      - review (dict)
-      - uploads (dict) OPTIONAL
-      - consent (dict) OPTIONAL
+    Rules:
+    - one active locked submission at a time per user
+    - allowed to submit again only when no locked submission exists
+      or after rejection flow is handled manually
     """
-    db = get_database()
-    col: Collection = db[COLLECTION]
-
+    col = _collection()
     now = _now()
+
+    latest = col.find_one(
+        {"user_id": _oid(user_id)},
+        sort=[("created_at", -1)],
+    )
+
+    if latest and str(latest.get("status", "")).lower() in LOCKED_STATUSES:
+        raise ValueError(
+            "An intake submission is already submitted or under review for this account."
+        )
+
+    status = str(payload.get("status") or "submitted").strip().lower()
+    review_locked = status in LOCKED_STATUSES
 
     record: dict[str, Any] = {
         "user_id": _oid(user_id),
-        "email": email,
+        "email": str(email).strip().lower(),
         "package_slug": payload["package_slug"],
         "package_name": payload["package_name"],
-        "status": "submitted",
+        "status": status,
+        "review_locked": review_locked,
         "household": payload["household"],
         "family_map": payload["family_map"],
-        # ✅ NEW: optional steps stored if provided
         "uploads": payload.get("uploads", {}) or {},
         "consent": payload.get("consent", {}) or {},
         "review": payload["review"],
+        "submitted_at": now if status == "submitted" else None,
+        "review_started_at": None,
+        "reviewed_at": None,
+        "reviewed_by": None,
+        "review_notes": "",
+        "approval_notes": "",
+        "rejection_reason": "",
         "created_at": now,
         "updated_at": now,
     }
 
     result = col.insert_one(record)
-
     saved = col.find_one({"_id": result.inserted_id})
     if not saved:
-        # This should basically never happen, but it makes type-checkers happy
-        # and gives a real error if Mongo ever fails to return the record.
         raise RuntimeError("Failed to fetch saved intake submission after insert.")
 
     return _serialize(saved)
 
 
 def get_latest_for_user(user_id: str) -> Optional[dict[str, Any]]:
-    db = get_database()
-    col: Collection = db[COLLECTION]
+    col = _collection()
 
     doc = col.find_one(
         {"user_id": _oid(user_id)},
@@ -93,8 +109,7 @@ def get_latest_for_user(user_id: str) -> Optional[dict[str, Any]]:
 
 
 def list_for_user(user_id: str, limit: int = 10) -> list[dict[str, Any]]:
-    db = get_database()
-    col: Collection = db[COLLECTION]
+    col = _collection()
 
     cursor = (
         col.find({"user_id": _oid(user_id)})
@@ -105,8 +120,7 @@ def list_for_user(user_id: str, limit: int = 10) -> list[dict[str, Any]]:
 
 
 def get_by_id(submission_id: str) -> Optional[dict[str, Any]]:
-    db = get_database()
-    col: Collection = db[COLLECTION]
+    col = _collection()
 
     try:
         oid = _oid(submission_id)
@@ -115,3 +129,78 @@ def get_by_id(submission_id: str) -> Optional[dict[str, Any]]:
 
     doc = col.find_one({"_id": oid})
     return _serialize(doc) if doc else None
+
+
+def list_all(limit: int = 50, status: Optional[str] = None) -> list[dict[str, Any]]:
+    col = _collection()
+
+    query: dict[str, Any] = {}
+    if status:
+        query["status"] = str(status).strip().lower()
+
+    cursor = (
+        col.find(query)
+        .sort("created_at", -1)
+        .limit(int(limit))
+    )
+    return [_serialize(d) for d in cursor]
+
+
+def update_status(
+    *,
+    submission_id: str,
+    new_status: str,
+    reviewed_by: str,
+    review_notes: str = "",
+    approval_notes: str = "",
+    rejection_reason: str = "",
+) -> dict[str, Any]:
+    col = _collection()
+
+    try:
+        oid = _oid(submission_id)
+    except Exception:
+        raise ValueError("Invalid submission id.")
+
+    existing = col.find_one({"_id": oid})
+    if not existing:
+        raise ValueError("Intake submission not found.")
+
+    status_normalized = str(new_status).strip().lower()
+    if status_normalized not in REVIEWABLE_STATUSES:
+        raise ValueError("Invalid intake submission status.")
+
+    now = _now()
+
+    update_doc: dict[str, Any] = {
+        "status": status_normalized,
+        "updated_at": now,
+        "reviewed_by": reviewed_by,
+        "review_notes": review_notes or "",
+        "approval_notes": approval_notes or "",
+        "rejection_reason": rejection_reason or "",
+    }
+
+    if status_normalized == "in_review":
+        update_doc["review_started_at"] = now
+        update_doc["review_locked"] = True
+
+    elif status_normalized == "approved":
+        update_doc["reviewed_at"] = now
+        update_doc["review_locked"] = True
+
+    elif status_normalized == "rejected":
+        update_doc["reviewed_at"] = now
+        update_doc["review_locked"] = False
+
+    elif status_normalized == "submitted":
+        update_doc["submitted_at"] = now
+        update_doc["review_locked"] = True
+
+    col.update_one({"_id": oid}, {"$set": update_doc})
+
+    saved = col.find_one({"_id": oid})
+    if not saved:
+        raise RuntimeError("Failed to fetch updated intake submission.")
+
+    return _serialize(saved)


### PR DESCRIPTION
- expanded intake submission schema to support review lifecycle states and reviewer metadata
- added submission lock state and review timeline fields
- updated intake submission service to prevent duplicate locked submissions per user
- added admin-ready status update support for submitted, in_review, approved, and rejected states
- prepared backend intake records for reviewer queue, approval actions, and dashboard status sync