### PR TITLE
Fix admin intake queue API routing for live browser requests

### DIFF
--- a/admin-intake-queue.html
+++ b/admin-intake-queue.html
@@ -124,9 +124,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-3"></script>
-    <script src="app.js?v=20260322-3"></script>
-    <script src="auth.js?v=20260322-3"></script>
-    <script src="admin-intake.js?v=20260322-3"></script>
+    <script src="config.js?v=20260322-6"></script>
+    <script src="app.js?v=20260322-6"></script>
+    <script src="auth.js?v=20260322-6"></script>
+    <script src="admin-intake.js?v=20260322-6"></script>
   </body>
 </html>

--- a/admin-intake-review.html
+++ b/admin-intake-review.html
@@ -175,9 +175,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-3"></script>
-    <script src="app.js?v=20260322-3"></script>
-    <script src="auth.js?v=20260322-3"></script>
-    <script src="admin-intake.js?v=20260322-3"></script>
+    <script src="config.js?v=20260322-6"></script>
+    <script src="app.js?v=20260322-6"></script>
+    <script src="auth.js?v=20260322-6"></script>
+    <script src="admin-intake.js?v=20260322-6"></script>
   </body>
 </html>

--- a/backend/app/routes/admin_intake_submissions.py
+++ b/backend/app/routes/admin_intake_submissions.py
@@ -44,6 +44,7 @@ def _reviewed_by(current_admin: dict[str, Any]) -> str:
     ).strip()
 
 
+@router.get("", response_model=list[IntakeSubmissionListItem], include_in_schema=False)
 @router.get("/", response_model=list[IntakeSubmissionListItem])
 def list_admin_intake_submissions(
     status_filter: Optional[str] = Query(default=None, alias="status"),


### PR DESCRIPTION
Added slash and non-slash support for the admin intake submission queue root route to prevent cross-origin redirect/network failures in Safari and live browser requests. Updated admin intake pages to use fresh versioned frontend scripts so the queue and review UI load the newest API behavior.