### PR TITLE
Expand backend internal admin access without removing cookie auth

### DIFF
--- a/admin-intake-queue.html
+++ b/admin-intake-queue.html
@@ -8,7 +8,7 @@
       name="description"
       content="Admin review queue for Tomb of Light intake submissions."
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="styles.css?v=20260324-6" />
   </head>
   <body>
     <div class="page-wrap">
@@ -17,6 +17,16 @@
           <a class="brand" href="index.html" aria-label="Tomb of Light home">
             <span>Tomb of Light<span class="brand-symbol">™</span></span>
           </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
 
           <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
             <a href="dashboard.html">Dashboard</a>
@@ -60,7 +70,9 @@
                     <option value="submitted">Submitted</option>
                     <option value="in_review">In Review</option>
                     <option value="approved">Approved</option>
+                    <option value="build_ready">Build Ready</option>
                     <option value="rejected">Rejected</option>
+                    <option value="in_production">In Production</option>
                   </select>
                 </label>
 
@@ -124,9 +136,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-7"></script>
-    <script src="app.js?v=20260322-7"></script>
-    <script src="auth.js?v=20260322-7"></script>
-    <script src="admin-intake.js?v=20260322-7"></script>
+    <script src="config.js?v=20260324-6"></script>
+    <script src="app.js?v=20260324-6"></script>
+    <script src="auth.js?v=20260324-6"></script>
+    <script src="admin-intake.js?v=20260324-6"></script>
   </body>
 </html>

--- a/admin-intake-review.html
+++ b/admin-intake-review.html
@@ -8,7 +8,7 @@
       name="description"
       content="Admin review detail page for Tomb of Light intake submissions."
     />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="styles.css?v=20260324-6" />
   </head>
   <body>
     <div class="page-wrap">
@@ -17,6 +17,16 @@
           <a class="brand" href="index.html" aria-label="Tomb of Light home">
             <span>Tomb of Light<span class="brand-symbol">™</span></span>
           </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
 
           <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
             <a href="dashboard.html">Dashboard</a>
@@ -151,6 +161,14 @@
                   </button>
 
                   <button
+                    class="btn btn-primary"
+                    type="button"
+                    data-admin-provision-build
+                  >
+                    Provision Build
+                  </button>
+
+                  <button
                     class="btn btn-secondary"
                     type="button"
                     data-admin-refresh-detail
@@ -175,9 +193,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-7"></script>
-    <script src="app.js?v=20260322-7"></script>
-    <script src="auth.js?v=20260322-7"></script>
-    <script src="admin-intake.js?v=20260322-7"></script>
+    <script src="config.js?v=20260324-6"></script>
+    <script src="app.js?v=20260324-6"></script>
+    <script src="auth.js?v=20260324-6"></script>
+    <script src="admin-intake.js?v=20260324-6"></script>
   </body>
 </html>

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -7,6 +7,20 @@
     return;
   }
 
+  const INTERNAL_ROLE_KEYS = new Set([
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+  ]);
+
   let allSubmissions = [];
   let currentSubmission = null;
 
@@ -19,16 +33,14 @@
       .replaceAll("'", "&#039;");
   }
 
