### PR TITLE
Harden families endpoint against legacy family records

### DIFF
--- a/backend/app/routes/families.py
+++ b/backend/app/routes/families.py
@@ -68,6 +68,13 @@ def _family_is_visible_to_user(
     return False
 
 
+def _safe_build_family_response(family: dict[str, Any]) -> FamilyResponse | None:
+    try:
+        return build_family_response(family)
+    except Exception:
+        return None
+
+
 @router.get("", response_model=list[FamilyResponse], include_in_schema=False)
 @router.get("/", response_model=list[FamilyResponse])
 def get_families(user: dict[str, Any] = Depends(get_current_user)):
@@ -79,23 +86,34 @@ def get_families(user: dict[str, Any] = Depends(get_current_user)):
 
     docs = list(families_collection.find().sort("created_at", -1))
 
-    if _is_admin(user):
-        return [build_family_response(family) for family in docs]
+    results: list[FamilyResponse] = []
 
-    visible_families = [
-        build_family_response(family)
-        for family in docs
+    if _is_admin(user):
+        for family in docs:
+            built = _safe_build_family_response(family)
+            if built is not None:
+                results.append(built)
+        return results
+
+    for family in docs:
         if _family_is_visible_to_user(
             family=family,
             current_user_id=current_user_id,
             current_user_email=current_user_email,
-        )
-    ]
+        ):
+            built = _safe_build_family_response(family)
+            if built is not None:
+                results.append(built)
 
-    return visible_families
+    return results
 
 
-@router.post("", response_model=FamilyResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
+@router.post(
+    "",
+    response_model=FamilyResponse,
+    status_code=status.HTTP_201_CREATED,
+    include_in_schema=False,
+)
 @router.post("/", response_model=FamilyResponse, status_code=status.HTTP_201_CREATED)
 def create_family_route(
     payload: FamilyCreate,

--- a/backend/app/schemas/family.py
+++ b/backend/app/schemas/family.py
@@ -1,4 +1,6 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -14,13 +16,47 @@ class FamilyResponse(BaseModel):
     created_by: str
     description: str | None = None
     created_at: str
+    owner_user_id: str | None = None
+    owner_email: str | None = None
+    visibility: str | None = None
 
 
-def build_family_response(data: dict) -> FamilyResponse:
+def _to_string(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value).strip()
+
+
+def _to_datetime_string(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+
+    if value is None:
+        return datetime.now(UTC).isoformat()
+
+    return str(value)
+
+
+def build_family_response(data: dict[str, Any]) -> FamilyResponse:
+    family_name = _to_string(
+        data.get("family_name") or data.get("name"),
+        "Unnamed Family",
+    )
+
+    created_by = _to_string(
+        data.get("created_by")
+        or data.get("owner_email")
+        or data.get("owner_user_id"),
+        "Unknown",
+    )
+
     return FamilyResponse(
-        id=str(data.get("_id", "")),
-        family_name=data["family_name"],
-        created_by=data["created_by"],
+        id=_to_string(data.get("_id")),
+        family_name=family_name,
+        created_by=created_by,
         description=data.get("description"),
-        created_at=data.get("created_at", datetime.now(UTC).isoformat()),
+        created_at=_to_datetime_string(data.get("created_at")),
+        owner_user_id=_to_string(data.get("owner_user_id")) or None,
+        owner_email=_to_string(data.get("owner_email")).lower() or None,
+        visibility=_to_string(data.get("visibility")) or None,
     )


### PR DESCRIPTION
Updated family response serialization to normalize mixed legacy and newer family documents without crashing the /families list endpoint. Added safer handling for datetime/string created_at values, missing legacy fields, and route-level defensive building so malformed old family rows do not break Tree View or Lineage Certificate family loading.