### PR TITLE
Fix platform viewer preview embed and add cleaner embedded viewer mode

### DIFF
--- a/platform.html
+++ b/platform.html
@@ -1,4 +1,6 @@
-<!doctype html>
+Paste this as your full updated platform.html:
+
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -15,7 +17,7 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
 
-    <link rel="stylesheet" href="styles.css?v=20260324-3" />
+    <link rel="stylesheet" href="styles.css?v=20260325-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -40,9 +42,7 @@
           </button>
 
           <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
-            <a href="platform.html" class="active" aria-current="page"
-              >Platform</a
-            >
+            <a href="platform.html" class="active" aria-current="page">Platform</a>
             <a href="how-it-works.html">How It Works</a>
             <a href="security.html">Security</a>
             <a href="compliance.html">Compliance</a>
@@ -50,9 +50,7 @@
           </nav>
 
           <div class="header-actions">
-            <a class="btn btn-primary" href="signup.html"
-              >Request Early Access</a
-            >
+            <a class="btn btn-primary" href="signup.html">Request Early Access</a>
           </div>
         </div>
       </header>
@@ -63,20 +61,17 @@
             <div class="page-hero-panel">
               <span class="eyebrow">Platform Overview</span>
               <h1 id="platform-hero-title">
-                A digital legacy platform designed for lineage, memory, and
-                continuity.
+                A digital legacy platform designed for lineage, memory, and continuity.
               </h1>
               <p>
-                Tomb of Light transforms family history into a guided digital
-                experience built around portraits, generations, navigation,
-                protected records, and long-term stewardship.
+                Tomb of Light transforms family history into a guided digital experience
+                built around portraits, generations, navigation, protected records, and
+                long-term stewardship.
               </p>
 
               <div class="hero-actions">
                 <a class="btn btn-primary" href="viewer/">Open Viewer</a>
-                <a class="btn btn-secondary" href="signup.html"
-                  >Request Early Access</a
-                >
+                <a class="btn btn-secondary" href="signup.html">Request Early Access</a>
               </div>
 
               <div class="hero-meta" aria-label="Platform highlights">
@@ -89,10 +84,7 @@
           </div>
         </section>
 
-        <section
-          class="section section-tight"
-          aria-labelledby="platform-core-title"
-        >
+        <section class="section section-tight" aria-labelledby="platform-core-title">
           <div class="container">
             <div class="section-head section-head-wide">
               <span class="eyebrow">Core Platform Layers</span>
@@ -100,9 +92,8 @@
                 Built to feel like a living system, not a file dump.
               </h2>
               <p class="section-lead">
-                Every Tomb of Light experience is structured around clear
-                lineage architecture, visual navigation, private family
-                stewardship, and guided production.
+                Every Tomb of Light experience is structured around clear lineage architecture,
+                visual navigation, private family stewardship, and guided production.
               </p>
             </div>
 
@@ -111,9 +102,8 @@
                 <div class="card-number" aria-hidden="true">01</div>
                 <h3>Lineage Architecture</h3>
                 <p class="card-copy">
-                  Family structures are organized into a connected experience
-                  that reflects parents, descendants, branches, and generations
-                  in a more meaningful format.
+                  Family structures are organized into a connected experience that reflects
+                  parents, descendants, branches, and generations in a more meaningful format.
                 </p>
               </article>
 
@@ -121,9 +111,8 @@
                 <div class="card-number" aria-hidden="true">02</div>
                 <h3>Interactive Viewing</h3>
                 <p class="card-copy">
-                  Families can move through portraits and generations through a
-                  cinematic viewer instead of static galleries, disconnected
-                  folders, or flat family charts.
+                  Families can move through portraits and generations through a cinematic viewer
+                  instead of static galleries, disconnected folders, or flat family charts.
                 </p>
               </article>
 
@@ -131,9 +120,8 @@
                 <div class="card-number" aria-hidden="true">03</div>
                 <h3>Private Stewardship</h3>
                 <p class="card-copy">
-                  The platform is designed around controlled visibility, guided
-                  delivery, and a more careful digital legacy environment for
-                  sensitive family history.
+                  The platform is designed around controlled visibility, guided delivery, and a
+                  more careful digital legacy environment for sensitive family history.
                 </p>
               </article>
             </div>
@@ -145,13 +133,10 @@
             <div class="architecture-panel">
               <div class="section-head section-head-wide">
                 <span class="eyebrow">Experience Flow</span>
