### PR TITLE
Upgrade admin family manager page for delete-capable workflow

### DIFF
--- a/admin-family-manager.html
+++ b/admin-family-manager.html
@@ -8,7 +8,7 @@
       name="description"
       content="Admin family build manager for Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260325-2" />
+    <link rel="stylesheet" href="styles.css?v=20260325-3" />
   </head>
   <body>
     <div class="page-wrap">
@@ -31,16 +31,16 @@
           <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
             <a href="dashboard.html">Dashboard</a>
             <a href="admin-intake-queue.html">Admin Intake Queue</a>
-            <a href="admin-family-manager.html" aria-current="page"
-              >Family Manager</a
-            >
+            <a href="admin-family-manager.html" aria-current="page">
+              Family Manager
+            </a>
             <a href="faq.html">FAQ</a>
           </nav>
 
           <div class="header-actions">
-            <a class="btn btn-secondary" href="dashboard.html"
-              >Back to Dashboard</a
-            >
+            <a class="btn btn-secondary" href="dashboard.html">
+              Back to Dashboard
+            </a>
           </div>
         </div>
       </header>
@@ -103,6 +103,10 @@
 
             <div class="form-panel">
               <span class="eyebrow">Current Members</span>
+              <p class="helper" style="margin-bottom: 1rem">
+                Delete relationships tied to a member before deleting that
+                member.
+              </p>
               <div class="grid-3" data-admin-family-members-list></div>
               <div
                 class="helper"
@@ -115,6 +119,10 @@
 
             <div class="form-panel">
               <span class="eyebrow">Current Relationships</span>
+              <p class="helper" style="margin-bottom: 1rem">
+                Relationship delete controls appear on each relationship card
+                after the family is loaded.
+              </p>
               <div class="grid-3" data-admin-family-relationships-list></div>
               <div
                 class="helper"
@@ -282,9 +290,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260325-2"></script>
-    <script src="app.js?v=20260325-2"></script>
-    <script src="auth.js?v=20260325-2"></script>
-    <script src="admin-family-manager.js?v=20260325-2"></script>
+    <script src="config.js?v=20260325-3"></script>
+    <script src="app.js?v=20260325-3"></script>
+    <script src="auth.js?v=20260325-3"></script>
+    <script src="admin-family-manager.js?v=20260325-3"></script>
   </body>
 </html>

--- a/admin-family-manager.js
+++ b/admin-family-manager.js
@@ -245,6 +245,16 @@
             <p class="card-copy"><strong>Verified:</strong> ${verified ? "Yes" : "No"}</p>
             <p class="card-copy"><strong>Member ID:</strong> ${escapeHtml(member.id || "—")}</p>
             <p class="card-copy"><strong>Bio:</strong> ${escapeHtml(member.bio || "—")}</p>
+            <div class="inline-actions" style="margin-top: 1rem;">
+              <button
+                class="btn btn-secondary"
+                type="button"
+                data-delete-member-id="${escapeHtml(member.id || "")}"
+                data-delete-member-name="${escapeHtml(getDisplayName(member))}"
+              >
+                Delete Member
+              </button>
+            </div>
           </div>
         `;
       })
@@ -291,6 +301,15 @@
             <p class="card-copy"><strong>Target:</strong> ${escapeHtml(target ? getDisplayName(target) : relationship.target_member_id || "—")}</p>
             <p class="card-copy"><strong>Relationship ID:</strong> ${escapeHtml(relationship.id || relationship._id || "—")}</p>
             <p class="card-copy"><strong>Notes:</strong> ${escapeHtml(relationship.notes || "—")}</p>
+            <div class="inline-actions" style="margin-top: 1rem;">
+              <button
+                class="btn btn-secondary"
+                type="button"
+                data-delete-relationship-id="${escapeHtml(relationship.id || relationship._id || "")}"
+              >
+                Delete Relationship
+              </button>
+            </div>
           </div>
         `;
       })
@@ -535,6 +554,77 @@
     }
   }
 
