### PR TITLE
Add portrait-native link keys and entitlement-based workspace access

### DIFF
--- a/admin-family-manager.js
+++ b/admin-family-manager.js
@@ -40,6 +40,65 @@
       .toLowerCase();
   }
 
+  function normalizePackageCode(value) {
+    const normalized = normalizeValue(value);
+    const mapping = {
+      "legacy-snapshot": "legacy_snapshot",
+      legacy_snapshot: "legacy_snapshot",
+      "legacy-portrait-intro": "legacy_portrait_intro",
+      legacy_portrait_intro: "legacy_portrait_intro",
+      "digital-legacy-portrait": "digital_legacy_portrait",
+      digital_legacy_portrait: "digital_legacy_portrait",
+      "starter-family-tree": "household_foundation",
+      starter_family_tree: "household_foundation",
+      "household-foundation": "household_foundation",
+      household_foundation: "household_foundation",
+      "heirloom-legacy-tree": "heirloom_legacy_tree",
+      heirloom_legacy_tree: "heirloom_legacy_tree",
+      "legacy-plus": "legacy_plus",
+      legacy_plus: "legacy_plus",
+      "family-estate-concierge": "family_estate_concierge",
+      family_estate_concierge: "family_estate_concierge",
+      "command-structure-network": "command_structure_network",
+      command_structure_network: "command_structure_network",
+    };
+    return mapping[normalized] || normalized;
+  }
+
+  function resolvePackageLane(packageCode) {
+    const normalized = normalizePackageCode(packageCode);
+
+    if (
+      normalized === "legacy_snapshot" ||
+      normalized === "legacy_portrait_intro" ||
+      normalized === "digital_legacy_portrait"
+    ) {
+      return "portrait";
+    }
+
+    if (
+      normalized === "household_foundation" ||
+      normalized === "heirloom_legacy_tree" ||
+      normalized === "legacy_plus"
+    ) {
+      return "household";
+    }
+
+    if (normalized === "family_estate_concierge") {
+      return "network";
+    }
+
+    if (normalized === "command_structure_network") {
+      return "organization";
+    }
+
+    return "unknown";
+  }
+
+  function supportsFamilyBuild(lane) {
+    return lane === "household" || lane === "network";
+  }
+
   function humanizeValue(value) {
     const normalized = normalizeValue(value);
     if (!normalized) return "Unknown";
@@ -227,9 +286,12 @@
     selectNode.innerHTML = `<option value="">Select a family build</option>`;
 
     familyBuilds.forEach(function (item) {
+      const lane = resolvePackageLane(
+        item.package_code || item.package_slug || "",
+      );
       const option = document.createElement("option");
       option.value = item.family_root_id;
-      option.textContent = `${item.email || "Unknown Email"} — ${item.family_root_id}`;
+      option.textContent = `${item.package_name || humanizeValue(lane)} — ${item.email || "Unknown Email"} — ${item.family_root_id}`;
       selectNode.appendChild(option);
     });
 
@@ -237,8 +299,13 @@
       "family_id",
     );
     if (fromQuery) {
-      selectNode.value = fromQuery;
-      currentFamilyId = fromQuery;
+      const exists = familyBuilds.some(function (item) {
+        return String(item.family_root_id || "") === String(fromQuery);
+      });
+      if (exists) {
+        selectNode.value = fromQuery;
+        currentFamilyId = fromQuery;
+      }
     }
   }
 
@@ -556,6 +623,10 @@
       familyBuilds = (Array.isArray(submissions) ? submissions : []).filter(
         function (item) {
           const familyRootId = String(item.family_root_id || "").trim();
+          const lane = resolvePackageLane(
+            item.package_code || item.package_slug || "",
+          );
+          if (!supportsFamilyBuild(lane)) return false;
           if (!familyRootId) return false;
           if (seen.has(familyRootId)) return false;
           seen.add(familyRootId);
@@ -568,7 +639,7 @@
       if (statusNode) {
         statusNode.textContent = familyBuilds.length
           ? `Loaded ${familyBuilds.length} provisioned family build(s).`
-          : "No provisioned family builds were found yet.";
+          : "No provisioned household or network family builds were found yet.";
       }
     } catch (error) {
       console.error("Family build options load failed:", error);

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -21,6 +21,15 @@
     "marketing",
   ]);
 
+  const LINK_KEY_ENABLED_PACKAGES = new Set([
+    "digital_legacy_portrait",
+    "household_foundation",
+    "heirloom_legacy_tree",
+    "legacy_plus",
+    "family_estate_concierge",
+    "command_structure_network",
+  ]);
+
   let allSubmissions = [];
   let currentSubmission = null;
 
@@ -34,9 +43,7 @@
   }
 
   function normalizeValue(value) {
-    return String(value || "")
-      .trim()
-      .toLowerCase();
+    return String(value || "").trim().toLowerCase();
   }
 
   function normalizeStatus(status) {
@@ -62,6 +69,100 @@
     } catch (error) {
       return String(value);
     }
+  }
+
+  function normalizePackageCode(value) {
+    const normalized = normalizeValue(value);
+    const mapping = {
+      "legacy-snapshot": "legacy_snapshot",
+      legacy_snapshot: "legacy_snapshot",
+      "legacy-portrait-intro": "legacy_portrait_intro",
+      legacy_portrait_intro: "legacy_portrait_intro",
+      "digital-legacy-portrait": "digital_legacy_portrait",
+      digital_legacy_portrait: "digital_legacy_portrait",
+      "starter-family-tree": "household_foundation",
+      starter_family_tree: "household_foundation",
+      "household-foundation": "household_foundation",
+      household_foundation: "household_foundation",
+      "heirloom-legacy-tree": "heirloom_legacy_tree",
+      heirloom_legacy_tree: "heirloom_legacy_tree",
+      "legacy-plus": "legacy_plus",
+      legacy_plus: "legacy_plus",
+      "family-estate-concierge": "family_estate_concierge",
+      family_estate_concierge: "family_estate_concierge",
+      "command-structure-network": "command_structure_network",
+      command_structure_network: "command_structure_network",
+    };
+
+    return mapping[normalized] || normalized;
+  }
+
+  function resolvePackageLane(packageCode) {
+    const normalized = normalizePackageCode(packageCode);
+
+    if (
+      normalized === "legacy_snapshot" ||
+      normalized === "legacy_portrait_intro" ||
+      normalized === "digital_legacy_portrait"
+    ) {
+      return "portrait";
+    }
+
+    if (
+      normalized === "household_foundation" ||
+      normalized === "heirloom_legacy_tree" ||
+      normalized === "legacy_plus"
+    ) {
+      return "household";
+    }
+
+    if (normalized === "family_estate_concierge") {
+      return "network";
+    }
+
+    if (normalized === "command_structure_network") {
+      return "organization";
+    }
+
+    return "unknown";
+  }
+
+  function getSubmissionPackageCode(submission) {
+    return normalizePackageCode(
+      submission &&
+        (submission.package_code || submission.package_slug || submission.package_name)
+    );
+  }
+
+  function isFamilyBuildLane(lane) {
+    return lane === "household" || lane === "network";
+  }
+
+  function packageSupportsLinkKeys(packageCode) {
+    return LINK_KEY_ENABLED_PACKAGES.has(normalizePackageCode(packageCode));
+  }
+
+  function isFamilyBuildSubmission(submission) {
+    const lane = resolvePackageLane(getSubmissionPackageCode(submission));
+    return isFamilyBuildLane(lane) && !!String(submission?.family_root_id || "").trim();
+  }
+
+  function isProvisionedSubmission(submission) {
+    if (!submission) return false;
+
+    const statusValue = normalizeStatus(submission.status);
+    return (
+      !!submission.provisioned_at ||
+      !!submission.project_id ||
+      [
+        "build_ready",
+        "in_production",
+        "qa_review",
+        "client_review",
+        "delivered",
+        "archived",
+      ].includes(statusValue)
+    );
   }
 
   function setStatus(node, message, type) {
@@ -139,37 +240,42 @@
     throw lastError || new Error("All API request attempts failed.");
   }
 
