### PR TITLE
 index.html and styles.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
 
-    <link rel="stylesheet" href="styles.css?v=20260329-2" />
+    <link rel="stylesheet" href="styles.css?v=20260329-3" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -196,18 +196,20 @@
                 </div>
               </div>
 
-              <div class="hero-visual-card hero-demo-card">
+              <div class="hero-visual-card hero-demo-card hero-viewer-card">
                 <div class="hero-demo-card-top">
                   <div>
                     <span class="eyebrow">Live Experience</span>
                     <h2>Preview the living archive before you enter it.</h2>
                   </div>
 
-                  <a class="mini-link" href="viewer/">Open Full Viewer</a>
+                  <a class="mini-link hero-viewer-link" href="viewer/">
+                    Open Full Viewer
+                  </a>
                 </div>
 
-                <div class="hero-demo-embed">
-                  <div class="hero-demo-stage">
+                <div class="hero-demo-embed hero-viewer-embed">
+                  <div class="hero-demo-stage hero-viewer-stage">
                     <iframe
                       src="viewer/viewer-preview.html"
                       title="Tomb of Light Prototype Viewer - Interactive family lineage experience"

--- a/styles.css
+++ b/styles.css
@@ -605,6 +605,15 @@ select:focus-visible {
   background: #02050b;
 }
 
