### PR TITLE
Add admin intake queue and review UI

### DIFF
--- a/admin-intake-queue.html
+++ b/admin-intake-queue.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Intake Queue | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Admin review queue for Tomb of Light intake submissions."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="admin-intake-queue.html" aria-current="page"
+              >Admin Intake Queue</a
+            >
+            <a href="faq.html">FAQ</a>
+          </nav>
+
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="dashboard.html"
+              >Back to Dashboard</a
+            >
+          </div>
+        </div>
+      </header>
+
+      <main data-admin-queue-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Admin Review Layer</span>
+              <h1>Intake Submission Queue</h1>
+              <p data-admin-queue-status>
+                Loading intake submissions for review...
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Queue Filters</span>
+
+              <div class="form-grid two-col">
+                <label>
+                  Submission Status
+                  <select data-admin-queue-filter>
+                    <option value="all">All</option>
+                    <option value="submitted">Submitted</option>
+                    <option value="in_review">In Review</option>
+                    <option value="approved">Approved</option>
+                    <option value="rejected">Rejected</option>
+                  </select>
+                </label>
+
+                <label>
+                  Refresh Queue
+                  <button
+                    class="btn btn-secondary"
+                    type="button"
+                    data-admin-queue-refresh
+                    style="margin-top: 0.45rem"
+                  >
+                    Refresh
+                  </button>
+                </label>
+              </div>
+
+              <div
+                class="helper"
+                data-admin-queue-action-status
+                aria-live="polite"
+                style="display: none"
+              ></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Queue Summary</span>
+              <div class="grid-3" data-admin-queue-summary>
+                <div>
+                  <div class="card-number">1</div>
+                  <h3>Loading</h3>
+                  <p class="card-copy">Queue summary is loading now.</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Submission Records</span>
+              <div class="grid-3" data-admin-queue-list></div>
+
+              <div
+                class="helper"
+                data-admin-queue-empty
+                aria-live="polite"
+                style="display: none; margin-top: 1rem"
+              >
+                No intake submissions match the current filter.
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="config.js?v=20260322-2"></script>
+    <script src="app.js?v=20260322-2"></script>
+    <script src="auth.js?v=20260322-2"></script>
+    <script src="admin-intake.js?v=20260322-2"></script>
+  </body>
+</html>

