### PR TITLE
Add approved intake provisioning pipeline and admin production controls

### DIFF
--- a/admin-intake-queue.html
+++ b/admin-intake-queue.html
@@ -124,9 +124,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-2"></script>
-    <script src="app.js?v=20260322-2"></script>
-    <script src="auth.js?v=20260322-2"></script>
-    <script src="admin-intake.js?v=20260322-2"></script>
+    <script src="config.js?v=20260322-3"></script>
+    <script src="app.js?v=20260322-3"></script>
+    <script src="auth.js?v=20260322-3"></script>
+    <script src="admin-intake.js?v=20260322-3"></script>
   </body>
 </html>

--- a/admin-intake-review.html
+++ b/admin-intake-review.html
@@ -175,9 +175,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-2"></script>
-    <script src="app.js?v=20260322-2"></script>
-    <script src="auth.js?v=20260322-2"></script>
-    <script src="admin-intake.js?v=20260322-2"></script>
+    <script src="config.js?v=20260322-3"></script>
+    <script src="app.js?v=20260322-3"></script>
+    <script src="auth.js?v=20260322-3"></script>
+    <script src="admin-intake.js?v=20260322-3"></script>
   </body>
 </html>

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -80,7 +80,11 @@
 
   function ensureAdminAccess(me) {
     const role = normalizeStatus(me && me.role);
-    if (role !== "admin") {
+    if (
+      !["admin", "super_admin", "platform_admin", "operations_admin"].includes(
+        role,
+      )
+    ) {
       throw new Error("Admin access is required to use this page.");
     }
   }
@@ -107,6 +111,8 @@
       in_review: 0,
       approved: 0,
       rejected: 0,
+      build_ready: 0,
+      in_production: 0,
     };
 
     submissions.forEach(function (item) {
@@ -117,31 +123,12 @@
     });
 
     node.innerHTML = `
-      <div>
-        <div class="card-number">A</div>
-        <h3>All</h3>
-        <p class="card-copy">${counts.all} submission(s)</p>
-      </div>
-      <div>
-        <div class="card-number">B</div>
-        <h3>Submitted</h3>
-        <p class="card-copy">${counts.submitted} waiting for review</p>
-      </div>
-      <div>
-        <div class="card-number">C</div>
-        <h3>In Review</h3>
-        <p class="card-copy">${counts.in_review} currently open</p>
-      </div>
-      <div>
-        <div class="card-number">D</div>
-        <h3>Approved</h3>
-        <p class="card-copy">${counts.approved} approved</p>
-      </div>
-      <div>
-        <div class="card-number">E</div>
-        <h3>Rejected</h3>
-        <p class="card-copy">${counts.rejected} rejected</p>
-      </div>
+      <div><div class="card-number">A</div><h3>All</h3><p class="card-copy">${counts.all} submission(s)</p></div>
+      <div><div class="card-number">B</div><h3>Submitted</h3><p class="card-copy">${counts.submitted} waiting</p></div>
+      <div><div class="card-number">C</div><h3>In Review</h3><p class="card-copy">${counts.in_review} active</p></div>
+      <div><div class="card-number">D</div><h3>Approved</h3><p class="card-copy">${counts.approved} approved</p></div>
+      <div><div class="card-number">E</div><h3>Build Ready</h3><p class="card-copy">${counts.build_ready} provisioned</p></div>
+      <div><div class="card-number">F</div><h3>Rejected</h3><p class="card-copy">${counts.rejected} rejected</p></div>
     `;
   }
 
@@ -177,6 +164,8 @@
             ${valueLine("Created", formatDate(item.created_at))}
             ${valueLine("Submitted", formatDate(item.submitted_at))}
             ${valueLine("Reviewed By", item.reviewed_by || "—")}
+            ${valueLine("Family Root", item.family_root_id || "—")}
+            ${valueLine("Project ID", item.project_id || "—")}
             <div class="inline-actions" style="margin-top: 1rem;">
               <a class="btn btn-primary" href="admin-intake-review.html?submission_id=${encodeURIComponent(item.id)}">
                 Open Review