+.hero-viewer-card {
+  position: relative;
+}
+
+.hero-viewer-stage {
+  position: relative;
+  isolation: isolate;
+}
+
 .hero-tech-fixed {
   position: relative;
   isolation: isolate;
@@ -2680,6 +2689,15 @@ textarea {
     width: min(var(--container), calc(100% - 24px));
   }
 
+  .hero {
+    padding: 28px 0 14px;
+  }
+
+  .hero-shell,
+  .hero-visual-cosmic {
+    gap: 16px;
+  }
+
   .portal-entry-section {
     padding-top: 28px;
   }
@@ -2691,8 +2709,9 @@ textarea {
   }
 
   .site-header-inner {
-    min-height: 78px;
-    padding: 14px 0;
+    min-height: 74px;
+    padding: 12px 0;
+    gap: 12px;
     flex-wrap: nowrap;
   }
 
@@ -2731,7 +2750,6 @@ textarea {
     padding-bottom: 10px;
   }
 
-  .hero,
   .page-hero,
   .thank-you-hero {
     padding-top: 42px;
@@ -2750,7 +2768,7 @@ textarea {
   .form-panel,
   .architecture-panel,
   .thank-you-card {
-    padding: 24px;
+    padding: 22px;
     border-radius: 26px;
   }
 
@@ -2783,13 +2801,50 @@ textarea {
   }
 
   .brand {
-    font-size: 1.5rem;
+    font-size: 1.42rem;
   }
 
   .hero-copy h1,
   .page-hero h1 {
     max-width: none;
-    font-size: clamp(2.3rem, 8vw, 3.6rem);
+    font-size: clamp(2rem, 7.2vw, 2.95rem);
+    line-height: 1.01;
+    letter-spacing: -0.04em;
+  }
+
+  .hero-lead,
+  .hero-sublead {
+    font-size: 0.98rem;
+  }
+
+  .hero-actions,
+  .hero-meta {
+    margin-top: 18px;
+    gap: 10px;
+  }
+
+  .signal-row {
+    margin-top: 14px;
+    gap: 8px 12px;
+    font-size: 0.9rem;
+  }
+
+  .meta-pill {
+    padding: 9px 12px;
+    font-size: 0.86rem;
+  }
+
+  .hero-demo-card {
+    padding: 20px;
+  }
+
+  .hero-demo-card-top {
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .hero-demo-card-top h2 {
+    font-size: clamp(1.55rem, 6vw, 2.15rem);
   }
 
   .hero-demo-embed {
@@ -2802,8 +2857,62 @@ textarea {
     min-height: 0;
   }
 
+  .hero-viewer-card .hero-demo-card-top h2 {
+    font-size: clamp(1.45rem, 5.5vw, 1.9rem);
+    max-width: 13ch;
+  }
+
+  .hero-viewer-link {
+    display: inline-flex;
+    width: 100%;
+    min-height: 48px;
+    align-items: center;
+    justify-content: center;
+    padding: 0 18px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.045);
+    color: var(--text);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  }
+
+  .hero-viewer-link:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.18);
+  }
+
+  .hero-viewer-embed {
+    border-radius: 22px;
+  }
+
+  .hero-viewer-stage {
+    aspect-ratio: 16 / 7.5;
+    max-height: 248px;
+  }
+
+  .hero-viewer-stage::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 72px;
+    background: linear-gradient(
+      180deg,
+      rgba(2, 5, 11, 0),
+      rgba(2, 5, 11, 0.78)
+    );
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .hero-viewer-stage iframe {
+    pointer-events: none;
+  }
+
   .hero-manifesto {
     padding: 16px 18px;
+    margin-top: 18px;
+    font-size: 0.96rem;
+    line-height: 1.68;
   }
 
   .receive-stack,
@@ -2812,16 +2921,17 @@ textarea {
   }
 
   .cosmos-stage {
-    min-height: 320px;
+    min-height: 272px;
   }
 
   .cosmos-core {
-    width: 146px;
+    width: 134px;
   }
 
   .cosmos-node {
-    font-size: 0.68rem;
-    letter-spacing: 0.08em;
+    font-size: 0.64rem;
+    letter-spacing: 0.06em;
+    padding: 8px 11px;
   }
 
   .cosmos-node-left {
@@ -2891,12 +3001,13 @@ textarea {
 
 @media (max-width: 700px) {
   .site-header-inner {
-    min-height: 76px;
-    padding: 12px 0;
+    min-height: 68px;
+    padding: 10px 0;
+    gap: 10px;
   }
 
   .brand {
-    font-size: 1.45rem;
+    font-size: 1.28rem;
   }
 
   .dashboard-presence-title {
@@ -2942,10 +3053,65 @@ textarea {
     justify-content: stretch;
   }
 
-  .header-actions .btn,
-  .menu-toggle {
+  .header-actions .btn {
     width: 100%;
     justify-content: center;
+  }
+
+  .menu-toggle {
+    width: auto;
+    min-height: 48px;
+    padding: 0 16px;
+    border-radius: 999px;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 22px;
+    padding-bottom: 10px;
+  }
+
+  .hero-shell,
+  .hero-visual-cosmic {
+    gap: 12px;
+  }
+
+  .hero-copy-premium,
+  .hero-visual-card {
+    padding: 20px;
+    border-radius: 24px;
+  }
+
+  .hero-copy h1 {
+    font-size: clamp(1.9rem, 8.9vw, 2.5rem);
+  }
+
+  .hero-sublead {
+    font-size: 0.95rem;
+    line-height: 1.62;
+  }
+
+  .hero-meta {
+    margin-top: 16px;
+  }
+
+  .meta-pill {
+    font-size: 0.82rem;
+  }
+
+  .hero-demo-card-top .eyebrow {
+    margin-bottom: 8px;
+  }
+
+  .hero-demo-card-top h2 {
+    font-size: clamp(1.35rem, 7vw, 1.72rem);
+    line-height: 1.08;
+  }
+
+  .hero-viewer-stage {
+    aspect-ratio: 16 / 6.9;
+    max-height: 214px;
+    border-radius: 18px;
   }
 
   .presence-badge {


### PR DESCRIPTION
compressed the phone rhythm overall: smaller headline scale, lighter header, reduced card padding, tighter meta/signal spacing, and a shorter cosmic stage so the homepage feels designed for mobile instead of just stacked from desktop. I bumped the homepage stylesheet version too so the new responsive CSS can refresh cleanly after deploy.