-  function normalizeStatus(status) {
-    return String(status || "")
+  function normalizeValue(value) {
+    return String(value || "")
       .trim()
       .toLowerCase();
   }
 
-  function normalizeRole(role) {
-    return String(role || "")
-      .trim()
-      .toLowerCase();
+  function normalizeStatus(status) {
+    return normalizeValue(status);
   }
 
   function humanizeStatus(status) {
@@ -85,12 +97,17 @@
   }
 
   function ensureAdminAccess(me) {
-    const role = normalizeRole(me && me.role);
-    if (
-      !["admin", "super_admin", "platform_admin", "operations_admin"].includes(
-        role,
-      )
-    ) {
+    const values = [
+      normalizeValue(me && me.role),
+      normalizeValue(me && me.access_tier),
+      normalizeValue(me && me.department_role),
+    ];
+
+    const hasAccess = values.some(function (value) {
+      return INTERNAL_ROLE_KEYS.has(value);
+    });
+
+    if (!hasAccess) {
       throw new Error("Admin access is required to use this page.");
     }
   }
@@ -131,8 +148,8 @@
       submitted: 0,
       in_review: 0,
       approved: 0,
-      rejected: 0,
       build_ready: 0,
+      rejected: 0,
       in_production: 0,
     };
 
@@ -200,8 +217,12 @@
 
   async function loadQueue() {
     const statusNode = document.querySelector("[data-admin-queue-status]");
+    const actionNode = document.querySelector(
+      "[data-admin-queue-action-status]",
+    );
+
     try {
-      clearStatus(document.querySelector("[data-admin-queue-action-status]"));
+      clearStatus(actionNode);
 
       allSubmissions = await apiRequestWithFallback(
         [
@@ -229,7 +250,7 @@
       }
 
       setStatus(
-        document.querySelector("[data-admin-queue-action-status]"),
+        actionNode,
         error.message || "Unable to load intake submissions.",
         "error",
       );
@@ -238,37 +259,18 @@
 
   function renderReviewBlock(node, title, number, lines) {
     if (!node) return;
+
     node.innerHTML = `
       <div>
         <div class="card-number">${escapeHtml(number)}</div>
         <h3>${escapeHtml(title)}</h3>
-        <p class="card-copy">${lines.map(escapeHtml).join("<br />")}</p>
+        <p class="card-copy">${(lines || []).map(escapeHtml).join("<br />")}</p>
       </div>
     `;
   }
 
-  function ensureProvisionButton() {
-    const form = document.querySelector("[data-admin-review-form]");
-    if (!form) return;
-
-    const actionsRow = form.querySelector(".inline-actions");
-    if (!actionsRow) return;
-
-    if (actionsRow.querySelector("[data-admin-provision-build]")) return;
-
-    const button = document.createElement("button");
-    button.className = "btn btn-primary";
-    button.type = "button";
-    button.setAttribute("data-admin-provision-build", "true");
-    button.textContent = "Provision Build";
-
-    actionsRow.insertBefore(button, actionsRow.lastElementChild);
-  }
-
   function renderDetail(submission) {
     currentSubmission = submission;
-
-    ensureProvisionButton();
 
     const pageStatus = document.querySelector(
       "[data-admin-review-page-status]",
@@ -373,12 +375,14 @@
 
     const form = document.querySelector("[data-admin-review-form]");
     if (form) {
-      form.querySelector('[name="review_notes"]').value =
-        submission.review_notes || "";
-      form.querySelector('[name="approval_notes"]').value =
-        submission.approval_notes || "";
-      form.querySelector('[name="rejection_reason"]').value =
-        submission.rejection_reason || "";
+      const reviewNotes = form.querySelector('[name="review_notes"]');
+      const approvalNotes = form.querySelector('[name="approval_notes"]');
+      const rejectionReason = form.querySelector('[name="rejection_reason"]');
+
+      if (reviewNotes) reviewNotes.value = submission.review_notes || "";
+      if (approvalNotes) approvalNotes.value = submission.approval_notes || "";
+      if (rejectionReason)
+        rejectionReason.value = submission.rejection_reason || "";
     }
   }
 
@@ -407,7 +411,6 @@
       renderDetail(submission);
     } catch (error) {
       console.error("Admin intake detail load failed:", error);
-
       setStatus(
         statusNode,
         error.message || "Unable to load the intake submission.",
@@ -429,18 +432,34 @@
       };
     }
 
+    const reviewNotes =
+      (form.querySelector('[name="review_notes"]') || {}).value || "";
     const approvalNotes =
-      form.querySelector('[name="approval_notes"]').value || "";
+      (form.querySelector('[name="approval_notes"]') || {}).value || "";
+    const rejectionReason =
+      (form.querySelector('[name="rejection_reason"]') || {}).value || "";
 
     return {
-      review_notes: form.querySelector('[name="review_notes"]').value || "",
+      review_notes: reviewNotes,
       approval_notes: approvalNotes,
-      rejection_reason:
-        form.querySelector('[name="rejection_reason"]').value || "",
+      rejection_reason: rejectionReason,
       family_name_override: "",
       project_name_override: "",
       production_notes: approvalNotes,
     };
+  }
+
+  function setReviewButtonsDisabled(disabled) {
+    [
+      "[data-admin-mark-review]",
+      "[data-admin-approve]",
+      "[data-admin-reject]",
+      "[data-admin-provision-build]",
+      "[data-admin-refresh-detail]",
+    ].forEach(function (selector) {
+      const button = document.querySelector(selector);
+      if (button) button.disabled = disabled;
+    });
   }
 
   async function runAdminAction(action) {
@@ -485,7 +504,9 @@
           };
 
     try {
+      setReviewButtonsDisabled(true);
       setStatus(statusNode, "Submitting admin action...", "info");
+
       const result = await app.apiRequest(pathMap[action], {
         method: "POST",
         body: JSON.stringify(requestBody),
@@ -502,6 +523,8 @@
     } catch (error) {
       console.error("Admin action failed:", error);
       setStatus(statusNode, error.message || "Admin action failed.", "error");
+    } finally {
+      setReviewButtonsDisabled(false);
     }
   }
 
@@ -532,6 +555,7 @@
 
       const node = document.querySelector("[data-admin-queue-action-status]");
       setStatus(node, error.message || "Admin access is required.", "error");
+
       const hero = document.querySelector("[data-admin-queue-status]");
       if (hero) {
         hero.textContent = "Admin access could not be confirmed.";
@@ -550,6 +574,9 @@
       const reviewBtn = document.querySelector("[data-admin-mark-review]");
       const approveBtn = document.querySelector("[data-admin-approve]");
       const rejectBtn = document.querySelector("[data-admin-reject]");
+      const provisionBtn = document.querySelector(
+        "[data-admin-provision-build]",
+      );
       const refreshBtn = document.querySelector("[data-admin-refresh-detail]");
 
       if (reviewBtn) {
@@ -570,22 +597,23 @@
         });
       }
 
+      if (provisionBtn) {
+        provisionBtn.addEventListener("click", function () {
+          runAdminAction("provision");
+        });
+      }
+
       if (refreshBtn) {
         refreshBtn.addEventListener("click", function () {
           loadReviewDetail();
         });
       }
-
-      document.addEventListener("click", function (event) {
-        const button = event.target.closest("[data-admin-provision-build]");
-        if (!button) return;
-        runAdminAction("provision");
-      });
     } catch (error) {
       console.error("Admin review page setup failed:", error);
 
       const node = document.querySelector("[data-admin-review-action-status]");
       setStatus(node, error.message || "Admin access is required.", "error");
+
       const hero = document.querySelector("[data-admin-review-page-status]");
       if (hero) {
         hero.textContent = "Admin access could not be confirmed.";

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -8,13 +8,18 @@ from app.services.auth_service import get_user_by_email
 
 COOKIE_NAME = "tol_access_token"
 
-ADMIN_ROLES = {
+INTERNAL_ADMIN_KEYS = {
     "admin",
     "super_admin",
+    "root_admin",
     "platform_admin",
     "operations_admin",
     "finance_admin",
     "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
 }
 
 ALLOWED_COOKIE_AUTH_ORIGINS = {
@@ -25,6 +30,10 @@ ALLOWED_COOKIE_AUTH_ORIGINS = {
 }
 
 bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _normalize_value(value) -> str:
+    return str(value or "").strip().lower()
 
 
 def _normalize_user(user: dict, payload: dict) -> dict:
@@ -43,10 +52,6 @@ def _normalize_user(user: dict, payload: dict) -> dict:
         normalized_user["user_id"] = str(raw_id)
 
     return normalized_user
-
-
-def _normalize_role(role: str | None) -> str:
-    return str(role or "").strip().lower()
 
 
 def _extract_request_origin(request: Request) -> str:
@@ -93,6 +98,15 @@ def _get_token_from_request(
     return None, None
 
 
+def _has_internal_admin_access(user: dict) -> bool:
+    values = {
+        _normalize_value(user.get("role")),
+        _normalize_value(user.get("access_tier")),
+        _normalize_value(user.get("department_role")),
+    }
+    return any(value in INTERNAL_ADMIN_KEYS for value in values if value)
+
+
 def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
@@ -132,7 +146,8 @@ def get_current_user(
 
     normalized_user = _normalize_user(user, payload)
 
-    if normalized_user.get("status") != "active":
+    status_value = _normalize_value(normalized_user.get("status"))
+    if status_value not in {"", "active"}:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User is inactive.",
@@ -142,7 +157,7 @@ def get_current_user(
 
 
 def require_admin(current_user: dict = Depends(get_current_user)) -> dict:
-    if _normalize_role(current_user.get("role")) not in ADMIN_ROLES:
+    if not _has_internal_admin_access(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required.",

--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -6,21 +6,24 @@
     return;
   }
 
-  function normalizeRole(role) {
-    return String(role || "")
+  const INTERNAL_ROLE_KEYS = new Set([
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+  ]);
+
+  function normalizeValue(value) {
+    return String(value || "")
       .trim()
       .toLowerCase();
-  }
-
-  function isInternalRole(role) {
-    return [
-      "admin",
-      "super_admin",
-      "platform_admin",
-      "operations_admin",
-      "finance_admin",
-      "marketing_admin",
-    ].includes(normalizeRole(role));
   }
 
   function escapeHtml(value) {
@@ -30,6 +33,24 @@
       .replaceAll(">", "&gt;")
       .replaceAll('"', "&quot;")
       .replaceAll("'", "&#039;");
+  }
+
+  function getInternalRoleKey(me) {
+    const role = normalizeValue(me && me.role);
+    const accessTier = normalizeValue(me && me.access_tier);
+    const departmentRole = normalizeValue(me && me.department_role);
+
+    return accessTier || departmentRole || role;
+  }
+
+  function isInternalRole(me) {
+    const role = normalizeValue(me && me.role);
+    const accessTier = normalizeValue(me && me.access_tier);
+    const departmentRole = normalizeValue(me && me.department_role);
+
+    return [role, accessTier, departmentRole].some(function (value) {
+      return INTERNAL_ROLE_KEYS.has(value);
+    });
   }
 
   function card(number, title, copy, href, buttonText) {
@@ -52,27 +73,23 @@
     `;
   }
 
-  function getInternalRoleKey(me) {
-    const accessTier = normalizeRole(me && me.access_tier);
-    const departmentRole = normalizeRole(me && me.department_role);
-    const role = normalizeRole(me && me.role);
-
-    return accessTier || departmentRole || role;
-  }
-
   function getRoleTitle(me) {
     const roleKey = getInternalRoleKey(me);
 
     if (roleKey === "root_admin") return "Company Root Control";
     if (roleKey === "super_admin") return "Executive Control";
-    if (roleKey === "operations_admin" || roleKey === "operations")
+    if (roleKey === "operations_admin" || roleKey === "operations") {
       return "Operations Control";
-    if (roleKey === "finance_admin" || roleKey === "finance")
+    }
+    if (roleKey === "finance_admin" || roleKey === "finance") {
       return "Finance Control";
-    if (roleKey === "marketing_admin" || roleKey === "marketing")
+    }
+    if (roleKey === "marketing_admin" || roleKey === "marketing") {
       return "Marketing Control";
-    if (roleKey === "platform_admin" || roleKey === "executive_technology")
+    }
+    if (roleKey === "platform_admin" || roleKey === "executive_technology") {
       return "Platform Control";
+    }
     return "Internal Control";
   }
 
@@ -138,6 +155,25 @@
       ];
     }
 
+    if (roleKey === "platform_admin" || roleKey === "executive_technology") {
+      return [
+        card(
+          "A",
+          "Intake Queue",
+          "Access internal onboarding review workflow and troubleshoot intake state transitions.",
+          "admin-intake-queue.html",
+          "Open Intake Queue",
+        ),
+        card(
+          "B",
+          "Platform Tools",
+          "Platform health, operational debugging, and system-level workflow support.",
+          "",
+          "",
+        ),
+      ];
+    }
+
     if (roleKey === "finance_admin" || roleKey === "finance") {
       return [
         card(
@@ -176,25 +212,6 @@
       ];
     }
 
-    if (roleKey === "platform_admin" || roleKey === "executive_technology") {
-      return [
-        card(
-          "A",
-          "Intake Queue",
-          "Access internal onboarding review workflow and troubleshoot intake state transitions.",
-          "admin-intake-queue.html",
-          "Open Intake Queue",
-        ),
-        card(
-          "B",
-          "Platform Tools",
-          "Platform health, operational debugging, and system-level workflow support.",
-          "",
-          "",
-        ),
-      ];
-    }
-
     return [];
   }
 
@@ -224,8 +241,7 @@
     if (!anchor) return;
     if (document.querySelector("[data-admin-tools-panel]")) return;
 
-    const role = normalizeRole(me && me.role);
-    if (!isInternalRole(role)) return;
+    if (!isInternalRole(me)) return;
 
     const panel = document.createElement("div");
     panel.className = "form-panel";
@@ -236,7 +252,7 @@
     panel.innerHTML = `
       <span class="eyebrow">${escapeHtml(getRoleTitle(me))}</span>
       <p class="card-copy" style="margin-bottom: 1.25rem;">
-        This internal workspace is reserved for authorized Tomb of Light operational roles and is separate from the public marketing experience.
+        This internal workspace is reserved for authorized Tomb of Light operational roles and is separate from the public customer workspace.
       </p>
       <div class="grid-3">
         ${cards}
@@ -253,7 +269,7 @@
     try {
       const me = await app.apiRequest("/auth/me", { method: "GET" });
 
-      if (isInternalRole(me && me.role)) {
+      if (isInternalRole(me)) {
         hideCustomerPanels();
         updateHeroForInternal();
         injectAdminPanel(me);


### PR DESCRIPTION
Merged the existing cookie-auth and bearer-auth dependency logic with broader internal role detection so admin pages can be used by authorized operational roles beyond the base admin role. Preserved origin checks for cookie-authenticated unsafe requests and kept the current user normalization and active-status enforcement intact.