@@ -232,8 +221,28 @@
     `;
   }
 
+  function ensureProvisionButton() {
+    const form = document.querySelector("[data-admin-review-form]");
+    if (!form) return;
+
+    const actionsRow = form.querySelector(".inline-actions");
+    if (!actionsRow) return;
+
+    if (actionsRow.querySelector("[data-admin-provision-build]")) return;
+
+    const button = document.createElement("button");
+    button.className = "btn btn-primary";
+    button.type = "button";
+    button.setAttribute("data-admin-provision-build", "true");
+    button.textContent = "Provision Build";
+
+    actionsRow.insertBefore(button, actionsRow.lastElementChild);
+  }
+
   function renderDetail(submission) {
     currentSubmission = submission;
+
+    ensureProvisionButton();
 
     const pageStatus = document.querySelector(
       "[data-admin-review-page-status]",
@@ -264,15 +273,21 @@
         `Email: ${submission.email || "—"}`,
         `Package: ${submission.package_name || submission.package_slug || "—"}`,
         `Review Locked: ${submission.review_locked ? "Yes" : "No"}`,
+        `Family Root ID: ${submission.family_root_id || "—"}`,
+        `Household ID: ${submission.household_id || "—"}`,
+        `Project ID: ${submission.project_id || "—"}`,
       ],
     );
 
-    renderReviewBlock(timelineNode, "Review Timeline", "2", [
+    renderReviewBlock(timelineNode, "Review Timeline and Pipeline", "2", [
       `Created: ${formatDate(submission.created_at)}`,
       `Submitted: ${formatDate(submission.submitted_at)}`,
       `Review Started: ${formatDate(submission.review_started_at)}`,
       `Reviewed: ${formatDate(submission.reviewed_at)}`,
       `Reviewed By: ${submission.reviewed_by || "—"}`,
+      `Provisioned: ${formatDate(submission.provisioned_at)}`,
+      `Provisioned By: ${submission.provisioned_by || "—"}`,
+      `Production Notes: ${submission.production_notes || "—"}`,
     ]);
 
     const household = submission.household || {};
@@ -375,14 +390,23 @@
         review_notes: "",
         approval_notes: "",
         rejection_reason: "",
+        family_name_override: "",
+        project_name_override: "",
+        production_notes: "",
       };
     }
 
+    const approvalNotes =
+      form.querySelector('[name="approval_notes"]').value || "";
+
     return {
       review_notes: form.querySelector('[name="review_notes"]').value || "",
-      approval_notes: form.querySelector('[name="approval_notes"]').value || "",
+      approval_notes: approvalNotes,
       rejection_reason:
         form.querySelector('[name="rejection_reason"]').value || "",
+      family_name_override: "",
+      project_name_override: "",
+      production_notes: approvalNotes,
     };
   }
 
@@ -411,27 +435,39 @@
       in_review: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/in-review`,
       approve: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/approve`,
       reject: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/reject`,
+      provision: `/admin/intake-submissions/${encodeURIComponent(submissionId)}/provision-build`,
     };
 
+    const requestBody =
+      action === "provision"
+        ? {
+            family_name_override: payload.family_name_override,
+            project_name_override: payload.project_name_override,
+            production_notes: payload.production_notes,
+          }
+        : {
+            review_notes: payload.review_notes,
+            approval_notes: payload.approval_notes,
+            rejection_reason: payload.rejection_reason,
+          };
+
     try {
-      setStatus(statusNode, "Submitting admin review action...", "info");
+      setStatus(statusNode, "Submitting admin action...", "info");
       const result = await app.apiRequest(pathMap[action], {
         method: "POST",
-        body: JSON.stringify(payload),
+        body: JSON.stringify(requestBody),
       });
 
       renderDetail(result);
-      setStatus(
-        statusNode,
-        `Submission updated to ${humanizeStatus(result.status)}.`,
-        "success",
-      );
+
+      const label =
+        action === "provision"
+          ? "Build provisioned successfully."
+          : `Submission updated to ${humanizeStatus(result.status)}.`;
+
+      setStatus(statusNode, label, "success");
     } catch (error) {
-      setStatus(
-        statusNode,
-        error.message || "Admin review action failed.",
-        "error",
-      );
+      setStatus(statusNode, error.message || "Admin action failed.", "error");
     }
   }
 
