### PR TITLE
Add admin intake submission review queue routes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.config import settings
 from app.database import close_mongo_connection, connect_to_mongo, get_database
 
 from app.routes.audit_logs import router as audit_logs_router
+from app.routes.admin_intake_submissions import router as admin_intake_submissions_router
 from app.routes.auth import router as auth_router
 from app.routes.canonical_persons import router as canonical_persons_router
 from app.routes.certificate_versions import router as certificate_versions_router
@@ -76,6 +77,7 @@ app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(intake_router)
 app.include_router(intake_submissions_router)
+app.include_router(admin_intake_submissions_router)
 app.include_router(projects_router)
 app.include_router(families_router)
 app.include_router(family_graph_router)

--- a/backend/app/routes/admin_intake_submissions.py
+++ b/backend/app/routes/admin_intake_submissions.py
@@ -1,0 +1,148 @@
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from app.dependencies.auth import require_admin
+from app.schemas.intake_submission import (
+    IntakeSubmissionListItem,
+    IntakeSubmissionResponse,
+    IntakeSubmissionStatusUpdate,
+)
+from app.services.intake_submission_service import (
+    get_by_id,
+    list_all,
+    update_status,
+)
+
+router = APIRouter(
+    prefix="/admin/intake-submissions",
+    tags=["Admin Intake Submissions"],
+)
+
+
+class IntakeAdminNotesPayload(BaseModel):
+    review_notes: str = Field(default="")
+    approval_notes: str = Field(default="")
+    rejection_reason: str = Field(default="")
+
+
+def _reviewed_by(current_admin: dict[str, Any]) -> str:
+    return str(
+        current_admin.get("email")
+        or current_admin.get("full_name")
+        or current_admin.get("name")
+        or current_admin.get("id")
+        or "admin"
+    ).strip()
+
+
+@router.get("/", response_model=list[IntakeSubmissionListItem])
+def list_admin_intake_submissions(
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=200),
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    return list_all(limit=limit, status=status_filter)
+
+
+@router.get("/{submission_id}", response_model=IntakeSubmissionResponse)
+def get_admin_intake_submission(
+    submission_id: str,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    submission = get_by_id(submission_id)
+    if not submission:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Intake submission not found.",
+        )
+    return submission
+
+
+@router.post("/{submission_id}/status", response_model=IntakeSubmissionResponse)
+def set_admin_intake_submission_status(
+    submission_id: str,
+    payload: IntakeSubmissionStatusUpdate,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    try:
+        return update_status(
+            submission_id=submission_id,
+            new_status=payload.status,
+            reviewed_by=_reviewed_by(current_admin),
+            review_notes=payload.review_notes,
+            approval_notes=payload.approval_notes,
+            rejection_reason=payload.rejection_reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{submission_id}/in-review", response_model=IntakeSubmissionResponse)
+def mark_admin_intake_in_review(
+    submission_id: str,
+    payload: IntakeAdminNotesPayload,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    try:
+        return update_status(
+            submission_id=submission_id,
+            new_status="in_review",
+            reviewed_by=_reviewed_by(current_admin),
+            review_notes=payload.review_notes,
+            approval_notes=payload.approval_notes,
+            rejection_reason=payload.rejection_reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{submission_id}/approve", response_model=IntakeSubmissionResponse)
+def approve_admin_intake_submission(
+    submission_id: str,
+    payload: IntakeAdminNotesPayload,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    try:
+        return update_status(
+            submission_id=submission_id,
+            new_status="approved",
+            reviewed_by=_reviewed_by(current_admin),
+            review_notes=payload.review_notes,
+            approval_notes=payload.approval_notes,
+            rejection_reason="",
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{submission_id}/reject", response_model=IntakeSubmissionResponse)
+def reject_admin_intake_submission(
+    submission_id: str,
+    payload: IntakeAdminNotesPayload,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    try:
+        return update_status(
+            submission_id=submission_id,
+            new_status="rejected",
+            reviewed_by=_reviewed_by(current_admin),
+            review_notes=payload.review_notes,
+            approval_notes="",
+            rejection_reason=payload.rejection_reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc


### PR DESCRIPTION
- added admin-only intake submission queue routes
- added endpoints to list, open, review, approve, reject, and update intake submission statuses
- connected new admin intake routes into main.py
- prepared backend workflow for reviewer queue, approval actions, and dashboard state sync
- separated reviewer actions from standard customer intake submission flow