-                <h2 id="platform-flow-title">
-                  How the platform experience comes together.
-                </h2>
+                <h2 id="platform-flow-title">How the platform experience comes together.</h2>
                 <p class="section-lead">
-                  Tomb of Light is designed as a guided process from family
-                  intake to final delivery, turning personal history into a
-                  structured digital legacy experience.
+                  Tomb of Light is designed as a guided process from family intake to final
+                  delivery, turning personal history into a structured digital legacy experience.
                 </p>
               </div>
 
@@ -161,9 +146,8 @@
                     <span class="flow-label">01 Intake</span>
                     <h3>Family data and media gathering</h3>
                     <p>
-                      Families begin by providing names, relationships,
-                      portraits, media, and family structure details needed to
-                      organize the lineage experience.
+                      Families begin by providing names, relationships, portraits, media, and
+                      family structure details needed to organize the lineage experience.
                     </p>
                   </div>
 
@@ -171,9 +155,8 @@
                     <span class="flow-label">02 Structure</span>
                     <h3>Lineage mapping and branch organization</h3>
                     <p>
-                      Family records are organized into a clearer architecture
-                      that supports a visual, navigable, multi-generation
-                      experience.
+                      Family records are organized into a clearer architecture that supports a
+                      visual, navigable, multi-generation experience.
                     </p>
                   </div>
 
@@ -181,9 +164,8 @@
                     <span class="flow-label">03 Build</span>
                     <h3>Viewer assembly and visual presentation</h3>
                     <p>
-                      Portraits, branches, descendants, and narrative layers are
-                      assembled into a premium digital lineage experience
-                      families can explore.
+                      Portraits, branches, descendants, and narrative layers are assembled into
+                      a premium digital lineage experience families can explore.
                     </p>
                   </div>
                 </div>
@@ -193,9 +175,8 @@
                     <span class="flow-label">04 Review</span>
                     <h3>Guided revision and refinement</h3>
                     <p>
-                      Families review the build, confirm structure, and refine
-                      the presentation before final delivery and access are
-                      completed.
+                      Families review the build, confirm structure, and refine the presentation
+                      before final delivery and access are completed.
                     </p>
                   </div>
 
@@ -203,9 +184,8 @@
                     <span class="flow-label">05 Delivery</span>
                     <h3>Private access and legacy handoff</h3>
                     <p>
-                      Once approved, the family receives a completed legacy
-                      experience with guided access, secure delivery, and
-                      continuation options.
+                      Once approved, the family receives a completed legacy experience with guided
+                      access, secure delivery, and continuation options.
                     </p>
                   </div>
 
@@ -213,37 +193,29 @@
                     <span class="flow-label">06 Continuity</span>
                     <h3>Expansion across generations</h3>
                     <p>
-                      The platform is built to support future additions, lineage
-                      growth, and ongoing family preservation over time.
+                      The platform is built to support future additions, lineage growth, and
+                      ongoing family preservation over time.
                     </p>
                   </div>
                 </div>
               </div>
 
               <div class="inline-actions architecture-actions">
-                <a class="btn btn-primary" href="signup.html"
-                  >Start Your Legacy</a
-                >
-                <a class="btn btn-secondary" href="how-it-works.html"
-                  >See How It Works</a
-                >
+                <a class="btn btn-primary" href="signup.html">Start Your Legacy</a>
+                <a class="btn btn-secondary" href="how-it-works.html">See How It Works</a>
               </div>
             </div>
           </div>
         </section>
 
-        <section
-          class="section section-tight"
-          aria-labelledby="platform-viewer-title"
-        >
+        <section class="section section-tight" aria-labelledby="platform-viewer-title">
           <div class="container">
             <div class="viewer-panel">
               <div class="viewer-panel-top">
                 <div>
                   <span class="eyebrow">Interactive Viewer</span>
                   <h2 id="platform-viewer-title">
-                    A family experience designed to be explored, not just
-                    stored.
+                    A family experience designed to be explored, not just stored.
                   </h2>
                 </div>
                 <a class="mini-link" href="viewer/">Open Full Viewer</a>
@@ -253,12 +225,11 @@
                 <div class="platform-prototype-stage">
                   <div class="platform-prototype-frame">
                     <iframe
-                      src="viewer/?embed=1"
+                      src="viewer/?embed=1&preview=1&v=20260325-1"
                       title="Tomb of Light Prototype Viewer"
                       loading="lazy"
                       allowfullscreen