--- a/admin-intake-review.html
+++ b/admin-intake-review.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Intake Review | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Admin review detail page for Tomb of Light intake submissions."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="admin-intake-queue.html">Admin Intake Queue</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="admin-intake-queue.html"
+              >Back to Queue</a
+            >
+          </div>
+        </div>
+      </header>
+
+      <main data-admin-review-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Admin Review Detail</span>
+              <h1>Review Intake Submission</h1>
+              <p data-admin-review-page-status>Loading submission details...</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Submission Overview</span>
+              <div class="grid-3" data-admin-review-meta>
+                <div>
+                  <div class="card-number">1</div>
+                  <h3>Loading</h3>
+                  <p class="card-copy">Submission overview is loading.</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Review Timeline</span>
+              <div class="grid-3" data-admin-review-timeline>
+                <div>
+                  <div class="card-number">2</div>
+                  <h3>Loading</h3>
+                  <p class="card-copy">Review timeline is loading.</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Household</span>
+              <div class="grid-3" data-admin-review-household></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Family Map</span>
+              <div class="grid-3" data-admin-review-family-map></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Uploads</span>
+              <div class="grid-3" data-admin-review-uploads></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Consent</span>
+              <div class="grid-3" data-admin-review-consent></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Reviewer Actions</span>
+
+              <form class="form-grid" data-admin-review-form novalidate>
+                <label>
+                  Reviewer Notes
+                  <textarea
+                    name="review_notes"
+                    rows="5"
+                    placeholder="Internal review notes for this submission."
+                  ></textarea>
+                </label>
+
+                <label>
+                  Approval Notes
+                  <textarea
+                    name="approval_notes"
+                    rows="4"
+                    placeholder="Optional approval notes or next-step instructions."
+                  ></textarea>
+                </label>
+
+                <label>
+                  Rejection Reason
+                  <textarea
+                    name="rejection_reason"
+                    rows="4"
+                    placeholder="Required when rejecting a submission."
+                  ></textarea>
+                </label>
+
+                <div
+                  class="helper"
+                  data-admin-review-action-status
+                  aria-live="polite"
+                  style="display: none"
+                ></div>
+
+                <div class="inline-actions" style="margin-top: 1.5rem">
+                  <button
+                    class="btn btn-secondary"
+                    type="button"
+                    data-admin-mark-review
+                  >
+                    Mark In Review
+                  </button>
+
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    data-admin-approve
+                  >
+                    Approve
+                  </button>
+
+                  <button
+                    class="btn btn-secondary"
+                    type="button"
+                    data-admin-reject
+                  >
+                    Reject
+                  </button>
+
+                  <button
+                    class="btn btn-secondary"
+                    type="button"
+                    data-admin-refresh-detail
+                  >
+                    Refresh
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="config.js?v=20260322-2"></script>
+    <script src="app.js?v=20260322-2"></script>
+    <script src="auth.js?v=20260322-2"></script>
+    <script src="admin-intake.js?v=20260322-2"></script>
+  </body>
+</html>

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -1,0 +1,520 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") {
+    console.error("admin-intake.js requires app.js/auth.js first.");
+    return;
+  }
+
+  let allSubmissions = [];
+  let currentSubmission = null;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function normalizeStatus(status) {
+    return String(status || "")
+      .trim()
+      .toLowerCase();
+  }
+
+  function humanizeStatus(status) {
+    const normalized = normalizeStatus(status);
+    if (!normalized) return "Unknown";
+
+    return normalized
+      .split("_")
+      .map(function (part) {
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join(" ");
+  }
+
+  function formatDate(value) {
+    if (!value) return "—";
+    try {
+      return new Date(value).toLocaleString();
+    } catch (error) {
+      return String(value);
+    }
+  }
+
+  function setStatus(node, message, type) {
+    if (!node) return;
+
+    node.style.display = "block";
+    node.textContent = message;
+    node.dataset.state = type || "info";
+
+    if (type === "error") {
+      node.style.color = "#ffb3b3";
+    } else if (type === "success") {
+      node.style.color = "#cfe8cf";
+    } else {
+      node.style.color = "#d6e6ff";
+    }
+  }
+
+  function clearStatus(node) {
+    if (!node) return;
+    node.style.display = "none";
+    node.textContent = "";
+    node.dataset.state = "";
+  }
+
+  function valueLine(label, value) {
+    return `<p class="card-copy"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value || "—")}</p>`;
+  }
+
+  function getQueryParam(name) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(name) || "";
+  }
+
+  function ensureAdminAccess(me) {
+    const role = normalizeStatus(me && me.role);
+    if (role !== "admin") {
+      throw new Error("Admin access is required to use this page.");
+    }
+  }
+
+  async function requireAdmin() {
+    const token = app.getToken ? app.getToken() : null;
+    if (!token) {
+      window.location.href = "signin.html";
+      return null;
+    }
+
+    const me = await app.apiRequest("/auth/me", { method: "GET" });
+    ensureAdminAccess(me);
+    return me;
+  }
+
+  function renderSummaryCards(submissions) {
+    const node = document.querySelector("[data-admin-queue-summary]");
+    if (!node) return;
+
+    const counts = {
+      all: submissions.length,
+      submitted: 0,
+      in_review: 0,
+      approved: 0,
+      rejected: 0,
+    };
+
+    submissions.forEach(function (item) {
+      const status = normalizeStatus(item.status);
+      if (Object.prototype.hasOwnProperty.call(counts, status)) {
+        counts[status] += 1;
+      }
+    });
+
+    node.innerHTML = `
+      <div>
+        <div class="card-number">A</div>
+        <h3>All</h3>
+        <p class="card-copy">${counts.all} submission(s)</p>
+      </div>
+      <div>
+        <div class="card-number">B</div>
+        <h3>Submitted</h3>
+        <p class="card-copy">${counts.submitted} waiting for review</p>
+      </div>
+      <div>
+        <div class="card-number">C</div>
+        <h3>In Review</h3>
+        <p class="card-copy">${counts.in_review} currently open</p>
+      </div>
+      <div>
+        <div class="card-number">D</div>
+        <h3>Approved</h3>
+        <p class="card-copy">${counts.approved} approved</p>
+      </div>
+      <div>
+        <div class="card-number">E</div>
+        <h3>Rejected</h3>
+        <p class="card-copy">${counts.rejected} rejected</p>
+      </div>
+    `;
+  }
+
+  function renderQueueList() {
+    const filterNode = document.querySelector("[data-admin-queue-filter]");
+    const listNode = document.querySelector("[data-admin-queue-list]");
+    const emptyNode = document.querySelector("[data-admin-queue-empty]");
+    if (!listNode) return;
+
+    const filterValue = normalizeStatus(filterNode ? filterNode.value : "all");
+    const filtered = allSubmissions.filter(function (item) {
+      if (filterValue === "all") return true;
+      return normalizeStatus(item.status) === filterValue;
+    });
+
+    if (!filtered.length) {
+      listNode.innerHTML = "";
+      if (emptyNode) emptyNode.style.display = "block";
+      return;
+    }
+
+    if (emptyNode) emptyNode.style.display = "none";
+
+    listNode.innerHTML = filtered
+      .map(function (item, index) {
+        return `
+          <div class="family-record-card">
+            <div class="card-number">${index + 1}</div>
+            <h3>${escapeHtml(item.package_name || item.package_slug || "Submission")}</h3>
+            ${valueLine("Status", humanizeStatus(item.status))}
+            ${valueLine("Email", item.email)}
+            ${valueLine("Submission ID", item.id)}
+            ${valueLine("Created", formatDate(item.created_at))}
+            ${valueLine("Submitted", formatDate(item.submitted_at))}
+            ${valueLine("Reviewed By", item.reviewed_by || "—")}
+            <div class="inline-actions" style="margin-top: 1rem;">
+              <a class="btn btn-primary" href="admin-intake-review.html?submission_id=${encodeURIComponent(item.id)}">
+                Open Review
+              </a>
+            </div>
+          </div>
+        `;
+      })
+      .join("");
+  }
+
+  async function loadQueue() {
+    const statusNode = document.querySelector("[data-admin-queue-status]");
+    try {
+      clearStatus(document.querySelector("[data-admin-queue-action-status]"));
+      allSubmissions = await app.apiRequest(
+        "/admin/intake-submissions?limit=100",
+        {
+          method: "GET",
+        },
+      );
+
+      if (!Array.isArray(allSubmissions)) {
+        allSubmissions = [];
+      }
+
+      renderSummaryCards(allSubmissions);
+      renderQueueList();
+
+      if (statusNode) {
+        statusNode.textContent = `Loaded ${allSubmissions.length} intake submission(s) for admin review.`;
+      }
+    } catch (error) {
+      if (statusNode) {
+        statusNode.textContent = "Intake queue could not be loaded.";
+      }
+      setStatus(
+        document.querySelector("[data-admin-queue-action-status]"),
+        error.message || "Unable to load intake submissions.",
+        "error",
+      );
+    }
+  }
+
+  function renderReviewBlock(node, title, number, lines) {
+    if (!node) return;
+    node.innerHTML = `
+      <div>
+        <div class="card-number">${escapeHtml(number)}</div>
+        <h3>${escapeHtml(title)}</h3>
+        <p class="card-copy">${lines.map(escapeHtml).join("<br />")}</p>
+      </div>
+    `;
+  }
+
+  function renderDetail(submission) {
+    currentSubmission = submission;
+
+    const pageStatus = document.querySelector(
+      "[data-admin-review-page-status]",
+    );
+    const metaNode = document.querySelector("[data-admin-review-meta]");
+    const timelineNode = document.querySelector("[data-admin-review-timeline]");
+    const householdNode = document.querySelector(
+      "[data-admin-review-household]",
+    );
+    const familyMapNode = document.querySelector(
+      "[data-admin-review-family-map]",
+    );
+    const uploadsNode = document.querySelector("[data-admin-review-uploads]");
+    const consentNode = document.querySelector("[data-admin-review-consent]");
+
+    if (pageStatus) {
+      pageStatus.textContent = `Submission ${submission.id} is currently ${humanizeStatus(submission.status)}.`;
+    }
+
+    renderReviewBlock(
+      metaNode,
+      submission.package_name ||
+        submission.package_slug ||
+        "Submission Overview",
+      "1",
+      [
+        `Status: ${humanizeStatus(submission.status)}`,
+        `Email: ${submission.email || "—"}`,
+        `Package: ${submission.package_name || submission.package_slug || "—"}`,
+        `Review Locked: ${submission.review_locked ? "Yes" : "No"}`,
+      ],
+    );
+
+    renderReviewBlock(timelineNode, "Review Timeline", "2", [
+      `Created: ${formatDate(submission.created_at)}`,
+      `Submitted: ${formatDate(submission.submitted_at)}`,
+      `Review Started: ${formatDate(submission.review_started_at)}`,
+      `Reviewed: ${formatDate(submission.reviewed_at)}`,
+      `Reviewed By: ${submission.reviewed_by || "—"}`,
+    ]);
+
+    const household = submission.household || {};
+    renderReviewBlock(
+      householdNode,
+      household.household_name || "Household",
+      "3",
+      [
+        `Primary Contact: ${household.primary_contact_name || "—"}`,
+        `Email: ${household.primary_contact_email || "—"}`,
+        `Phone: ${household.primary_contact_phone || "—"}`,
+        `Co-Owner: ${household.co_owner_name || "—"}`,
+        `Role: ${household.household_role || "—"}`,
+        `Scope: ${household.project_scope || "—"}`,
+        `Notes: ${household.special_notes || "—"}`,
+      ],
+    );
+
+    const familyMap = submission.family_map || {};
+    renderReviewBlock(
+      familyMapNode,
+      familyMap.family_branch_name || "Family Map",
+      "4",
+      [
+        `People in Scope: ${familyMap.people_in_scope || "—"}`,
+        `Parent One: ${familyMap.parent_one || "—"}`,
+        `Parent Two: ${familyMap.parent_two || "—"}`,
+        `Spouse / Partner: ${familyMap.spouse_partner || "—"}`,
+        `Children: ${familyMap.children_names || "—"}`,
+        `Summary: ${familyMap.family_structure_summary || "—"}`,
+        `Branch Notes: ${familyMap.branch_notes || "—"}`,
+      ],
+    );
+
+    const uploads = submission.uploads || {};
+    renderReviewBlock(uploadsNode, "Uploads", "5", [
+      `Approx. Upload Count: ${uploads.approx_upload_count || "—"}`,
+      `Primary Asset Type: ${uploads.primary_asset_type || "—"}`,
+      `Key Portraits: ${uploads.key_portraits || "—"}`,
+      `Supporting Records: ${uploads.supporting_records || "—"}`,
+      `Quality Notes: ${uploads.quality_notes || "—"}`,
+    ]);
+
+    const consent = submission.consent || {};
+    const review = submission.review || {};
+    renderReviewBlock(consentNode, "Consent and Review Notes", "6", [
+      `Process Consent: ${consent.consent_process ? "Yes" : "No"}`,
+      `Store Consent: ${consent.consent_store ? "Yes" : "No"}`,
+      `Visibility: ${consent.visibility_preference || "—"}`,
+      `Consent Notes: ${consent.consent_notes || "—"}`,
+      `Final Intake Notes: ${review.final_intake_notes || "—"}`,
+      `Confirm Accuracy: ${review.confirm_accuracy ? "Yes" : "No"}`,
+      `Reviewer Notes: ${submission.review_notes || "—"}`,
+      `Approval Notes: ${submission.approval_notes || "—"}`,
+      `Rejection Reason: ${submission.rejection_reason || "—"}`,
+    ]);
+
+    const form = document.querySelector("[data-admin-review-form]");
+    if (form) {
+      form.querySelector('[name="review_notes"]').value =
+        submission.review_notes || "";
+      form.querySelector('[name="approval_notes"]').value =
+        submission.approval_notes || "";
+      form.querySelector('[name="rejection_reason"]').value =
+        submission.rejection_reason || "";
+    }
+  }
+
+  async function loadReviewDetail() {
+    const submissionId = getQueryParam("submission_id");
+    const statusNode = document.querySelector(
+      "[data-admin-review-action-status]",
+    );
+
+    if (!submissionId) {
+      setStatus(statusNode, "Missing submission_id in page URL.", "error");
+      return;
+    }
+
+    try {
+      clearStatus(statusNode);
+      const submission = await app.apiRequest(
+        `/admin/intake-submissions/${encodeURIComponent(submissionId)}`,
+        { method: "GET" },
+      );
+      renderDetail(submission);
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Unable to load the intake submission.",
+        "error",
+      );
+    }
+  }
+
+  function getActionPayload() {
+    const form = document.querySelector("[data-admin-review-form]");
+    if (!form) {
+      return {
+        review_notes: "",
+        approval_notes: "",
+        rejection_reason: "",
+      };
+    }
+
+    return {
+      review_notes: form.querySelector('[name="review_notes"]').value || "",
+      approval_notes: form.querySelector('[name="approval_notes"]').value || "",
+      rejection_reason:
+        form.querySelector('[name="rejection_reason"]').value || "",
+    };
+  }
+
+  async function runAdminAction(action) {
+    const statusNode = document.querySelector(
+      "[data-admin-review-action-status]",
+    );
+    const submissionId = getQueryParam("submission_id");
+    if (!submissionId) {
+      setStatus(statusNode, "Missing submission_id in page URL.", "error");
+      return;
+    }
+
+    const payload = getActionPayload();
+
+    if (action === "reject" && !String(payload.rejection_reason || "").trim()) {
+      setStatus(
+        statusNode,
+        "Rejection reason is required before rejecting.",
+        "error",
+      );
+      return;
+    }
+
+    const pathMap = {
+      in_review: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/in-review`,
+      approve: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/approve`,
+      reject: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/reject`,
+    };
+
+    try {
+      setStatus(statusNode, "Submitting admin review action...", "info");
+      const result = await app.apiRequest(pathMap[action], {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+
+      renderDetail(result);
+      setStatus(
+        statusNode,
+        `Submission updated to ${humanizeStatus(result.status)}.`,
+        "success",
+      );
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Admin review action failed.",
+        "error",
+      );
+    }
+  }
+
+  async function setupQueuePage() {
+    const page = document.querySelector("[data-admin-queue-page]");
+    if (!page) return;
+
+    try {
+      await requireAdmin();
+      await loadQueue();
+
+      const filterNode = document.querySelector("[data-admin-queue-filter]");
+      const refreshNode = document.querySelector("[data-admin-queue-refresh]");
+
+      if (filterNode) {
+        filterNode.addEventListener("change", function () {
+          renderQueueList();
+        });
+      }
+
+      if (refreshNode) {
+        refreshNode.addEventListener("click", function () {
+          loadQueue();
+        });
+      }
+    } catch (error) {
+      const node = document.querySelector("[data-admin-queue-action-status]");
+      setStatus(node, error.message || "Admin access is required.", "error");
+      const hero = document.querySelector("[data-admin-queue-status]");
+      if (hero) {
+        hero.textContent = "Admin access could not be confirmed.";
+      }
+    }
+  }
+
+  async function setupReviewPage() {
+    const page = document.querySelector("[data-admin-review-page]");
+    if (!page) return;
+
+    try {
+      await requireAdmin();
+      await loadReviewDetail();
+
+      const reviewBtn = document.querySelector("[data-admin-mark-review]");
+      const approveBtn = document.querySelector("[data-admin-approve]");
+      const rejectBtn = document.querySelector("[data-admin-reject]");
+      const refreshBtn = document.querySelector("[data-admin-refresh-detail]");
+
+      if (reviewBtn) {
+        reviewBtn.addEventListener("click", function () {
+          runAdminAction("in_review");
+        });
+      }
+
+      if (approveBtn) {
+        approveBtn.addEventListener("click", function () {
+          runAdminAction("approve");
+        });
+      }
+
+      if (rejectBtn) {
+        rejectBtn.addEventListener("click", function () {
+          runAdminAction("reject");
+        });
+      }
+
+      if (refreshBtn) {
+        refreshBtn.addEventListener("click", function () {
+          loadReviewDetail();
+        });
+      }
+    } catch (error) {
+      const node = document.querySelector("[data-admin-review-action-status]");
+      setStatus(node, error.message || "Admin access is required.", "error");
+      const hero = document.querySelector("[data-admin-review-page-status]");
+      if (hero) {
+        hero.textContent = "Admin access could not be confirmed.";
+      }
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupQueuePage();
+    setupReviewPage();
+  });
+})();

--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -1,0 +1,70 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") {
+    return;
+  }
+
+  function normalizeRole(role) {
+    return String(role || "")
+      .trim()
+      .toLowerCase();
+  }
+
+  function injectAdminPanel() {
+    const dashboard = document.querySelector("[data-dashboard]");
+    const authRequired = document.querySelector("[data-auth-required]");
+    if (!dashboard || !authRequired) return;
+    if (document.querySelector("[data-admin-tools-panel]")) return;
+
+    const panel = document.createElement("div");
+    panel.className = "form-panel";
+    panel.setAttribute("data-admin-tools-panel", "true");
+
+    panel.innerHTML = `
+      <span class="eyebrow">Admin Tools</span>
+      <div class="grid-3">
+        <div>
+          <div class="card-number">A</div>
+          <h3>Intake Queue</h3>
+          <p class="card-copy">Review submitted intake records, mark them in review, approve, or reject.</p>
+        </div>
+        <div>
+          <div class="card-number">B</div>
+          <h3>Operational Review</h3>
+          <p class="card-copy">Use the admin account to control the intake workflow and internal checkpoints.</p>
+        </div>
+        <div>
+          <div class="card-number">C</div>
+          <h3>Admin Access</h3>
+          <p class="card-copy">This panel only appears when the logged-in account is an admin.</p>
+        </div>
+      </div>
+
+      <div class="inline-actions" style="margin-top: 1.5rem;">
+        <a class="btn btn-primary" href="admin-intake-queue.html">Open Intake Queue</a>
+      </div>
+    `;
+
+    authRequired.prepend(panel);
+  }
+
+  async function setupAdminDashboardTools() {
+    const dashboard = document.querySelector("[data-dashboard]");
+    if (!dashboard) return;
+
+    try {
+      const me = await app.apiRequest("/auth/me", { method: "GET" });
+      if (normalizeRole(me && me.role) === "admin") {
+        injectAdminPanel();
+      }
+    } catch (error) {
+      // ignore for non-admin or session issues already handled elsewhere
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupAdminDashboardTools();
+  });
+})();

--- a/dashboard.html
+++ b/dashboard.html
@@ -283,5 +283,6 @@
     <script src="app.js?v=20260322-1"></script>
     <script src="auth.js?v=20260322-1"></script>
     <script src="dashboard-intake.js?v=20260322-1"></script>
+    <script src="dashboard-admin.js?v=20260322-2"></script>
   </body>
 </html>


### PR DESCRIPTION
- added admin-intake-queue.html for listing and filtering intake submissions
- added admin-intake-review.html for reviewing, approving, and rejecting individual submissions
- added admin-intake.js to power admin queue and review actions against the admin intake API
- added dashboard-admin.js to surface an admin intake queue entry point on the dashboard for admin accounts
- connected the frontend admin review flow to the new admin intake submission backend routes