### PR TITLE
patched the top viewer bugs in viewer/js/script.js, viewer/css/style.…

### DIFF
--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -263,23 +263,45 @@ a {
 }
 
 .eye-hint {
+  appearance: none;
   position: absolute;
   width: 44px;
   height: 44px;
+  padding: 0;
   border-radius: 999px;
   border: 1px solid rgba(214, 176, 102, 0.38);
+  background: rgba(214, 176, 102, 0.08);
   box-shadow: 0 0 0 4px rgba(214, 176, 102, 0.10);
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, -50%);
+  transition:
+    opacity var(--transition),
+    transform var(--transition),
+    box-shadow var(--transition),
+    background var(--transition);
 }
 
-body.show-eyes .eye-hint {
+.eye-hint.is-visible {
   opacity: 0.85;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.eye-hint.is-visible:hover {
+  transform: translate(-50%, -50%) scale(1.05);
+  box-shadow: 0 0 0 6px rgba(214, 176, 102, 0.14);
+  background: rgba(214, 176, 102, 0.14);
+}
+
+.eye-hint.is-visible:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 3px;
 }
 
 .embed-mode .eye-hint {
   opacity: 0 !important;
+  pointer-events: none !important;
 }
 
 .narration-text {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tomb of Light | Genesis Prototype</title>
 
-    <link rel="stylesheet" href="css/style.css?v=20260325-1" />
+    <link rel="stylesheet" href="css/style.css?v=20260329-2" />
 
     <script>
       (function () {
@@ -188,8 +188,9 @@
           <p class="viewer-instructions" id="viewerInstructions">
             Hold <strong>C</strong>, then click
             <strong>Left Eye</strong> (Parents) or
-            <strong>Right Eye</strong> (Descendants). Use scroll/pinch to zoom.
-            (Full viewer only)
+            <strong>Right Eye</strong> (Descendants). You can also use the
+            navigation controls below. Use scroll, pinch, or the zoom buttons
+            to adjust the photo scale. (Full viewer only)
           </p>
         </div>
       </header>
@@ -237,6 +238,10 @@
           <div class="viewer-line"></div>
 
           <div class="controls" id="controls">
+            <button type="button" onclick="navigateParents()">Parents</button>
+            <button type="button" onclick="navigateDescendants()">
+              Descendants
+            </button>
             <button type="button" onclick="zoomOut()">Zoom Out</button>
             <button type="button" onclick="zoomIn()">Zoom In</button>
             <button type="button" onclick="resetViewer()">Reset</button>
@@ -273,6 +278,6 @@
       </main>
     </div>
 
-    <script src="js/script.js?v=20260325-1"></script>
+    <script src="js/script.js?v=20260329-2"></script>
   </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -289,6 +289,7 @@
   let scale = 1;
   const SCALE_MIN = 0.65;
   const SCALE_MAX = 1.25;
+  const ZOOM_STEP = 0.12;
 
   function clamp(v, min, max) {
     return Math.min(max, Math.max(min, v));
@@ -409,6 +410,8 @@
 
     eyeLeft.classList.toggle("is-visible", visible);
     eyeRight.classList.toggle("is-visible", visible);
+    eyeLeft.setAttribute("aria-hidden", visible ? "false" : "true");
+    eyeRight.setAttribute("aria-hidden", visible ? "false" : "true");
   }
 
   function onKeyDown(e) {
@@ -441,14 +444,30 @@
   // ----------------------------
   // Existing button controls still work (full viewer only)
   // ----------------------------
-  function zoomIn() {
+  function navigateParents() {
     if (EMBED_MODE) return;
-    goRightEye();
-  }
-  function zoomOut() {
-    if (EMBED_MODE) return;
+    markInteraction();
     goLeftEye();
   }
+
+  function navigateDescendants() {
+    if (EMBED_MODE) return;
+    markInteraction();
+    goRightEye();
+  }
+
+  function zoomIn() {
+    if (EMBED_MODE) return;
+    markInteraction();
+    setZoom(scale + ZOOM_STEP, true);
+  }
+
+  function zoomOut() {
+    if (EMBED_MODE) return;
+    markInteraction();
+    setZoom(scale - ZOOM_STEP, true);
+  }
+
   function resetViewer() {
     if (EMBED_MODE) return;
     setZoom(1, false);
@@ -456,6 +475,8 @@
     if (isPlaying) startNarrationAutoAdvance();
   }
 
+  window.navigateParents = navigateParents;
+  window.navigateDescendants = navigateDescendants;
   window.zoomIn = zoomIn;
   window.zoomOut = zoomOut;
   window.resetViewer = resetViewer;

--- a/viewer/viewer-preview.html
+++ b/viewer/viewer-preview.html
@@ -13,7 +13,7 @@
   <main class="viewer-preview-shell">
     <div class="viewer-preview-stage">
       <iframe
-        src="index.html?embed=1&v=20260320-2"
+        src="index.html?embed=1&v=20260329-2"
         title="Tomb of Light Viewer Preview"
         loading="lazy"
         allowfullscreen>


### PR DESCRIPTION
…css, viewer/index.html, and viewer/viewer-preview.html.

The broken eye interaction is fixed now: the eye targets actually become visible with the class JS was toggling, they accept clicks when revealed, and they stay disabled in embed mode. I also fixed the mislabeled controls by separating navigation from zoom: the buttons now include Parents and Descendants for lineage movement, while Zoom In and Zoom Out actually change image scale. I updated the on-screen instructions to match that behavior and bumped the viewer asset versions so the new code won’t get hidden behind cache.