### PR TITLE
Lock intake pages for build-ready and later production states

### DIFF
--- a/intake-consent.html
+++ b/intake-consent.html
@@ -181,9 +181,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake-family-map.html
+++ b/intake-family-map.html
@@ -225,9 +225,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake-household.html
+++ b/intake-household.html
@@ -224,9 +224,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake-review.html
+++ b/intake-review.html
@@ -200,9 +200,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake-uploads.html
+++ b/intake-uploads.html
@@ -183,9 +183,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake-welcome.html
+++ b/intake-welcome.html
@@ -158,9 +158,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-1"></script>
-    <script src="app.js?v=20260322-1"></script>
-    <script src="auth.js?v=20260322-1"></script>
-    <script src="intake.js?v=20260322-1"></script>
+    <script src="config.js?v=20260322-8"></script>
+    <script src="app.js?v=20260322-8"></script>
+    <script src="auth.js?v=20260322-8"></script>
+    <script src="intake.js?v=20260322-8"></script>
   </body>
 </html>

--- a/intake.js
+++ b/intake.js
@@ -4,7 +4,18 @@
   const app = window.TOLApp || window.TOLAuth;
   const DRAFT_KEY = "tol_intake_draft_v1";
   const LATEST_SUBMISSION_CACHE_KEY = "tol_latest_intake_submission_v1";
-  const LOCKED_STATUSES = new Set(["submitted", "in_review", "approved"]);
+
+  const LOCKED_STATUSES = new Set([
+    "submitted",
+    "in_review",
+    "approved",
+    "build_ready",
+    "in_production",
+    "qa_review",
+    "client_review",
+    "delivered",
+    "archived",
+  ]);
 
   if (!app || typeof app.apiRequest !== "function") {
     console.error("intake.js requires app.js/auth.js to be loaded first.");
@@ -103,6 +114,24 @@
     if (normalized === "approved") {
       return "Your intake has been approved.";
     }
+    if (normalized === "build_ready") {
+      return "Your intake has been approved and provisioned for production.";
+    }
+    if (normalized === "in_production") {
+      return "Your intake has moved into production.";
+    }
+    if (normalized === "qa_review") {
+      return "Your project is in internal quality review.";
+    }
+    if (normalized === "client_review") {
+      return "Your project is prepared for client review.";
+    }
+    if (normalized === "delivered") {
+      return "Your project has been delivered.";
+    }
+    if (normalized === "archived") {
+      return "Your project has been archived.";
+    }
     if (normalized === "rejected") {
       return "Your intake was rejected and can be edited and resubmitted.";
     }
@@ -119,7 +148,25 @@
       return "Reviewer is evaluating your intake details.";
     }
     if (normalized === "approved") {
-      return "Proceed to family build, members, relationships, and production setup.";
+      return "Approved and waiting for production provisioning.";
+    }
+    if (normalized === "build_ready") {
+      return "Production records have been created and the build is ready to move forward.";
+    }
+    if (normalized === "in_production") {
+      return "Your lineage build is actively being produced.";
+    }
+    if (normalized === "qa_review") {
+      return "Your project is being checked in internal quality review.";
+    }
+    if (normalized === "client_review") {
+      return "Your project is ready for your review.";
+    }
+    if (normalized === "delivered") {
+      return "Your project has been delivered.";
+    }
+    if (normalized === "archived") {
+      return "Your project has been archived.";
     }
     if (normalized === "rejected") {
       return "Review the feedback, update your intake, and resubmit.";
@@ -227,19 +274,6 @@
     }
   }
 
-  async function getSubmissionList(limit) {
-    try {
-      return await app.apiRequest(
-        `/intake-submissions/my-list?limit=${limit || 10}`,
-        {
-          method: "GET",
-        },
-      );
-    } catch (error) {
-      return [];
-    }
-  }
-
   function lockFormForReview(form, statusNode, latestSubmission) {
     if (!form || !latestSubmission) return;
 
@@ -261,7 +295,11 @@
     });
 
     if (statusNode) {
-      setStatus(statusNode, statusMessage(status), "info");
+      setStatus(
+        statusNode,
+        `${statusMessage(status)} ${reviewNextStep(status)}`,
+        "info",
+      );
     }
   }
 
@@ -321,7 +359,7 @@
             intakeStatus.textContent = statusMessage(latestSubmission.status);
           }
           if (packageSummary) {
-            packageSummary.textContent = `Your latest intake is currently ${humanizeStatus(latestSubmission.status).toLowerCase()}. ${reviewNextStep(latestSubmission.status)}`;
+            packageSummary.textContent = `${statusMessage(latestSubmission.status)} ${reviewNextStep(latestSubmission.status)}`;
           }
           if (intakeStart) {
             intakeStart.textContent = "View Submitted Intake";


### PR DESCRIPTION
Updated intake.js so customer intake pages stay locked not only for submitted, in review, and approved states, but also for build_ready and later production-phase states. This fixes the founder customer account continuing to show “Submit Intake Review” after the admin approval and provisioning pipeline already moved the submission forward.