+  async function deleteRelationship(relationshipId) {
+    const actionNode = document.querySelector(
+      "[data-admin-family-action-status]",
+    );
+
+    if (!relationshipId) {
+      setStatus(actionNode, "Missing relationship id.", "error");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "Delete this relationship? This action cannot be undone.",
+    );
+    if (!confirmed) return;
+
+    try {
+      setStatus(actionNode, "Deleting relationship...", "info");
+
+      await app.apiRequest(
+        `/relationships/${encodeURIComponent(relationshipId)}`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      await loadFamilyGraph();
+      setStatus(actionNode, "Relationship deleted successfully.", "success");
+    } catch (error) {
+      console.error("Delete relationship failed:", error);
+      setStatus(
+        actionNode,
+        error.message || "Unable to delete relationship.",
+        "error",
+      );
+    }
+  }
+
+  async function deleteMember(memberId, memberName) {
+    const actionNode = document.querySelector(
+      "[data-admin-family-action-status]",
+    );
+
+    if (!memberId) {
+      setStatus(actionNode, "Missing member id.", "error");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete ${memberName || "this member"}?\n\nIf relationships still point to this member, delete those relationships first.`,
+    );
+    if (!confirmed) return;
+
+    try {
+      setStatus(actionNode, "Deleting family member...", "info");
+
+      await app.apiRequest(`/family-members/${encodeURIComponent(memberId)}`, {
+        method: "DELETE",
+      });
+
+      await loadFamilyGraph();
+      setStatus(actionNode, "Family member deleted successfully.", "success");
+    } catch (error) {
+      console.error("Delete member failed:", error);
+      setStatus(
+        actionNode,
+        error.message || "Unable to delete family member.",
+        "error",
+      );
+    }
+  }
+
   async function setupAdminFamilyManagerPage() {
     const page = document.querySelector("[data-admin-family-manager-page]");
     if (!page) return;
@@ -562,6 +652,26 @@
       if (relationshipForm) {
         relationshipForm.addEventListener("submit", handleCreateRelationship);
       }
+
+      document.addEventListener("click", function (event) {
+        const relationshipButton = event.target.closest(
+          "[data-delete-relationship-id]",
+        );
+        if (relationshipButton) {
+          deleteRelationship(
+            relationshipButton.getAttribute("data-delete-relationship-id"),
+          );
+          return;
+        }
+
+        const memberButton = event.target.closest("[data-delete-member-id]");
+        if (memberButton) {
+          deleteMember(
+            memberButton.getAttribute("data-delete-member-id"),
+            memberButton.getAttribute("data-delete-member-name"),
+          );
+        }
+      });
 
       const selectNode = document.querySelector("[data-admin-family-select]");
       if (selectNode && selectNode.value) {

--- a/backend/app/routes/family_members.py
+++ b/backend/app/routes/family_members.py
@@ -38,7 +38,32 @@ def _current_user_display_name(user: dict[str, Any]) -> str:
 
 
 def _is_admin(user: dict[str, Any]) -> bool:
-    return str(user.get("role", "")).strip().lower() == "admin"
+    role = str(user.get("role", "")).strip().lower()
+    access_tier = str(user.get("access_tier", "")).strip().lower()
+    department_role = str(user.get("department_role", "")).strip().lower()
+
+    return role in {
+        "admin",
+        "super_admin",
+        "root_admin",
+        "platform_admin",
+        "operations_admin",
+        "finance_admin",
+        "marketing_admin",
+    } or access_tier in {
+        "super_admin",
+        "root_admin",
+        "platform_admin",
+        "operations_admin",
+        "finance_admin",
+        "marketing_admin",
+        "executive_technology",
+    } or department_role in {
+        "operations",
+        "finance",
+        "marketing",
+        "executive_technology",
+    }
 
 
 def _family_is_visible_to_user(
@@ -73,7 +98,6 @@ def _family_is_visible_to_user(
     if current_user_email in shared_with_emails:
         return True
 
-    # Backward-compatible fallback for older family records
     if not owner_user_id and not owner_email:
         created_by = str(family.get("created_by") or "").strip()
         if created_by and (
@@ -157,7 +181,16 @@ def _serialize_member(member: dict[str, Any]) -> dict[str, Any]:
         "spouse_id": member.get("spouse_id"),
         "bio": member.get("bio"),
         "created_at": member.get("created_at"),
+        "is_verified": member.get("is_verified"),
+        "verification_status": member.get("verification_status"),
     }
+
+
+def _display_name(member: dict[str, Any]) -> str:
+    first_name = str(member.get("first_name") or "").strip()
+    last_name = str(member.get("last_name") or "").strip()
+    joined = f"{first_name} {last_name}".strip()
+    return joined or "Unknown Member"
 
 
 @router.get("-index")
@@ -282,4 +315,55 @@ def update_family_member(
         "message": "Family member updated successfully.",
         "family_member_id": member_id,
         "match_candidates_created": created_candidates,
+    }
+
+
+@router.delete("/{member_id}")
+def delete_family_member(
+    member_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    existing, _family = _require_family_access_for_member(member_id, current_user)
+
+    relationship_count = db.relationships.count_documents(
+        {
+            "$or": [
+                {"source_member_id": member_id},
+                {"target_member_id": member_id},
+            ]
+        }
+    )
+
+    if relationship_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Cannot delete member while {relationship_count} relationship(s) still reference this record. "
+                "Delete those relationships first."
+            ),
+        )
+
+    user_id = _current_user_id(current_user)
+
+    db.family_members.delete_one({"_id": ObjectId(member_id)})
+
+    create_audit_log(
+        action="family_member_deleted",
+        actor_user_id=user_id,
+        entity_type="family_member",
+        entity_id=member_id,
+        details={
+            "family_id": str(existing.get("family_id") or ""),
+            "display_name": _display_name(existing),
+        },
+    )
+
+    return {
+        "status": "deleted",
+        "family_member_id": member_id,
+        "display_name": _display_name(existing),
     }


### PR DESCRIPTION
Updated the Admin Family Manager page structure and asset versions to support the new delete-enabled family operations workflow. Added clearer guidance around member and relationship removal, preserved the current family build load/create sections, and bumped cache versions so the latest admin family manager JavaScript and styling changes load immediately in production.