-                    >
-                    </iframe>
+                    ></iframe>
                   </div>
                 </div>
               </div>
@@ -268,8 +239,8 @@
                   <div class="card-number" aria-hidden="true">01</div>
                   <h3>Begin with the Portrait</h3>
                   <p>
-                    Start from a central family portrait and enter a lineage
-                    experience built around identity, ancestry, and connection.
+                    Start from a central family portrait and enter a lineage experience built
+                    around identity, ancestry, and connection.
                   </p>
                 </article>
 
@@ -277,8 +248,8 @@
                   <div class="card-number" aria-hidden="true">02</div>
                   <h3>Move Through Generations</h3>
                   <p>
-                    Explore parents, descendants, and branches in a more visual
-                    and meaningful structure.
+                    Explore parents, descendants, and branches in a more visual and meaningful
+                    structure.
                   </p>
                 </article>
 
@@ -286,8 +257,8 @@
                   <div class="card-number" aria-hidden="true">03</div>
                   <h3>Return to the Record</h3>
                   <p>
-                    Revisit family history through a premium digital experience
-                    designed for continuity rather than one-time viewing.
+                    Revisit family history through a premium digital experience designed for
+                    continuity rather than one-time viewing.
                   </p>
                 </article>
               </div>
@@ -295,10 +266,7 @@
           </div>
         </section>
 
-        <section
-          class="section section-tight"
-          aria-labelledby="platform-why-title"
-        >
+        <section class="section section-tight" aria-labelledby="platform-why-title">
           <div class="container">
             <div class="section-head section-head-wide">
               <span class="eyebrow">Why Families Choose This Model</span>
@@ -306,9 +274,8 @@
                 A more intentional way to preserve family legacy.
               </h2>
               <p class="section-lead">
-                Tomb of Light is designed for families who want more than a
-                storage account, a printed chart, or a folder of scattered
-                files.
+                Tomb of Light is designed for families who want more than a storage account,
+                a printed chart, or a folder of scattered files.
               </p>
             </div>
 
@@ -316,32 +283,32 @@
               <article class="trust-card">
                 <h3>More Human Than Storage</h3>
                 <p class="card-copy">
-                  The experience is built around meaning, memory, and lineage
-                  rather than simple file retention.
+                  The experience is built around meaning, memory, and lineage rather than
+                  simple file retention.
                 </p>
               </article>
 
               <article class="trust-card">
                 <h3>More Visual Than Records Alone</h3>
                 <p class="card-copy">
-                  Portraits, generations, and branches are presented in a format
-                  families can actually explore.
+                  Portraits, generations, and branches are presented in a format families
+                  can actually explore.
                 </p>
               </article>
 
               <article class="trust-card">
                 <h3>More Guided Than DIY Tools</h3>
                 <p class="card-copy">
-                  Each build is custom produced rather than left entirely to the
-                  customer to assemble alone.
+                  Each build is custom produced rather than left entirely to the customer to
+                  assemble alone.
                 </p>
               </article>
 
               <article class="trust-card">
                 <h3>More Enduring Than Social Platforms</h3>
                 <p class="card-copy">
-                  Tomb of Light is positioned around continuity and stewardship
-                  instead of short-term posting.
+                  Tomb of Light is positioned around continuity and stewardship instead of
+                  short-term posting.
                 </p>
               </article>
             </div>
@@ -356,18 +323,13 @@
                 Build a lineage experience worthy of your family story.
               </h2>
               <p class="section-lead">
-                Begin with a portrait, expand into a multi-generation archive,
-                or request a guided consultation for larger family legacy
-                projects.
+                Begin with a portrait, expand into a multi-generation archive, or request a
+                guided consultation for larger family legacy projects.
               </p>
 
               <div class="cta-actions">
-                <a class="btn btn-primary" href="signup.html"
-                  >Request Early Access</a
-                >
-                <a class="btn btn-secondary" href="index.html#pricing"
-                  >View Packages</a
-                >
+                <a class="btn btn-primary" href="signup.html">Request Early Access</a>
+                <a class="btn btn-secondary" href="index.html#pricing">View Packages</a>
               </div>
             </div>
           </div>
@@ -383,8 +345,8 @@
                   Tomb of Light<span class="brand-symbol">™</span>
                 </div>
                 <p class="footer-copy">
