### PR TITLE
Build secure upload backend for member photos and verification evidence

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -29,6 +30,25 @@ class Settings(BaseSettings):
         "https://www.tomboflight.com"
     )
 
+    # Upload / storage
+    upload_storage_dir: str = "storage/uploads"
+    render_disk_mount_path: str = ""
+    upload_max_image_mb: int = 10
+    upload_max_document_mb: int = 25
+
+    upload_image_content_types: str = (
+        "image/jpeg,"
+        "image/png,"
+        "image/webp"
+    )
+
+    upload_document_content_types: str = (
+        "application/pdf,"
+        "image/jpeg,"
+        "image/png,"
+        "image/webp"
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -43,6 +63,37 @@ class Settings(BaseSettings):
             for origin in self.allowed_origins.split(",")
             if origin.strip()
         ]
+
+    @property
+    def upload_image_content_types_list(self) -> list[str]:
+        return [
+            value.strip().lower()
+            for value in self.upload_image_content_types.split(",")
+            if value.strip()
+        ]
+
+    @property
+    def upload_document_content_types_list(self) -> list[str]:
+        return [
+            value.strip().lower()
+            for value in self.upload_document_content_types.split(",")
+            if value.strip()
+        ]
+
+    @property
+    def upload_max_image_bytes(self) -> int:
+        return self.upload_max_image_mb * 1024 * 1024
+
+    @property
+    def upload_max_document_bytes(self) -> int:
+        return self.upload_max_document_mb * 1024 * 1024
+
+    @property
+    def upload_root_path(self) -> str:
+        mount_path = str(self.render_disk_mount_path or "").strip().rstrip("/")
+        if mount_path:
+            return str(Path(mount_path) / "uploads")
+        return str(Path(self.upload_storage_dir))
 
 
 @lru_cache

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from bson import ObjectId
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
+from fastapi.responses import FileResponse
+
+from app.config import settings
+from app.database import get_database
+from app.dependencies.auth import get_current_user
+from app.services.upload_service import (
+    serialize_upload_record,
+    store_member_photo_upload,
+    store_verification_evidence_upload,
+)
+
+router = APIRouter(prefix="/uploads", tags=["Uploads"])
+
+INTERNAL_ADMIN_KEYS = {
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+}
+
+
+def _normalize_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return _normalize_email(raw_email)
+
+
+def _current_user_display_name(user: dict[str, Any]) -> str:
+    raw_name = user.get("full_name") or user.get("name") or ""
+    return _normalize_value(raw_name)
+
+
+def _actor_label(user: dict[str, Any]) -> str:
+    return (
+        _normalize_email(user.get("email"))
+        or _normalize_value(user.get("full_name"))
+        or _normalize_value(user.get("name"))
+        or _normalize_value(user.get("id"))
+        or "system"
+    )
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    values = {
+        _normalize_value(user.get("role")).lower(),
+        _normalize_value(user.get("access_tier")).lower(),
+        _normalize_value(user.get("department_role")).lower(),
+    }
+    return any(value in INTERNAL_ADMIN_KEYS for value in values if value)
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = _normalize_value(family.get("owner_user_id"))
+    owner_email = _normalize_email(family.get("owner_email"))
+
+    shared_with_user_ids = [
+        _normalize_value(value)
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        _normalize_email(value)
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    if not owner_user_id and not owner_email:
+        created_by = _normalize_value(family.get("created_by"))
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_family_access_by_family_id(
+    family_id: str,
+    db: Any,
+    current_user: dict[str, Any],
+) -> dict[str, Any]:
+    if not family_id:
+        raise HTTPException(status_code=400, detail="family_id is required.")
+
+    if not ObjectId.is_valid(family_id):
+        raise HTTPException(status_code=400, detail="Invalid family id.")
+
+    family = db["families"].find_one({"_id": ObjectId(family_id)})
+    if not family:
+        raise HTTPException(status_code=404, detail="Family not found.")
+
+    if _is_admin(current_user):
+        return family
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_display_name(current_user)
+
+    if not _family_is_visible_to_user(
+        family=family,
+        current_user_id=current_user_id,
+        current_user_email=current_user_email,
+        current_user_name=current_user_name,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this family.",
+        )
+
+    return family
+
+
+def _require_member_access(
+    member_id: str,
+    db: Any,
+    current_user: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not ObjectId.is_valid(member_id):
+        raise HTTPException(status_code=400, detail="Invalid member id.")
+
+    member = db["family_members"].find_one({"_id": ObjectId(member_id)})
+    if not member:
+        raise HTTPException(status_code=404, detail="Family member not found.")
+
+    family_id = _normalize_value(member.get("family_id"))
+    family = _require_family_access_by_family_id(family_id, db, current_user)
+    return member, family
+
+
+def _require_upload_access(
+    upload_id: str,
+    db: Any,
+    current_user: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not ObjectId.is_valid(upload_id):
+        raise HTTPException(status_code=400, detail="Invalid upload id.")
+
+    upload_record = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
+    if not upload_record:
+        raise HTTPException(status_code=404, detail="Upload not found.")
+
+    family_id = _normalize_value(upload_record.get("family_id"))
+    family = _require_family_access_by_family_id(family_id, db, current_user)
+    return upload_record, family
+
+
+def _serialize_uploads(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [serialize_upload_record(record) for record in records]
+
+
+def _absolute_upload_path(relative_path: str) -> Path:
+    root = Path(settings.upload_root_path).resolve()
+    candidate = (root / relative_path).resolve()
+
+    if not str(candidate).startswith(str(root)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Resolved upload path is invalid.",
+        )
+
+    return candidate
+
+
+@router.post("/member-photo")
+async def upload_member_photo(
+    family_id: str = Form(...),
+    member_id: str = Form(...),
+    file: UploadFile = File(...),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    member, _family = _require_member_access(member_id, db, current_user)
+    actual_family_id = _normalize_value(member.get("family_id"))
+
+    if _normalize_value(family_id) != actual_family_id:
+        raise HTTPException(
+            status_code=400,
+            detail="family_id does not match the selected member.",
+        )
+
+    upload_record = await store_member_photo_upload(
+        db=db,
+        family_id=actual_family_id,
+        member_id=member_id,
+        upload=file,
+        uploaded_by=_actor_label(current_user),
+    )
+
+    return {
+        "message": "Member photo uploaded successfully.",
+        "upload": upload_record,
+        "member_id": member_id,
+        "family_id": actual_family_id,
+    }
+
+
+@router.post("/verification-evidence")
+async def upload_verification_evidence(
+    family_id: str = Form(...),
+    member_id: str = Form(...),
+    verification_type: str = Form(...),
+    evidence_kind: str = Form("supporting_record"),
+    file: UploadFile = File(...),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    member, _family = _require_member_access(member_id, db, current_user)
+    actual_family_id = _normalize_value(member.get("family_id"))
+
+    if _normalize_value(family_id) != actual_family_id:
+        raise HTTPException(
+            status_code=400,
+            detail="family_id does not match the selected member.",
+        )
+
+    upload_record = await store_verification_evidence_upload(
+        db=db,
+        family_id=actual_family_id,
+        member_id=member_id,
+        verification_type=_normalize_value(verification_type),
+        evidence_kind=_normalize_value(evidence_kind),
+        upload=file,
+        uploaded_by=_actor_label(current_user),
+    )
+
+    return {
+        "message": "Verification evidence uploaded successfully.",
+        "upload": upload_record,
+        "member_id": member_id,
+        "family_id": actual_family_id,
+    }
+
+
+@router.get("/member/{member_id}")
+def list_member_uploads(
+    member_id: str,
+    category: Optional[str] = Query(default=None),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    member, _family = _require_member_access(member_id, db, current_user)
+
+    query: dict[str, Any] = {"member_id": str(member.get("_id"))}
+    if category:
+      query["category"] = _normalize_value(category)
+
+    records = list(db["uploaded_files"].find(query).sort("created_at", -1))
+    return {
+        "member_id": str(member.get("_id")),
+        "count": len(records),
+        "uploads": _serialize_uploads(records),
+    }
+
+
+@router.get("/family/{family_id}")
+def list_family_uploads(
+    family_id: str,
+    category: Optional[str] = Query(default=None),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    _require_family_access_by_family_id(family_id, db, current_user)
+
+    query: dict[str, Any] = {"family_id": family_id}
+    if category:
+      query["category"] = _normalize_value(category)
+
+    records = list(db["uploaded_files"].find(query).sort("created_at", -1))
+    return {
+        "family_id": family_id,
+        "count": len(records),
+        "uploads": _serialize_uploads(records),
+    }
+
+
+@router.get("/{upload_id}/download")
+def download_upload(
+    upload_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    upload_record, _family = _require_upload_access(upload_id, db, current_user)
+
+    relative_path = _normalize_value(upload_record.get("relative_path"))
+    if not relative_path:
+        raise HTTPException(status_code=404, detail="Upload path missing.")
+
+    absolute_path = _absolute_upload_path(relative_path)
+    if not absolute_path.exists():
+        raise HTTPException(status_code=404, detail="Upload file not found on disk.")
+
+    return FileResponse(
+        path=absolute_path,
+        media_type=upload_record.get("content_type") or "application/octet-stream",
+        filename=upload_record.get("original_filename") or absolute_path.name,
+    )
+
+
+@router.delete("/{upload_id}")
+def delete_upload(
+    upload_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    upload_record, _family = _require_upload_access(upload_id, db, current_user)
+
+    relative_path = _normalize_value(upload_record.get("relative_path"))
+    if relative_path:
+        absolute_path = _absolute_upload_path(relative_path)
+        if absolute_path.exists():
+            absolute_path.unlink()
+
+    db["uploaded_files"].delete_one({"_id": ObjectId(upload_id)})
+
+    if _normalize_value(upload_record.get("category")) == "member_photo":
+        member_id = _normalize_value(upload_record.get("member_id"))
+        if ObjectId.is_valid(member_id):
+            db["family_members"].update_one(
+                {
+                    "_id": ObjectId(member_id),
+                    "photo_upload_id": upload_id,
+                },
+                {
+                    "$set": {
+                        "photo_upload_id": "",
+                        "photo_path": "",
+                        "photo_original_filename": "",
+                        "photo_content_type": "",
+                        "photo_size_bytes": 0,
+                        "updated_by": _actor_label(current_user),
+                    }
+                },
+            )
+
+    return {
+        "status": "deleted",
+        "upload_id": upload_id,
+    }

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from bson import ObjectId
+from fastapi import HTTPException, UploadFile, status
+
+from app.config import settings
+
+CHUNK_SIZE = 1024 * 1024
+
+IMAGE_CONTENT_TYPES = set(settings.upload_image_content_types_list)
+DOCUMENT_CONTENT_TYPES = set(settings.upload_document_content_types_list)
+EVIDENCE_CONTENT_TYPES = IMAGE_CONTENT_TYPES | DOCUMENT_CONTENT_TYPES
+
+EXTENSION_BY_CONTENT_TYPE = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "application/pdf": ".pdf",
+}
+
+
+def _safe_path_token(value: Any) -> str:
+    raw = str(value or "").strip()
+    cleaned = "".join(ch for ch in raw if ch.isalnum() or ch in {"-", "_"})
+    return cleaned or "unknown"
+
+
+def _safe_original_filename(filename: str | None) -> str:
+    return Path(str(filename or "upload")).name
+
+
+def _extension_for_upload(filename: str | None, content_type: str) -> str:
+    mapped = EXTENSION_BY_CONTENT_TYPE.get(content_type.lower())
+    if mapped:
+        return mapped
+
+    suffix = Path(str(filename or "")).suffix.lower()
+    if suffix and 1 <= len(suffix) <= 10:
+        return suffix
+
+    return ".bin"
+
+
+def _upload_root() -> Path:
+    root = Path(settings.upload_root_path)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+async def _save_upload_to_disk(
+    upload: UploadFile,
+    destination: Path,
+    max_bytes: int,
+) -> int:
+    size_bytes = 0
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with destination.open("wb") as file_handle:
+            while True:
+                chunk = await upload.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+
+                size_bytes += len(chunk)
+                if size_bytes > max_bytes:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=f"Upload exceeded max allowed size of {max_bytes} bytes.",
+                    )
+
+                file_handle.write(chunk)
+    except Exception:
+        if destination.exists():
+            destination.unlink(missing_ok=True)
+        raise
+    finally:
+        await upload.close()
+
+    return size_bytes
+
+
+def serialize_upload_record(record: dict[str, Any]) -> dict[str, Any]:
+    record_id = str(record.get("_id") or record.get("id") or "")
+    return {
+        "id": record_id,
+        "family_id": record.get("family_id"),
+        "member_id": record.get("member_id"),
+        "category": record.get("category"),
+        "evidence_kind": record.get("evidence_kind"),
+        "verification_type": record.get("verification_type"),
+        "original_filename": record.get("original_filename"),
+        "stored_filename": record.get("stored_filename"),
+        "relative_path": record.get("relative_path"),
+        "content_type": record.get("content_type"),
+        "size_bytes": record.get("size_bytes"),
+        "uploaded_by": record.get("uploaded_by"),
+        "created_at": record.get("created_at"),
+        "download_path": f"/uploads/{record_id}/download" if record_id else "",
+    }
+
+
+async def store_member_photo_upload(
+    *,
+    db: Any,
+    family_id: str,
+    member_id: str,
+    upload: UploadFile,
+    uploaded_by: str,
+) -> dict[str, Any]:
+    content_type = str(upload.content_type or "").strip().lower()
+    if content_type not in IMAGE_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported member photo type. Allowed: JPEG, PNG, WEBP.",
+        )
+
+    original_filename = _safe_original_filename(upload.filename)
+    extension = _extension_for_upload(original_filename, content_type)
+
+    family_token = _safe_path_token(family_id)
+    member_token = _safe_path_token(member_id)
+    stored_filename = f"{uuid4().hex}{extension}"
+
+    relative_path = (
+        Path("member_photos") / family_token / member_token / stored_filename
+    )
+    absolute_path = _upload_root() / relative_path
+
+    size_bytes = await _save_upload_to_disk(
+        upload=upload,
+        destination=absolute_path,
+        max_bytes=settings.upload_max_image_bytes,
+    )
+
+    now_iso = datetime.now(UTC).isoformat()
+
+    upload_record = {
+        "family_id": family_id,
+        "member_id": member_id,
+        "category": "member_photo",
+        "evidence_kind": "",
+        "verification_type": "",
+        "original_filename": original_filename,
+        "stored_filename": stored_filename,
+        "relative_path": str(relative_path).replace("\\", "/"),
+        "content_type": content_type,
+        "size_bytes": size_bytes,
+        "uploaded_by": uploaded_by,
+        "storage_provider": "local_disk",
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+
+    result = db["uploaded_files"].insert_one(upload_record)
+    upload_record["_id"] = result.inserted_id
+    upload_id = str(result.inserted_id)
+
+    db["family_members"].update_one(
+        {"_id": ObjectId(member_id)},
+        {
+            "$set": {
+                "photo_upload_id": upload_id,
+                "photo_path": upload_record["relative_path"],
+                "photo_original_filename": original_filename,
+                "photo_content_type": content_type,
+                "photo_size_bytes": size_bytes,
+                "updated_at": now_iso,
+                "updated_by": uploaded_by,
+            }
+        },
+    )
+
+    return serialize_upload_record(upload_record)
+
+
+async def store_verification_evidence_upload(
+    *,
+    db: Any,
+    family_id: str,
+    member_id: str,
+    verification_type: str,
+    evidence_kind: str,
+    upload: UploadFile,
+    uploaded_by: str,
+) -> dict[str, Any]:
+    content_type = str(upload.content_type or "").strip().lower()
+    if content_type not in EVIDENCE_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported evidence file type. Allowed: PDF, JPEG, PNG, WEBP.",
+        )
+
+    original_filename = _safe_original_filename(upload.filename)
+    extension = _extension_for_upload(original_filename, content_type)
+
+    family_token = _safe_path_token(family_id)
+    member_token = _safe_path_token(member_id)
+    evidence_token = _safe_path_token(evidence_kind or "supporting_record")
+    stored_filename = f"{uuid4().hex}{extension}"
+
+    relative_path = (
+        Path("verification_evidence")
+        / family_token
+        / member_token
+        / evidence_token
+        / stored_filename
+    )
+    absolute_path = _upload_root() / relative_path
+
+    size_bytes = await _save_upload_to_disk(
+        upload=upload,
+        destination=absolute_path,
+        max_bytes=settings.upload_max_document_bytes,
+    )
+
+    now_iso = datetime.now(UTC).isoformat()
+
+    upload_record = {
+        "family_id": family_id,
+        "member_id": member_id,
+        "category": "verification_evidence",
+        "evidence_kind": evidence_kind,
+        "verification_type": verification_type,
+        "original_filename": original_filename,
+        "stored_filename": stored_filename,
+        "relative_path": str(relative_path).replace("\\", "/"),
+        "content_type": content_type,
+        "size_bytes": size_bytes,
+        "uploaded_by": uploaded_by,
+        "storage_provider": "local_disk",
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+
+    result = db["uploaded_files"].insert_one(upload_record)
+    upload_record["_id"] = result.inserted_id
+
+    return serialize_upload_record(upload_record)


### PR DESCRIPTION
Added the first real upload/storage backend layer to Tomb of Light, including configurable upload settings in config.py, a new uploads.py route set for member photo uploads, verification evidence uploads, private file downloads, and upload deletion, plus an upload_service.py service to validate file types, enforce size limits, generate safe filenames, write files to disk, and store upload metadata in MongoDB. This prepares the platform for customer document uploads, admin evidence review, and family member portrait management while keeping uploads tied to authenticated family access.