### PR TITLE
updated the backend catalog

### DIFF
--- a/admin-intake.js
+++ b/admin-intake.js
@@ -27,7 +27,6 @@
     "heirloom_legacy_tree",
     "legacy_plus",
     "family_estate_concierge",
-    "command_structure_network",
   ]);
 
   let allSubmissions = [];
@@ -353,9 +352,9 @@
         });
 
         configureActionLink(certificateLink, {
-          text: "Open Lineage Certificate",
-          href: "lineage-certificate.html",
-          show: false,
+          text: "Open Linking Keys",
+          href: "link-keys.html",
+          show: linkKeysEnabled,
         });
 
         return;
@@ -363,15 +362,15 @@
 
       if (lane === "organization") {
         configureActionLink(familyManagerLink, {
-          text: "Open Customer Dashboard",
-          href: "dashboard.html",
+          text: "Open Structure Workspace",
+          href: "verification-upload.html",
           show: true,
         });
 
         configureActionLink(familyTreeLink, {
-          text: "Open Structure Uploads",
-          href: "verification-upload.html",
-          show: true,
+          text: "Open Family Tree",
+          href: "tree-view.html",
+          show: false,
         });
 
         configureActionLink(certificateLink, {

--- a/auth.js
+++ b/auth.js
@@ -25,7 +25,6 @@
     "heirloom_legacy_tree",
     "legacy_plus",
     "family_estate_concierge",
-    "command_structure_network",
   ]);
 
   const NARRATION_ENABLED_PACKAGES = new Set([

--- a/backend/app/core/package_catalog.py
+++ b/backend/app/core/package_catalog.py
@@ -396,8 +396,8 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
         "can_use_lineage_certificate": False,
         "can_open_family_intake": False,
         "can_open_org_intake": True,
-        "can_use_link_keys": True,
-        "can_manage_link_keys": True,
+        "can_use_link_keys": False,
+        "can_manage_link_keys": False,
         "allowed_addons": [
             "extra_org_node",
             "extra_org_level",

--- a/backend/app/services/link_key_service.py
+++ b/backend/app/services/link_key_service.py
@@ -8,6 +8,7 @@ from bson import ObjectId
 
 from app.core.package_catalog import get_package
 from app.database import get_database
+from app.services.entitlement_service import resolve_project_entitlements
 
 
 def _utcnow_iso() -> str:
@@ -93,7 +94,13 @@ def _get_project_entitlement(project_id: str) -> dict[str, Any] | None:
 def project_supports_link_keys(project_id: str) -> bool:
     entitlement = _get_project_entitlement(project_id)
     if entitlement:
-        resolved = entitlement.get("resolved_entitlements") or {}
+        try:
+            resolved = resolve_project_entitlements(
+                str(entitlement.get("package_code") or "").strip(),
+                list(entitlement.get("active_addons", [])),
+            )
+        except Exception:
+            resolved = entitlement.get("resolved_entitlements") or {}
         if "can_use_link_keys" in resolved:
             return bool(resolved.get("can_use_link_keys"))
 

--- a/backend/app/services/project_entitlement_service.py
+++ b/backend/app/services/project_entitlement_service.py
@@ -25,16 +25,22 @@ def _serialize(document: dict[str, Any] | None) -> dict[str, Any] | None:
     if not document:
         return None
 
-    resolved = document.get("resolved_entitlements") or {}
+    package_code = str(document.get("package_code") or "").strip()
+    active_addons = list(document.get("active_addons", []))
+
+    try:
+        resolved = resolve_project_entitlements(package_code, active_addons)
+    except Exception:
+        resolved = document.get("resolved_entitlements") or {}
 
     return {
         "id": str(document.get("_id")),
         "project_id": document.get("project_id"),
         "user_id": document.get("user_id"),
-        "package_code": document.get("package_code"),
+        "package_code": package_code or document.get("package_code"),
         "package_name": document.get("package_name") or resolved.get("display_name"),
         "package_lane": document.get("package_lane"),
-        "active_addons": document.get("active_addons", []),
+        "active_addons": active_addons,
         "maintenance_plan": document.get("maintenance_plan"),
         "maintenance_status": document.get("maintenance_status"),
         "maintenance_started_at": document.get("maintenance_started_at"),

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
                 </p>
                 <div class="hero-meta" aria-label="Package details">
                   <span class="meta-pill">$399</span>
-                  <span class="meta-pill">3–5 business days</span>
+                  <span class="meta-pill">Self only</span>
                 </div>
                 <ul class="package-list">
                   <li>1 buyer account</li>

--- a/link-keys.html
+++ b/link-keys.html
@@ -6,7 +6,7 @@
     <title>Link Keys | Tomb of Light</title>
     <meta
       name="description"
-      content="Generate, share, approve, and manage Tomb of Light link keys for portrait, household, network, and organization workspaces."
+      content="Generate, share, approve, and manage Tomb of Light link keys for eligible portrait, household, and network workspaces."
     />
     <link rel="stylesheet" href="styles.css?v=20260328-7" />
   </head>
@@ -100,8 +100,8 @@
             <div class="form-panel" data-link-keys-main-panel>
               <span class="eyebrow">Your Link Key</span>
               <div class="helper" style="margin-bottom: 1rem">
-                Generate a link key for your current workspace. Share this key
-                with the other person or branch you want to connect.
+                Generate a link key for your current eligible workspace. Share
+                this key with the other person or branch you want to connect.
               </div>
 
               <label>


### PR DESCRIPTION
Link keys now go to:

digital_legacy_portrait
household_foundation
heirloom_legacy_tree
legacy_plus
family_estate_concierge
They stay off for:

legacy_snapshot
legacy_portrait_intro
command_structure_network