@@ -503,6 +539,12 @@
           loadReviewDetail();
         });
       }
+
+      document.addEventListener("click", function (event) {
+        const button = event.target.closest("[data-admin-provision-build]");
+        if (!button) return;
+        runAdminAction("provision");
+      });
     } catch (error) {
       const node = document.querySelector("[data-admin-review-action-status]");
       setStatus(node, error.message || "Admin access is required.", "error");

--- a/backend/app/routes/admin_intake_submissions.py
+++ b/backend/app/routes/admin_intake_submissions.py
@@ -9,6 +9,7 @@ from app.schemas.intake_submission import (
     IntakeSubmissionResponse,
     IntakeSubmissionStatusUpdate,
 )
+from app.services.intake_pipeline_service import provision_build_from_submission
 from app.services.intake_submission_service import (
     get_by_id,
     list_all,
@@ -25,6 +26,12 @@ class IntakeAdminNotesPayload(BaseModel):
     review_notes: str = Field(default="")
     approval_notes: str = Field(default="")
     rejection_reason: str = Field(default="")
+
+
+class IntakeProvisionBuildPayload(BaseModel):
+    family_name_override: str = Field(default="")
+    project_name_override: str = Field(default="")
+    production_notes: str = Field(default="")
 
 
 def _reviewed_by(current_admin: dict[str, Any]) -> str:
@@ -140,6 +147,27 @@ def reject_admin_intake_submission(
             review_notes=payload.review_notes,
             approval_notes="",
             rejection_reason=payload.rejection_reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{submission_id}/provision-build", response_model=IntakeSubmissionResponse)
+def provision_admin_intake_build(
+    submission_id: str,
+    payload: IntakeProvisionBuildPayload,
+    current_admin: dict[str, Any] = Depends(require_admin),
+):
+    try:
+        return provision_build_from_submission(
+            submission_id=submission_id,
+            provisioned_by=_reviewed_by(current_admin),
+            family_name_override=payload.family_name_override,
+            project_name_override=payload.project_name_override,
+            production_notes=payload.production_notes,
         )
     except ValueError as exc:
         raise HTTPException(

--- a/backend/app/schemas/intake_submission.py
+++ b/backend/app/schemas/intake_submission.py
@@ -87,6 +87,13 @@ class IntakeSubmissionResponse(BaseModel):
     approval_notes: Optional[str] = None
     rejection_reason: Optional[str] = None
 
+    family_root_id: Optional[str] = None
+    household_id: Optional[str] = None
+    project_id: Optional[str] = None
+    provisioned_at: Optional[datetime] = None
+    provisioned_by: Optional[str] = None
+    production_notes: Optional[str] = None
+
     created_at: datetime
     updated_at: datetime
 
@@ -102,4 +109,6 @@ class IntakeSubmissionListItem(BaseModel):
     submitted_at: Optional[datetime] = None
     reviewed_at: Optional[datetime] = None
     reviewed_by: Optional[str] = None
+    family_root_id: Optional[str] = None
+    project_id: Optional[str] = None
     created_at: datetime

--- a/backend/app/services/intake_pipeline_service.py
+++ b/backend/app/services/intake_pipeline_service.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+
+from app.database import get_database
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _oid(value: str) -> ObjectId:
+    return ObjectId(value)
+
+
+def _serialize_submission(doc: dict[str, Any]) -> dict[str, Any]:
+    out = dict(doc)
+    out["id"] = str(out.pop("_id"))
+    if "user_id" in out and isinstance(out["user_id"], ObjectId):
+        out["user_id"] = str(out["user_id"])
+    return out
+
+
+def _normalize_visibility(value: str | None) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"private"}:
+        return "private"
+    if normalized in {"family", "family-only", "family_only"}:
+        return "family_only"
+    if normalized in {"public", "certificate-only", "certificate_only"}:
+        return "certificate_only"
+    return "private"
+
+
+def provision_build_from_submission(
+    *,
+    submission_id: str,
+    provisioned_by: str,
+    family_name_override: str = "",
+    project_name_override: str = "",
+    production_notes: str = "",
+) -> dict[str, Any]:
+    db = get_database()
+
+    submissions = db["intake_submissions"]
+    families = db["families"]
+    households = db["households"]
+    projects = db["projects"]
+
+    submission = submissions.find_one({"_id": _oid(submission_id)})
+    if not submission:
+        raise ValueError("Intake submission not found.")
+
+    status = str(submission.get("status", "")).strip().lower()
+    allowed_statuses = {
+        "approved",
+        "build_ready",
+        "in_production",
+        "qa_review",
+        "client_review",
+        "delivered",
+        "archived",
+    }
+    if status not in allowed_statuses:
+        raise ValueError("Submission must be approved before provisioning a build.")
+
+    existing_family_root_id = str(submission.get("family_root_id") or "").strip()
+    existing_household_id = str(submission.get("household_id") or "").strip()
+    existing_project_id = str(submission.get("project_id") or "").strip()
+
+    household = submission.get("household") or {}
+    family_map = submission.get("family_map") or {}
+    consent = submission.get("consent") or {}
+    review = submission.get("review") or {}
+
+    owner_user_id = submission.get("user_id")
+    owner_user_id_str = str(owner_user_id) if owner_user_id is not None else ""
+    owner_email = str(submission.get("email") or "").strip().lower()
+
+    family_name = (
+        family_name_override.strip()
+        or str(household.get("household_name") or "").strip()
+        or str(family_map.get("family_branch_name") or "").strip()
+        or "Tomb of Light Family"
+    )
+
+    created_by = (
+        str(household.get("primary_contact_name") or "").strip()
+        or owner_email
+        or "Unknown"
+    )
+
+    family_description = (
+        str(family_map.get("family_structure_summary") or "").strip()
+        or str(household.get("project_scope") or "").strip()
+        or str(review.get("final_intake_notes") or "").strip()
+        or None
+    )
+
+    visibility = _normalize_visibility(consent.get("visibility_preference"))
+
+    family_doc = None
+    if existing_family_root_id and ObjectId.is_valid(existing_family_root_id):
+        family_doc = families.find_one({"_id": ObjectId(existing_family_root_id)})
+
+    if family_doc is None:
+        family_doc = families.find_one(
+            {
+                "$or": [
+                    {"intake_submission_id": submission_id},
+                    {
+                        "owner_user_id": owner_user_id_str,
+                        "family_name": family_name,
+                    },
+                ]
+            }
+        )
+
+    if family_doc is None:
+        family_payload = {
+            "family_name": family_name,
+            "created_by": created_by,
+            "description": family_description,
+            "owner_user_id": owner_user_id_str,
+            "owner_email": owner_email,
+            "visibility": visibility,
+            "shared_with_user_ids": [],
+            "shared_with_emails": [],
+            "package_slug": submission.get("package_slug"),
+            "package_name": submission.get("package_name"),
+            "source": "approved_intake",
+            "intake_submission_id": submission_id,
+            "created_at": _now(),
+        }
+        family_result = families.insert_one(family_payload)
+        family_payload["_id"] = family_result.inserted_id
+        family_doc = family_payload
+
+    family_root_id = str(family_doc["_id"])
+
+    household_doc = None
+    if existing_household_id and ObjectId.is_valid(existing_household_id):
+        household_doc = households.find_one({"_id": ObjectId(existing_household_id)})
+
+    if household_doc is None:
+        household_doc = households.find_one({"intake_submission_id": submission_id})
+
+    if household_doc is None:
+        household_payload = {
+            "family_id": family_root_id,
+            "intake_submission_id": submission_id,
+            "owner_user_id": owner_user_id_str,
+            "owner_email": owner_email,
+            "household_name": household.get("household_name"),
+            "primary_contact_name": household.get("primary_contact_name"),
+            "primary_contact_email": household.get("primary_contact_email"),
+            "primary_contact_phone": household.get("primary_contact_phone"),
+            "co_owner_name": household.get("co_owner_name"),
+            "household_role": household.get("household_role"),
+            "project_scope": household.get("project_scope"),
+            "special_notes": household.get("special_notes"),
+            "status": "build_ready",
+            "source": "approved_intake",
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+        household_result = households.insert_one(household_payload)
+        household_payload["_id"] = household_result.inserted_id
+        household_doc = household_payload
+
+    household_id = str(household_doc["_id"])
+
+    project_doc = None
+    if existing_project_id and ObjectId.is_valid(existing_project_id):
+        project_doc = projects.find_one({"_id": ObjectId(existing_project_id)})
+
+    if project_doc is None:
+        project_doc = projects.find_one({"intake_submission_id": submission_id})
+
+    project_name = (
+        project_name_override.strip()
+        or f"{family_name} Production Build"
+    )
+
+    if project_doc is None:
+        project_payload = {
+            "name": project_name,
+            "family_id": family_root_id,
+            "household_id": household_id,
+            "owner_user_id": owner_user_id_str,
+            "owner_email": owner_email,
+            "package_slug": submission.get("package_slug"),
+            "package_name": submission.get("package_name"),
+            "status": "build_ready",
+            "phase": "intake_approved",
+            "source": "approved_intake",
+            "intake_submission_id": submission_id,
+            "created_by": provisioned_by,
+            "notes": production_notes or "",
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+        project_result = projects.insert_one(project_payload)
+        project_payload["_id"] = project_result.inserted_id
+        project_doc = project_payload
+
+    project_id = str(project_doc["_id"])
+
+    submissions.update_one(
+        {"_id": _oid(submission_id)},
+        {
+            "$set": {
+                "status": "build_ready",
+                "review_locked": True,
+                "family_root_id": family_root_id,
+                "household_id": household_id,
+                "project_id": project_id,
+                "provisioned_at": _now(),
+                "provisioned_by": provisioned_by,
+                "production_notes": production_notes or "",
+                "updated_at": _now(),
+            }
+        },
+    )
+
+    saved = submissions.find_one({"_id": _oid(submission_id)})
+    if not saved:
+        raise RuntimeError("Failed to fetch provisioned intake submission.")
+
+    return _serialize_submission(saved)

--- a/backend/app/services/intake_submission_service.py
+++ b/backend/app/services/intake_submission_service.py
@@ -10,8 +10,16 @@ from app.database import get_database
 
 COLLECTION = "intake_submissions"
 
-LOCKED_STATUSES = {"submitted", "in_review", "approved"}
-REVIEWABLE_STATUSES = {"submitted", "in_review", "approved", "rejected"}
+PIPELINE_STATUSES = {
+    "build_ready",
+    "in_production",
+    "qa_review",
+    "client_review",
+    "delivered",
+    "archived",
+}
+LOCKED_STATUSES = {"submitted", "in_review", "approved"} | PIPELINE_STATUSES
+REVIEWABLE_STATUSES = {"submitted", "in_review", "approved", "rejected"} | PIPELINE_STATUSES
 
 
 def _now() -> datetime:
@@ -43,14 +51,6 @@ def create_intake_submission(
     email: str,
     payload: dict[str, Any],
 ) -> dict[str, Any]:
-    """
-    Create a submitted intake record.
-
-    Rules:
-    - one active locked submission at a time per user
-    - allowed to submit again only when no locked submission exists
-      or after rejection flow is handled manually
-    """
     col = _collection()
     now = _now()
 
@@ -86,6 +86,12 @@ def create_intake_submission(
         "review_notes": "",
         "approval_notes": "",
         "rejection_reason": "",
+        "family_root_id": None,
+        "household_id": None,
+        "project_id": None,
+        "provisioned_at": None,
+        "provisioned_by": None,
+        "production_notes": "",
         "created_at": now,
         "updated_at": now,
     }
@@ -181,7 +187,11 @@ def update_status(
         "rejection_reason": rejection_reason or "",
     }
 
-    if status_normalized == "in_review":
+    if status_normalized == "submitted":
+        update_doc["submitted_at"] = now
+        update_doc["review_locked"] = True
+
+    elif status_normalized == "in_review":
         update_doc["review_started_at"] = now
         update_doc["review_locked"] = True
 
@@ -193,8 +203,7 @@ def update_status(
         update_doc["reviewed_at"] = now
         update_doc["review_locked"] = False
 
-    elif status_normalized == "submitted":
-        update_doc["submitted_at"] = now
+    elif status_normalized in PIPELINE_STATUSES:
         update_doc["review_locked"] = True
 
     col.update_one({"_id": oid}, {"$set": update_doc})

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -1,30 +1,32 @@
 (function () {
-  'use strict';
+  "use strict";
 
   const app = window.TOLApp || window.TOLAuth;
 
-  if (!app || typeof app.apiRequest !== 'function') {
+  if (!app || typeof app.apiRequest !== "function") {
     return;
   }
 
   function normalizeStatus(status) {
-    return String(status || '').trim().toLowerCase();
+    return String(status || "")
+      .trim()
+      .toLowerCase();
   }
 
   function humanizeStatus(status) {
     const normalized = normalizeStatus(status);
-    if (!normalized) return 'Unknown';
+    if (!normalized) return "Unknown";
 
     return normalized
-      .split('_')
+      .split("_")
       .map(function (part) {
         return part.charAt(0).toUpperCase() + part.slice(1);
       })
-      .join(' ');
+      .join(" ");
   }
 
   function formatDate(value) {
-    if (!value) return '—';
+    if (!value) return "—";
     try {
       return new Date(value).toLocaleString();
     } catch (error) {
@@ -41,20 +43,26 @@
     return `
       <div class="family-record-card">
         <div class="card-number">${index + 1}</div>
-        <h3>${humanizeStatus(item.status || 'unknown')}</h3>
-        <p class="card-copy"><strong>Package:</strong> ${item.package_name || item.package_slug || '—'}</p>
+        <h3>${humanizeStatus(item.status || "unknown")}</h3>
+        <p class="card-copy"><strong>Package:</strong> ${item.package_name || item.package_slug || "—"}</p>
         <p class="card-copy"><strong>Created:</strong> ${formatDate(item.created_at)}</p>
-        <p class="card-copy"><strong>Submission ID:</strong> ${item.id || '—'}</p>
+        <p class="card-copy"><strong>Submission ID:</strong> ${item.id || "—"}</p>
+        <p class="card-copy"><strong>Family Root ID:</strong> ${item.family_root_id || "—"}</p>
+        <p class="card-copy"><strong>Project ID:</strong> ${item.project_id || "—"}</p>
       </div>
     `;
   }
 
   async function getLatestSubmission() {
     try {
-      return await app.apiRequest('/intake-submissions/my-latest', { method: 'GET' });
+      return await app.apiRequest("/intake-submissions/my-latest", {
+        method: "GET",
+      });
     } catch (error) {
-      const message = String(error && error.message ? error.message : error).toLowerCase();
-      if (message.includes('no intake submissions found')) {
+      const message = String(
+        error && error.message ? error.message : error,
+      ).toLowerCase();
+      if (message.includes("no intake submissions found")) {
         return null;
       }
       throw error;
@@ -63,102 +71,134 @@
 
   async function getSubmissionHistory() {
     try {
-      return await app.apiRequest('/intake-submissions/my-list?limit=10', { method: 'GET' });
+      return await app.apiRequest("/intake-submissions/my-list?limit=10", {
+        method: "GET",
+      });
     } catch (error) {
       return [];
     }
   }
 
+  function nextStepForStatus(status) {
+    const normalized = normalizeStatus(status);
+
+    if (normalized === "submitted") return "Waiting for review to begin.";
+    if (normalized === "in_review")
+      return "Reviewer is evaluating your intake.";
+    if (normalized === "approved")
+      return "Approved. Waiting for internal build provisioning.";
+    if (normalized === "build_ready")
+      return "Your approved intake has been provisioned for production.";
+    if (normalized === "in_production")
+      return "Your legacy build is currently in production.";
+    if (normalized === "qa_review")
+      return "Your project is in internal quality review.";
+    if (normalized === "client_review")
+      return "Your project is prepared for client review.";
+    if (normalized === "delivered") return "Your project has been delivered.";
+    if (normalized === "archived") return "Your project has been archived.";
+    if (normalized === "rejected")
+      return "Review the feedback, update your intake, and resubmit.";
+    return "Complete your intake and submit it for review.";
+  }
+
   async function setupDashboardIntake() {
-    const dashboard = document.querySelector('[data-dashboard]');
+    const dashboard = document.querySelector("[data-dashboard]");
     if (!dashboard) return;
 
-    const intakeCardStatus = document.querySelector('[data-intake-card-status]');
-    const currentPackage = document.querySelector('[data-intake-current-package]');
-    const statusBadge = document.querySelector('[data-intake-status-badge]');
-    const submissionId = document.querySelector('[data-intake-submission-id]');
-    const submittedAt = document.querySelector('[data-intake-submitted-at]');
-    const nextStep = document.querySelector('[data-intake-next-step]');
-    const lockNote = document.querySelector('[data-intake-lock-note]');
-    const openAction = document.querySelector('[data-intake-open-action]');
-    const historyStatus = document.querySelector('[data-intake-history-status]');
-    const historyList = document.querySelector('[data-intake-history-list]');
+    const intakeCardStatus = document.querySelector(
+      "[data-intake-card-status]",
+    );
+    const currentPackage = document.querySelector(
+      "[data-intake-current-package]",
+    );
+    const statusBadge = document.querySelector("[data-intake-status-badge]");
+    const submissionId = document.querySelector("[data-intake-submission-id]");
+    const submittedAt = document.querySelector("[data-intake-submitted-at]");
+    const nextStep = document.querySelector("[data-intake-next-step]");
+    const lockNote = document.querySelector("[data-intake-lock-note]");
+    const openAction = document.querySelector("[data-intake-open-action]");
+    const historyStatus = document.querySelector(
+      "[data-intake-history-status]",
+    );
+    const historyList = document.querySelector("[data-intake-history-list]");
 
     try {
       const latest = await getLatestSubmission();
 
       if (!latest) {
-        text(intakeCardStatus, 'No intake submission found yet.');
-        text(currentPackage, 'No package detected');
-        text(statusBadge, 'Not submitted');
-        text(submissionId, '—');
-        text(submittedAt, '—');
-        text(nextStep, 'Open your intake flow and submit the review step.');
-        text(lockNote, 'Editing is open because no final submission exists yet.');
+        text(intakeCardStatus, "No intake submission found yet.");
+        text(currentPackage, "No package detected");
+        text(statusBadge, "Not submitted");
+        text(submissionId, "—");
+        text(submittedAt, "—");
+        text(nextStep, "Open your intake flow and submit the review step.");
+        text(
+          lockNote,
+          "Editing is open because no final submission exists yet.",
+        );
 
         if (openAction) {
-          openAction.textContent = 'Open Intake';
-          openAction.setAttribute('href', 'intake-welcome.html');
+          openAction.textContent = "Open Intake";
+          openAction.setAttribute("href", "intake-welcome.html");
         }
       } else {
         const status = normalizeStatus(latest.status);
 
         text(
           intakeCardStatus,
-          `Latest intake status: ${humanizeStatus(status)}.`
+          `Latest intake status: ${humanizeStatus(status)}.`,
         );
-        text(currentPackage, latest.package_name || latest.package_slug || '—');
+        text(currentPackage, latest.package_name || latest.package_slug || "—");
         text(statusBadge, humanizeStatus(status));
-        text(submissionId, latest.id || '—');
+        text(submissionId, latest.id || "—");
         text(submittedAt, formatDate(latest.submitted_at || latest.created_at));
+        text(nextStep, nextStepForStatus(status));
 
-        if (status === 'submitted') {
-          text(nextStep, 'Waiting for review to begin.');
-          text(lockNote, 'Editing is locked while the submission is waiting for review.');
-        } else if (status === 'in_review') {
-          text(nextStep, 'Reviewer is evaluating your intake.');
-          text(lockNote, 'Editing is locked while the submission is under review.');
-        } else if (status === 'approved') {
-          text(nextStep, 'Approved. Proceed into family build and production steps.');
-          text(lockNote, 'Editing is locked because the submission was approved.');
-        } else if (status === 'rejected') {
-          text(nextStep, 'Review the feedback, update your intake, and resubmit.');
-          text(lockNote, 'Editing is open because the submission was rejected.');
-        } else {
-          text(nextStep, 'Return to the intake flow if updates are needed.');
-          text(lockNote, latest.review_locked ? 'Editing is currently locked.' : 'Editing is currently open.');
-        }
-
-        if (openAction) {
-          openAction.textContent = status === 'rejected' ? 'Resume Intake' : 'View Intake';
-          openAction.setAttribute(
-            'href',
-            status === 'rejected' ? 'intake-household.html' : 'intake-review.html'
+        if (status === "rejected") {
+          text(
+            lockNote,
+            "Editing is open because the submission was rejected.",
           );
+          if (openAction) {
+            openAction.textContent = "Resume Intake";
+            openAction.setAttribute("href", "intake-household.html");
+          }
+        } else {
+          text(
+            lockNote,
+            latest.review_locked
+              ? "Editing is currently locked."
+              : "Editing is currently open.",
+          );
+          if (openAction) {
+            openAction.textContent = "View Intake";
+            openAction.setAttribute("href", "intake-review.html");
+          }
         }
       }
 
       const history = await getSubmissionHistory();
 
       if (!Array.isArray(history) || history.length === 0) {
-        text(historyStatus, 'No intake submissions found yet.');
-        if (historyList) historyList.innerHTML = '';
+        text(historyStatus, "No intake submissions found yet.");
+        if (historyList) historyList.innerHTML = "";
       } else {
-        text(historyStatus, 'Your intake history is listed below.');
+        text(historyStatus, "Your intake history is listed below.");
         if (historyList) {
-          historyList.innerHTML = history.map(renderHistoryItem).join('');
+          historyList.innerHTML = history.map(renderHistoryItem).join("");
         }
       }
     } catch (error) {
-      text(intakeCardStatus, 'Intake status is temporarily unavailable.');
-      text(statusBadge, 'Unavailable');
-      text(nextStep, 'Please try again shortly.');
-      text(lockNote, 'Could not determine current submission lock state.');
-      text(historyStatus, 'Intake history is temporarily unavailable.');
+      text(intakeCardStatus, "Intake status is temporarily unavailable.");
+      text(statusBadge, "Unavailable");
+      text(nextStep, "Please try again shortly.");
+      text(lockNote, "Could not determine current submission lock state.");
+      text(historyStatus, "Intake history is temporarily unavailable.");
     }
   }
 
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener("DOMContentLoaded", function () {
     setupDashboardIntake();
   });
 })();

--- a/dashboard.html
+++ b/dashboard.html
@@ -279,11 +279,10 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="dashboard-intake.js?v=20260322-1"></script>
-    <script src="dashboard-admin.js?v=20260322-2"></script>
+    <script src="config.js?v=20260322-3"></script>
+    <script src="app.js?v=20260322-3"></script>
+    <script src="auth.js?v=20260322-3"></script>
+    <script src="dashboard-intake.js?v=20260322-3"></script>
     <script src="dashboard-admin.js?v=20260322-3"></script>
   </body>
 </html>


### PR DESCRIPTION
- expanded intake submission schema and service to support build provisioning metadata
- added intake_pipeline_service to provision family root, household, and project records from approved submissions
- extended admin intake submission routes with provision-build action
- upgraded admin-intake.js to support build provisioning from the review UI
- upgraded dashboard-intake.js to reflect approved, build_ready, and production-stage statuses
- aligned Tomb of Light intake workflow with a controlled internal production pipeline instead of blind automatic creation