-  function isProvisionedSubmission(submission) {
-    if (!submission) return false;
+  function configureActionLink(node, { text, href, show = true }) {
+    if (!node) return;
+    node.textContent = text;
+    node.setAttribute("href", href);
+    node.style.display = show ? "" : "none";
+  }
 
-    const statusValue = normalizeStatus(submission.status);
-    return (
-      !!submission.provisioned_at ||
-      !!submission.family_root_id ||
-      !!submission.household_id ||
-      !!submission.project_id ||
-      statusValue === "build_ready" ||
-      statusValue === "in_production"
-    );
+  function getProvisionedWorkspaceLabel(submission) {
+    const lane = resolvePackageLane(getSubmissionPackageCode(submission));
+
+    if (lane === "portrait") return "live portrait workspace";
+    if (lane === "organization") return "live organization workspace";
+    return "live family build";
+  }
+
+  function getProvisionedActionMessage(submission) {
+    const lane = resolvePackageLane(getSubmissionPackageCode(submission));
+
+    if (lane === "portrait") {
+      return "This submission is already provisioned. Use the customer dashboard or Verification Uploads instead.";
+    }
+
+    if (lane === "organization") {
+      return "This submission is already provisioned. Use the customer dashboard or structure upload tools instead.";
+    }
+
+    return "This submission is already provisioned. Use Family Manager, Family Tree, or Lineage Certificate instead.";
   }
 
   function updateReviewActionState(submission) {
-    const postBuildNotice = document.querySelector(
-      "[data-admin-post-build-notice]",
-    );
-    const postBuildActions = document.querySelector(
-      "[data-admin-post-build-actions]",
-    );
+    const postBuildNotice = document.querySelector("[data-admin-post-build-notice]");
+    const postBuildActions = document.querySelector("[data-admin-post-build-actions]");
 
-    const familyManagerLink = document.querySelector(
-      "[data-admin-open-family-manager]",
-    );
-    const familyTreeLink = document.querySelector(
-      "[data-admin-open-family-tree]",
-    );
-    const certificateLink = document.querySelector(
-      "[data-admin-open-lineage-certificate]",
-    );
+    const familyManagerLink = document.querySelector("[data-admin-open-family-manager]");
+    const familyTreeLink = document.querySelector("[data-admin-open-family-tree]");
+    const certificateLink = document.querySelector("[data-admin-open-lineage-certificate]");
 
     const reviewBtn = document.querySelector("[data-admin-mark-review]");
     const approveBtn = document.querySelector("[data-admin-approve]");
@@ -178,37 +284,104 @@
 
     const provisioned = isProvisionedSubmission(submission);
     const statusValue = normalizeStatus(submission && submission.status);
-
-    if (familyManagerLink) {
-      familyManagerLink.href =
-        submission && submission.family_root_id
-          ? `admin-family-manager.html?family_id=${encodeURIComponent(submission.family_root_id)}`
-          : "admin-family-manager.html";
-    }
-
-    if (familyTreeLink) {
-      familyTreeLink.href =
-        submission && submission.family_root_id
-          ? `tree-view.html?family_id=${encodeURIComponent(submission.family_root_id)}`
-          : "tree-view.html";
-    }
-
-    if (certificateLink) {
-      certificateLink.href =
-        submission && submission.family_root_id
-          ? `lineage-certificate.html?family_id=${encodeURIComponent(submission.family_root_id)}`
-          : "lineage-certificate.html";
-    }
+    const packageCode = getSubmissionPackageCode(submission);
+    const lane = resolvePackageLane(packageCode);
+    const hasFamilyBuild = isFamilyBuildSubmission(submission);
+    const linkKeysEnabled = packageSupportsLinkKeys(packageCode);
 
     if (provisioned) {
-      if (postBuildNotice) postBuildNotice.style.display = "block";
+      if (postBuildNotice) {
+        let notice = `This submission has already been provisioned into a ${getProvisionedWorkspaceLabel(submission)}.`;
+
+        if (linkKeysEnabled) {
+          notice += " Link capabilities are enabled for this package.";
+        }
+
+        postBuildNotice.textContent = notice;
+        postBuildNotice.style.display = "block";
+      }
+
       if (postBuildActions) postBuildActions.style.display = "flex";
 
       if (reviewBtn) reviewBtn.style.display = "none";
       if (approveBtn) approveBtn.style.display = "none";
       if (rejectBtn) rejectBtn.style.display = "none";
       if (provisionBtn) provisionBtn.style.display = "none";
-      return;
+
+      if (hasFamilyBuild) {
+        configureActionLink(familyManagerLink, {
+          text: "Open Family Manager",
+          href:
+            submission && submission.family_root_id
+              ? `admin-family-manager.html?family_id=${encodeURIComponent(submission.family_root_id)}`
+              : "admin-family-manager.html",
+          show: true,
+        });
+
+        configureActionLink(familyTreeLink, {
+          text: "Open Family Tree",
+          href:
+            submission && submission.family_root_id
+              ? `tree-view.html?family_id=${encodeURIComponent(submission.family_root_id)}`
+              : "tree-view.html",
+          show: true,
+        });
+
+        configureActionLink(certificateLink, {
+          text: "Open Lineage Certificate",
+          href:
+            submission && submission.family_root_id
+              ? `lineage-certificate.html?family_id=${encodeURIComponent(submission.family_root_id)}`
+              : "lineage-certificate.html",
+          show: true,
+        });
+
+        return;
+      }
+
+      if (lane === "portrait") {
+        configureActionLink(familyManagerLink, {
+          text: "Open Customer Dashboard",
+          href: "dashboard.html",
+          show: true,
+        });
+
+        configureActionLink(familyTreeLink, {
+          text: "Open Verification Uploads",
+          href: "verification-upload.html",
+          show: true,
+        });
+
+        configureActionLink(certificateLink, {
+          text: "Open Lineage Certificate",
+          href: "lineage-certificate.html",
+          show: false,
+        });
+
+        return;
+      }
+
+      if (lane === "organization") {
+        configureActionLink(familyManagerLink, {
+          text: "Open Customer Dashboard",
+          href: "dashboard.html",
+          show: true,
+        });
+
+        configureActionLink(familyTreeLink, {
+          text: "Open Structure Uploads",
+          href: "verification-upload.html",
+          show: true,
+        });
+
+        configureActionLink(certificateLink, {
+          text: "Open Lineage Certificate",
+          href: "lineage-certificate.html",
+          show: false,
+        });
+
+        return;
+      }
     }
 
     if (postBuildNotice) postBuildNotice.style.display = "none";
@@ -276,11 +449,13 @@
 
     listNode.innerHTML = filtered
       .map(function (item, index) {
+        const lane = resolvePackageLane(getSubmissionPackageCode(item));
         return `
           <div class="family-record-card">
             <div class="card-number">${index + 1}</div>
             <h3>${escapeHtml(item.package_name || item.package_slug || "Submission")}</h3>
             ${valueLine("Status", humanizeStatus(item.status))}
+            ${valueLine("Lane", lane)}
             ${valueLine("Email", item.email)}
             ${valueLine("Submission ID", item.id)}
             ${valueLine("Created", formatDate(item.created_at))}
@@ -301,9 +476,7 @@
 
   async function loadQueue() {
     const statusNode = document.querySelector("[data-admin-queue-status]");
-    const actionNode = document.querySelector(
-      "[data-admin-queue-action-status]",
-    );
+    const actionNode = document.querySelector("[data-admin-queue-action-status]");
 
     try {
       clearStatus(actionNode);
@@ -356,25 +529,22 @@
   function renderDetail(submission) {
     currentSubmission = submission;
 
-    const pageStatus = document.querySelector(
-      "[data-admin-review-page-status]",
-    );
+    const pageStatus = document.querySelector("[data-admin-review-page-status]");
     const metaNode = document.querySelector("[data-admin-review-meta]");
     const timelineNode = document.querySelector("[data-admin-review-timeline]");
-    const householdNode = document.querySelector(
-      "[data-admin-review-household]",
-    );
-    const familyMapNode = document.querySelector(
-      "[data-admin-review-family-map]",
-    );
+    const householdNode = document.querySelector("[data-admin-review-household]");
+    const familyMapNode = document.querySelector("[data-admin-review-family-map]");
     const uploadsNode = document.querySelector("[data-admin-review-uploads]");
     const consentNode = document.querySelector("[data-admin-review-consent]");
 
     const provisioned = isProvisionedSubmission(submission);
+    const packageCode = getSubmissionPackageCode(submission);
+    const lane = resolvePackageLane(packageCode);
+    const hasFamilyBuild = isFamilyBuildSubmission(submission);
 
     if (pageStatus) {
       pageStatus.textContent = provisioned
-        ? `Submission ${submission.id} is currently ${humanizeStatus(submission.status)} and has already been provisioned into a live family build.`
+        ? `Submission ${submission.id} is currently ${humanizeStatus(submission.status)} and has already been provisioned into a ${getProvisionedWorkspaceLabel(submission)}.`
         : `Submission ${submission.id} is currently ${humanizeStatus(submission.status)}.`;
     }
 
@@ -386,11 +556,12 @@
       "1",
       [
         `Status: ${humanizeStatus(submission.status)}`,
+        `Lane: ${lane}`,
         `Email: ${submission.email || "—"}`,
         `Package: ${submission.package_name || submission.package_slug || "—"}`,
         `Review Locked: ${submission.review_locked ? "Yes" : "No"}`,
-        `Family Root ID: ${submission.family_root_id || "—"}`,
-        `Household ID: ${submission.household_id || "—"}`,
+        `Family Root ID: ${hasFamilyBuild ? submission.family_root_id || "—" : "Not applicable"}`,
+        `Household ID: ${hasFamilyBuild ? submission.household_id || "—" : "Not applicable"}`,
         `Project ID: ${submission.project_id || "—"}`,
       ],
     );
@@ -409,7 +580,12 @@
     const household = submission.household || {};
     renderReviewBlock(
       householdNode,
-      household.household_name || "Household",
+      household.household_name ||
+        (lane === "portrait"
+          ? "Portrait Intake"
+          : lane === "organization"
+            ? "Structure Intake"
+            : "Household"),
       "3",
       [
         `Primary Contact: ${household.primary_contact_name || "—"}`,
@@ -425,7 +601,8 @@
     const familyMap = submission.family_map || {};
     renderReviewBlock(
       familyMapNode,
-      familyMap.family_branch_name || "Family Map",
+      familyMap.family_branch_name ||
+        (lane === "organization" ? "Structure Map" : "Family Map"),
       "4",
       [
         `People in Scope: ${familyMap.people_in_scope || "—"}`,
@@ -479,9 +656,7 @@
 
   async function loadReviewDetail() {
     const submissionId = getQueryParam("submission_id");
-    const statusNode = document.querySelector(
-      "[data-admin-review-action-status]",
-    );
+    const statusNode = document.querySelector("[data-admin-review-action-status]");
 
     if (!submissionId) {
       setStatus(statusNode, "Missing submission_id in page URL.", "error");
@@ -555,9 +730,7 @@
   }
 
   async function runAdminAction(action) {
-    const statusNode = document.querySelector(
-      "[data-admin-review-action-status]",
-    );
+    const statusNode = document.querySelector("[data-admin-review-action-status]");
     const submissionId = getQueryParam("submission_id");
     if (!submissionId) {
       setStatus(statusNode, "Missing submission_id in page URL.", "error");
@@ -565,11 +738,7 @@
     }
 
     if (currentSubmission && isProvisionedSubmission(currentSubmission)) {
-      setStatus(
-        statusNode,
-        "This submission is already provisioned. Use Family Manager, Family Tree, or Lineage Certificate instead.",
-        "error",
-      );
+      setStatus(statusNode, getProvisionedActionMessage(currentSubmission), "error");
       return;
     }
 
@@ -586,8 +755,7 @@
 
     if (
       action === "provision" &&
-      normalizeStatus(currentSubmission && currentSubmission.status) !==
-        "approved"
+      normalizeStatus(currentSubmission && currentSubmission.status) !== "approved"
     ) {
       setStatus(
         statusNode,
@@ -628,9 +796,14 @@
 
       renderDetail(result);
 
+      const lane = resolvePackageLane(getSubmissionPackageCode(result));
       const label =
         action === "provision"
-          ? "Build provisioned successfully."
+          ? lane === "portrait"
+            ? "Portrait workspace provisioned successfully."
+            : lane === "organization"
+              ? "Organization workspace provisioned successfully."
+              : "Family build provisioned successfully."
           : `Submission updated to ${humanizeStatus(result.status)}.`;
 
       setStatus(statusNode, label, "success");
@@ -688,13 +861,9 @@
       const reviewBtn = document.querySelector("[data-admin-mark-review]");
       const approveBtn = document.querySelector("[data-admin-approve]");
       const rejectBtn = document.querySelector("[data-admin-reject]");
-      const provisionBtn = document.querySelector(
-        "[data-admin-provision-build]",
-      );
+      const provisionBtn = document.querySelector("[data-admin-provision-build]");
       const refreshBtn = document.querySelector("[data-admin-refresh-detail]");
-      const refreshPostBtn = document.querySelector(
-        "[data-admin-refresh-detail-post]",
-      );
+      const refreshPostBtn = document.querySelector("[data-admin-refresh-detail-post]");
 
       if (reviewBtn) {
         reviewBtn.addEventListener("click", function () {

--- a/auth.js
+++ b/auth.js
@@ -1038,6 +1038,7 @@
     const page = window.location.pathname.split("/").pop() || "";
 
     const uploadPages = new Set(["verification-upload.html"]);
+    const linkKeyPages = new Set(["link-keys.html"]);
     const familyIntakePages = new Set([
       "intake-welcome.html",
       "intake-household.html",
@@ -1051,6 +1052,7 @@
 
     if (
       !uploadPages.has(page) &&
+      !linkKeyPages.has(page) &&
       !familyIntakePages.has(page) &&
       !familyTreePages.has(page) &&
       !certificatePages.has(page)
@@ -1102,6 +1104,11 @@
         )
       ) {
         window.location.href = "dashboard.html?purchase_required=1";
+        return;
+      }
+
+      if (linkKeyPages.has(page) && !resolved.can_use_link_keys) {
+        window.location.href = "dashboard.html?upgrade_required=1";
         return;
       }
 

--- a/auth.js
+++ b/auth.js
@@ -5,6 +5,40 @@
   const POST_LOGIN_REDIRECT = "dashboard.html";
   const SIGNUP_POLICY_VERSION = "2026-03-26";
 
+  const INTERNAL_ROLE_KEYS = new Set([
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+  ]);
+
+  const LINK_KEY_ENABLED_PACKAGES = new Set([
+    "digital_legacy_portrait",
+    "household_foundation",
+    "heirloom_legacy_tree",
+    "legacy_plus",
+    "family_estate_concierge",
+    "command_structure_network",
+  ]);
+
+  const NARRATION_ENABLED_PACKAGES = new Set([
+    "heirloom_legacy_tree",
+    "legacy_plus",
+    "family_estate_concierge",
+  ]);
+
+  const HOUSEHOLD_LINK_ENABLED_PACKAGES = new Set([
+    "legacy_plus",
+    "family_estate_concierge",
+  ]);
+
   if (!app) {
     console.error("auth.js requires app.js to be loaded first.");
     return;
@@ -14,6 +48,16 @@
     return String(value || "")
       .trim()
       .toLowerCase();
+  }
+
+  function isInternalRole(user) {
+    const role = normalizeValue(user && user.role);
+    const accessTier = normalizeValue(user && user.access_tier);
+    const departmentRole = normalizeValue(user && user.department_role);
+
+    return [role, accessTier, departmentRole].some(function (value) {
+      return INTERNAL_ROLE_KEYS.has(value);
+    });
   }
 
   function getAccessTokenFromResponse(loginData) {
@@ -166,6 +210,63 @@
     };
 
     return mapping[normalized] || normalized || "Package";
+  }
+
+  function packageSupportsLinkKeys(packageCode) {
+    return LINK_KEY_ENABLED_PACKAGES.has(stripMaintenanceSuffix(packageCode));
+  }
+
+  function buildFallbackEntitlements(packageCode, packageLane) {
+    const normalizedCode = stripMaintenanceSuffix(packageCode);
+    const lane =
+      normalizeValue(packageLane) || resolvePackageLane(normalizedCode);
+
+    return {
+      package_code: normalizedCode,
+      package_lane: lane,
+      can_upload_portraits: true,
+      can_upload_verification_docs: true,
+      can_build_household: lane === "household" || lane === "network",
+      can_build_family_tree: lane === "household" || lane === "network",
+      can_build_org_chart: lane === "organization",
+      can_link_households: HOUSEHOLD_LINK_ENABLED_PACKAGES.has(normalizedCode),
+      can_link_org_units: lane === "organization",
+      can_use_viewer: true,
+      can_use_narration: NARRATION_ENABLED_PACKAGES.has(normalizedCode),
+      can_use_lineage_certificate: lane === "household" || lane === "network",
+      can_open_family_intake: lane === "household" || lane === "network",
+      can_open_org_intake: lane === "organization",
+      can_use_link_keys: packageSupportsLinkKeys(normalizedCode),
+      can_manage_link_keys: packageSupportsLinkKeys(normalizedCode),
+      allowed_addons: [],
+      upgrade_targets: [],
+    };
+  }
+
+  function getResolvedEntitlements(
+    activeEntitlement,
+    packageCode,
+    packageLane,
+  ) {
+    const fallback = buildFallbackEntitlements(packageCode, packageLane);
+    const resolved =
+      activeEntitlement &&
+      activeEntitlement.resolved_entitlements &&
+      typeof activeEntitlement.resolved_entitlements === "object"
+        ? activeEntitlement.resolved_entitlements
+        : {};
+
+    return Object.assign({}, fallback, resolved, {
+      package_code: stripMaintenanceSuffix(
+        resolved.package_code || activeEntitlement?.package_code || packageCode,
+      ),
+      package_lane:
+        normalizeValue(
+          resolved.package_lane ||
+            activeEntitlement?.package_lane ||
+            packageLane,
+        ) || fallback.package_lane,
+    });
   }
 
   function getPaidOrder(orders) {
@@ -435,9 +536,20 @@
       resolvePackageLane(packageCode);
 
     const packageName =
+      activeEntitlement?.package_name ||
+      activeEntitlement?.resolved_entitlements?.display_name ||
       paidOrder?.package_name ||
       activeProject?.package_name ||
       resolvePackageDisplayName(packageCode);
+
+    const hasPackageAccess = Boolean(
+      activeEntitlement || activeProject || paidOrder,
+    );
+    const resolvedEntitlements = getResolvedEntitlements(
+      activeEntitlement,
+      packageCode,
+      packageLane,
+    );
 
     return {
       user: user || null,
@@ -450,7 +562,9 @@
       packageCode,
       packageLane,
       packageName,
-      hasPaidPackage: !!paidOrder,
+      resolvedEntitlements,
+      hasPackageAccess,
+      hasPaidPackage: hasPackageAccess,
     };
   }
 
@@ -475,21 +589,37 @@
     );
     const upgradeAction = document.querySelector("[data-upgrade-action]");
 
-    const hasPaidOrder = !!context?.hasPaidPackage;
+    const hasPackageAccess = !!context?.hasPackageAccess;
     const packageLane = normalizeValue(context?.packageLane);
     const packageName = context?.packageName || "your package";
+    const resolved =
+      context?.resolvedEntitlements ||
+      buildFallbackEntitlements(context?.packageCode, context?.packageLane);
 
-    setPaidActionState(hasPaidOrder);
+    const canUploadRecords = Boolean(
+      resolved.can_upload_verification_docs || resolved.can_upload_portraits,
+    );
+    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
+    const canOpenFamilyIntake = Boolean(resolved.can_open_family_intake);
+    const upgradeTargets = Array.isArray(resolved.upgrade_targets)
+      ? resolved.upgrade_targets
+      : [];
+    const allowedAddons = Array.isArray(resolved.allowed_addons)
+      ? resolved.allowed_addons
+      : [];
+
+    setPaidActionState(hasPackageAccess);
 
     if (intakeOpenAction) {
-      setActionEnabled(intakeOpenAction, hasPaidOrder);
-      intakeOpenAction.style.display = hasPaidOrder ? "" : "none";
+      const showIntakeAction = hasPackageAccess && canOpenFamilyIntake;
+      setActionEnabled(intakeOpenAction, showIntakeAction);
+      intakeOpenAction.style.display = showIntakeAction ? "" : "none";
     }
 
     if (upgradeAction) {
       upgradeAction.style.display = "";
 
-      if (!hasPaidOrder) {
+      if (!hasPackageAccess) {
         setActionHrefAndText(
           upgradeAction,
           "index.html#pricing",
@@ -501,19 +631,25 @@
           "index.html#pricing",
           "Upgrade to Household Package",
         );
-      } else if (packageLane === "organization") {
-        setActionHrefAndText(
-          upgradeAction,
-          "index.html#pricing",
-          "View Expansion Options",
-        );
-      } else if (packageLane === "household") {
+      } else if (upgradeTargets.length && allowedAddons.length) {
         setActionHrefAndText(
           upgradeAction,
           "index.html#pricing",
           "View Add-Ons & Upgrades",
         );
-      } else if (packageLane === "network") {
+      } else if (allowedAddons.length) {
+        setActionHrefAndText(
+          upgradeAction,
+          "index.html#pricing",
+          "View Add-Ons",
+        );
+      } else if (upgradeTargets.length) {
+        setActionHrefAndText(
+          upgradeAction,
+          "index.html#pricing",
+          "View Upgrade Options",
+        );
+      } else if (packageLane === "organization" || packageLane === "network") {
         setActionHrefAndText(
           upgradeAction,
           "index.html#pricing",
@@ -530,28 +666,36 @@
 
     if (!accessStatus) return;
 
-    if (!hasPaidOrder) {
+    if (!hasPackageAccess) {
       accessStatus.textContent =
         "Purchase required. Buy a Tomb of Light package to unlock platform tools.";
       return;
     }
 
     if (packageLane === "portrait") {
-      accessStatus.textContent = `Access unlocked through ${packageName}. This portrait lane includes uploads and verification workflows. Upgrade to a household package for family build tools.`;
+      accessStatus.textContent = canUseLinkKeys
+        ? `Access unlocked through ${packageName}. This portrait package includes uploads, verification workflows, and link capabilities. Household build tools require an upgrade.`
+        : `Access unlocked through ${packageName}. This portrait package includes uploads and verification workflows. Household build tools require an upgrade.`;
       return;
     }
 
     if (packageLane === "organization") {
-      accessStatus.textContent = `Access unlocked through ${packageName}. This organization lane includes structure and verification workflows. Expansion options are available if you need more scope.`;
+      accessStatus.textContent = canUseLinkKeys
+        ? `Access unlocked through ${packageName}. This organization package includes structure workflows, verification uploads, and link capabilities.`
+        : `Access unlocked through ${packageName}. This organization package includes structure workflows and verification uploads.`;
       return;
     }
 
     if (packageLane === "network") {
-      accessStatus.textContent = `Access unlocked through ${packageName}. Network and branch workflows are active for this account.`;
+      accessStatus.textContent = canUseLinkKeys
+        ? `Access unlocked through ${packageName}. Network, branch, verification, and link capabilities are active for this account.`
+        : `Access unlocked through ${packageName}. Network, branch, and verification workflows are active for this account.`;
       return;
     }
 
-    accessStatus.textContent = `Access unlocked through ${packageName}. Family build tools and verification workflows are active.`;
+    accessStatus.textContent = canUseLinkKeys
+      ? `Access unlocked through ${packageName}. Family build tools, verification uploads, and link capabilities are active.`
+      : `Access unlocked through ${packageName}. Family build tools and verification uploads are active.`;
   }
 
   function renderNoIntakeBecauseNoPurchase() {
@@ -584,7 +728,8 @@
       nextStep.textContent = "Purchase a package first to unlock intake.";
     }
     if (lockNote) {
-      lockNote.textContent = "Intake is locked until a paid package exists.";
+      lockNote.textContent =
+        "Intake is locked until a package is attached to your account.";
     }
     if (intakeHistoryStatus) {
       intakeHistoryStatus.textContent = "No intake submissions found yet.";
@@ -788,6 +933,15 @@
 
       if (authRequired) authRequired.style.display = "block";
 
+      if (isInternalRole(me)) {
+        app.setStatus(
+          statusNode,
+          "You are signed in to the Tomb of Light internal operations portal.",
+          "success",
+        );
+        return;
+      }
+
       app.setStatus(
         statusNode,
         "You are signed in and connected to the Tomb of Light platform.",
@@ -841,11 +995,11 @@
       updateAccessState(context);
       publishDashboardContext(context);
 
-      if (!context.hasPaidPackage) {
+      if (!context.hasPackageAccess) {
         renderNoIntakeBecauseNoPurchase();
         app.setStatus(
           statusNode,
-          "Your customer workspace is connected, but no paid package is active yet.",
+          "Your customer workspace is connected, but no active package is attached yet.",
           "error",
         );
         return;
@@ -883,20 +1037,24 @@
   async function gatePurchaseRequiredPages() {
     const page = window.location.pathname.split("/").pop() || "";
 
-    const paidOnlyPages = new Set(["verification-upload.html"]);
-
-    const householdOrNetworkOnlyPages = new Set([
+    const uploadPages = new Set(["verification-upload.html"]);
+    const familyIntakePages = new Set([
       "intake-welcome.html",
       "intake-household.html",
       "intake-family-map.html",
       "intake-uploads.html",
       "intake-consent.html",
       "intake-review.html",
-      "tree-view.html",
-      "lineage-certificate.html",
     ]);
+    const familyTreePages = new Set(["tree-view.html"]);
+    const certificatePages = new Set(["lineage-certificate.html"]);
 
-    if (!paidOnlyPages.has(page) && !householdOrNetworkOnlyPages.has(page)) {
+    if (
+      !uploadPages.has(page) &&
+      !familyIntakePages.has(page) &&
+      !familyTreePages.has(page) &&
+      !certificatePages.has(page)
+    ) {
       return;
     }
 
@@ -915,6 +1073,10 @@
         300,
       );
 
+      if (isInternalRole(me)) {
+        return;
+      }
+
       const orders = await withRetry(
         function () {
           return fetchOrders();
@@ -924,19 +1086,36 @@
       );
 
       const context = await getDashboardContext(me, orders);
+      const resolved =
+        context?.resolvedEntitlements ||
+        buildFallbackEntitlements(context?.packageCode, context?.packageLane);
 
-      if (!context || !context.hasPaidPackage) {
+      if (!context || !context.hasPackageAccess) {
         window.location.href = "dashboard.html?purchase_required=1";
         return;
       }
 
-      const lane = normalizeValue(context.packageLane);
-
-      if (paidOnlyPages.has(page)) {
+      if (
+        uploadPages.has(page) &&
+        !(
+          resolved.can_upload_verification_docs || resolved.can_upload_portraits
+        )
+      ) {
+        window.location.href = "dashboard.html?purchase_required=1";
         return;
       }
 
-      if (!["household", "network"].includes(lane)) {
+      if (familyIntakePages.has(page) && !resolved.can_open_family_intake) {
+        window.location.href = "dashboard.html?upgrade_required=1";
+        return;
+      }
+
+      if (familyTreePages.has(page) && !resolved.can_build_family_tree) {
+        window.location.href = "dashboard.html?upgrade_required=1";
+        return;
+      }
+
+      if (certificatePages.has(page) && !resolved.can_use_lineage_certificate) {
         window.location.href = "dashboard.html?upgrade_required=1";
       }
     } catch (error) {
@@ -1012,9 +1191,13 @@
     fetchProjectEntitlements,
     fetchProjects,
     getDashboardContext,
+    getResolvedEntitlements,
+    buildFallbackEntitlements,
     normalizePackageCode,
     resolvePackageLane,
     resolvePackageDisplayName,
+    packageSupportsLinkKeys,
+    isInternalRole,
     getPaidOrder,
   };
 })();

--- a/backend/app/core/package_catalog.py
+++ b/backend/app/core/package_catalog.py
@@ -4,6 +4,62 @@ from copy import deepcopy
 from typing import Any
 
 
+PACKAGE_CODE_ALIASES: dict[str, str] = {
+    "legacy-snapshot": "legacy_snapshot",
+    "legacy_snapshot": "legacy_snapshot",
+    "legacy-portrait-intro": "legacy_portrait_intro",
+    "legacy_portrait_intro": "legacy_portrait_intro",
+    "digital-legacy-portrait": "digital_legacy_portrait",
+    "digital_legacy_portrait": "digital_legacy_portrait",
+    "starter-family-tree": "household_foundation",
+    "starter_family_tree": "household_foundation",
+    "household-foundation": "household_foundation",
+    "household_foundation": "household_foundation",
+    "heirloom-legacy-tree": "heirloom_legacy_tree",
+    "heirloom_legacy_tree": "heirloom_legacy_tree",
+    "legacy-plus": "legacy_plus",
+    "legacy_plus": "legacy_plus",
+    "family-estate-concierge": "family_estate_concierge",
+    "family_estate_concierge": "family_estate_concierge",
+    "command-structure-network": "command_structure_network",
+    "command_structure_network": "command_structure_network",
+}
+
+ADDON_CODE_ALIASES: dict[str, str] = {
+    "extra-upload-pack": "extra_upload_pack",
+    "extra_upload_pack": "extra_upload_pack",
+    "extra-storage": "extra_storage",
+    "extra_storage": "extra_storage",
+    "portrait-polish": "portrait_polish",
+    "portrait_polish": "portrait_polish",
+    "tribute-narration": "tribute_narration",
+    "tribute_narration": "tribute_narration",
+    "rush-delivery": "rush_delivery",
+    "rush_delivery": "rush_delivery",
+    "extra-mapped-person": "extra_mapped_person",
+    "extra_mapped_person": "extra_mapped_person",
+    "extra-zoom-layer": "extra_zoom_layer",
+    "extra_zoom_layer": "extra_zoom_layer",
+    "additional-narration-minute": "additional_narration_minute",
+    "additional_narration_minute": "additional_narration_minute",
+    "on-site-photo-scanning": "on_site_photo_scanning",
+    "on_site_photo_scanning": "on_site_photo_scanning",
+    "extra-linked-household": "extra_linked_household",
+    "extra_linked_household": "extra_linked_household",
+    "extra-branch": "extra_branch",
+    "extra_branch": "extra_branch",
+    "white-glove-archive-support": "white_glove_archive_support",
+    "white_glove_archive_support": "white_glove_archive_support",
+    "extra-org-node": "extra_org_node",
+    "extra_org_node": "extra_org_node",
+    "extra-org-level": "extra_org_level",
+    "extra_org_level": "extra_org_level",
+    "extra-admin-seat": "extra_admin_seat",
+    "extra_admin_seat": "extra_admin_seat",
+    "command-report-addon": "command_report_addon",
+    "command_report_addon": "command_report_addon",
+}
+
 PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
     "legacy_snapshot": {
         "package_code": "legacy_snapshot",
@@ -29,6 +85,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": False,
+        "can_use_lineage_certificate": False,
+        "can_open_family_intake": False,
+        "can_open_org_intake": False,
+        "can_use_link_keys": False,
+        "can_manage_link_keys": False,
         "allowed_addons": [
             "extra_upload_pack",
             "extra_storage",
@@ -70,6 +131,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": False,
+        "can_use_lineage_certificate": False,
+        "can_open_family_intake": False,
+        "can_open_org_intake": False,
+        "can_use_link_keys": False,
+        "can_manage_link_keys": False,
         "allowed_addons": [
             "extra_upload_pack",
             "extra_storage",
@@ -110,6 +176,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": False,
+        "can_use_lineage_certificate": False,
+        "can_open_family_intake": False,
+        "can_open_org_intake": False,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_upload_pack",
             "extra_storage",
@@ -149,6 +220,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": False,
+        "can_use_lineage_certificate": True,
+        "can_open_family_intake": True,
+        "can_open_org_intake": False,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_mapped_person",
             "extra_zoom_layer",
@@ -188,6 +264,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": True,
+        "can_use_lineage_certificate": True,
+        "can_open_family_intake": True,
+        "can_open_org_intake": False,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_mapped_person",
             "extra_zoom_layer",
@@ -226,6 +307,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": True,
+        "can_use_lineage_certificate": True,
+        "can_open_family_intake": True,
+        "can_open_org_intake": False,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_mapped_person",
             "extra_zoom_layer",
@@ -264,6 +350,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": True,
+        "can_use_lineage_certificate": True,
+        "can_open_family_intake": True,
+        "can_open_org_intake": False,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_mapped_person",
             "extra_zoom_layer",
@@ -302,6 +393,11 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_upload_verification_docs": True,
         "can_use_viewer": True,
         "can_use_narration": False,
+        "can_use_lineage_certificate": False,
+        "can_open_family_intake": False,
+        "can_open_org_intake": True,
+        "can_use_link_keys": True,
+        "can_manage_link_keys": True,
         "allowed_addons": [
             "extra_org_node",
             "extra_org_level",
@@ -457,15 +553,31 @@ def get_addon_catalog() -> dict[str, dict[str, Any]]:
     return deepcopy(ADDON_CATALOG)
 
 
+def _normalize_package_code(package_code: str) -> str:
+    return PACKAGE_CODE_ALIASES.get(
+        str(package_code or "").strip(),
+        str(package_code or "").strip(),
+    )
+
+
+def _normalize_addon_code(addon_code: str) -> str:
+    return ADDON_CODE_ALIASES.get(
+        str(addon_code or "").strip(),
+        str(addon_code or "").strip(),
+    )
+
+
 def get_package(package_code: str) -> dict[str, Any] | None:
-    if not package_code:
+    normalized = _normalize_package_code(package_code)
+    if not normalized:
         return None
-    value = PACKAGE_CATALOG.get(str(package_code).strip())
+    value = PACKAGE_CATALOG.get(normalized)
     return deepcopy(value) if value else None
 
 
 def get_addon(addon_code: str) -> dict[str, Any] | None:
-    if not addon_code:
+    normalized = _normalize_addon_code(addon_code)
+    if not normalized:
         return None
-    value = ADDON_CATALOG.get(str(addon_code).strip())
+    value = ADDON_CATALOG.get(normalized)
     return deepcopy(value) if value else None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.routes.lineage_graph import router as lineage_graph_router
 from app.routes.lineage_nodes import router as lineage_nodes_router
 from app.routes.lineage_proof import router as lineage_proof_router
 from app.routes.lineage_query import router as lineage_query_router
+from app.routes.link_keys import router as link_keys_router
 from app.routes.link_requests import router as link_requests_router
 from app.routes.match_candidates import router as match_candidates_router
 from app.routes.match_generation import router as match_generation_router
@@ -169,6 +170,7 @@ app.include_router(narrative_records_router)
 # ----------------------------
 # Linking + Requests
 # ----------------------------
+app.include_router(link_keys_router)
 app.include_router(link_requests_router)
 
 # ----------------------------
@@ -211,6 +213,15 @@ def root():
             "/uploads/member/{member_id}",
             "/uploads/family/{family_id}",
             "/uploads/{upload_id}/download",
+            "/link-keys/my-list",
+            "/link-keys/my-active?project_id={project_id}",
+            "/link-keys/project/{project_id}/generate",
+            "/link-keys/{key_id}/revoke",
+            "/link-requests",
+            "/link-requests/my-list",
+            "/link-requests/{request_id}/approve",
+            "/link-requests/{request_id}/reject",
+            "/link-requests/{request_id}/revoke",
             "/webhooks/stripe",
             "/orders/record-checkout",
             "/orders/my-orders",

--- a/backend/app/routes/link_keys.py
+++ b/backend/app/routes/link_keys.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.dependencies.auth import get_current_user, require_admin
+from app.schemas.link_key import LinkKeyResponse, build_link_key_response
+from app.services.link_key_service import (
+    generate_link_key,
+    get_active_key_for_project,
+    list_link_keys_for_user,
+    revoke_link_key,
+    user_can_access_project,
+)
+
+router = APIRouter(prefix="/link-keys", tags=["Link Keys"])
+
+INTERNAL_ADMIN_KEYS = {
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+}
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    role = str(user.get("role") or "").strip().lower()
+    access_tier = str(user.get("access_tier") or "").strip().lower()
+    department_role = str(user.get("department_role") or "").strip().lower()
+
+    return any(
+        value in INTERNAL_ADMIN_KEYS
+        for value in (role, access_tier, department_role)
+    )
+
+
+@router.get("/my-list")
+def list_my_link_keys(
+    project_id: str | None = Query(default=None),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _current_user_id(current_user)
+    items = list_link_keys_for_user(user_id, project_id=project_id, include_revoked=True)
+    return {"items": [build_link_key_response(item) for item in items]}
+
+
+@router.get("/my-active", response_model=LinkKeyResponse)
+def get_my_active_link_key(
+    project_id: str = Query(..., min_length=1),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _current_user_id(current_user)
+    allow_admin = _is_admin(current_user)
+
+    if not allow_admin and not user_can_access_project(project_id, user_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this project link key.",
+        )
+
+    item = get_active_key_for_project(project_id)
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active link key found for this project.",
+        )
+
+    return build_link_key_response(item)
+
+
+@router.post("/project/{project_id}/generate", response_model=LinkKeyResponse)
+def generate_project_link_key(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _current_user_id(current_user)
+    allow_admin = _is_admin(current_user)
+
+    try:
+        item = generate_link_key(
+            project_id=project_id,
+            user_id=user_id,
+            allow_admin=allow_admin,
+        )
+        return build_link_key_response(item)
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{key_id}/revoke", response_model=LinkKeyResponse)
+def revoke_project_link_key(
+    key_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _current_user_id(current_user)
+    allow_admin = _is_admin(current_user)
+
+    try:
+        item = revoke_link_key(
+            key_id=key_id,
+            actor_user_id=user_id,
+            allow_admin=allow_admin,
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Link key not found.",
+        )
+
+    return build_link_key_response(item)

--- a/backend/app/routes/link_requests.py
+++ b/backend/app/routes/link_requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from app.dependencies.auth import get_current_user, require_admin
@@ -15,7 +15,9 @@ from app.services.link_request_service import (
     approve_link_request,
     create_link_request,
     list_link_requests,
+    list_link_requests_for_user,
     reject_link_request,
+    revoke_link_request,
 )
 
 router = APIRouter(prefix="/link-requests", tags=["Link Requests"])
@@ -51,8 +53,7 @@ def _current_user_id(user: dict[str, Any]) -> str:
 
 def _current_user_display(user: dict[str, Any]) -> str:
     return (
-        str(user.get("full_name") or user.get("name") or user.get("email") or "")
-        .strip()
+        str(user.get("full_name") or user.get("name") or user.get("email") or "").strip()
         or "Unknown User"
     )
 
@@ -63,8 +64,8 @@ def _is_admin(user: dict[str, Any]) -> bool:
     department_role = str(user.get("department_role") or "").strip().lower()
 
     return any(
-      value in INTERNAL_ADMIN_KEYS
-      for value in (role, access_tier, department_role)
+        value in INTERNAL_ADMIN_KEYS
+        for value in (role, access_tier, department_role)
     )
 
 
@@ -76,30 +77,71 @@ def get_link_requests(
     return [build_link_request_response(item) for item in requests]
 
 
+@router.get("/my-list")
+def get_my_link_requests(
+    project_id: str | None = Query(default=None),
+    direction: str = Query(default="all"),
+    status_value: str | None = Query(default=None, alias="status"),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _current_user_id(current_user)
+    items = list_link_requests_for_user(
+        user_id,
+        project_id=project_id,
+        direction=direction,
+        status=status_value,
+    )
+    return {"items": [build_link_request_response(item) for item in items]}
+
+
 @router.post("/", response_model=LinkRequestResponse, status_code=status.HTTP_201_CREATED)
 def create_link_request_route(
     payload: LinkRequestCreate,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    request = create_link_request(
-        payload,
-        requested_by=_current_user_display(current_user),
-        requested_by_user_id=_current_user_id(current_user),
-    )
-    return build_link_request_response(request)
+    try:
+        request = create_link_request(
+            payload,
+            requested_by=_current_user_display(current_user),
+            requested_by_user_id=_current_user_id(current_user),
+        )
+        return build_link_request_response(request)
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
 
 @router.post("/{request_id}/approve", response_model=LinkRequestResponse)
 def approve_link_request_route(
     request_id: str,
     payload: LinkRequestDecision | None = None,
-    current_user: dict[str, Any] = Depends(require_admin),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    updated_request = approve_link_request(
-        request_id,
-        approved_by=_current_user_display(current_user),
-        approval_notes=(payload.notes if payload else None),
-    )
+    try:
+        updated_request = approve_link_request(
+            request_id,
+            approved_by=_current_user_display(current_user),
+            approver_user_id=_current_user_id(current_user),
+            approval_notes=(payload.notes if payload else None),
+            is_admin=_is_admin(current_user),
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     if updated_request is None:
         raise HTTPException(status_code=404, detail="Link request not found.")
@@ -111,13 +153,57 @@ def approve_link_request_route(
 def reject_link_request_route(
     request_id: str,
     payload: LinkRequestDecision | None = None,
-    current_user: dict[str, Any] = Depends(require_admin),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    updated_request = reject_link_request(
-        request_id,
-        rejected_by=_current_user_display(current_user),
-        rejection_notes=(payload.notes if payload else None),
-    )
+    try:
+        updated_request = reject_link_request(
+            request_id,
+            rejected_by=_current_user_display(current_user),
+            rejector_user_id=_current_user_id(current_user),
+            rejection_notes=(payload.notes if payload else None),
+            is_admin=_is_admin(current_user),
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    if updated_request is None:
+        raise HTTPException(status_code=404, detail="Link request not found.")
+
+    return build_link_request_response(updated_request)
+
+
+@router.post("/{request_id}/revoke", response_model=LinkRequestResponse)
+def revoke_link_request_route(
+    request_id: str,
+    payload: LinkRequestDecision | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        updated_request = revoke_link_request(
+            request_id,
+            revoked_by=_current_user_display(current_user),
+            revoker_user_id=_current_user_id(current_user),
+            revoke_notes=(payload.notes if payload else None),
+            is_admin=_is_admin(current_user),
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     if updated_request is None:
         raise HTTPException(status_code=404, detail="Link request not found.")

--- a/backend/app/routes/link_requests.py
+++ b/backend/app/routes/link_requests.py
@@ -1,6 +1,11 @@
-from fastapi import APIRouter, HTTPException
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from app.dependencies.auth import get_current_user, require_admin
 from app.schemas.link_request import (
     LinkRequestCreate,
     LinkRequestResponse,
@@ -15,26 +20,86 @@ from app.services.link_request_service import (
 
 router = APIRouter(prefix="/link-requests", tags=["Link Requests"])
 
+INTERNAL_ADMIN_KEYS = {
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+}
+
 
 class LinkRequestDecision(BaseModel):
-    decided_by: str = Field(..., min_length=1, max_length=150)
+    notes: str | None = Field(default=None, max_length=1000)
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_display(user: dict[str, Any]) -> str:
+    return (
+        str(user.get("full_name") or user.get("name") or user.get("email") or "")
+        .strip()
+        or "Unknown User"
+    )
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    role = str(user.get("role") or "").strip().lower()
+    access_tier = str(user.get("access_tier") or "").strip().lower()
+    department_role = str(user.get("department_role") or "").strip().lower()
+
+    return any(
+      value in INTERNAL_ADMIN_KEYS
+      for value in (role, access_tier, department_role)
+    )
 
 
 @router.get("/", response_model=list[LinkRequestResponse])
-def get_link_requests():
+def get_link_requests(
+    current_user: dict[str, Any] = Depends(require_admin),
+):
     requests = list_link_requests()
     return [build_link_request_response(item) for item in requests]
 
 
-@router.post("/", response_model=LinkRequestResponse)
-def create_link_request_route(payload: LinkRequestCreate):
-    request = create_link_request(payload)
+@router.post("/", response_model=LinkRequestResponse, status_code=status.HTTP_201_CREATED)
+def create_link_request_route(
+    payload: LinkRequestCreate,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    request = create_link_request(
+        payload,
+        requested_by=_current_user_display(current_user),
+        requested_by_user_id=_current_user_id(current_user),
+    )
     return build_link_request_response(request)
 
 
 @router.post("/{request_id}/approve", response_model=LinkRequestResponse)
-def approve_link_request_route(request_id: str, payload: LinkRequestDecision):
-    updated_request = approve_link_request(request_id, payload.decided_by)
+def approve_link_request_route(
+    request_id: str,
+    payload: LinkRequestDecision | None = None,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    updated_request = approve_link_request(
+        request_id,
+        approved_by=_current_user_display(current_user),
+        approval_notes=(payload.notes if payload else None),
+    )
 
     if updated_request is None:
         raise HTTPException(status_code=404, detail="Link request not found.")
@@ -43,8 +108,16 @@ def approve_link_request_route(request_id: str, payload: LinkRequestDecision):
 
 
 @router.post("/{request_id}/reject", response_model=LinkRequestResponse)
-def reject_link_request_route(request_id: str, payload: LinkRequestDecision):
-    updated_request = reject_link_request(request_id, payload.decided_by)
+def reject_link_request_route(
+    request_id: str,
+    payload: LinkRequestDecision | None = None,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    updated_request = reject_link_request(
+        request_id,
+        rejected_by=_current_user_display(current_user),
+        rejection_notes=(payload.notes if payload else None),
+    )
 
     if updated_request is None:
         raise HTTPException(status_code=404, detail="Link request not found.")

--- a/backend/app/routes/project_entitlements.py
+++ b/backend/app/routes/project_entitlements.py
@@ -16,6 +16,20 @@ from app.services.project_entitlement_service import (
 
 router = APIRouter(prefix="/project-entitlements", tags=["Project Entitlements"])
 
+INTERNAL_ADMIN_KEYS = {
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "finance_admin",
+    "marketing_admin",
+    "executive_technology",
+    "operations",
+    "finance",
+    "marketing",
+}
+
 
 class ApplyProjectEntitlementPayload(BaseModel):
     project_id: str = Field(min_length=1)
@@ -35,6 +49,17 @@ def _current_user_id(user: dict[str, Any]) -> str:
             detail="Authenticated user id is missing.",
         )
     return str(raw_id)
+
+
+def _is_admin(user: dict[str, Any]) -> bool:
+    role = str(user.get("role") or "").strip().lower()
+    access_tier = str(user.get("access_tier") or "").strip().lower()
+    department_role = str(user.get("department_role") or "").strip().lower()
+
+    return any(
+        value in INTERNAL_ADMIN_KEYS
+        for value in (role, access_tier, department_role)
+    )
 
 
 @router.post("/apply")
@@ -72,9 +97,8 @@ def get_project_entitlement_route(
         )
 
     current_user_id = _current_user_id(current_user)
-    current_role = str(current_user.get("role") or "").strip().lower()
 
-    if current_role != "admin" and entitlement.get("user_id") != current_user_id:
+    if not _is_admin(current_user) and entitlement.get("user_id") != current_user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to view this project entitlement.",
@@ -89,7 +113,7 @@ def list_my_project_entitlements(
 ):
     current_user_id = _current_user_id(current_user)
     return {
-        "items": list_user_project_entitlements(current_user_id),
+        "items": list_user_project_entitlements(current_user_id, active_only=True),
     }
 
 
@@ -107,9 +131,8 @@ def get_project_upgrade_quote_route(
         )
 
     current_user_id = _current_user_id(current_user)
-    current_role = str(current_user.get("role") or "").strip().lower()
 
-    if current_role != "admin" and entitlement.get("user_id") != current_user_id:
+    if not _is_admin(current_user) and entitlement.get("user_id") != current_user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to view this upgrade quote.",

--- a/backend/app/schemas/link_key.py
+++ b/backend/app/schemas/link_key.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class LinkKeyResponse(BaseModel):
+    id: str
+    project_id: str
+    package_code: str | None = None
+    package_name: str | None = None
+    package_lane: str | None = None
+    key_value: str
+    status: str
+    created_at: str
+    updated_at: str | None = None
+    revoked_at: str | None = None
+
+
+def build_link_key_response(data: dict[str, Any]) -> LinkKeyResponse:
+    return LinkKeyResponse(
+        id=str(data.get("_id", "")),
+        project_id=str(data.get("project_id") or ""),
+        package_code=(str(data.get("package_code")) if data.get("package_code") else None),
+        package_name=(str(data.get("package_name")) if data.get("package_name") else None),
+        package_lane=(str(data.get("package_lane")) if data.get("package_lane") else None),
+        key_value=str(data.get("key_value") or ""),
+        status=str(data.get("status") or "active"),
+        created_at=str(data.get("created_at") or datetime.now(UTC).isoformat()),
+        updated_at=(str(data.get("updated_at")) if data.get("updated_at") else None),
+        revoked_at=(str(data.get("revoked_at")) if data.get("revoked_at") else None),
+    )

--- a/backend/app/schemas/link_request.py
+++ b/backend/app/schemas/link_request.py
@@ -7,22 +7,30 @@ from pydantic import BaseModel, Field
 
 
 class LinkRequestCreate(BaseModel):
-    source_household_id: str = Field(..., min_length=1)
-    target_household_id: str = Field(..., min_length=1)
-    source_key: str = Field(..., min_length=1, max_length=150)
+    source_project_id: str = Field(..., min_length=1)
     target_key: str = Field(..., min_length=1, max_length=150)
     notes: str | None = Field(default=None, max_length=1000)
 
 
 class LinkRequestResponse(BaseModel):
     id: str
-    source_household_id: str
-    target_household_id: str
+    source_project_id: str
+    target_project_id: str
+    source_household_id: str | None = None
+    target_household_id: str | None = None
     source_key: str
     target_key: str
     status: str
     requested_by: str
     requested_by_user_id: str | None = None
+    source_package_code: str | None = None
+    source_package_name: str | None = None
+    source_project_name: str | None = None
+    source_owner_email: str | None = None
+    target_package_code: str | None = None
+    target_package_name: str | None = None
+    target_project_name: str | None = None
+    target_owner_email: str | None = None
     notes: str | None = None
     approved_by: str | None = None
     approved_at: str | None = None
@@ -30,14 +38,30 @@ class LinkRequestResponse(BaseModel):
     rejected_by: str | None = None
     rejected_at: str | None = None
     rejection_notes: str | None = None
+    revoked_by: str | None = None
+    revoked_at: str | None = None
+    revoke_notes: str | None = None
     created_at: str
+    updated_at: str | None = None
 
 
 def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
     return LinkRequestResponse(
         id=str(data.get("_id", "")),
-        source_household_id=str(data.get("source_household_id") or ""),
-        target_household_id=str(data.get("target_household_id") or ""),
+        source_project_id=str(data.get("source_project_id") or ""),
+        target_project_id=str(data.get("target_project_id") or ""),
+        source_household_id=(
+            str(data.get("source_household_id"))
+            if data.get("source_household_id") is not None
+            and str(data.get("source_household_id")).strip()
+            else None
+        ),
+        target_household_id=(
+            str(data.get("target_household_id"))
+            if data.get("target_household_id") is not None
+            and str(data.get("target_household_id")).strip()
+            else None
+        ),
         source_key=str(data.get("source_key") or ""),
         target_key=str(data.get("target_key") or ""),
         status=str(data.get("status") or "pending"),
@@ -47,6 +71,46 @@ def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
             if data.get("requested_by_user_id") is not None
             else None
         ),
+        source_package_code=(
+            str(data.get("source_package_code"))
+            if data.get("source_package_code")
+            else None
+        ),
+        source_package_name=(
+            str(data.get("source_package_name"))
+            if data.get("source_package_name")
+            else None
+        ),
+        source_project_name=(
+            str(data.get("source_project_name"))
+            if data.get("source_project_name")
+            else None
+        ),
+        source_owner_email=(
+            str(data.get("source_owner_email"))
+            if data.get("source_owner_email")
+            else None
+        ),
+        target_package_code=(
+            str(data.get("target_package_code"))
+            if data.get("target_package_code")
+            else None
+        ),
+        target_package_name=(
+            str(data.get("target_package_name"))
+            if data.get("target_package_name")
+            else None
+        ),
+        target_project_name=(
+            str(data.get("target_project_name"))
+            if data.get("target_project_name")
+            else None
+        ),
+        target_owner_email=(
+            str(data.get("target_owner_email"))
+            if data.get("target_owner_email")
+            else None
+        ),
         notes=data.get("notes"),
         approved_by=data.get("approved_by"),
         approved_at=data.get("approved_at"),
@@ -54,5 +118,9 @@ def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
         rejected_by=data.get("rejected_by"),
         rejected_at=data.get("rejected_at"),
         rejection_notes=data.get("rejection_notes"),
+        revoked_by=data.get("revoked_by"),
+        revoked_at=data.get("revoked_at"),
+        revoke_notes=data.get("revoke_notes"),
         created_at=str(data.get("created_at") or datetime.now(UTC).isoformat()),
+        updated_at=(str(data.get("updated_at")) if data.get("updated_at") else None),
     )

--- a/backend/app/schemas/link_request.py
+++ b/backend/app/schemas/link_request.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -7,9 +11,7 @@ class LinkRequestCreate(BaseModel):
     target_household_id: str = Field(..., min_length=1)
     source_key: str = Field(..., min_length=1, max_length=150)
     target_key: str = Field(..., min_length=1, max_length=150)
-    status: str = Field(default="pending", min_length=1, max_length=50)
-    requested_by: str = Field(..., min_length=1, max_length=150)
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=1000)
 
 
 class LinkRequestResponse(BaseModel):
@@ -20,27 +22,37 @@ class LinkRequestResponse(BaseModel):
     target_key: str
     status: str
     requested_by: str
+    requested_by_user_id: str | None = None
     notes: str | None = None
     approved_by: str | None = None
     approved_at: str | None = None
+    approval_notes: str | None = None
     rejected_by: str | None = None
     rejected_at: str | None = None
+    rejection_notes: str | None = None
     created_at: str
 
 
-def build_link_request_response(data: dict) -> LinkRequestResponse:
+def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
     return LinkRequestResponse(
         id=str(data.get("_id", "")),
-        source_household_id=data["source_household_id"],
-        target_household_id=data["target_household_id"],
-        source_key=data["source_key"],
-        target_key=data["target_key"],
-        status=data.get("status", "pending"),
-        requested_by=data["requested_by"],
+        source_household_id=str(data.get("source_household_id") or ""),
+        target_household_id=str(data.get("target_household_id") or ""),
+        source_key=str(data.get("source_key") or ""),
+        target_key=str(data.get("target_key") or ""),
+        status=str(data.get("status") or "pending"),
+        requested_by=str(data.get("requested_by") or ""),
+        requested_by_user_id=(
+            str(data.get("requested_by_user_id"))
+            if data.get("requested_by_user_id") is not None
+            else None
+        ),
         notes=data.get("notes"),
         approved_by=data.get("approved_by"),
         approved_at=data.get("approved_at"),
+        approval_notes=data.get("approval_notes"),
         rejected_by=data.get("rejected_by"),
         rejected_at=data.get("rejected_at"),
-        created_at=data.get("created_at", datetime.now(UTC).isoformat()),
+        rejection_notes=data.get("rejection_notes"),
+        created_at=str(data.get("created_at") or datetime.now(UTC).isoformat()),
     )

--- a/backend/app/services/entitlement_service.py
+++ b/backend/app/services/entitlement_service.py
@@ -32,8 +32,9 @@ def resolve_project_entitlements(
     entitlements = deepcopy(package)
     entitlements["active_addons"] = []
 
-    for addon_code in active_addon_codes or []:
-        addon = get_addon_or_raise(addon_code)
+    for raw_addon_code in active_addon_codes or []:
+        addon = get_addon_or_raise(raw_addon_code)
+        addon_code = str(addon.get("addon_code") or raw_addon_code).strip()
 
         if package["package_lane"] not in addon.get("allowed_lanes", []):
             raise ValueError(
@@ -45,22 +46,37 @@ def resolve_project_entitlements(
         if addon_code == "extra_upload_pack":
             entitlements["max_uploads"] = int(entitlements.get("max_uploads", 0)) + 10
         elif addon_code == "extra_storage":
-            entitlements["max_storage_gb"] = float(entitlements.get("max_storage_gb", 0)) + 10
+            entitlements["max_storage_gb"] = float(
+                entitlements.get("max_storage_gb", 0)
+            ) + 10
         elif addon_code == "extra_mapped_person":
             entitlements["max_members"] = int(entitlements.get("max_members", 0)) + 1
         elif addon_code == "extra_zoom_layer":
-            entitlements["max_zoom_layers"] = int(entitlements.get("max_zoom_layers", 0)) + 1
+            entitlements["max_zoom_layers"] = int(
+                entitlements.get("max_zoom_layers", 0)
+            ) + 1
         elif addon_code == "extra_linked_household":
-            entitlements["max_households"] = int(entitlements.get("max_households", 0)) + 1
+            entitlements["max_households"] = int(
+                entitlements.get("max_households", 0)
+            ) + 1
             entitlements["can_link_households"] = True
         elif addon_code == "extra_branch":
-            entitlements["max_households"] = int(entitlements.get("max_households", 0)) + 1
+            entitlements["max_households"] = int(
+                entitlements.get("max_households", 0)
+            ) + 1
+            entitlements["can_link_households"] = True
         elif addon_code == "extra_org_node":
-            entitlements["max_org_nodes"] = int(entitlements.get("max_org_nodes", 0)) + 1
+            entitlements["max_org_nodes"] = int(
+                entitlements.get("max_org_nodes", 0)
+            ) + 1
         elif addon_code == "extra_org_level":
-            entitlements["max_zoom_layers"] = int(entitlements.get("max_zoom_layers", 0)) + 1
+            entitlements["max_zoom_layers"] = int(
+                entitlements.get("max_zoom_layers", 0)
+            ) + 1
         elif addon_code == "extra_admin_seat":
-            entitlements["extra_admin_seats"] = int(entitlements.get("extra_admin_seats", 0)) + 1
+            entitlements["extra_admin_seats"] = int(
+                entitlements.get("extra_admin_seats", 0)
+            ) + 1
 
     entitlements["resolved"] = True
     return entitlements
@@ -74,10 +90,14 @@ def can_purchase_addon(package_code: str, addon_code: str) -> bool:
 
 def can_upgrade(from_package_code: str, to_package_code: str) -> bool:
     package = get_package_or_raise(from_package_code)
-    return _normalize(to_package_code) in package.get("upgrade_targets", [])
+    target_package = get_package_or_raise(to_package_code)
+    return target_package["package_code"] in package.get("upgrade_targets", [])
 
 
-def compute_upgrade_quote(from_package_code: str, to_package_code: str) -> dict[str, Any]:
+def compute_upgrade_quote(
+    from_package_code: str,
+    to_package_code: str,
+) -> dict[str, Any]:
     from_package = get_package_or_raise(from_package_code)
     to_package = get_package_or_raise(to_package_code)
 

--- a/backend/app/services/intake_pipeline_service.py
+++ b/backend/app/services/intake_pipeline_service.py
@@ -27,7 +27,7 @@ def _serialize_submission(doc: dict[str, Any]) -> dict[str, Any]:
 
 def _normalize_visibility(value: str | None) -> str:
     normalized = str(value or "").strip().lower()
-    if normalized in {"private"}:
+    if normalized == "private":
         return "private"
     if normalized in {"family", "family-only", "family_only"}:
         return "family_only"
@@ -59,6 +59,73 @@ def _normalize_package_code(value: str | None) -> str:
         "command_structure_network": "command_structure_network",
     }
     return mapping.get(normalized, normalized or "unknown")
+
+
+def _supports_family_build(package: dict[str, Any]) -> bool:
+    return bool(
+        package.get("can_build_family_tree") or package.get("can_build_household")
+    )
+
+
+def _supports_org_build(package: dict[str, Any]) -> bool:
+    return bool(package.get("can_build_org_chart"))
+
+
+def _split_name(full_name: str, fallback_email: str) -> tuple[str, str]:
+    name = str(full_name or "").strip()
+    if not name:
+        local_part = (
+            str(fallback_email or "")
+            .split("@")[0]
+            .replace(".", " ")
+            .replace("_", " ")
+        )
+        name = local_part.strip()
+
+    parts = [part for part in name.split() if part]
+    if not parts:
+        return "Primary", "Contact"
+    if len(parts) == 1:
+        return parts[0], "Contact"
+    return parts[0], " ".join(parts[1:])
+
+
+def _seed_primary_member(
+    *,
+    db,
+    family_id: str,
+    submission_id: str,
+    owner_user_id: str,
+    owner_email: str,
+    household: dict[str, Any],
+):
+    family_members = db["family_members"]
+
+    existing = family_members.find_one({"family_id": family_id})
+    if existing is not None:
+        return
+
+    primary_contact_name = str(household.get("primary_contact_name") or "").strip()
+    first_name, last_name = _split_name(primary_contact_name, owner_email)
+    project_scope = str(household.get("project_scope") or "").strip()
+
+    member_payload = {
+        "family_id": family_id,
+        "first_name": first_name,
+        "last_name": last_name,
+        "generation": 1,
+        "bio": project_scope or "",
+        "owner_user_id": owner_user_id,
+        "owner_email": owner_email,
+        "source": "approved_intake_seed",
+        "intake_submission_id": submission_id,
+        "is_verified": False,
+        "verification_status": "unverified",
+        "created_at": _now(),
+        "updated_at": _now(),
+    }
+
+    family_members.insert_one(member_payload)
 
 
 def provision_build_from_submission(
@@ -109,9 +176,14 @@ def provision_build_from_submission(
     package_code = _normalize_package_code(
         submission.get("package_code") or submission.get("package_slug")
     )
-    package_name = str(submission.get("package_name") or "").strip() or "Tomb of Light Package"
+    package_name = (
+        str(submission.get("package_name") or "").strip() or "Tomb of Light Package"
+    )
     package = get_package(package_code) or {}
-    project_lane = str(package.get("package_lane") or "household").strip().lower()
+    project_lane = str(package.get("package_lane") or "portrait").strip().lower()
+
+    supports_family_build = _supports_family_build(package)
+    supports_org_build = _supports_org_build(package)
 
     family_name = (
         family_name_override.strip()
@@ -135,77 +207,81 @@ def provision_build_from_submission(
 
     visibility = _normalize_visibility(consent.get("visibility_preference"))
 
-    family_doc = None
-    if existing_family_root_id and ObjectId.is_valid(existing_family_root_id):
-        family_doc = families.find_one({"_id": ObjectId(existing_family_root_id)})
+    family_root_id = ""
+    household_id = ""
 
-    if family_doc is None:
-        family_doc = families.find_one(
-            {
-                "$or": [
-                    {"intake_submission_id": submission_id},
-                    {
-                        "owner_user_id": owner_user_id_str,
-                        "family_name": family_name,
-                    },
-                ]
+    if supports_family_build:
+        family_doc = None
+        if existing_family_root_id and ObjectId.is_valid(existing_family_root_id):
+            family_doc = families.find_one({"_id": ObjectId(existing_family_root_id)})
+
+        if family_doc is None:
+            family_doc = families.find_one({"intake_submission_id": submission_id})
+
+        if family_doc is None:
+            family_payload = {
+                "family_name": family_name,
+                "created_by": created_by,
+                "description": family_description,
+                "owner_user_id": owner_user_id_str,
+                "owner_email": owner_email,
+                "visibility": visibility,
+                "shared_with_user_ids": [],
+                "shared_with_emails": [],
+                "package_code": package_code,
+                "package_slug": package_code,
+                "package_name": package_name,
+                "source": "approved_intake",
+                "intake_submission_id": submission_id,
+                "created_at": _now(),
+                "updated_at": _now(),
             }
+            family_result = families.insert_one(family_payload)
+            family_payload["_id"] = family_result.inserted_id
+            family_doc = family_payload
+
+        family_root_id = str(family_doc["_id"])
+
+        household_doc = None
+        if existing_household_id and ObjectId.is_valid(existing_household_id):
+            household_doc = households.find_one({"_id": ObjectId(existing_household_id)})
+
+        if household_doc is None:
+            household_doc = households.find_one({"intake_submission_id": submission_id})
+
+        if household_doc is None:
+            household_payload = {
+                "family_id": family_root_id,
+                "intake_submission_id": submission_id,
+                "owner_user_id": owner_user_id_str,
+                "owner_email": owner_email,
+                "household_name": household.get("household_name"),
+                "primary_contact_name": household.get("primary_contact_name"),
+                "primary_contact_email": household.get("primary_contact_email"),
+                "primary_contact_phone": household.get("primary_contact_phone"),
+                "co_owner_name": household.get("co_owner_name"),
+                "household_role": household.get("household_role"),
+                "project_scope": household.get("project_scope"),
+                "special_notes": household.get("special_notes"),
+                "status": "build_ready",
+                "source": "approved_intake",
+                "created_at": _now(),
+                "updated_at": _now(),
+            }
+            household_result = households.insert_one(household_payload)
+            household_payload["_id"] = household_result.inserted_id
+            household_doc = household_payload
+
+        household_id = str(household_doc["_id"])
+
+        _seed_primary_member(
+            db=db,
+            family_id=family_root_id,
+            submission_id=submission_id,
+            owner_user_id=owner_user_id_str,
+            owner_email=owner_email,
+            household=household,
         )
-
-    if family_doc is None:
-        family_payload = {
-            "family_name": family_name,
-            "created_by": created_by,
-            "description": family_description,
-            "owner_user_id": owner_user_id_str,
-            "owner_email": owner_email,
-            "visibility": visibility,
-            "shared_with_user_ids": [],
-            "shared_with_emails": [],
-            "package_code": package_code,
-            "package_slug": package_code,
-            "package_name": package_name,
-            "source": "approved_intake",
-            "intake_submission_id": submission_id,
-            "created_at": _now(),
-        }
-        family_result = families.insert_one(family_payload)
-        family_payload["_id"] = family_result.inserted_id
-        family_doc = family_payload
-
-    family_root_id = str(family_doc["_id"])
-
-    household_doc = None
-    if existing_household_id and ObjectId.is_valid(existing_household_id):
-        household_doc = households.find_one({"_id": ObjectId(existing_household_id)})
-
-    if household_doc is None:
-        household_doc = households.find_one({"intake_submission_id": submission_id})
-
-    if household_doc is None:
-        household_payload = {
-            "family_id": family_root_id,
-            "intake_submission_id": submission_id,
-            "owner_user_id": owner_user_id_str,
-            "owner_email": owner_email,
-            "household_name": household.get("household_name"),
-            "primary_contact_name": household.get("primary_contact_name"),
-            "primary_contact_email": household.get("primary_contact_email"),
-            "primary_contact_phone": household.get("primary_contact_phone"),
-            "co_owner_name": household.get("co_owner_name"),
-            "household_role": household.get("household_role"),
-            "project_scope": household.get("project_scope"),
-            "special_notes": household.get("special_notes"),
-            "status": "build_ready",
-            "source": "approved_intake",
-            "created_at": _now(),
-            "updated_at": _now(),
-        }
-        household_result = households.insert_one(household_payload)
-        household_payload["_id"] = household_result.inserted_id
-        household_doc = household_payload
-
-    household_id = str(household_doc["_id"])
 
     project_doc = None
     if existing_project_id and ObjectId.is_valid(existing_project_id):
@@ -214,14 +290,21 @@ def provision_build_from_submission(
     if project_doc is None:
         project_doc = projects.find_one({"intake_submission_id": submission_id})
 
-    project_name = project_name_override.strip() or f"{family_name} Production Build"
+    if supports_family_build:
+        default_project_name = f"{family_name} Production Build"
+    elif supports_org_build:
+        default_project_name = f"{package_name} Organization Workspace"
+    else:
+        default_project_name = f"{package_name} Portrait Workspace"
+
+    project_name = project_name_override.strip() or default_project_name
 
     project_payload = {
         "name": project_name,
         "project_name": project_name,
         "project_lane": project_lane,
-        "family_id": family_root_id,
-        "household_id": household_id,
+        "family_id": family_root_id or None,
+        "household_id": household_id or None,
         "organization_id": None,
         "owner_user_id": owner_user_id_str,
         "owner_email": owner_email,
@@ -254,25 +337,32 @@ def provision_build_from_submission(
 
     project_id = str(project_doc["_id"])
 
-    submissions.update_one(
-        {"_id": _oid(submission_id)},
-        {
-            "$set": {
-                "status": "build_ready",
-                "review_locked": True,
-                "family_root_id": family_root_id,
-                "household_id": household_id,
-                "project_id": project_id,
-                "package_code": package_code,
-                "package_slug": package_code,
-                "package_name": package_name,
-                "provisioned_at": _now(),
-                "provisioned_by": provisioned_by,
-                "production_notes": production_notes or "",
-                "updated_at": _now(),
-            }
-        },
-    )
+    submission_set: dict[str, Any] = {
+        "status": "build_ready",
+        "review_locked": True,
+        "project_id": project_id,
+        "project_lane": project_lane,
+        "package_code": package_code,
+        "package_slug": package_code,
+        "package_name": package_name,
+        "provisioned_at": _now(),
+        "provisioned_by": provisioned_by,
+        "production_notes": production_notes or "",
+        "updated_at": _now(),
+    }
+
+    update_doc: dict[str, Any] = {"$set": submission_set}
+
+    if supports_family_build:
+        submission_set["family_root_id"] = family_root_id
+        submission_set["household_id"] = household_id
+    else:
+        update_doc["$unset"] = {
+            "family_root_id": "",
+            "household_id": "",
+        }
+
+    submissions.update_one({"_id": _oid(submission_id)}, update_doc)
 
     saved = submissions.find_one({"_id": _oid(submission_id)})
     if not saved:

--- a/backend/app/services/link_key_service.py
+++ b/backend/app/services/link_key_service.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.core.package_catalog import get_package
+from app.database import get_database
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _keys_collection():
+    db = get_database()
+    return db["project_link_keys"]
+
+
+def _projects_collection():
+    db = get_database()
+    return db["projects"]
+
+
+def _entitlements_collection():
+    db = get_database()
+    return db["project_entitlements"]
+
+
+def _serialize_key(document: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not document:
+        return None
+
+    return {
+        "_id": document.get("_id"),
+        "id": str(document.get("_id")),
+        "project_id": str(document.get("project_id") or ""),
+        "user_id": str(document.get("user_id") or ""),
+        "package_code": document.get("package_code"),
+        "package_name": document.get("package_name"),
+        "package_lane": document.get("package_lane"),
+        "key_value": document.get("key_value"),
+        "status": document.get("status", "active"),
+        "created_at": document.get("created_at"),
+        "updated_at": document.get("updated_at"),
+        "revoked_at": document.get("revoked_at"),
+    }
+
+
+def get_project_by_id(project_id: str) -> dict[str, Any] | None:
+    oid = _to_object_id(project_id)
+    if oid is None:
+        return None
+    return _projects_collection().find_one({"_id": oid})
+
+
+def get_project_summary(project_id: str) -> dict[str, Any] | None:
+    project = get_project_by_id(project_id)
+    if not project:
+        return None
+
+    raw_id = project.get("_id")
+    package_code = str(project.get("package_code") or project.get("package_slug") or "").strip()
+    package = get_package(package_code) or {}
+
+    return {
+        "project_id": str(raw_id),
+        "project_name": str(project.get("project_name") or project.get("name") or "Workspace").strip(),
+        "owner_user_id": str(project.get("owner_user_id") or "").strip(),
+        "owner_email": str(project.get("owner_email") or "").strip(),
+        "package_code": package_code or None,
+        "package_name": str(project.get("package_name") or package.get("display_name") or "").strip() or None,
+        "package_lane": str(project.get("project_lane") or package.get("package_lane") or "").strip() or None,
+        "household_id": str(project.get("household_id") or "").strip() or None,
+        "family_id": str(project.get("family_id") or "").strip() or None,
+    }
+
+
+def _get_project_entitlement(project_id: str) -> dict[str, Any] | None:
+    entitlements = _entitlements_collection()
+    return entitlements.find_one({"project_id": str(project_id), "status": "active"}) or entitlements.find_one({"project_id": str(project_id)})
+
+
+def project_supports_link_keys(project_id: str) -> bool:
+    entitlement = _get_project_entitlement(project_id)
+    if entitlement:
+        resolved = entitlement.get("resolved_entitlements") or {}
+        if "can_use_link_keys" in resolved:
+            return bool(resolved.get("can_use_link_keys"))
+
+    project = get_project_by_id(project_id)
+    if not project:
+        return False
+
+    package_code = str(project.get("package_code") or project.get("package_slug") or "").strip()
+    package = get_package(package_code) or {}
+    return bool(package.get("can_use_link_keys", False))
+
+
+def user_can_access_project(project_id: str, user_id: str) -> bool:
+    summary = get_project_summary(project_id)
+    if not summary:
+        return False
+    return str(summary.get("owner_user_id") or "") == str(user_id or "")
+
+
+def list_owned_project_ids(user_id: str) -> list[str]:
+    cursor = _projects_collection().find({"owner_user_id": str(user_id or "")})
+    return [str(item.get("_id")) for item in cursor]
+
+
+def get_active_key_doc_for_project(project_id: str) -> dict[str, Any] | None:
+    return _keys_collection().find_one(
+        {
+            "project_id": str(project_id),
+            "status": "active",
+        },
+        sort=[("created_at", -1)],
+    )
+
+
+def get_active_key_for_project(project_id: str) -> dict[str, Any] | None:
+    return _serialize_key(get_active_key_doc_for_project(project_id))
+
+
+def get_key_doc_by_value(key_value: str) -> dict[str, Any] | None:
+    return _keys_collection().find_one(
+        {
+            "key_value": str(key_value or "").strip(),
+            "status": "active",
+        }
+    )
+
+
+def list_link_keys_for_user(
+    user_id: str,
+    *,
+    project_id: str | None = None,
+    include_revoked: bool = True,
+) -> list[dict[str, Any]]:
+    if project_id:
+        if not user_can_access_project(project_id, user_id):
+            return []
+        owned_project_ids = [str(project_id)]
+    else:
+        owned_project_ids = list_owned_project_ids(user_id)
+
+    if not owned_project_ids:
+        return []
+
+    query: dict[str, Any] = {"project_id": {"$in": owned_project_ids}}
+    if not include_revoked:
+        query["status"] = "active"
+
+    cursor = _keys_collection().find(query).sort("created_at", -1)
+    return [item for item in (_serialize_key(doc) for doc in cursor) if item is not None]
+
+
+def _generate_raw_link_key() -> str:
+    return f"tolk_{secrets.token_hex(12)}"
+
+
+def generate_link_key(
+    *,
+    project_id: str,
+    user_id: str,
+    allow_admin: bool = False,
+) -> dict[str, Any]:
+    if not allow_admin and not user_can_access_project(project_id, user_id):
+        raise PermissionError("Not authorized to generate a link key for this project.")
+
+    if not project_supports_link_keys(project_id):
+        raise ValueError("This package does not include link capabilities.")
+
+    project_summary = get_project_summary(project_id)
+    if not project_summary:
+        raise ValueError("Project not found.")
+
+    keys = _keys_collection()
+    now = _utcnow_iso()
+
+    keys.update_many(
+        {"project_id": str(project_id), "status": "active"},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_at": now,
+                "updated_at": now,
+            }
+        },
+    )
+
+    document = {
+        "project_id": str(project_id),
+        "user_id": str(user_id),
+        "package_code": project_summary.get("package_code"),
+        "package_name": project_summary.get("package_name"),
+        "package_lane": project_summary.get("package_lane"),
+        "key_value": _generate_raw_link_key(),
+        "status": "active",
+        "created_at": now,
+        "updated_at": now,
+        "revoked_at": None,
+    }
+
+    result = keys.insert_one(document)
+    document["_id"] = result.inserted_id
+    return _serialize_key(document) or {}
+
+
+def revoke_link_key(
+    *,
+    key_id: str,
+    actor_user_id: str,
+    allow_admin: bool = False,
+) -> dict[str, Any] | None:
+    oid = _to_object_id(key_id)
+    if oid is None:
+        return None
+
+    keys = _keys_collection()
+    document = keys.find_one({"_id": oid})
+    if not document:
+        return None
+
+    project_id = str(document.get("project_id") or "")
+    if not allow_admin and not user_can_access_project(project_id, actor_user_id):
+        raise PermissionError("Not authorized to revoke this link key.")
+
+    now = _utcnow_iso()
+    keys.update_one(
+        {"_id": oid},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_at": now,
+                "updated_at": now,
+            }
+        },
+    )
+
+    updated = keys.find_one({"_id": oid})
+    return _serialize_key(updated)

--- a/backend/app/services/link_request_service.py
+++ b/backend/app/services/link_request_service.py
@@ -1,9 +1,20 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
+from typing import Any
 
 from bson import ObjectId
 
 from app.database import get_database
 from app.schemas.link_request import LinkRequestCreate
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _normalize_id(value: Any) -> str:
+    return str(value or "").strip()
 
 
 def list_link_requests() -> list[dict]:
@@ -14,14 +25,37 @@ def list_link_requests() -> list[dict]:
     return list(db.link_requests.find().sort("created_at", -1))
 
 
-def create_link_request(payload: LinkRequestCreate) -> dict:
+def create_link_request(
+    payload: LinkRequestCreate,
+    *,
+    requested_by: str,
+    requested_by_user_id: str | None = None,
+) -> dict:
     db = get_database()
     data = payload.model_dump()
-    data["created_at"] = datetime.now(UTC).isoformat()
+    data["status"] = "pending"
+    data["requested_by"] = str(requested_by or "").strip() or "Unknown User"
+    data["requested_by_user_id"] = (
+        str(requested_by_user_id).strip() if requested_by_user_id else None
+    )
+    data["created_at"] = _utcnow_iso()
+    data["updated_at"] = data["created_at"]
 
     if db is None:
         data["_id"] = "local-link-request-preview"
         return data
+
+    existing = db.link_requests.find_one(
+        {
+            "source_household_id": data["source_household_id"],
+            "target_household_id": data["target_household_id"],
+            "source_key": data["source_key"],
+            "target_key": data["target_key"],
+            "status": "pending",
+        }
+    )
+    if existing is not None:
+        return existing
 
     result = db.link_requests.insert_one(data)
     data["_id"] = result.inserted_id
@@ -39,15 +73,19 @@ def get_link_request_by_id(request_id: str) -> dict | None:
         return None
 
 
-def approve_link_request(request_id: str, approved_by: str) -> dict | None:
+def approve_link_request(
+    request_id: str,
+    approved_by: str,
+    approval_notes: str | None = None,
+) -> dict | None:
     db = get_database()
     if db is None:
         return None
 
     try:
-        object_id = ObjectId(request_id)
+      object_id = ObjectId(request_id)
     except Exception:
-        return None
+      return None
 
     request = db.link_requests.find_one({"_id": object_id})
     if request is None:
@@ -59,15 +97,25 @@ def approve_link_request(request_id: str, approved_by: str) -> dict | None:
             "$set": {
                 "status": "approved",
                 "approved_by": approved_by,
-                "approved_at": datetime.now(UTC).isoformat(),
+                "approved_at": _utcnow_iso(),
+                "approval_notes": approval_notes,
+                "updated_at": _utcnow_iso(),
             }
         },
     )
 
     existing_link = db.household_links.find_one(
         {
-            "source_household_id": request["source_household_id"],
-            "target_household_id": request["target_household_id"],
+            "$or": [
+                {
+                    "source_household_id": request["source_household_id"],
+                    "target_household_id": request["target_household_id"],
+                },
+                {
+                    "source_household_id": request["target_household_id"],
+                    "target_household_id": request["source_household_id"],
+                },
+            ]
         }
     )
 
@@ -78,14 +126,21 @@ def approve_link_request(request_id: str, approved_by: str) -> dict | None:
             "relationship_type": "linked_household",
             "link_status": "approved",
             "linked_by_key": request["source_key"],
-            "created_at": datetime.now(UTC).isoformat(),
+            "source_key": request["source_key"],
+            "target_key": request["target_key"],
+            "created_at": _utcnow_iso(),
+            "updated_at": _utcnow_iso(),
         }
         db.household_links.insert_one(household_link)
 
     return db.link_requests.find_one({"_id": object_id})
 
 
-def reject_link_request(request_id: str, rejected_by: str) -> dict | None:
+def reject_link_request(
+    request_id: str,
+    rejected_by: str,
+    rejection_notes: str | None = None,
+) -> dict | None:
     db = get_database()
     if db is None:
         return None
@@ -105,7 +160,9 @@ def reject_link_request(request_id: str, rejected_by: str) -> dict | None:
             "$set": {
                 "status": "rejected",
                 "rejected_by": rejected_by,
-                "rejected_at": datetime.now(UTC).isoformat(),
+                "rejected_at": _utcnow_iso(),
+                "rejection_notes": rejection_notes,
+                "updated_at": _utcnow_iso(),
             }
         },
     )

--- a/backend/app/services/link_request_service.py
+++ b/backend/app/services/link_request_service.py
@@ -7,164 +7,383 @@ from bson import ObjectId
 
 from app.database import get_database
 from app.schemas.link_request import LinkRequestCreate
+from app.services.link_key_service import (
+    get_active_key_doc_for_project,
+    get_key_doc_by_value,
+    get_project_summary,
+    list_owned_project_ids,
+    project_supports_link_keys,
+    user_can_access_project,
+)
 
 
 def _utcnow_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _normalize_id(value: Any) -> str:
-    return str(value or "").strip()
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _requests_collection():
+    db = get_database()
+    return db["link_requests"]
+
+
+def _household_links_collection():
+    db = get_database()
+    return db["household_links"]
+
+
+def _projects_collection():
+    db = get_database()
+    return db["projects"]
+
+
+def _enrich_request(document: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not document:
+        return None
+
+    source_summary = get_project_summary(str(document.get("source_project_id") or ""))
+    target_summary = get_project_summary(str(document.get("target_project_id") or ""))
+
+    result = dict(document)
+    if source_summary:
+        result["source_project_name"] = source_summary.get("project_name")
+        result["source_owner_email"] = source_summary.get("owner_email")
+        result["source_package_code"] = source_summary.get("package_code")
+        result["source_package_name"] = source_summary.get("package_name")
+        result["source_household_id"] = source_summary.get("household_id")
+    if target_summary:
+        result["target_project_name"] = target_summary.get("project_name")
+        result["target_owner_email"] = target_summary.get("owner_email")
+        result["target_package_code"] = target_summary.get("package_code")
+        result["target_package_name"] = target_summary.get("package_name")
+        result["target_household_id"] = target_summary.get("household_id")
+
+    return result
 
 
 def list_link_requests() -> list[dict]:
-    db = get_database()
-    if db is None:
+    cursor = _requests_collection().find().sort("created_at", -1)
+    return [item for item in (_enrich_request(doc) for doc in cursor) if item is not None]
+
+
+def list_link_requests_for_user(
+    user_id: str,
+    *,
+    project_id: str | None = None,
+    direction: str = "all",
+    status: str | None = None,
+) -> list[dict]:
+    if project_id:
+        if not user_can_access_project(project_id, user_id):
+            return []
+        owned_project_ids = [str(project_id)]
+    else:
+        owned_project_ids = list_owned_project_ids(user_id)
+
+    if not owned_project_ids:
         return []
 
-    return list(db.link_requests.find().sort("created_at", -1))
+    direction_value = str(direction or "all").strip().lower()
+    query: dict[str, Any] = {}
+
+    if direction_value == "incoming":
+        query["target_project_id"] = {"$in": owned_project_ids}
+    elif direction_value == "outgoing":
+        query["source_project_id"] = {"$in": owned_project_ids}
+    else:
+        query["$or"] = [
+            {"source_project_id": {"$in": owned_project_ids}},
+            {"target_project_id": {"$in": owned_project_ids}},
+        ]
+
+    if status:
+        query["status"] = str(status).strip().lower()
+
+    cursor = _requests_collection().find(query).sort("created_at", -1)
+    return [item for item in (_enrich_request(doc) for doc in cursor) if item is not None]
 
 
 def create_link_request(
     payload: LinkRequestCreate,
     *,
     requested_by: str,
-    requested_by_user_id: str | None = None,
+    requested_by_user_id: str,
 ) -> dict:
-    db = get_database()
-    data = payload.model_dump()
-    data["status"] = "pending"
-    data["requested_by"] = str(requested_by or "").strip() or "Unknown User"
-    data["requested_by_user_id"] = (
-        str(requested_by_user_id).strip() if requested_by_user_id else None
-    )
-    data["created_at"] = _utcnow_iso()
-    data["updated_at"] = data["created_at"]
+    source_project_id = str(payload.source_project_id or "").strip()
+    target_key = str(payload.target_key or "").strip()
 
-    if db is None:
-        data["_id"] = "local-link-request-preview"
-        return data
+    if not user_can_access_project(source_project_id, requested_by_user_id):
+        raise PermissionError("Not authorized to create a link request for this project.")
 
-    existing = db.link_requests.find_one(
+    if not project_supports_link_keys(source_project_id):
+        raise ValueError("Your package does not include link capabilities.")
+
+    source_project = get_project_summary(source_project_id)
+    if not source_project:
+        raise ValueError("Source project not found.")
+
+    source_key_doc = get_active_key_doc_for_project(source_project_id)
+    if source_key_doc is None:
+        raise ValueError("Generate a link key for your workspace before requesting a link.")
+
+    target_key_doc = get_key_doc_by_value(target_key)
+    if target_key_doc is None:
+        raise ValueError("Target link key was not found or is no longer active.")
+
+    target_project_id = str(target_key_doc.get("project_id") or "").strip()
+    if not target_project_id:
+        raise ValueError("Target link key is invalid.")
+
+    if source_project_id == target_project_id:
+        raise ValueError("You cannot link a project to itself.")
+
+    if not project_supports_link_keys(target_project_id):
+        raise ValueError("The target workspace does not support link capabilities.")
+
+    target_project = get_project_summary(target_project_id)
+    if not target_project:
+        raise ValueError("Target project not found.")
+
+    existing = _requests_collection().find_one(
         {
-            "source_household_id": data["source_household_id"],
-            "target_household_id": data["target_household_id"],
-            "source_key": data["source_key"],
-            "target_key": data["target_key"],
-            "status": "pending",
+            "status": {"$in": ["pending", "approved"]},
+            "$or": [
+                {
+                    "source_project_id": source_project_id,
+                    "target_project_id": target_project_id,
+                },
+                {
+                    "source_project_id": target_project_id,
+                    "target_project_id": source_project_id,
+                },
+            ],
         }
     )
     if existing is not None:
-        return existing
+        raise ValueError("A pending or approved link already exists between these workspaces.")
 
-    result = db.link_requests.insert_one(data)
+    data = {
+        "source_project_id": source_project_id,
+        "target_project_id": target_project_id,
+        "source_household_id": source_project.get("household_id"),
+        "target_household_id": target_project.get("household_id"),
+        "source_key": str(source_key_doc.get("key_value") or ""),
+        "target_key": str(target_key_doc.get("key_value") or ""),
+        "status": "pending",
+        "requested_by": str(requested_by or "").strip() or "Unknown User",
+        "requested_by_user_id": str(requested_by_user_id or "").strip(),
+        "notes": payload.notes,
+        "source_package_code": source_project.get("package_code"),
+        "source_package_name": source_project.get("package_name"),
+        "target_package_code": target_project.get("package_code"),
+        "target_package_name": target_project.get("package_name"),
+        "created_at": _utcnow_iso(),
+        "updated_at": _utcnow_iso(),
+    }
+
+    result = _requests_collection().insert_one(data)
     data["_id"] = result.inserted_id
-    return data
+    return _enrich_request(data) or data
 
 
 def get_link_request_by_id(request_id: str) -> dict | None:
-    db = get_database()
-    if db is None:
+    object_id = _to_object_id(request_id)
+    if object_id is None:
         return None
 
-    try:
-        return db.link_requests.find_one({"_id": ObjectId(request_id)})
-    except Exception:
-        return None
+    request = _requests_collection().find_one({"_id": object_id})
+    return _enrich_request(request)
+
+
+def _can_manage_request(request: dict[str, Any], user_id: str, *, side: str) -> bool:
+    source_project_id = str(request.get("source_project_id") or "")
+    target_project_id = str(request.get("target_project_id") or "")
+
+    if side == "source":
+        return user_can_access_project(source_project_id, user_id)
+    if side == "target":
+        return user_can_access_project(target_project_id, user_id)
+    return user_can_access_project(source_project_id, user_id) or user_can_access_project(
+        target_project_id, user_id
+    )
 
 
 def approve_link_request(
     request_id: str,
+    *,
     approved_by: str,
+    approver_user_id: str,
     approval_notes: str | None = None,
+    is_admin: bool = False,
 ) -> dict | None:
-    db = get_database()
-    if db is None:
+    object_id = _to_object_id(request_id)
+    if object_id is None:
         return None
 
-    try:
-      object_id = ObjectId(request_id)
-    except Exception:
-      return None
-
-    request = db.link_requests.find_one({"_id": object_id})
+    request = _requests_collection().find_one({"_id": object_id})
     if request is None:
         return None
 
-    db.link_requests.update_one(
+    if not is_admin and not _can_manage_request(request, approver_user_id, side="target"):
+        raise PermissionError("Not authorized to approve this link request.")
+
+    if str(request.get("status") or "").strip().lower() == "approved":
+        return _enrich_request(request)
+
+    now = _utcnow_iso()
+    _requests_collection().update_one(
         {"_id": object_id},
         {
             "$set": {
                 "status": "approved",
                 "approved_by": approved_by,
-                "approved_at": _utcnow_iso(),
+                "approved_at": now,
                 "approval_notes": approval_notes,
-                "updated_at": _utcnow_iso(),
+                "updated_at": now,
             }
         },
     )
 
-    existing_link = db.household_links.find_one(
-        {
-            "$or": [
-                {
-                    "source_household_id": request["source_household_id"],
-                    "target_household_id": request["target_household_id"],
-                },
-                {
-                    "source_household_id": request["target_household_id"],
-                    "target_household_id": request["source_household_id"],
-                },
-            ]
-        }
-    )
+    source_household_id = str(request.get("source_household_id") or "").strip()
+    target_household_id = str(request.get("target_household_id") or "").strip()
 
-    if existing_link is None:
-        household_link = {
-            "source_household_id": request["source_household_id"],
-            "target_household_id": request["target_household_id"],
-            "relationship_type": "linked_household",
-            "link_status": "approved",
-            "linked_by_key": request["source_key"],
-            "source_key": request["source_key"],
-            "target_key": request["target_key"],
-            "created_at": _utcnow_iso(),
-            "updated_at": _utcnow_iso(),
-        }
-        db.household_links.insert_one(household_link)
+    if source_household_id and target_household_id:
+        existing_link = _household_links_collection().find_one(
+            {
+                "$or": [
+                    {
+                        "source_household_id": source_household_id,
+                        "target_household_id": target_household_id,
+                    },
+                    {
+                        "source_household_id": target_household_id,
+                        "target_household_id": source_household_id,
+                    },
+                ]
+            }
+        )
 
-    return db.link_requests.find_one({"_id": object_id})
+        if existing_link is None:
+            _household_links_collection().insert_one(
+                {
+                    "source_household_id": source_household_id,
+                    "target_household_id": target_household_id,
+                    "relationship_type": "linked_household",
+                    "link_status": "approved",
+                    "linked_by_key": request.get("source_key"),
+                    "source_key": request.get("source_key"),
+                    "target_key": request.get("target_key"),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+    updated = _requests_collection().find_one({"_id": object_id})
+    return _enrich_request(updated)
 
 
 def reject_link_request(
     request_id: str,
+    *,
     rejected_by: str,
+    rejector_user_id: str,
     rejection_notes: str | None = None,
+    is_admin: bool = False,
 ) -> dict | None:
-    db = get_database()
-    if db is None:
+    object_id = _to_object_id(request_id)
+    if object_id is None:
         return None
 
-    try:
-        object_id = ObjectId(request_id)
-    except Exception:
-        return None
-
-    request = db.link_requests.find_one({"_id": object_id})
+    request = _requests_collection().find_one({"_id": object_id})
     if request is None:
         return None
 
-    db.link_requests.update_one(
+    if not is_admin and not _can_manage_request(request, rejector_user_id, side="target"):
+        raise PermissionError("Not authorized to reject this link request.")
+
+    current_status = str(request.get("status") or "").strip().lower()
+    if current_status == "approved":
+        raise ValueError("Approved links must be revoked, not rejected.")
+
+    now = _utcnow_iso()
+    _requests_collection().update_one(
         {"_id": object_id},
         {
             "$set": {
                 "status": "rejected",
                 "rejected_by": rejected_by,
-                "rejected_at": _utcnow_iso(),
+                "rejected_at": now,
                 "rejection_notes": rejection_notes,
-                "updated_at": _utcnow_iso(),
+                "updated_at": now,
             }
         },
     )
 
-    return db.link_requests.find_one({"_id": object_id})
+    updated = _requests_collection().find_one({"_id": object_id})
+    return _enrich_request(updated)
+
+
+def revoke_link_request(
+    request_id: str,
+    *,
+    revoked_by: str,
+    revoker_user_id: str,
+    revoke_notes: str | None = None,
+    is_admin: bool = False,
+) -> dict | None:
+    object_id = _to_object_id(request_id)
+    if object_id is None:
+        return None
+
+    request = _requests_collection().find_one({"_id": object_id})
+    if request is None:
+        return None
+
+    if not is_admin and not _can_manage_request(request, revoker_user_id, side="either"):
+        raise PermissionError("Not authorized to revoke this link request.")
+
+    current_status = str(request.get("status") or "").strip().lower()
+    if current_status not in {"pending", "approved"}:
+        raise ValueError("Only pending or approved link requests can be revoked.")
+
+    now = _utcnow_iso()
+    _requests_collection().update_one(
+        {"_id": object_id},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_by": revoked_by,
+                "revoked_at": now,
+                "revoke_notes": revoke_notes,
+                "updated_at": now,
+            }
+        },
+    )
+
+    source_household_id = str(request.get("source_household_id") or "").strip()
+    target_household_id = str(request.get("target_household_id") or "").strip()
+
+    if source_household_id and target_household_id:
+        _household_links_collection().delete_many(
+            {
+                "$or": [
+                    {
+                        "source_household_id": source_household_id,
+                        "target_household_id": target_household_id,
+                    },
+                    {
+                        "source_household_id": target_household_id,
+                        "target_household_id": source_household_id,
+                    },
+                ]
+            }
+        )
+
+    updated = _requests_collection().find_one({"_id": object_id})
+    return _enrich_request(updated)

--- a/backend/app/services/project_entitlement_service.py
+++ b/backend/app/services/project_entitlement_service.py
@@ -25,11 +25,14 @@ def _serialize(document: dict[str, Any] | None) -> dict[str, Any] | None:
     if not document:
         return None
 
+    resolved = document.get("resolved_entitlements") or {}
+
     return {
         "id": str(document.get("_id")),
         "project_id": document.get("project_id"),
         "user_id": document.get("user_id"),
         "package_code": document.get("package_code"),
+        "package_name": document.get("package_name") or resolved.get("display_name"),
         "package_lane": document.get("package_lane"),
         "active_addons": document.get("active_addons", []),
         "maintenance_plan": document.get("maintenance_plan"),
@@ -38,7 +41,7 @@ def _serialize(document: dict[str, Any] | None) -> dict[str, Any] | None:
         "maintenance_renews_at": document.get("maintenance_renews_at"),
         "delivered_at": document.get("delivered_at"),
         "status": document.get("status"),
-        "resolved_entitlements": document.get("resolved_entitlements", {}),
+        "resolved_entitlements": resolved,
         "created_at": document.get("created_at"),
         "updated_at": document.get("updated_at"),
     }
@@ -50,13 +53,16 @@ def _compute_maintenance_fields(
 ) -> tuple[str, datetime | None, datetime | None]:
     plan = str(maintenance_plan or "").strip().lower()
 
-    if plan in {"", "not_started", "pending_delivery", "unselected"} or delivered_at is None:
+    if (
+        plan in {"", "not_started", "pending_delivery", "unselected"}
+        or delivered_at is None
+    ):
         return "not_started", None, None
 
     if plan == "lifetime":
         return "active", delivered_at, None
 
-    if plan == "annual" or plan == "yearly":
+    if plan in {"annual", "yearly"}:
         return "active", delivered_at, delivered_at + timedelta(days=365)
 
     return "active", delivered_at, delivered_at + timedelta(days=30)
@@ -88,7 +94,8 @@ def upsert_project_entitlement(
     document: dict[str, Any] = {
         "project_id": project_id,
         "user_id": user_id,
-        "package_code": package_code,
+        "package_code": resolved.get("package_code") or package_code,
+        "package_name": resolved.get("display_name") or package_code,
         "package_lane": resolved.get("package_lane"),
         "active_addons": active_addons or [],
         "maintenance_plan": maintenance_plan,
@@ -126,9 +133,19 @@ def get_project_entitlement(project_id: str) -> dict[str, Any] | None:
     return _serialize(document)
 
 
-def list_user_project_entitlements(user_id: str) -> list[dict[str, Any]]:
+def list_user_project_entitlements(
+    user_id: str,
+    *,
+    active_only: bool = True,
+) -> list[dict[str, Any]]:
     collection = _collection()
-    cursor = collection.find({"user_id": user_id}).sort("updated_at", -1)
+
+    query: dict[str, Any] = {"user_id": user_id}
+    if active_only:
+        query["status"] = "active"
+
+    cursor = collection.find(query).sort("updated_at", -1)
+
     return [
         serialized
         for serialized in (_serialize(cast(dict[str, Any], document)) for document in cursor)

--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -35,40 +35,36 @@
       .replaceAll("'", "&#039;");
   }
 
-  function getInternalRoleKey(me) {
-    const role = normalizeValue(me && me.role);
-    const accessTier = normalizeValue(me && me.access_tier);
-    const departmentRole = normalizeValue(me && me.department_role);
+  function getRoleSignals(me) {
+    return [
+      normalizeValue(me && me.role),
+      normalizeValue(me && me.access_tier),
+      normalizeValue(me && me.department_role),
+    ].filter(Boolean);
+  }
 
-    return accessTier || departmentRole || role;
+  function getInternalRoleKey(me) {
+    const signals = getRoleSignals(me);
+    return (
+      signals.find(function (value) {
+        return INTERNAL_ROLE_KEYS.has(value);
+      }) || ""
+    );
   }
 
   function isInternalRole(me) {
-    const role = normalizeValue(me && me.role);
-    const accessTier = normalizeValue(me && me.access_tier);
-    const departmentRole = normalizeValue(me && me.department_role);
-
-    return [role, accessTier, departmentRole].some(function (value) {
-      return INTERNAL_ROLE_KEYS.has(value);
-    });
+    return Boolean(getInternalRoleKey(me));
   }
 
   function card(number, title, copy, href, buttonText) {
-    const action =
-      href && buttonText
-        ? `<div class="inline-actions" style="margin-top: 1rem;">
-             <a class="btn btn-primary" href="${escapeHtml(href)}">${escapeHtml(buttonText)}</a>
-           </div>`
-        : `<div class="inline-actions" style="margin-top: 1rem;">
-             <span class="btn btn-secondary" aria-disabled="true">Coming Next</span>
-           </div>`;
-
     return `
       <div class="family-record-card">
         <div class="card-number">${escapeHtml(number)}</div>
         <h3>${escapeHtml(title)}</h3>
         <p class="card-copy">${escapeHtml(copy)}</p>
-        ${action}
+        <div class="inline-actions" style="margin-top: 1rem;">
+          <a class="btn btn-primary" href="${escapeHtml(href)}">${escapeHtml(buttonText)}</a>
+        </div>
       </div>
     `;
   }
@@ -78,6 +74,7 @@
 
     if (roleKey === "root_admin") return "Company Root Control";
     if (roleKey === "super_admin") return "Executive Control";
+    if (roleKey === "admin") return "Administrative Control";
     if (roleKey === "operations_admin" || roleKey === "operations") {
       return "Operations Control";
     }
@@ -96,125 +93,31 @@
   function getRoleCards(me) {
     const roleKey = getInternalRoleKey(me);
 
-    if (["root_admin", "super_admin", "admin"].includes(roleKey)) {
+    if (
+      [
+        "root_admin",
+        "super_admin",
+        "admin",
+        "operations_admin",
+        "operations",
+        "platform_admin",
+        "executive_technology",
+      ].includes(roleKey)
+    ) {
       return [
         card(
           "A",
           "Intake Queue",
-          "Review submitted intake records, move them through approval, and provision build records.",
+          "Review submitted intake records, move them through approval, and provision package workspaces correctly by lane.",
           "admin-intake-queue.html",
           "Open Intake Queue",
         ),
         card(
           "B",
           "Family Manager",
-          "Load provisioned family roots, add members, and create lineage relationships without Mongo or Swagger.",
+          "Load real household and network family builds, add members, and manage lineage relationships in the live platform.",
           "admin-family-manager.html",
           "Open Family Manager",
-        ),
-        card(
-          "C",
-          "Operations Pipeline",
-          "Track approved submissions, build readiness, verification flow, and delivery progression.",
-          "",
-          "",
-        ),
-        card(
-          "D",
-          "Platform Control",
-          "Use system-level oversight for workflow governance, audit review, and environment control.",
-          "",
-          "",
-        ),
-        card(
-          "E",
-          "Marketing Intelligence",
-          "Review demand, conversion, and growth metrics without exposing protected customer lineage data.",
-          "",
-          "",
-        ),
-      ];
-    }
-
-    if (roleKey === "operations_admin" || roleKey === "operations") {
-      return [
-        card(
-          "A",
-          "Intake Queue",
-          "Review submitted onboarding records and move customer submissions through the review process.",
-          "admin-intake-queue.html",
-          "Open Intake Queue",
-        ),
-        card(
-          "B",
-          "Family Manager",
-          "Prepare provisioned family builds by adding members and wiring relationships in the live platform.",
-          "admin-family-manager.html",
-          "Open Family Manager",
-        ),
-      ];
-    }
-
-    if (roleKey === "platform_admin" || roleKey === "executive_technology") {
-      return [
-        card(
-          "A",
-          "Intake Queue",
-          "Access internal onboarding review workflow and troubleshoot intake state transitions.",
-          "admin-intake-queue.html",
-          "Open Intake Queue",
-        ),
-        card(
-          "B",
-          "Family Manager",
-          "Operate the live family build layer by loading provisioned families and managing lineage records.",
-          "admin-family-manager.html",
-          "Open Family Manager",
-        ),
-        card(
-          "C",
-          "Platform Tools",
-          "Platform health, operational debugging, and system-level workflow support.",
-          "",
-          "",
-        ),
-      ];
-    }
-
-    if (roleKey === "finance_admin" || roleKey === "finance") {
-      return [
-        card(
-          "A",
-          "Finance Oversight",
-          "Track orders, package activation, payment truth, and customer billing checkpoints.",
-          "",
-          "",
-        ),
-        card(
-          "B",
-          "Revenue View",
-          "Use finance-specific reporting without exposing protected family lineage content.",
-          "",
-          "",
-        ),
-      ];
-    }
-
-    if (roleKey === "marketing_admin" || roleKey === "marketing") {
-      return [
-        card(
-          "A",
-          "Marketing Intelligence",
-          "View conversion-level business insight and campaign-facing reporting without exposing private customer lineage records.",
-          "",
-          "",
-        ),
-        card(
-          "B",
-          "Growth Oversight",
-          "Prepare future campaign, funnel, and acquisition visibility inside a controlled internal environment.",
-          "",
-          "",
         ),
       ];
     }
@@ -228,6 +131,22 @@
       .forEach(function (node) {
         node.style.display = "none";
       });
+  }
+
+  function hideCustomerNavItems() {
+    [
+      'a[href="intake-review.html"]',
+      'a[href="verification-upload.html"]',
+      'a[href="link-keys.html"]',
+      'a[href="tree-view.html"]',
+      'a[href="lineage-certificate.html"]',
+    ].forEach(function (selector) {
+      document
+        .querySelectorAll(`.site-nav ${selector}`)
+        .forEach(function (node) {
+          node.style.display = "none";
+        });
+    });
   }
 
   function updateHeroForInternal() {
@@ -246,7 +165,9 @@
   function injectAdminPanel(me) {
     const anchor = document.querySelector("[data-admin-portal-anchor]");
     if (!anchor) return;
-    if (document.querySelector("[data-admin-tools-panel]")) return;
+
+    const existing = document.querySelector("[data-admin-tools-panel]");
+    if (existing) existing.remove();
 
     if (!isInternalRole(me)) return;
 
@@ -254,16 +175,17 @@
     panel.className = "form-panel";
     panel.setAttribute("data-admin-tools-panel", "true");
 
-    const cards = getRoleCards(me).join("");
+    const cards = getRoleCards(me);
+    const cardsMarkup = cards.length
+      ? `<div class="grid-3">${cards.join("")}</div>`
+      : `<p class="card-copy">No dedicated browser-based tools are currently published for this internal role.</p>`;
 
     panel.innerHTML = `
       <span class="eyebrow">${escapeHtml(getRoleTitle(me))}</span>
       <p class="card-copy" style="margin-bottom: 1.25rem;">
         This internal workspace is reserved for authorized Tomb of Light operational roles and is separate from the public customer workspace.
       </p>
-      <div class="grid-3">
-        ${cards}
-      </div>
+      ${cardsMarkup}
     `;
 
     anchor.prepend(panel);
@@ -278,6 +200,7 @@
 
       if (isInternalRole(me)) {
         hideCustomerPanels();
+        hideCustomerNavItems();
         updateHeroForInternal();
         injectAdminPanel(me);
       }

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -141,6 +141,7 @@
 
   function updateBuildPathPanel(config) {
     const panel =
+      findPanelByText("Your Build Path") ||
       findPanelByText("Your Family Build Path") ||
       findPanelByText("Your Portrait Workflow") ||
       findPanelByText("Your Command Build Path") ||
@@ -183,23 +184,42 @@
     );
   }
 
-  function getLaneConfig(packageLane) {
-    const lane = normalizeValue(packageLane);
+  function getEntitlementConfig(context) {
+    const resolved = context?.resolvedEntitlements || {};
+    const lane = normalizeValue(context?.packageLane || resolved?.package_lane);
+    const packageName = context?.packageName || "Active Package";
+
+    const canBuildFamilyTree = Boolean(resolved.can_build_family_tree);
+    const canUseCertificate = Boolean(resolved.can_use_lineage_certificate);
+    const canUploadRecords = Boolean(
+      resolved.can_upload_verification_docs || resolved.can_upload_portraits,
+    );
+    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
+    const canOpenFamilyIntake = Boolean(resolved.can_open_family_intake);
+    const canOpenOrgIntake = Boolean(resolved.can_open_org_intake);
 
     if (lane === "portrait") {
       return {
         lane: "portrait",
         presenceBadge: "Portrait Lane Active",
         presenceTitle: "Your portrait workspace is live and connected.",
-        presenceCopy:
-          "Tomb of Light is now reading from your portrait package, uploads, and verification records. This workspace is focused on your personal legacy build.",
+        presenceCopy: canUseLinkKeys
+          ? "Tomb of Light is now reading from your portrait package, uploads, verification records, and link capabilities."
+          : "Tomb of Light is now reading from your portrait package, uploads, and verification records.",
         stages: [
           { title: "Portrait Record", subtitle: "Connected" },
-          { title: "Verification", subtitle: "Upload Ready" },
-          { title: "Delivery Path", subtitle: "Preparing" },
+          {
+            title: "Verification",
+            subtitle: canUploadRecords ? "Upload Ready" : "Locked",
+          },
+          {
+            title: "Link Capabilities",
+            subtitle: canUseLinkKeys ? "Enabled" : "Unavailable",
+          },
         ],
-        workspaceCopy:
-          "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your portrait workspace connects package access, portrait uploads, verification records, guided delivery, and link capabilities in one place."
+          : "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
         primaryActionText: "Upload Portrait & Records",
         primaryActionHref: "verification-upload.html",
         secondaryActionText: "Verification Uploads",
@@ -221,13 +241,16 @@
             copy: "Upload IDs and supporting records that help verify the portrait record.",
           },
           {
-            title: "Delivery & Upgrade Path",
-            copy: "Receive your portrait package and upgrade to a household package whenever you are ready.",
+            title: "Delivery, Linking & Upgrade Path",
+            copy: canUseLinkKeys
+              ? "Receive your portrait package, use link capabilities, and upgrade whenever you are ready."
+              : "Receive your portrait package and upgrade whenever you are ready.",
           },
         ],
         platformStatusTitle: "Entitled Tools",
-        platformStatusCopy:
-          "This portrait lane includes portrait uploads and verification workflows. Household build tools require an upgrade.",
+        platformStatusCopy: canUseLinkKeys
+          ? "This portrait lane includes portrait uploads, verification workflows, and link capabilities. Household build tools require an upgrade."
+          : "This portrait lane includes portrait uploads and verification workflows. Household build tools require an upgrade.",
         upgradeText: "Upgrade to Household Package",
         upgradeHref: "index.html#pricing",
       };
@@ -239,15 +262,23 @@
         presenceBadge: "Organization Lane Active",
         presenceTitle:
           "Your command structure workspace is live and connected.",
-        presenceCopy:
-          "Tomb of Light is now reading from your organization package, role structure scope, and supporting record workflow.",
+        presenceCopy: canUseLinkKeys
+          ? "Tomb of Light is now reading from your organization package, role structure scope, supporting record workflow, and link capabilities."
+          : "Tomb of Light is now reading from your organization package, role structure scope, and supporting record workflow.",
         stages: [
           { title: "Organization Root", subtitle: "Connected" },
-          { title: "Structure Build", subtitle: "Configured" },
-          { title: "Command Outputs", subtitle: "Preparing" },
+          {
+            title: "Structure Build",
+            subtitle: canOpenOrgIntake ? "Configured" : "Prepared",
+          },
+          {
+            title: "Link Capabilities",
+            subtitle: canUseLinkKeys ? "Enabled" : "Unavailable",
+          },
         ],
-        workspaceCopy:
-          "Your organization workspace connects package access, command structure planning, uploads, and guided record handling in one place.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your organization workspace connects package access, command structure planning, uploads, and link capabilities in one place."
+          : "Your organization workspace connects package access, command structure planning, uploads, and guided record handling in one place.",
         primaryActionText: "Upload Structure Records",
         primaryActionHref: "verification-upload.html",
         secondaryActionText: "Upload Structure Records",
@@ -269,13 +300,16 @@
             copy: "Add leadership roles, officers, or command nodes as the structure expands.",
           },
           {
-            title: "Supporting Records",
-            copy: "Upload supporting records and materials tied to the organization build.",
+            title: "Supporting Records & Expansion",
+            copy: canUseLinkKeys
+              ? "Upload supporting materials, use link capabilities, and expand the structure when needed."
+              : "Upload supporting records and materials tied to the organization build.",
           },
         ],
         platformStatusTitle: "Entitled Tools",
-        platformStatusCopy:
-          "This organization lane includes structure and verification workflows. Expansion options are available if you need more scope.",
+        platformStatusCopy: canUseLinkKeys
+          ? "This organization lane includes structure workflows, verification uploads, and link capabilities."
+          : "This organization lane includes structure and verification workflows. Expansion options are available if you need more scope.",
         upgradeText: "View Expansion Options",
         upgradeHref: "index.html#pricing",
       };
@@ -286,25 +320,33 @@
         lane: "network",
         presenceBadge: "Network Lane Active",
         presenceTitle: "Your network workspace is live and connected.",
-        presenceCopy:
-          "Tomb of Light is now reading from your branch network package, household connections, and expanded lineage workflow.",
+        presenceCopy: canUseLinkKeys
+          ? "Tomb of Light is now reading from your branch network package, household connections, lineage workflow, and link capabilities."
+          : "Tomb of Light is now reading from your branch network package, household connections, and expanded lineage workflow.",
         stages: [
           { title: "Branch Root", subtitle: "Connected" },
-          { title: "Network Build", subtitle: "Build Ready" },
-          { title: "Living Outputs", subtitle: "Tree + Certificate Live" },
+          {
+            title: "Network Build",
+            subtitle: canBuildFamilyTree ? "Build Ready" : "Prepared",
+          },
+          {
+            title: "Living Outputs",
+            subtitle: canUseCertificate ? "Tree + Certificate Live" : "Live",
+          },
         ],
-        workspaceCopy:
-          "Your network workspace connects package access, linked branches, lineage structure, and verification records in one place.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your network workspace connects package access, linked branches, lineage structure, verification records, and link capabilities in one place."
+          : "Your network workspace connects package access, linked branches, lineage structure, and verification records in one place.",
         primaryActionText: "Continue Network Build",
         primaryActionHref: "tree-view.html",
         secondaryActionText: "Upload Verification Docs",
         secondaryActionHref: "verification-upload.html",
-        showTree: true,
-        showCertificate: true,
+        showTree: canBuildFamilyTree,
+        showCertificate: canUseCertificate,
         showVerification: true,
-        navTree: true,
-        navCertificate: true,
-        navIntake: true,
+        navTree: canBuildFamilyTree,
+        navCertificate: canUseCertificate,
+        navIntake: canOpenFamilyIntake,
         buildPathEyebrow: "Your Network Build Path",
         buildSteps: [
           {
@@ -316,13 +358,16 @@
             copy: "Add linked households, branches, and connected lineage structures over time.",
           },
           {
-            title: "Verification Evidence",
-            copy: "Upload IDs, certificates, and supporting family records for the network build.",
+            title: "Verification, Delivery & Linking",
+            copy: canUseLinkKeys
+              ? "Upload supporting records, continue delivery, and use link capabilities across the network."
+              : "Upload IDs, certificates, and supporting family records for the network build.",
           },
         ],
         platformStatusTitle: "Entitled Tools",
-        platformStatusCopy:
-          "This network lane includes branch, lineage, and verification workflows.",
+        platformStatusCopy: canUseLinkKeys
+          ? "This network lane includes branch, lineage, verification, certificate, and link workflows."
+          : "This network lane includes branch, lineage, and verification workflows.",
         upgradeText: "View Expansion Options",
         upgradeHref: "index.html#pricing",
       };
@@ -332,25 +377,33 @@
       lane: "household",
       presenceBadge: "Household Lane Active",
       presenceTitle: "Your lineage workspace is live and connected.",
-      presenceCopy:
-        "Tomb of Light is now reading from your household package, family structure, project records, and verification workflow. This workspace is designed to grow as your family grows.",
+      presenceCopy: canUseLinkKeys
+        ? "Tomb of Light is now reading from your household package, family structure, verification workflow, and link capabilities."
+        : "Tomb of Light is now reading from your household package, family structure, project records, and verification workflow.",
       stages: [
         { title: "Family Root", subtitle: "Connected" },
-        { title: "Production Build", subtitle: "Build Ready" },
-        { title: "Living Outputs", subtitle: "Tree + Certificate Live" },
+        {
+          title: "Production Build",
+          subtitle: canBuildFamilyTree ? "Build Ready" : "Prepared",
+        },
+        {
+          title: "Living Outputs",
+          subtitle: canUseCertificate ? "Tree + Certificate Live" : "Live",
+        },
       ],
-      workspaceCopy:
-        "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, and document-backed verification in one place.",
+      workspaceCopy: canUseLinkKeys
+        ? "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, verification, and link capabilities in one place."
+        : "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, and document-backed verification in one place.",
       primaryActionText: "Continue Family Build",
       primaryActionHref: "tree-view.html",
       secondaryActionText: "Upload Verification Docs",
       secondaryActionHref: "verification-upload.html",
-      showTree: true,
-      showCertificate: true,
+      showTree: canBuildFamilyTree,
+      showCertificate: canUseCertificate,
       showVerification: true,
-      navTree: true,
-      navCertificate: true,
-      navIntake: true,
+      navTree: canBuildFamilyTree,
+      navCertificate: canUseCertificate,
+      navIntake: canOpenFamilyIntake,
       buildPathEyebrow: "Your Family Build Path",
       buildSteps: [
         {
@@ -362,32 +415,41 @@
           copy: "Add parents, spouses, children, and connected branches over time.",
         },
         {
-          title: "Verification Evidence",
-          copy: "Upload IDs, birth certificates, marriage records, adoption records, and supporting family documents for review.",
+          title: "Verification, Delivery & Linking",
+          copy: canUseLinkKeys
+            ? "Upload supporting family documents, continue delivery, and use link capabilities as included in your package."
+            : "Upload IDs, birth certificates, marriage records, adoption records, and supporting family documents for review.",
         },
       ],
       platformStatusTitle: "Entitled Tools",
-      platformStatusCopy:
-        "Family build tools and verification workflows are active for this household lane package.",
+      platformStatusCopy: canUseLinkKeys
+        ? "Family build tools, verification workflows, certificate access, and link capabilities are active for this package."
+        : "Family build tools and verification workflows are active for this household lane package.",
       upgradeText: "View Add-Ons & Upgrades",
       upgradeHref: "index.html#pricing",
     };
   }
 
-  function getLaneAwareIntakeMessages(lane, status) {
-    const normalizedLane = normalizeValue(lane);
+  function getLaneAwareIntakeMessages(context, status) {
+    const resolved = context?.resolvedEntitlements || {};
+    const normalizedLane = normalizeValue(
+      context?.packageLane || resolved.package_lane,
+    );
     const normalizedStatus = normalizeStatus(status);
+    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
 
     if (normalizedLane === "portrait") {
       if (normalizedStatus === "build_ready") {
         return {
-          cardCopy:
-            "Your portrait package is approved and ready for portrait and verification work.",
+          cardCopy: canUseLinkKeys
+            ? "Your portrait package is approved and ready for portrait, verification, and link-enabled work."
+            : "Your portrait package is approved and ready for portrait and verification work.",
           nextStep: "Upload portrait and supporting verification records.",
           lockNote:
             "Editing is locked because this portrait package has already been approved and provisioned.",
-          workspaceCopy:
-            "Your portrait intake has been approved and provisioned. This workspace now moves from onboarding into the portrait record stage.",
+          workspaceCopy: canUseLinkKeys
+            ? "Your portrait intake has been approved and provisioned. This workspace now moves into the portrait record stage with link capabilities available."
+            : "Your portrait intake has been approved and provisioned. This workspace now moves from onboarding into the portrait record stage.",
         };
       }
 
@@ -395,22 +457,25 @@
         cardCopy: "Your portrait intake information is shown below.",
         nextStep: "Upload portrait and supporting verification records.",
         lockNote: "Intake lock state is based on your current review status.",
-        workspaceCopy:
-          "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your portrait workspace connects package access, portrait uploads, verification records, guided delivery, and link capabilities in one place."
+          : "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
       };
     }
 
     if (normalizedLane === "organization") {
       if (normalizedStatus === "build_ready") {
         return {
-          cardCopy:
-            "Your organization package is approved and ready for structure and record work.",
+          cardCopy: canUseLinkKeys
+            ? "Your organization package is approved and ready for structure, record, and link-enabled work."
+            : "Your organization package is approved and ready for structure and record work.",
           nextStep:
             "Upload leadership, structure, and supporting records to continue.",
           lockNote:
             "Editing is locked because this organization package has already been approved and provisioned.",
-          workspaceCopy:
-            "Your organization intake has been approved and provisioned. This workspace now moves into the command structure stage.",
+          workspaceCopy: canUseLinkKeys
+            ? "Your organization intake has been approved and provisioned. This workspace now moves into the command structure stage with link capabilities available."
+            : "Your organization intake has been approved and provisioned. This workspace now moves into the command structure stage.",
         };
       }
 
@@ -418,34 +483,39 @@
         cardCopy: "Your organization intake information is shown below.",
         nextStep: "Upload structure and supporting records to continue.",
         lockNote: "Intake lock state is based on your current review status.",
-        workspaceCopy:
-          "Your organization workspace connects package access, command structure planning, uploads, and guided record handling in one place.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your organization workspace connects package access, command structure planning, uploads, and link capabilities in one place."
+          : "Your organization workspace connects package access, command structure planning, uploads, and guided record handling in one place.",
       };
     }
 
     if (normalizedLane === "network" && normalizedStatus === "build_ready") {
       return {
-        cardCopy:
-          "Your network intake has been approved and provisioned for production.",
+        cardCopy: canUseLinkKeys
+          ? "Your network intake has been approved and provisioned for production with link capabilities active."
+          : "Your network intake has been approved and provisioned for production.",
         nextStep:
           "Production records are created. Next step is building branches and linked households.",
         lockNote:
           "Editing is locked because this network project has already been approved and provisioned.",
-        workspaceCopy:
-          "Your network intake has been approved and provisioned. This workspace now moves into connected branch and household build.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your network intake has been approved and provisioned. This workspace now moves into connected branch, household build, and link-enabled operation."
+          : "Your network intake has been approved and provisioned. This workspace now moves into connected branch and household build.",
       };
     }
 
     if (normalizedStatus === "build_ready") {
       return {
-        cardCopy:
-          "Your intake has been approved and provisioned for production.",
+        cardCopy: canUseLinkKeys
+          ? "Your intake has been approved and provisioned for production with link capabilities active."
+          : "Your intake has been approved and provisioned for production.",
         nextStep:
           "Production records are created. Next step is building members and relationships.",
         lockNote:
           "Editing is locked. This intake has already been approved and provisioned.",
-        workspaceCopy:
-          "Your intake has been approved and provisioned. This workspace now moves from onboarding into the real family build stage.",
+        workspaceCopy: canUseLinkKeys
+          ? "Your intake has been approved and provisioned. This workspace now moves from onboarding into the real family build stage with link capabilities available."
+          : "Your intake has been approved and provisioned. This workspace now moves from onboarding into the real family build stage.",
       };
     }
 
@@ -453,8 +523,9 @@
       cardCopy: "Your most recent intake submission is shown below.",
       nextStep: "Continue and finalize your intake.",
       lockNote: "Editing is still open until final submission.",
-      workspaceCopy:
-        "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, and document-backed verification in one place.",
+      workspaceCopy: canUseLinkKeys
+        ? "Your Tomb of Light customer workspace connects package access, onboarding, lineage tools, and link capabilities in one place."
+        : "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, and document-backed verification in one place.",
     };
   }
 
@@ -571,8 +642,30 @@
     }
   }
 
-  function updatePrimaryIntakeAction(status, actionNode) {
+  function updatePrimaryIntakeAction(context, status, actionNode) {
     if (!actionNode) return;
+
+    const resolved = context?.resolvedEntitlements || {};
+    const lane = normalizeValue(context?.packageLane || resolved.package_lane);
+    const canOpenFamilyIntake = Boolean(resolved.can_open_family_intake);
+    const canOpenOrgIntake = Boolean(resolved.can_open_org_intake);
+
+    if (lane === "portrait") {
+      actionNode.textContent = "Upload Portrait & Records";
+      actionNode.setAttribute("href", "verification-upload.html");
+      return;
+    }
+
+    if (lane === "organization") {
+      actionNode.textContent = "Upload Structure Records";
+      actionNode.setAttribute("href", "verification-upload.html");
+      return;
+    }
+
+    if (!canOpenFamilyIntake && !canOpenOrgIntake) {
+      actionNode.style.display = "none";
+      return;
+    }
 
     const normalized = normalizeStatus(status);
 
@@ -635,11 +728,11 @@
           )
         : null);
 
-    if (!context || !context.hasPaidPackage) {
+    if (!context || !context.hasPackageAccess) {
       return;
     }
 
-    const config = getLaneConfig(context.packageLane);
+    const config = getEntitlementConfig(context);
     updateLaneUi(context, config);
 
     const intakeCardStatus = document.querySelector(
@@ -688,22 +781,13 @@
         );
 
         if (openAction) {
-          if (config.lane === "portrait") {
-            openAction.textContent = "Upload Portrait & Records";
-            openAction.setAttribute("href", "verification-upload.html");
-          } else if (config.lane === "organization") {
-            openAction.textContent = "Upload Structure Records";
-            openAction.setAttribute("href", "verification-upload.html");
-          } else {
-            openAction.textContent = "Open Intake";
-            openAction.setAttribute("href", "intake-welcome.html");
-          }
+          updatePrimaryIntakeAction(context, "", openAction);
         }
       } else {
         const status = normalizeStatus(
           latest.status || latest.submission_status,
         );
-        const laneMessages = getLaneAwareIntakeMessages(config.lane, status);
+        const laneMessages = getLaneAwareIntakeMessages(context, status);
 
         text(intakeCardStatus, laneMessages.cardCopy);
         text(statusBadge, humanizeStatus(status));
@@ -714,15 +798,7 @@
         text(workspaceCopy, laneMessages.workspaceCopy);
 
         if (openAction) {
-          if (config.lane === "portrait") {
-            openAction.textContent = "Upload Portrait & Records";
-            openAction.setAttribute("href", "verification-upload.html");
-          } else if (config.lane === "organization") {
-            openAction.textContent = "Upload Structure Records";
-            openAction.setAttribute("href", "verification-upload.html");
-          } else {
-            updatePrimaryIntakeAction(status, openAction);
-          }
+          updatePrimaryIntakeAction(context, status, openAction);
         }
       }
 

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -227,9 +227,11 @@
         showTree: false,
         showCertificate: false,
         showVerification: true,
+        showLinkKeys: canUseLinkKeys,
         navTree: false,
         navCertificate: false,
         navIntake: false,
+        navLinkKeys: canUseLinkKeys,
         buildPathEyebrow: "Your Portrait Workflow",
         buildSteps: [
           {
@@ -286,9 +288,11 @@
         showTree: false,
         showCertificate: false,
         showVerification: true,
+        showLinkKeys: canUseLinkKeys,
         navTree: false,
         navCertificate: false,
         navIntake: false,
+        navLinkKeys: canUseLinkKeys,
         buildPathEyebrow: "Your Command Build Path",
         buildSteps: [
           {
@@ -344,9 +348,11 @@
         showTree: canBuildFamilyTree,
         showCertificate: canUseCertificate,
         showVerification: true,
+        showLinkKeys: canUseLinkKeys,
         navTree: canBuildFamilyTree,
         navCertificate: canUseCertificate,
         navIntake: canOpenFamilyIntake,
+        navLinkKeys: canUseLinkKeys,
         buildPathEyebrow: "Your Network Build Path",
         buildSteps: [
           {
@@ -401,9 +407,11 @@
       showTree: canBuildFamilyTree,
       showCertificate: canUseCertificate,
       showVerification: true,
+      showLinkKeys: canUseLinkKeys,
       navTree: canBuildFamilyTree,
       navCertificate: canUseCertificate,
       navIntake: canOpenFamilyIntake,
+      navLinkKeys: canUseLinkKeys,
       buildPathEyebrow: "Your Family Build Path",
       buildSteps: [
         {
@@ -538,6 +546,7 @@
     applyNavVisibility("lineage-certificate.html", config.navCertificate);
     applyNavVisibility("intake-review.html", config.navIntake);
     applyNavVisibility("verification-upload.html", config.showVerification);
+    applyNavVisibility("link-keys.html", config.navLinkKeys);
 
     applyAction(
       "[data-dashboard-workspace-primary-action], [data-dashboard-package-primary-action]",
@@ -556,6 +565,12 @@
         show: config.showVerification,
       },
     );
+
+    applyAction("[data-dashboard-link-keys-action]", {
+      text: "Open Link Keys",
+      href: "link-keys.html",
+      show: config.showLinkKeys,
+    });
 
     applyAction(
       '[data-dashboard-workspace-tree-action], a[href="tree-view.html"][data-paid-action]',

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard | Tomb of Light</title>
     <meta name="description" content="Your Tomb of Light dashboard." />
-    <link rel="stylesheet" href="styles.css?v=20260328-6" />
+    <link rel="stylesheet" href="styles.css?v=20260328-7" />
   </head>
   <body>
     <div class="page-wrap">
@@ -31,6 +31,7 @@
             <a href="verification-upload.html" style="display: none"
               >Verification Uploads</a
             >
+            <a href="link-keys.html" style="display: none">Link Keys</a>
             <a href="tree-view.html" style="display: none">Family Tree</a>
             <a href="lineage-certificate.html" style="display: none"
               >Lineage Certificate</a
@@ -50,9 +51,9 @@
         <section class="page-hero dashboard-hero">
           <div class="container">
             <div class="page-hero-panel dashboard-hero-panel">
-              <span class="eyebrow" data-dashboard-hero-eyebrow
-                >Portal Access</span
-              >
+              <span class="eyebrow" data-dashboard-hero-eyebrow>
+                Portal Access
+              </span>
               <h1 data-dashboard-hero-title>Your Workspace</h1>
               <p data-dashboard-status>Loading your account...</p>
             </div>
@@ -129,6 +130,15 @@
                 </a>
                 <a
                   class="btn btn-secondary"
+                  href="link-keys.html"
+                  data-dashboard-link-keys-action
+                  data-paid-action
+                  style="display: none"
+                >
+                  Open Link Keys
+                </a>
+                <a
+                  class="btn btn-secondary"
                   href="lineage-certificate.html"
                   data-dashboard-workspace-certificate-action
                   data-paid-action
@@ -190,6 +200,15 @@
                 </a>
                 <a
                   class="btn btn-secondary"
+                  href="link-keys.html"
+                  data-dashboard-link-keys-action
+                  data-paid-action
+                  style="display: none"
+                >
+                  Open Link Keys
+                </a>
+                <a
+                  class="btn btn-secondary"
                   href="lineage-certificate.html"
                   data-dashboard-workspace-certificate-action
                   data-paid-action
@@ -223,6 +242,15 @@
                   style="display: none"
                 >
                   Upload Verification Docs
+                </a>
+                <a
+                  class="btn btn-secondary"
+                  href="link-keys.html"
+                  data-dashboard-link-keys-action
+                  data-paid-action
+                  style="display: none"
+                >
+                  Open Link Keys
                 </a>
                 <a
                   class="btn btn-secondary"
@@ -347,8 +375,8 @@
                   <div class="card-number">2</div>
                   <h3>Records and Structure</h3>
                   <p class="card-copy">
-                    Upload, verification, lineage, and structure features appear
-                    only when they are included in your package.
+                    Upload, verification, lineage, structure, and link features
+                    appear only when they are included in your package.
                   </p>
                 </div>
                 <div>
@@ -384,8 +412,8 @@
                   <div class="card-number">C</div>
                   <h3>Package Access</h3>
                   <p class="card-copy">
-                    Package access, uploads, intake, and lineage tools are
-                    controlled by your active entitlement.
+                    Package access, uploads, intake, lineage tools, and link
+                    capabilities are controlled by your active entitlement.
                   </p>
                 </div>
               </div>
@@ -405,10 +433,10 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260328-6"></script>
-    <script src="app.js?v=20260328-6"></script>
-    <script src="auth.js?v=20260328-6"></script>
-    <script src="dashboard-intake.js?v=20260328-6"></script>
-    <script src="dashboard-admin.js?v=20260328-6"></script>
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260328-7"></script>
+    <script src="auth.js?v=20260328-7"></script>
+    <script src="dashboard-intake.js?v=20260328-7"></script>
+    <script src="dashboard-admin.js?v=20260328-7"></script>
   </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard | Tomb of Light</title>
     <meta name="description" content="Your Tomb of Light dashboard." />
-    <link rel="stylesheet" href="styles.css?v=20260325-6" />
+    <link rel="stylesheet" href="styles.css?v=20260328-6" />
   </head>
   <body>
     <div class="page-wrap">
@@ -27,10 +27,14 @@
 
           <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html" aria-current="page">Dashboard</a>
-            <a href="intake-review.html">My Intake</a>
-            <a href="verification-upload.html">Verification Uploads</a>
-            <a href="tree-view.html">Family Tree</a>
-            <a href="lineage-certificate.html">Lineage Certificate</a>
+            <a href="intake-review.html" style="display: none">My Intake</a>
+            <a href="verification-upload.html" style="display: none"
+              >Verification Uploads</a
+            >
+            <a href="tree-view.html" style="display: none">Family Tree</a>
+            <a href="lineage-certificate.html" style="display: none"
+              >Lineage Certificate</a
+            >
             <a href="faq.html">Help</a>
           </nav>
 
@@ -46,9 +50,9 @@
         <section class="page-hero dashboard-hero">
           <div class="container">
             <div class="page-hero-panel dashboard-hero-panel">
-              <span class="eyebrow" data-dashboard-hero-eyebrow>
-                Portal Access
-              </span>
+              <span class="eyebrow" data-dashboard-hero-eyebrow
+                >Portal Access</span
+              >
               <h1 data-dashboard-hero-title>Your Workspace</h1>
               <p data-dashboard-status>Loading your account...</p>
             </div>
@@ -66,42 +70,41 @@
               data-dashboard-customer-only
             >
               <div class="dashboard-presence-top">
-                <span class="eyebrow">Live Build Status</span>
-                <span class="presence-badge">Digital Lineage Active</span>
+                <span class="eyebrow">Workspace Status</span>
+                <span class="presence-badge">Preparing Workspace</span>
               </div>
 
               <h2 class="dashboard-presence-title">
-                Your lineage workspace is live and connected.
+                Your workspace is loading.
               </h2>
 
               <p class="dashboard-presence-copy">
-                Tomb of Light is now reading from your real family, household,
-                project, family tree, and certificate records. This portal is
-                designed to grow as your family grows.
+                Tomb of Light is resolving the exact tools, limits, and
+                workflows attached to your active package.
               </p>
 
               <div class="workspace-stage-strip">
                 <div class="workspace-stage-node is-live">
                   <span class="workspace-stage-dot"></span>
                   <div>
-                    <strong>Family Root</strong>
-                    <small>Connected</small>
+                    <strong>Package Access</strong>
+                    <small>Resolving</small>
                   </div>
                 </div>
 
                 <div class="workspace-stage-node is-live">
                   <span class="workspace-stage-dot"></span>
                   <div>
-                    <strong>Production Build</strong>
-                    <small>Build Ready</small>
+                    <strong>Feature Scope</strong>
+                    <small>Checking</small>
                   </div>
                 </div>
 
                 <div class="workspace-stage-node is-live">
                   <span class="workspace-stage-dot"></span>
                   <div>
-                    <strong>Living Outputs</strong>
-                    <small>Tree + Certificate Live</small>
+                    <strong>Next Step</strong>
+                    <small>Preparing</small>
                   </div>
                 </div>
               </div>
@@ -109,16 +112,18 @@
               <div class="inline-actions" style="margin-top: 1.5rem">
                 <a
                   class="btn btn-primary"
-                  href="tree-view.html"
+                  href="verification-upload.html"
                   data-dashboard-workspace-primary-action
                   data-paid-action
+                  style="display: none"
                 >
-                  Continue Family Build
+                  Open Workspace
                 </a>
                 <a
                   class="btn btn-secondary"
                   href="verification-upload.html"
                   data-paid-action
+                  style="display: none"
                 >
                   Upload Verification Docs
                 </a>
@@ -127,6 +132,7 @@
                   href="lineage-certificate.html"
                   data-dashboard-workspace-certificate-action
                   data-paid-action
+                  style="display: none"
                 >
                   View Lineage Certificate
                 </a>
@@ -159,24 +165,26 @@
             <div class="form-panel" data-dashboard-customer-only>
               <span class="eyebrow">Customer Workspace</span>
               <p class="card-copy" data-dashboard-workspace-copy>
-                Your Tomb of Light customer workspace connects package access,
-                onboarding, family structure, lineage tools, and document-backed
-                verification in one place.
+                Your Tomb of Light customer workspace loads the exact package
+                access, onboarding, uploads, lineage tools, and verification
+                features attached to your account.
               </p>
 
               <div class="inline-actions" style="margin-top: 1.5rem">
                 <a
                   class="btn btn-primary"
-                  href="tree-view.html"
+                  href="verification-upload.html"
                   data-dashboard-workspace-primary-action
                   data-paid-action
+                  style="display: none"
                 >
-                  Continue Family Build
+                  Open Workspace
                 </a>
                 <a
                   class="btn btn-secondary"
                   href="verification-upload.html"
                   data-paid-action
+                  style="display: none"
                 >
                   Verification Uploads
                 </a>
@@ -185,6 +193,7 @@
                   href="lineage-certificate.html"
                   data-dashboard-workspace-certificate-action
                   data-paid-action
+                  style="display: none"
                 >
                   View Lineage Certificate
                 </a>
@@ -200,16 +209,18 @@
               <div class="inline-actions" style="margin-top: 1.5rem">
                 <a
                   class="btn btn-primary"
-                  href="tree-view.html"
+                  href="verification-upload.html"
                   data-dashboard-package-primary-action
                   data-paid-action
+                  style="display: none"
                 >
-                  Continue Family Build
+                  Open Workspace
                 </a>
                 <a
                   class="btn btn-secondary"
                   href="verification-upload.html"
                   data-paid-action
+                  style="display: none"
                 >
                   Upload Verification Docs
                 </a>
@@ -217,6 +228,7 @@
                   class="btn btn-secondary"
                   href="lineage-certificate.html"
                   data-paid-action
+                  style="display: none"
                 >
                   Open Lineage Certificate
                 </a>
@@ -297,6 +309,7 @@
                   class="btn btn-primary"
                   href="intake-review.html"
                   data-intake-open-action
+                  style="display: none"
                 >
                   View Intake Record
                 </a>
@@ -304,8 +317,9 @@
                   class="btn btn-secondary"
                   href="verification-upload.html"
                   data-paid-action
+                  style="display: none"
                 >
-                  Upload Family Records
+                  Upload Verification Records
                 </a>
               </div>
             </div>
@@ -319,30 +333,30 @@
             </div>
 
             <div class="form-panel" data-dashboard-customer-only>
-              <span class="eyebrow">Your Family Build Path</span>
+              <span class="eyebrow">Your Build Path</span>
               <div class="grid-3">
                 <div>
                   <div class="card-number">1</div>
-                  <h3>Family Root</h3>
+                  <h3>Package Scope</h3>
                   <p class="card-copy">
-                    Establish the household family record that anchors your
-                    lineage build.
+                    Tomb of Light resolves the exact tools, limits, and
+                    workflows attached to your active package.
                   </p>
                 </div>
                 <div>
                   <div class="card-number">2</div>
-                  <h3>Members and Relationships</h3>
+                  <h3>Records and Structure</h3>
                   <p class="card-copy">
-                    Add parents, spouses, children, and connected branches over
-                    time.
+                    Upload, verification, lineage, and structure features appear
+                    only when they are included in your package.
                   </p>
                 </div>
                 <div>
                   <div class="card-number">3</div>
-                  <h3>Verification Evidence</h3>
+                  <h3>Delivery and Growth</h3>
                   <p class="card-copy">
-                    Upload IDs, birth certificates, marriage records, adoption
-                    records, and supporting family documents for review.
+                    Your workspace can expand over time through package upgrades
+                    and approved add-ons.
                   </p>
                 </div>
               </div>
@@ -370,8 +384,8 @@
                   <div class="card-number">C</div>
                   <h3>Package Access</h3>
                   <p class="card-copy">
-                    Family build tools and upload workflows unlock once a paid
-                    package is recorded to your account.
+                    Package access, uploads, intake, and lineage tools are
+                    controlled by your active entitlement.
                   </p>
                 </div>
               </div>
@@ -391,10 +405,10 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260328-4"></script>
-    <script src="app.js?v=20260328-4"></script>
-    <script src="auth.js?v=20260328-4"></script>
-    <script src="dashboard-intake.js?v=20260328-4"></script>
-    <script src="dashboard-admin.js?v=20260328-4"></script>
+    <script src="config.js?v=20260328-6"></script>
+    <script src="app.js?v=20260328-6"></script>
+    <script src="auth.js?v=20260328-6"></script>
+    <script src="dashboard-intake.js?v=20260328-6"></script>
+    <script src="dashboard-admin.js?v=20260328-6"></script>
   </body>
 </html>

--- a/link-keys.html
+++ b/link-keys.html
@@ -1,0 +1,257 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Link Keys | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Generate, share, approve, and manage Tomb of Light link keys for portrait, household, network, and organization workspaces."
+    />
+    <link rel="stylesheet" href="styles.css?v=20260328-7" />
+  </head>
+  <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
+    <div class="site-watermark" aria-hidden="true"></div>
+
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+
+          <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="intake-review.html" style="display: none">My Intake</a>
+            <a href="verification-upload.html" style="display: none"
+              >Verification Uploads</a
+            >
+            <a href="link-keys.html" aria-current="page">Link Keys</a>
+            <a href="tree-view.html" style="display: none">Family Tree</a>
+            <a href="lineage-certificate.html" style="display: none"
+              >Lineage Certificate</a
+            >
+            <a href="faq.html">Help</a>
+          </nav>
+
+          <div class="header-actions">
+            <button class="btn btn-secondary" type="button" data-logout-btn>
+              Log Out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" data-link-keys-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Portrait-Native Linking</span>
+              <h1>Link Keys Workspace</h1>
+              <p data-link-keys-page-status>
+                Loading your linking workspace...
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Workspace Summary</span>
+              <div class="grid-3">
+                <div>
+                  <div class="card-number">1</div>
+                  <h3>Package</h3>
+                  <p class="card-copy" data-link-package-name>Loading...</p>
+                </div>
+                <div>
+                  <div class="card-number">2</div>
+                  <h3>Lane</h3>
+                  <p class="card-copy" data-link-package-lane>Loading...</p>
+                </div>
+                <div>
+                  <div class="card-number">3</div>
+                  <h3>Project</h3>
+                  <p class="card-copy" data-link-project-name>Loading...</p>
+                </div>
+              </div>
+
+              <div
+                class="helper"
+                data-link-keys-workspace-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+
+            <div class="form-panel" data-link-keys-main-panel>
+              <span class="eyebrow">Your Link Key</span>
+              <div class="helper" style="margin-bottom: 1rem">
+                Generate a link key for your current workspace. Share this key
+                with the other person or branch you want to connect.
+              </div>
+
+              <label>
+                Active Link Key
+                <input
+                  type="text"
+                  readonly
+                  value=""
+                  data-link-key-value
+                  placeholder="No active key yet"
+                />
+              </label>
+
+              <div class="inline-actions" style="margin-top: 1rem">
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                  data-link-key-generate
+                >
+                  Generate Link Key
+                </button>
+                <button
+                  class="btn btn-secondary"
+                  type="button"
+                  data-link-key-copy
+                >
+                  Copy Link Key
+                </button>
+                <button
+                  class="btn btn-secondary"
+                  type="button"
+                  data-link-key-revoke
+                >
+                  Revoke Link Key
+                </button>
+              </div>
+
+              <div
+                class="helper"
+                data-link-key-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+
+            <div class="form-panel" data-link-request-panel>
+              <span class="eyebrow">Request a Link</span>
+
+              <form class="form-grid" data-link-request-form novalidate>
+                <label>
+                  Target Link Key
+                  <input
+                    type="text"
+                    name="target_key"
+                    maxlength="150"
+                    required
+                    placeholder="Paste the other workspace’s link key"
+                  />
+                </label>
+
+                <label>
+                  Notes
+                  <textarea
+                    name="notes"
+                    rows="4"
+                    maxlength="1000"
+                    placeholder="Optional notes for the link request"
+                  ></textarea>
+                </label>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button class="btn btn-primary" type="submit">
+                    Send Link Request
+                  </button>
+                </div>
+              </form>
+
+              <div
+                class="helper"
+                data-link-request-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+
+            <div class="form-panel" data-link-incoming-panel>
+              <span class="eyebrow">Incoming Requests</span>
+              <div
+                class="grid-3"
+                data-link-incoming-list
+                style="margin-top: 1rem"
+              ></div>
+              <div
+                class="helper"
+                data-link-incoming-empty
+                style="display: none; margin-top: 1rem"
+              >
+                No incoming link requests found.
+              </div>
+            </div>
+
+            <div class="form-panel" data-link-outgoing-panel>
+              <span class="eyebrow">Outgoing Requests</span>
+              <div
+                class="grid-3"
+                data-link-outgoing-list
+                style="margin-top: 1rem"
+              ></div>
+              <div
+                class="helper"
+                data-link-outgoing-empty
+                style="display: none; margin-top: 1rem"
+              >
+                No outgoing link requests found.
+              </div>
+            </div>
+
+            <div class="form-panel" data-link-active-panel>
+              <span class="eyebrow">Active Links</span>
+              <div
+                class="grid-3"
+                data-link-active-list
+                style="margin-top: 1rem"
+              ></div>
+              <div
+                class="helper"
+                data-link-active-empty
+                style="display: none; margin-top: 1rem"
+              >
+                No active links found.
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260328-7"></script>
+    <script src="auth.js?v=20260328-7"></script>
+    <script src="link-keys.js?v=20260328-7"></script>
+  </body>
+</html>

--- a/link-keys.js
+++ b/link-keys.js
@@ -1,0 +1,664 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  const authPages = window.TOLAuthPages || {};
+
+  if (!app || typeof app.apiRequest !== "function") {
+    console.error("link-keys.js requires app.js/auth.js first.");
+    return;
+  }
+
+  let currentUser = null;
+  let currentContext = null;
+  let currentProjectId = "";
+  let currentKey = null;
+  let currentRequests = [];
+
+  function normalizeValue(value) {
+    return String(value || "")
+      .trim()
+      .toLowerCase();
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function humanizeStatus(status) {
+    const normalized = normalizeValue(status);
+    if (!normalized) return "Unknown";
+
+    return normalized
+      .split("_")
+      .map(function (part) {
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join(" ");
+  }
+
+  function setStatus(node, message, type) {
+    if (!node) return;
+
+    node.style.display = "block";
+    node.textContent = message;
+
+    if (type === "error") {
+      node.style.color = "#ffb3b3";
+    } else if (type === "success") {
+      node.style.color = "#cfe8cf";
+    } else {
+      node.style.color = "#d6e6ff";
+    }
+  }
+
+  function clearStatus(node) {
+    if (!node) return;
+    node.style.display = "none";
+    node.textContent = "";
+  }
+
+  function getProjectIdFromContext(context) {
+    return String(
+      context?.activeProject?.id || context?.activeProject?._id || "",
+    ).trim();
+  }
+
+  function getResolvedEntitlements(context) {
+    if (context?.resolvedEntitlements) return context.resolvedEntitlements;
+    if (authPages.buildFallbackEntitlements) {
+      return authPages.buildFallbackEntitlements(
+        context?.packageCode,
+        context?.packageLane,
+      );
+    }
+    return {};
+  }
+
+  function updateNav(context) {
+    const resolved = getResolvedEntitlements(context);
+
+    const navTree = document.querySelector(
+      '.site-nav a[href="tree-view.html"]',
+    );
+    const navCertificate = document.querySelector(
+      '.site-nav a[href="lineage-certificate.html"]',
+    );
+    const navIntake = document.querySelector(
+      '.site-nav a[href="intake-review.html"]',
+    );
+    const navVerification = document.querySelector(
+      '.site-nav a[href="verification-upload.html"]',
+    );
+
+    if (navTree) {
+      navTree.style.display = resolved.can_build_family_tree ? "" : "none";
+    }
+
+    if (navCertificate) {
+      navCertificate.style.display = resolved.can_use_lineage_certificate
+        ? ""
+        : "none";
+    }
+
+    if (navIntake) {
+      navIntake.style.display = resolved.can_open_family_intake ? "" : "none";
+    }
+
+    if (navVerification) {
+      navVerification.style.display =
+        resolved.can_upload_verification_docs || resolved.can_upload_portraits
+          ? ""
+          : "none";
+    }
+  }
+
+  function renderWorkspaceSummary(context) {
+    const resolved = getResolvedEntitlements(context);
+
+    const packageNameNode = document.querySelector("[data-link-package-name]");
+    const laneNode = document.querySelector("[data-link-package-lane]");
+    const projectNode = document.querySelector("[data-link-project-name]");
+
+    if (packageNameNode) {
+      packageNameNode.textContent = context?.packageName || "Active Package";
+    }
+
+    if (laneNode) {
+      laneNode.textContent =
+        resolved.package_lane || context?.packageLane || "unknown";
+    }
+
+    if (projectNode) {
+      projectNode.textContent =
+        context?.activeProject?.project_name ||
+        context?.activeProject?.name ||
+        "Current Workspace";
+    }
+  }
+
+  function renderCurrentKey() {
+    const keyInput = document.querySelector("[data-link-key-value]");
+    const generateBtn = document.querySelector("[data-link-key-generate]");
+    const revokeBtn = document.querySelector("[data-link-key-revoke]");
+
+    if (keyInput) {
+      keyInput.value = currentKey?.key_value || "";
+      keyInput.placeholder = currentKey ? "" : "No active key yet";
+    }
+
+    if (generateBtn) {
+      generateBtn.textContent = currentKey
+        ? "Regenerate Link Key"
+        : "Generate Link Key";
+    }
+
+    if (revokeBtn) {
+      revokeBtn.disabled = !currentKey;
+      revokeBtn.style.opacity = currentKey ? "" : "0.45";
+    }
+  }
+
+  function counterpartLabel(item) {
+    const isSource = String(item.source_project_id) === currentProjectId;
+    if (isSource) {
+      return (
+        item.target_project_name ||
+        item.target_owner_email ||
+        item.target_project_id ||
+        "Linked Workspace"
+      );
+    }
+    return (
+      item.source_project_name ||
+      item.source_owner_email ||
+      item.source_project_id ||
+      "Linked Workspace"
+    );
+  }
+
+  function requestMeta(item) {
+    const label = counterpartLabel(item);
+    const lines = [
+      `<p class="card-copy"><strong>Workspace:</strong> ${escapeHtml(label)}</p>`,
+      `<p class="card-copy"><strong>Status:</strong> ${escapeHtml(humanizeStatus(item.status))}</p>`,
+      `<p class="card-copy"><strong>Requested By:</strong> ${escapeHtml(item.requested_by || "—")}</p>`,
+      `<p class="card-copy"><strong>Created:</strong> ${escapeHtml(item.created_at || "—")}</p>`,
+    ];
+
+    if (item.notes) {
+      lines.push(
+        `<p class="card-copy"><strong>Notes:</strong> ${escapeHtml(item.notes)}</p>`,
+      );
+    }
+
+    return lines.join("");
+  }
+
+  function renderCardList(node, emptyNode, htmlItems) {
+    if (!node) return;
+
+    if (!htmlItems.length) {
+      node.innerHTML = "";
+      if (emptyNode) emptyNode.style.display = "block";
+      return;
+    }
+
+    if (emptyNode) emptyNode.style.display = "none";
+    node.innerHTML = htmlItems.join("");
+  }
+
+  function renderRequests() {
+    const incomingNode = document.querySelector("[data-link-incoming-list]");
+    const outgoingNode = document.querySelector("[data-link-outgoing-list]");
+    const activeNode = document.querySelector("[data-link-active-list]");
+
+    const incomingEmpty = document.querySelector("[data-link-incoming-empty]");
+    const outgoingEmpty = document.querySelector("[data-link-outgoing-empty]");
+    const activeEmpty = document.querySelector("[data-link-active-empty]");
+
+    const incoming = currentRequests.filter(function (item) {
+      return (
+        normalizeValue(item.status) === "pending" &&
+        String(item.target_project_id) === currentProjectId
+      );
+    });
+
+    const outgoing = currentRequests.filter(function (item) {
+      return (
+        normalizeValue(item.status) === "pending" &&
+        String(item.source_project_id) === currentProjectId
+      );
+    });
+
+    const active = currentRequests.filter(function (item) {
+      return (
+        normalizeValue(item.status) === "approved" &&
+        (String(item.source_project_id) === currentProjectId ||
+          String(item.target_project_id) === currentProjectId)
+      );
+    });
+
+    renderCardList(
+      incomingNode,
+      incomingEmpty,
+      incoming.map(function (item, index) {
+        return `
+          <div class="family-record-card">
+            <div class="card-number">${index + 1}</div>
+            <h3>Incoming Request</h3>
+            ${requestMeta(item)}
+            <div class="inline-actions" style="margin-top: 1rem">
+              <button class="btn btn-primary" type="button" data-link-action="approve" data-request-id="${escapeHtml(item.id)}">
+                Approve
+              </button>
+              <button class="btn btn-secondary" type="button" data-link-action="reject" data-request-id="${escapeHtml(item.id)}">
+                Reject
+              </button>
+            </div>
+          </div>
+        `;
+      }),
+    );
+
+    renderCardList(
+      outgoingNode,
+      outgoingEmpty,
+      outgoing.map(function (item, index) {
+        return `
+          <div class="family-record-card">
+            <div class="card-number">${index + 1}</div>
+            <h3>Outgoing Request</h3>
+            ${requestMeta(item)}
+            <div class="inline-actions" style="margin-top: 1rem">
+              <button class="btn btn-secondary" type="button" data-link-action="revoke" data-request-id="${escapeHtml(item.id)}">
+                Cancel Request
+              </button>
+            </div>
+          </div>
+        `;
+      }),
+    );
+
+    renderCardList(
+      activeNode,
+      activeEmpty,
+      active.map(function (item, index) {
+        return `
+          <div class="family-record-card">
+            <div class="card-number">${index + 1}</div>
+            <h3>Active Link</h3>
+            ${requestMeta(item)}
+            <div class="inline-actions" style="margin-top: 1rem">
+              <button class="btn btn-secondary" type="button" data-link-action="revoke" data-request-id="${escapeHtml(item.id)}">
+                Remove Link
+              </button>
+            </div>
+          </div>
+        `;
+      }),
+    );
+  }
+
+  async function loadCurrentKey() {
+    const statusNode = document.querySelector("[data-link-key-status]");
+    clearStatus(statusNode);
+
+    try {
+      const key = await app.apiRequest(
+        `/link-keys/my-active?project_id=${encodeURIComponent(currentProjectId)}`,
+        { method: "GET" },
+      );
+      currentKey = key || null;
+    } catch (error) {
+      const message = String(error?.message || error).toLowerCase();
+      if (message.includes("404") || message.includes("no active link key")) {
+        currentKey = null;
+      } else {
+        currentKey = null;
+        setStatus(
+          statusNode,
+          error.message || "Unable to load link key.",
+          "error",
+        );
+      }
+    }
+
+    renderCurrentKey();
+  }
+
+  async function loadRequests() {
+    const statusNode = document.querySelector("[data-link-request-status]");
+    clearStatus(statusNode);
+
+    try {
+      const payload = await app.apiRequest(
+        `/link-requests/my-list?project_id=${encodeURIComponent(currentProjectId)}`,
+        { method: "GET" },
+      );
+      currentRequests = Array.isArray(payload?.items) ? payload.items : [];
+      renderRequests();
+    } catch (error) {
+      currentRequests = [];
+      renderRequests();
+      setStatus(
+        statusNode,
+        error.message || "Unable to load link requests.",
+        "error",
+      );
+    }
+  }
+
+  async function generateLinkKey() {
+    const statusNode = document.querySelector("[data-link-key-status]");
+    setStatus(statusNode, "Generating link key...", "info");
+
+    try {
+      currentKey = await app.apiRequest(
+        `/link-keys/project/${encodeURIComponent(currentProjectId)}/generate`,
+        { method: "POST" },
+      );
+      renderCurrentKey();
+      setStatus(statusNode, "Link key generated successfully.", "success");
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Unable to generate link key.",
+        "error",
+      );
+    }
+  }
+
+  async function revokeCurrentKey() {
+    const statusNode = document.querySelector("[data-link-key-status]");
+    if (!currentKey?.id) {
+      setStatus(statusNode, "There is no active key to revoke.", "error");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "Revoke this link key? Existing requests are not deleted, but this key can no longer be used for new link requests.",
+    );
+    if (!confirmed) return;
+
+    setStatus(statusNode, "Revoking link key...", "info");
+
+    try {
+      await app.apiRequest(
+        `/link-keys/${encodeURIComponent(currentKey.id)}/revoke`,
+        {
+          method: "POST",
+        },
+      );
+      currentKey = null;
+      renderCurrentKey();
+      setStatus(statusNode, "Link key revoked successfully.", "success");
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Unable to revoke link key.",
+        "error",
+      );
+    }
+  }
+
+  async function copyCurrentKey() {
+    const statusNode = document.querySelector("[data-link-key-status]");
+    if (!currentKey?.key_value) {
+      setStatus(statusNode, "Generate a link key first.", "error");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(currentKey.key_value);
+      setStatus(statusNode, "Link key copied to clipboard.", "success");
+    } catch (error) {
+      setStatus(
+        statusNode,
+        "Unable to copy link key in this browser.",
+        "error",
+      );
+    }
+  }
+
+  async function submitLinkRequest(event) {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const statusNode = document.querySelector("[data-link-request-status]");
+    clearStatus(statusNode);
+
+    if (!currentKey?.key_value) {
+      setStatus(
+        statusNode,
+        "Generate your link key before sending a request.",
+        "error",
+      );
+      return;
+    }
+
+    const targetKey = String(form.target_key.value || "").trim();
+    const notes = String(form.notes.value || "").trim();
+
+    if (!targetKey) {
+      setStatus(statusNode, "Target link key is required.", "error");
+      return;
+    }
+
+    setStatus(statusNode, "Sending link request...", "info");
+
+    try {
+      await app.apiRequest("/link-requests", {
+        method: "POST",
+        body: JSON.stringify({
+          source_project_id: currentProjectId,
+          target_key: targetKey,
+          notes: notes || null,
+        }),
+      });
+
+      form.reset();
+      await loadRequests();
+      setStatus(statusNode, "Link request sent successfully.", "success");
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Unable to send link request.",
+        "error",
+      );
+    }
+  }
+
+  async function runRequestAction(requestId, action) {
+    const statusNode = document.querySelector("[data-link-request-status]");
+    let notes = "";
+
+    if (action === "reject") {
+      notes = window.prompt("Optional rejection note:", "") || "";
+    } else if (action === "revoke") {
+      notes = window.prompt("Optional revoke note:", "") || "";
+    } else if (action === "approve") {
+      notes = window.prompt("Optional approval note:", "") || "";
+    }
+
+    setStatus(statusNode, "Updating link request...", "info");
+
+    try {
+      await app.apiRequest(
+        `/link-requests/${encodeURIComponent(requestId)}/${action}`,
+        {
+          method: "POST",
+          body: JSON.stringify({ notes: notes || null }),
+        },
+      );
+
+      await loadRequests();
+      setStatus(statusNode, `Request ${action}d successfully.`, "success");
+    } catch (error) {
+      setStatus(
+        statusNode,
+        error.message || "Unable to update link request.",
+        "error",
+      );
+    }
+  }
+
+  function bindActions() {
+    const generateBtn = document.querySelector("[data-link-key-generate]");
+    const copyBtn = document.querySelector("[data-link-key-copy]");
+    const revokeBtn = document.querySelector("[data-link-key-revoke]");
+    const requestForm = document.querySelector("[data-link-request-form]");
+
+    if (generateBtn) {
+      generateBtn.addEventListener("click", generateLinkKey);
+    }
+
+    if (copyBtn) {
+      copyBtn.addEventListener("click", copyCurrentKey);
+    }
+
+    if (revokeBtn) {
+      revokeBtn.addEventListener("click", revokeCurrentKey);
+    }
+
+    if (requestForm) {
+      requestForm.addEventListener("submit", submitLinkRequest);
+    }
+
+    document.addEventListener("click", function (event) {
+      const actionButton = event.target.closest("[data-link-action]");
+      if (!actionButton) return;
+
+      const action = actionButton.getAttribute("data-link-action");
+      const requestId = actionButton.getAttribute("data-request-id");
+      if (!action || !requestId) return;
+
+      runRequestAction(requestId, action);
+    });
+
+    document.querySelectorAll("[data-logout-btn]").forEach(function (button) {
+      button.addEventListener("click", async function () {
+        try {
+          if (app.logoutUser) {
+            await app.logoutUser();
+          } else {
+            app.clearSession();
+          }
+        } catch (error) {
+          app.clearSession();
+        }
+
+        window.location.href = "signin.html";
+      });
+    });
+  }
+
+  async function setupLinkKeysPage() {
+    const page = document.querySelector("[data-link-keys-page]");
+    if (!page) return;
+
+    const pageStatusNode = document.querySelector(
+      "[data-link-keys-page-status]",
+    );
+    const workspaceStatusNode = document.querySelector(
+      "[data-link-keys-workspace-status]",
+    );
+    const mainPanel = document.querySelector("[data-link-keys-main-panel]");
+    const requestPanel = document.querySelector("[data-link-request-panel]");
+    const incomingPanel = document.querySelector("[data-link-incoming-panel]");
+    const outgoingPanel = document.querySelector("[data-link-outgoing-panel]");
+    const activePanel = document.querySelector("[data-link-active-panel]");
+
+    try {
+      const token = app.getToken ? app.getToken() : null;
+      if (!token) {
+        window.location.href = "signin.html";
+        return;
+      }
+
+      currentUser = await app.apiRequest("/auth/me", { method: "GET" });
+
+      const orders = authPages.fetchOrders ? await authPages.fetchOrders() : [];
+      currentContext = authPages.getDashboardContext
+        ? await authPages.getDashboardContext(currentUser, orders)
+        : null;
+
+      if (!currentContext || !currentContext.hasPackageAccess) {
+        throw new Error("No active package is attached to this account yet.");
+      }
+
+      currentProjectId = getProjectIdFromContext(currentContext);
+      if (!currentProjectId) {
+        throw new Error("No active project is attached to this account yet.");
+      }
+
+      const resolved = getResolvedEntitlements(currentContext);
+      if (!resolved.can_use_link_keys) {
+        throw new Error(
+          "Link capabilities are not included in your active package.",
+        );
+      }
+
+      renderWorkspaceSummary(currentContext);
+      updateNav(currentContext);
+
+      if (pageStatusNode) {
+        pageStatusNode.textContent = `Link capabilities are active for ${currentContext.packageName || "your package"}.`;
+      }
+
+      if (workspaceStatusNode) {
+        setStatus(
+          workspaceStatusNode,
+          "This workspace can generate a project link key, send link requests, and manage active links.",
+          "success",
+        );
+      }
+
+      [
+        mainPanel,
+        requestPanel,
+        incomingPanel,
+        outgoingPanel,
+        activePanel,
+      ].forEach(function (node) {
+        if (node) node.style.display = "";
+      });
+
+      await loadCurrentKey();
+      await loadRequests();
+      bindActions();
+    } catch (error) {
+      if (pageStatusNode) {
+        pageStatusNode.textContent =
+          error.message || "Link workspace could not be loaded.";
+      }
+
+      if (workspaceStatusNode) {
+        setStatus(
+          workspaceStatusNode,
+          error.message || "Link workspace could not be loaded.",
+          "error",
+        );
+      }
+
+      [
+        mainPanel,
+        requestPanel,
+        incomingPanel,
+        outgoingPanel,
+        activePanel,
+      ].forEach(function (node) {
+        if (node) node.style.display = "none";
+      });
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupLinkKeysPage();
+  });
+})();

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload verification records, portraits, and supporting family documents to Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260326-2" />
+    <link rel="stylesheet" href="styles.css?v=20260328-7" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -34,12 +34,15 @@
 
           <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html">Dashboard</a>
-            <a href="intake-review.html">My Intake</a>
+            <a href="intake-review.html" style="display: none">My Intake</a>
             <a href="verification-upload.html" aria-current="page">
               Verification Uploads
             </a>
-            <a href="tree-view.html">Family Tree</a>
-            <a href="lineage-certificate.html">Lineage Certificate</a>
+            <a href="link-keys.html" style="display: none">Link Keys</a>
+            <a href="tree-view.html" style="display: none">Family Tree</a>
+            <a href="lineage-certificate.html" style="display: none">
+              Lineage Certificate
+            </a>
             <a href="faq.html">Help</a>
           </nav>
 
@@ -485,9 +488,87 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260326-2"></script>
-    <script src="app.js?v=20260326-2"></script>
-    <script src="auth.js?v=20260326-2"></script>
-    <script src="verification-upload.js?v=20260326-2"></script>
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260328-7"></script>
+    <script src="auth.js?v=20260328-7"></script>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", async function () {
+        try {
+          const app = window.TOLApp || window.TOLAuth;
+          const auth = window.TOLAuthPages || {};
+          if (!app || typeof app.apiRequest !== "function") return;
+
+          const token = app.getToken ? app.getToken() : null;
+          if (!token) return;
+
+          const me = await app.apiRequest("/auth/me", { method: "GET" });
+          if (auth.isInternalRole && auth.isInternalRole(me)) {
+            document
+              .querySelectorAll('.site-nav a[href="verification-upload.html"]')
+              .forEach(function (node) {
+                node.style.display = "";
+              });
+            return;
+          }
+
+          const orders = auth.fetchOrders ? await auth.fetchOrders() : [];
+          const context = auth.getDashboardContext
+            ? await auth.getDashboardContext(me, orders)
+            : null;
+
+          const resolved =
+            context?.resolvedEntitlements ||
+            (auth.buildFallbackEntitlements
+              ? auth.buildFallbackEntitlements(
+                  context?.packageCode,
+                  context?.packageLane,
+                )
+              : {});
+
+          const canUpload =
+            !!resolved.can_upload_verification_docs ||
+            !!resolved.can_upload_portraits;
+          const canUseLinkKeys = !!resolved.can_use_link_keys;
+          const canOpenFamilyIntake = !!resolved.can_open_family_intake;
+          const canBuildFamilyTree = !!resolved.can_build_family_tree;
+          const canUseCertificate = !!resolved.can_use_lineage_certificate;
+
+          document
+            .querySelectorAll('.site-nav a[href="intake-review.html"]')
+            .forEach(function (node) {
+              node.style.display = canOpenFamilyIntake ? "" : "none";
+            });
+
+          document
+            .querySelectorAll('.site-nav a[href="verification-upload.html"]')
+            .forEach(function (node) {
+              node.style.display = canUpload ? "" : "none";
+            });
+
+          document
+            .querySelectorAll('.site-nav a[href="link-keys.html"]')
+            .forEach(function (node) {
+              node.style.display = canUseLinkKeys ? "" : "none";
+            });
+
+          document
+            .querySelectorAll('.site-nav a[href="tree-view.html"]')
+            .forEach(function (node) {
+              node.style.display = canBuildFamilyTree ? "" : "none";
+            });
+
+          document
+            .querySelectorAll('.site-nav a[href="lineage-certificate.html"]')
+            .forEach(function (node) {
+              node.style.display = canUseCertificate ? "" : "none";
+            });
+        } catch (error) {
+          console.error("Verification nav entitlement sync failed:", error);
+        }
+      });
+    </script>
+
+    <script src="verification-upload.js?v=20260328-7"></script>
   </body>
 </html>


### PR DESCRIPTION
Implemented full portrait-native linking support and package-aware access updates across backend and frontend.

- Added link key backend routes, schema, and service
- Added project-based link request flow and approval/revoke handling
- Updated main.py to register link key routes
- Updated auth.js purchase gating to allow link-keys.html only for entitled packages
- Updated dashboard and intake logic to recognize link-capable packages
- Updated admin dashboard tools and verification upload navigation
- Kept package access lane-aware so users only see what their package includes
- Supports Digital Legacy Portrait and above for link capabilities