-                  A private digital legacy platform for preserving and exploring
-                  family lineage across generations.
+                  A private digital legacy platform for preserving and exploring family lineage
+                  across generations.
                 </p>
                 <div class="cookie-status" data-cookie-status>
                   Your cookie preference has not been set yet.
@@ -406,10 +368,7 @@
 
             <div class="footer-bottom">
               <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
-              <span
-                >Tomb of Light technology and platform design are
-                proprietary.</span
-              >
+              <span>Tomb of Light technology and platform design are proprietary.</span>
             </div>
           </div>
         </div>
@@ -424,24 +383,22 @@
     >
       <div class="cookie-inner">
         <div class="cookie-copy">
-          We use essential site technologies and may use optional analytics
-          tools only where permitted. You can accept or decline optional
-          analytics cookies and review your choices at any time.
+          We use essential site technologies and may use optional analytics tools
+          only where permitted. You can accept or decline optional analytics cookies
+          and review your choices at any time.
         </div>
         <div class="cookie-actions">
-          <button class="btn btn-primary" type="button" data-cookie-accept>
+          <button class="btn btn-primary" type="button" data-cookie-accept">
             Accept
           </button>
-          <button class="btn btn-secondary" type="button" data-cookie-decline>
+          <button class="btn btn-secondary" type="button" data-cookie-decline">
             Decline
           </button>
-          <a class="btn btn-ghost" href="privacy-choices.html"
-            >Privacy Choices</a
-          >
+          <a class="btn btn-ghost" href="privacy-choices.html">Privacy Choices</a>
         </div>
       </div>
     </div>
 
-    <script src="app.js?v=20260324-2"></script>
+    <script src="app.js?v=20260325-1"></script>
   </body>
 </html>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,119 +1,278 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tomb of Light | Genesis Prototype</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tomb of Light | Genesis Prototype</title>
 
-  <!-- Cache-bust styles so updates always show -->
-  <link rel="stylesheet" href="css/style.css?v=20260320-2" />
+    <link rel="stylesheet" href="css/style.css?v=20260325-1" />
 
-  <!-- Add embed-mode ASAP to prevent flicker -->
-  <script>
-    (function () {
-      try {
-        const params = new URLSearchParams(window.location.search);
-        const isEmbedParam = params.get("embed") === "1";
-        const isInIframe = window.self !== window.top;
-        if (isEmbedParam || isInIframe) document.documentElement.classList.add("embed-mode");
-      } catch (e) {
-        // If cross-origin iframe blocks window.top access, treat as embed
-        document.documentElement.classList.add("embed-mode");
+    <script>
+      (function () {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          const isEmbedParam = params.get("embed") === "1";
+          const isPreviewParam = params.get("preview") === "1";
+          const isInIframe = window.self !== window.top;
+
+          if (isEmbedParam || isPreviewParam || isInIframe) {
+            document.documentElement.classList.add("embed-mode");
+          }
+
+          if (isPreviewParam) {
+            document.documentElement.classList.add("preview-mode");
+          }
+        } catch (e) {
+          document.documentElement.classList.add("embed-mode");
+        }
+      })();
+    </script>
+
+    <style>
+      html,
+      body {
+        min-height: 100%;
       }
-    })();
-  </script>
-</head>
 
-<body>
-  <div class="viewer-page">
-    <header class="viewer-header" id="viewerHeader">
-      <div class="viewer-brand-wrap">
-        <a href="../index.html" class="back-link" id="backLink">← Back to Tomb of Light</a>
+      html.embed-mode,
+      html.embed-mode body {
+        height: 100%;
+        overflow: hidden;
+        background: transparent !important;
+      }
 
-        <div class="viewer-brand">
-          Tomb of Light<span class="brand-symbol">™</span>
-        </div>
-      </div>
+      html.embed-mode .viewer-page {
+        min-height: 100vh;
+        padding: 0;
+        background: transparent;
+      }
 
-      <div class="viewer-header-copy">
-        <span class="viewer-kicker">Genesis Prototype</span>
-        <h1>Interactive Family Lineage</h1>
-        <p>
-          Navigate through generations of the Moreland lineage and explore
-          family branches through the Tomb of Light viewer.
-        </p>
+      html.embed-mode .viewer-header,
+      html.embed-mode .viewer-side-panel,
+      html.embed-mode .controls,
+      html.embed-mode .viewer-line,
+      html.embed-mode #backLink,
+      html.embed-mode #viewerInstructions,
+      html.embed-mode #narrationDisplay,
+      html.embed-mode #branchOptions {
+        display: none !important;
+      }
 
