### PR TITLE
Add role-based admin control panel to dashboard

### DIFF
--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -12,38 +12,201 @@
       .toLowerCase();
   }
 
-  function injectAdminPanel() {
-    const dashboard = document.querySelector("[data-dashboard]");
+  function isInternalRole(role) {
+    return [
+      "admin",
+      "super_admin",
+      "platform_admin",
+      "operations_admin",
+      "finance_admin",
+      "marketing_admin",
+    ].includes(normalizeRole(role));
+  }
+
+  function getRoleTitle(role) {
+    const normalized = normalizeRole(role);
+
+    if (normalized === "super_admin") return "Super Admin Control";
+    if (normalized === "platform_admin") return "Platform Admin Control";
+    if (normalized === "operations_admin") return "Operations Admin Control";
+    if (normalized === "finance_admin") return "Finance Admin Control";
+    if (normalized === "marketing_admin") return "Marketing Admin Control";
+    if (normalized === "admin") return "Admin Control";
+    return "Internal Control";
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function card(number, title, copy, href, buttonText) {
+    const action =
+      href && buttonText
+        ? `<div class="inline-actions" style="margin-top: 1rem;">
+           <a class="btn btn-primary" href="${escapeHtml(href)}">${escapeHtml(buttonText)}</a>
+         </div>`
+        : `<div class="inline-actions" style="margin-top: 1rem;">
+           <span class="btn btn-secondary" aria-disabled="true">Coming Next</span>
+         </div>`;
+
+    return `
+      <div class="family-record-card">
+        <div class="card-number">${escapeHtml(number)}</div>
+        <h3>${escapeHtml(title)}</h3>
+        <p class="card-copy">${escapeHtml(copy)}</p>
+        ${action}
+      </div>
+    `;
+  }
+
+  function getRoleCards(role) {
+    const normalized = normalizeRole(role);
+
+    if (normalized === "super_admin" || normalized === "admin") {
+      return [
+        card(
+          "A",
+          "Intake Queue",
+          "Review submitted intake records, mark them in review, approve, reject, and control onboarding flow.",
+          "admin-intake-queue.html",
+          "Open Intake Queue",
+        ),
+        card(
+          "B",
+          "Operations Pipeline",
+          "Track approved submissions, production readiness, verification flow, and delivery progression.",
+          "",
+          "",
+        ),
+        card(
+          "C",
+          "Finance Oversight",
+          "View package status, customer payment truth, operational finance checkpoints, and reporting visibility.",
+          "",
+          "",
+        ),
+        card(
+          "D",
+          "Platform Control",
+          "Use system-level oversight for workflow governance, audit review, and high-trust administrative control.",
+          "",
+          "",
+        ),
+        card(
+          "E",
+          "Marketing Intelligence",
+          "Review top-level demand, conversion, and funnel activity without exposing protected family records.",
+          "",
+          "",
+        ),
+      ];
+    }
+
+    if (normalized === "platform_admin") {
+      return [
+        card(
+          "A",
+          "Intake Queue",
+          "Access internal onboarding review workflow and troubleshoot intake state transitions.",
+          "admin-intake-queue.html",
+          "Open Intake Queue",
+        ),
+        card(
+          "B",
+          "Platform Tools",
+          "Platform health, operational debugging, and system-level workflow support.",
+          "",
+          "",
+        ),
+      ];
+    }
+
+    if (normalized === "operations_admin") {
+      return [
+        card(
+          "A",
+          "Intake Queue",
+          "Review submitted onboarding records and move customer submissions through the review process.",
+          "admin-intake-queue.html",
+          "Open Intake Queue",
+        ),
+        card(
+          "B",
+          "Operations Review",
+          "Prepare verified submissions for the family build, relationship setup, and delivery workflow.",
+          "",
+          "",
+        ),
+      ];
+    }
+
+    if (normalized === "finance_admin") {
+      return [
+        card(
+          "A",
+          "Finance Oversight",
+          "Track orders, package activation, payment truth, and customer billing checkpoints.",
+          "",
+          "",
+        ),
+        card(
+          "B",
+          "Revenue View",
+          "Use finance-specific reporting without exposing protected family lineage content.",
+          "",
+          "",
+        ),
+      ];
+    }
+
+    if (normalized === "marketing_admin") {
+      return [
+        card(
+          "A",
+          "Marketing Intelligence",
+          "View conversion-level business insights and campaign-facing reporting without exposing private customer lineage records.",
+          "",
+          "",
+        ),
+        card(
+          "B",
+          "Growth Oversight",
+          "Prepare future campaign, funnel, and acquisition visibility inside a controlled admin environment.",
+          "",
+          "",
+        ),
+      ];
+    }
+
+    return [];
+  }
+
+  function injectAdminPanel(me) {
     const authRequired = document.querySelector("[data-auth-required]");
-    if (!dashboard || !authRequired) return;
+    if (!authRequired) return;
     if (document.querySelector("[data-admin-tools-panel]")) return;
+
+    const role = normalizeRole(me && me.role);
+    if (!isInternalRole(role)) return;
 
     const panel = document.createElement("div");
     panel.className = "form-panel";
     panel.setAttribute("data-admin-tools-panel", "true");
 
-    panel.innerHTML = `
-      <span class="eyebrow">Admin Tools</span>
-      <div class="grid-3">
-        <div>
-          <div class="card-number">A</div>
-          <h3>Intake Queue</h3>
-          <p class="card-copy">Review submitted intake records, mark them in review, approve, or reject.</p>
-        </div>
-        <div>
-          <div class="card-number">B</div>
-          <h3>Operational Review</h3>
-          <p class="card-copy">Use the admin account to control the intake workflow and internal checkpoints.</p>
-        </div>
-        <div>
-          <div class="card-number">C</div>
-          <h3>Admin Access</h3>
-          <p class="card-copy">This panel only appears when the logged-in account is an admin.</p>
-        </div>
-      </div>
+    const cards = getRoleCards(role).join("");
 
-      <div class="inline-actions" style="margin-top: 1.5rem;">
-        <a class="btn btn-primary" href="admin-intake-queue.html">Open Intake Queue</a>
+    panel.innerHTML = `
+      <span class="eyebrow">${escapeHtml(getRoleTitle(role))}</span>
+      <p class="card-copy" style="margin-bottom: 1.25rem;">
+        This internal control layer is visible only to authorized Tomb of Light operational roles.
+      </p>
+      <div class="grid-3">
+        ${cards}
       </div>
     `;
 
@@ -56,11 +219,9 @@
 
     try {
       const me = await app.apiRequest("/auth/me", { method: "GET" });
-      if (normalizeRole(me && me.role) === "admin") {
-        injectAdminPanel();
-      }
+      injectAdminPanel(me);
     } catch (error) {
-      // ignore for non-admin or session issues already handled elsewhere
+      // session handling already exists elsewhere
     }
   }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -284,5 +284,6 @@
     <script src="auth.js?v=20260322-1"></script>
     <script src="dashboard-intake.js?v=20260322-1"></script>
     <script src="dashboard-admin.js?v=20260322-2"></script>
+    <script src="dashboard-admin.js?v=20260322-3"></script>
   </body>
 </html>


### PR DESCRIPTION
- upgraded dashboard-admin.js to support super_admin, platform_admin, operations_admin, finance_admin, marketing_admin, and admin roles
- added role-aware internal control panels without changing the shared customer dashboard shell
- kept admin intake queue live while showing future operational modules as coming next
- improved dashboard structure for a high-trust Tomb of Light founder and officer workflow