-        <p class="viewer-instructions" id="viewerInstructions">
-          Hold <strong>C</strong>, then click <strong>Left Eye</strong> (Parents) or
-          <strong>Right Eye</strong> (Descendants). Use scroll/pinch to zoom. (Full viewer only)
-        </p>
-      </div>
-    </header>
+      html.embed-mode .viewer-main {
+        min-height: 100vh;
+        height: 100vh;
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
+        padding: 18px;
+        margin: 0;
+      }
 
-    <main class="viewer-main">
-      <section class="viewer-stage-panel">
-        <div class="viewer-stage-top">
-          <div>
-            <span class="panel-kicker">Cinematic Viewer</span>
-            <h2 id="viewerTitle">Malik Moreland</h2>
+      html.embed-mode .viewer-stage-panel {
+        width: 100%;
+        max-width: 560px;
+        height: calc(100vh - 36px);
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        padding: 18px;
+        margin: 0 auto;
+        border-radius: 30px;
+        box-sizing: border-box;
+      }
+
+      html.embed-mode .viewer-stage-top {
+        flex: 0 0 auto;
+        margin-bottom: 14px;
+      }
+
+      html.embed-mode .viewer-stage-top h2 {
+        margin: 0 0 8px;
+        line-height: 1.05;
+      }
+
+      html.embed-mode .viewer-stage-shell {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border-radius: 28px;
+      }
+
+      html.embed-mode .viewer-stage-glow {
+        opacity: 0.5;
+      }
+
+      html.embed-mode .slideshow {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border-radius: 24px;
+      }
+
+      html.embed-mode #viewerImage {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        object-position: center center;
+        display: block;
+      }
+
+      html.embed-mode .eye-hint {
+        display: none !important;
+      }
+
+      html.preview-mode .viewer-stage-top {
+        margin-bottom: 12px;
+      }
+
+      html.preview-mode .viewer-status {
+        opacity: 0.92;
+      }
+
+      @media (max-width: 900px) {
+        html.embed-mode .viewer-main {
+          padding: 12px;
+        }
+
+        html.embed-mode .viewer-stage-panel {
+          height: calc(100vh - 24px);
+          padding: 14px;
+        }
+      }
+
+      @media (max-width: 640px) {
+        html.embed-mode .viewer-stage-panel {
+          border-radius: 24px;
+        }
+
+        html.embed-mode .viewer-stage-shell,
+        html.embed-mode .slideshow {
+          border-radius: 20px;
+        }
+
+        html.embed-mode .viewer-stage-top h2 {
+          font-size: clamp(1.6rem, 5vw, 2.2rem);
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="viewer-page">
+      <header class="viewer-header" id="viewerHeader">
+        <div class="viewer-brand-wrap">
+          <a href="../index.html" class="back-link" id="backLink"
+            >← Back to Tomb of Light</a
+          >
+
+          <div class="viewer-brand">
+            Tomb of Light<span class="brand-symbol">™</span>
           </div>
-
-          <div class="viewer-status" id="viewerStatus">Anchor Portrait</div>
         </div>
 
-        <div class="viewer-stage-shell" id="viewerStage">
-          <div class="viewer-stage-glow"></div>
+        <div class="viewer-header-copy">
+          <span class="viewer-kicker">Genesis Prototype</span>
+          <h1>Interactive Family Lineage</h1>
+          <p>
+            Navigate through generations of the Moreland lineage and explore
+            family branches through the Tomb of Light viewer.
+          </p>
 
-          <div class="slideshow" id="slideshow">
-            <img id="viewerImage" src="images/malik.jpg" alt="Malik Moreland" />
-
-            <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
-            <div class="eye-hint" id="eyeRight" aria-hidden="true"></div>
-          </div>
-
-          <div id="narrationDisplay" class="narration-text"></div>
-
-          <div class="branch-options" id="branchOptions">
-            <button type="button" onclick="selectBranch('julian')">Julian</button>
-            <button type="button" onclick="selectBranch('malik')">Malik</button>
-            <button type="button" onclick="selectBranch('selah')">Selah</button>
-          </div>
-        </div>
-
-        <div class="viewer-line"></div>
-
-        <div class="controls" id="controls">
-          <button type="button" onclick="zoomOut()">Zoom Out</button>
-          <button type="button" onclick="zoomIn()">Zoom In</button>
-          <button type="button" onclick="resetViewer()">Reset</button>
-          <button type="button" id="narrationToggleBtn" onclick="toggleNarration()">Narration: ON</button>
-        </div>
-      </section>
-
-      <aside class="viewer-side-panel" id="sidePanel">
-        <div class="side-card">
-          <span class="panel-kicker">Current Node</span>
-          <h3 id="currentNode">Malik Moreland</h3>
-          <p id="currentDescription">
-            Starting at the anchor portrait for the Genesis family line.
+          <p class="viewer-instructions" id="viewerInstructions">
+            Hold <strong>C</strong>, then click
+            <strong>Left Eye</strong> (Parents) or
+            <strong>Right Eye</strong> (Descendants). Use scroll/pinch to zoom.
+            (Full viewer only)
           </p>
         </div>
+      </header>
 
-        <div class="side-card">
-          <span class="panel-kicker">Lineage Flow</span>
-          <div class="path-list">
-            <div class="path-item">Malik → Parents</div>
-            <div class="path-item">Malik → Descendants</div>
-            <div class="path-item">Imani → Descendants</div>
-            <div class="path-item">Selah → Descendants</div>
-            <div class="path-item">Julian → Parents</div>
+      <main class="viewer-main">
+        <section class="viewer-stage-panel">
+          <div class="viewer-stage-top">
+            <div>
+              <span class="panel-kicker">Cinematic Viewer</span>
+              <h2 id="viewerTitle">Malik Moreland</h2>
+            </div>
+
+            <div class="viewer-status" id="viewerStatus">Anchor Portrait</div>
           </div>
-        </div>
-      </aside>
-    </main>
-  </div>
 
-  <!-- Cache-bust script too (critical if “C+click” changes weren’t showing) -->
-  <script src="js/script.js?v=20260320-2"></script>
-</body>
+          <div class="viewer-stage-shell" id="viewerStage">
+            <div class="viewer-stage-glow"></div>
+
+            <div class="slideshow" id="slideshow">
+              <img
+                id="viewerImage"
+                src="images/malik.jpg"
+                alt="Malik Moreland"
+              />
+
+              <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
+              <div class="eye-hint" id="eyeRight" aria-hidden="true"></div>
+            </div>
+
+            <div id="narrationDisplay" class="narration-text"></div>
+
+            <div class="branch-options" id="branchOptions">
+              <button type="button" onclick="selectBranch('julian')">
+                Julian
+              </button>
+              <button type="button" onclick="selectBranch('malik')">
+                Malik
+              </button>
+              <button type="button" onclick="selectBranch('selah')">
+                Selah
+              </button>
+            </div>
+          </div>
+
+          <div class="viewer-line"></div>
+
+          <div class="controls" id="controls">
+            <button type="button" onclick="zoomOut()">Zoom Out</button>
+            <button type="button" onclick="zoomIn()">Zoom In</button>
+            <button type="button" onclick="resetViewer()">Reset</button>
+            <button
+              type="button"
+              id="narrationToggleBtn"
+              onclick="toggleNarration()"
+            >
+              Narration: ON
+            </button>
+          </div>
+        </section>
+
+        <aside class="viewer-side-panel" id="sidePanel">
+          <div class="side-card">
+            <span class="panel-kicker">Current Node</span>
+            <h3 id="currentNode">Malik Moreland</h3>
+            <p id="currentDescription">
+              Starting at the anchor portrait for the Genesis family line.
+            </p>
+          </div>
+
+          <div class="side-card">
+            <span class="panel-kicker">Lineage Flow</span>
+            <div class="path-list">
+              <div class="path-item">Malik → Parents</div>
+              <div class="path-item">Malik → Descendants</div>
+              <div class="path-item">Imani → Descendants</div>
+              <div class="path-item">Selah → Descendants</div>
+              <div class="path-item">Julian → Parents</div>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+
+    <script src="js/script.js?v=20260325-1"></script>
+  </body>
 </html>


### PR DESCRIPTION
Updated platform.html to load the Tomb of Light viewer as a dedicated portrait-style embedded preview instead of the full operational viewer frame. Updated viewer/index.html to support embed and preview modes, hide non-essential full-view controls in platform embeds, improve centering and scaling, and present a cleaner cinematic showcase inside the platform page.