### PR TITLE
viewer automation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from app.routes.tree import router as tree_router
 from app.routes.uploads import router as uploads_router
 from app.routes.users import router as users_router
 from app.routes.verification_records import router as verification_records_router
+from app.routes.viewer_manifest import router as viewer_manifest_router
 
 
 def _resolve_allowed_origins() -> list[str]:
@@ -148,6 +149,7 @@ app.include_router(graph_integrity_router)
 app.include_router(orders_router)
 app.include_router(package_catalog_router)
 app.include_router(uploads_router)
+app.include_router(viewer_manifest_router)
 
 # Stripe Webhooks
 app.include_router(stripe_webhooks_router)
@@ -213,6 +215,7 @@ def root():
             "/uploads/member/{member_id}",
             "/uploads/family/{family_id}",
             "/uploads/{upload_id}/download",
+            "/viewer/manifest",
             "/link-keys/my-list",
             "/link-keys/my-active?project_id={project_id}",
             "/link-keys/project/{project_id}/generate",

--- a/backend/app/routes/viewer_manifest.py
+++ b/backend/app/routes/viewer_manifest.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.dependencies.auth import get_current_user, require_any_package_capability
+from app.services.viewer_manifest_service import build_viewer_manifest
+
+router = APIRouter(prefix="/viewer", tags=["Viewer"])
+
+
+@router.get("/manifest")
+def get_viewer_manifest(
+    project_id: str = Query(default=""),
+    family_id: str = Query(default=""),
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    require_any_package_capability(
+        current_user,
+        "can_use_viewer",
+        "can_upload_portraits",
+        "can_build_family_tree",
+        "can_build_org_chart",
+        detail="Your active package does not include viewer access.",
+    )
+
+    try:
+        return build_viewer_manifest(
+            current_user=current_user,
+            project_id=project_id,
+            family_id=family_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc

--- a/backend/app/services/intake_pipeline_service.py
+++ b/backend/app/services/intake_pipeline_service.py
@@ -7,6 +7,7 @@ from bson import ObjectId
 
 from app.core.package_catalog import get_package
 from app.database import get_database
+from app.services.viewer_manifest_service import ensure_project_workspace_anchor
 
 
 def _now() -> datetime:
@@ -334,6 +335,11 @@ def provision_build_from_submission(
             {"$set": project_payload},
         )
         project_doc = projects.find_one({"_id": project_doc["_id"]}) or project_doc
+
+    _family_doc, _primary_member, project_doc = ensure_project_workspace_anchor(
+        project=project_doc,
+        submission=submission,
+    )
 
     project_id = str(project_doc["_id"])
 

--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.core.package_catalog import get_package
+from app.database import get_database
+from app.dependencies.auth import has_internal_admin_access
+from app.services.project_service import list_projects
+
+DEFAULT_EYE_TARGETS = {
+    "left": {"x": 18, "y": 50},
+    "right": {"x": 82, "y": 50},
+}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: Any) -> str:
+    return _normalize_value(value).lower()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    return _normalize_value(user.get("id") or user.get("_id") or user.get("user_id"))
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    return _normalize_email(user.get("email"))
+
+
+def _display_name(member: dict[str, Any]) -> str:
+    joined = f"{_normalize_value(member.get('first_name'))} {_normalize_value(member.get('last_name'))}".strip()
+    return joined or _normalize_value(member.get("display_name")) or "Unknown Member"
+
+
+def _split_name(full_name: str, fallback_email: str) -> tuple[str, str]:
+    name = _normalize_value(full_name)
+    if not name:
+        local_part = (
+            _normalize_email(fallback_email).split("@")[0].replace(".", " ").replace("_", " ")
+        )
+        name = local_part.strip()
+
+    parts = [part for part in name.split() if part]
+    if not parts:
+        return "Primary", "Contact"
+    if len(parts) == 1:
+        return parts[0], "Contact"
+    return parts[0], " ".join(parts[1:])
+
+
+def _coerce_visibility(value: Any) -> str:
+    normalized = _normalize_value(value).lower()
+    if normalized == "private":
+        return "private"
+    if normalized in {"family", "family_only", "family-only"}:
+        return "family_only"
+    if normalized in {"public", "certificate_only", "certificate-only"}:
+        return "certificate_only"
+    return "private"
+
+
+def _to_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except Exception:
+            return _now()
+    return _now()
+
+
+def _sort_projects(projects: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        projects,
+        key=lambda item: _to_datetime(item.get("updated_at") or item.get("created_at")),
+        reverse=True,
+    )
+
+
+def _sort_members(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _generation(member: dict[str, Any]) -> tuple[int, str]:
+        raw_generation = member.get("generation")
+        if isinstance(raw_generation, int):
+            generation = raw_generation
+        else:
+            try:
+                generation = int(raw_generation)
+            except Exception:
+                generation = 999
+        return generation, _display_name(member).lower()
+
+    return sorted(members, key=_generation)
+
+
+def _lane_from_project(project: dict[str, Any]) -> str:
+    lane = _normalize_value(project.get("project_lane")).lower()
+    if lane:
+        return lane
+
+    package = get_package(_normalize_value(project.get("package_code")))
+    return _normalize_value((package or {}).get("package_lane")).lower() or "portrait"
+
+
+def _find_submission_for_project(project: dict[str, Any]) -> dict[str, Any] | None:
+    db = get_database()
+    if db is None:
+        return None
+
+    submissions = db["intake_submissions"]
+    intake_submission_id = _normalize_value(project.get("intake_submission_id"))
+    project_id = _normalize_value(project.get("_id") or project.get("id"))
+    owner_user_id = _normalize_value(project.get("owner_user_id"))
+
+    if intake_submission_id and ObjectId.is_valid(intake_submission_id):
+        found = submissions.find_one({"_id": ObjectId(intake_submission_id)})
+        if found:
+            return found
+
+    if project_id:
+        found = submissions.find_one({"project_id": project_id})
+        if found:
+            return found
+
+    if owner_user_id and ObjectId.is_valid(owner_user_id):
+        found = submissions.find_one(
+            {"user_id": ObjectId(owner_user_id)},
+            sort=[("created_at", -1)],
+        )
+        if found:
+            return found
+
+    return None
+
+
+def resolve_project_for_viewer(
+    *,
+    current_user: dict[str, Any],
+    project_id: str = "",
+    family_id: str = "",
+) -> dict[str, Any] | None:
+    is_admin = has_internal_admin_access(current_user)
+    normalized_project_id = _normalize_value(project_id)
+    normalized_family_id = _normalize_value(family_id)
+
+    if is_admin and not normalized_project_id and not normalized_family_id:
+        return None
+
+    projects = list_projects(
+        owner_user_id=_current_user_id(current_user),
+        owner_email=_current_user_email(current_user),
+        is_admin=is_admin,
+    )
+
+    sorted_projects = _sort_projects(projects)
+
+    if normalized_project_id:
+        for project in sorted_projects:
+            candidate_id = _normalize_value(project.get("_id") or project.get("id"))
+            if candidate_id == normalized_project_id:
+                return project
+        return None
+
+    if normalized_family_id:
+        for project in sorted_projects:
+            if _normalize_value(project.get("family_id")) == normalized_family_id:
+                return project
+        return None
+
+    return sorted_projects[0] if sorted_projects else None
+
+
+def _build_anchor_family_name(
+    *,
+    lane: str,
+    project: dict[str, Any],
+    submission: dict[str, Any] | None,
+) -> str:
+    household = submission.get("household") if isinstance(submission, dict) else {}
+    family_map = submission.get("family_map") if isinstance(submission, dict) else {}
+    package_name = _normalize_value(project.get("package_name")) or "Tomb of Light"
+    project_name = _normalize_value(project.get("project_name") or project.get("name"))
+    owner_email = _normalize_email(project.get("owner_email"))
+    owner_name = _normalize_value(
+        household.get("primary_contact_name")
+        if isinstance(household, dict)
+        else ""
+    ) or _normalize_value(project.get("owner_name"))
+
+    if not owner_name and owner_email:
+        owner_name = owner_email.split("@")[0].replace(".", " ").replace("_", " ").title()
+
+    if lane in {"household", "network"}:
+        return (
+            _normalize_value(household.get("household_name"))
+            or _normalize_value(family_map.get("family_branch_name"))
+            or project_name
+            or "Tomb of Light Family"
+        )
+
+    if lane == "organization":
+        base = (
+            _normalize_value(household.get("household_name"))
+            or project_name
+            or package_name
+            or "Organization Workspace"
+        )
+        return f"{base} Command Workspace"
+
+    base = owner_name or project_name or package_name or "Portrait Workspace"
+    return f"{base} Portrait Workspace"
+
+
+def _build_anchor_description(
+    *,
+    lane: str,
+    project: dict[str, Any],
+    submission: dict[str, Any] | None,
+) -> str:
+    household = submission.get("household") if isinstance(submission, dict) else {}
+    family_map = submission.get("family_map") if isinstance(submission, dict) else {}
+    review = submission.get("review") if isinstance(submission, dict) else {}
+
+    return (
+        _normalize_value(family_map.get("family_structure_summary"))
+        or _normalize_value(household.get("project_scope"))
+        or _normalize_value(review.get("final_intake_notes"))
+        or _normalize_value(project.get("notes"))
+        or (
+            "Private lineage viewer workspace for guided family portraits."
+            if lane in {"household", "network"}
+            else "Private portrait viewer workspace for guided legacy delivery."
+            if lane == "portrait"
+            else "Private structure viewer workspace for guided organizational records."
+        )
+    )
+
+
+def _serialize_family_summary(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize_value(family.get("_id")),
+        "family_name": _normalize_value(family.get("family_name")) or "Workspace",
+        "description": _normalize_value(family.get("description")),
+        "visibility": _normalize_value(family.get("visibility")) or "private",
+    }
+
+
+def _serialize_project_summary(project: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize_value(project.get("_id") or project.get("id")),
+        "name": _normalize_value(project.get("project_name") or project.get("name")) or "Workspace",
+        "package_name": _normalize_value(project.get("package_name")) or "Tomb of Light Package",
+        "package_code": _normalize_value(project.get("package_code")),
+        "lane": _lane_from_project(project),
+        "family_id": _normalize_value(project.get("family_id")) or None,
+    }
+
+
+def ensure_project_workspace_anchor(
+    *,
+    project: dict[str, Any],
+    submission: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any]]:
+    db = get_database()
+    if db is None:
+        return None, None, project
+
+    lane = _lane_from_project(project)
+    if lane not in {"portrait", "household", "network", "organization"}:
+        return None, None, project
+
+    submission = submission or _find_submission_for_project(project)
+
+    families = db["families"]
+    family_members = db["family_members"]
+    projects = db["projects"]
+
+    project_id = _normalize_value(project.get("_id") or project.get("id"))
+    project_object_id = project.get("_id")
+    owner_user_id = _normalize_value(project.get("owner_user_id"))
+    owner_email = _normalize_email(project.get("owner_email"))
+    package_code = _normalize_value(project.get("package_code"))
+    package_name = _normalize_value(project.get("package_name")) or "Tomb of Light Package"
+    submission_id = _normalize_value((submission or {}).get("_id"))
+
+    family_doc = None
+    existing_family_id = _normalize_value(project.get("family_id"))
+
+    if existing_family_id and ObjectId.is_valid(existing_family_id):
+        family_doc = families.find_one({"_id": ObjectId(existing_family_id)})
+
+    if family_doc is None and submission_id:
+        family_doc = families.find_one({"intake_submission_id": submission_id})
+
+    if family_doc is None and project_id:
+        family_doc = families.find_one({"project_id": project_id})
+
+    if family_doc is None:
+        household = submission.get("household") if isinstance(submission, dict) else {}
+        created_by = _normalize_value(
+            household.get("primary_contact_name") if isinstance(household, dict) else ""
+        ) or owner_email or "Tomb of Light"
+
+        family_payload = {
+            "family_name": _build_anchor_family_name(
+                lane=lane,
+                project=project,
+                submission=submission,
+            ),
+            "created_by": created_by,
+            "description": _build_anchor_description(
+                lane=lane,
+                project=project,
+                submission=submission,
+            ),
+            "owner_user_id": owner_user_id,
+            "owner_email": owner_email,
+            "visibility": _coerce_visibility(
+                ((submission or {}).get("consent") or {}).get("visibility_preference")
+                if isinstance(submission, dict)
+                else "private"
+            ),
+            "shared_with_user_ids": [],
+            "shared_with_emails": [],
+            "package_code": package_code,
+            "package_slug": package_code,
+            "package_name": package_name,
+            "project_id": project_id,
+            "workspace_lane": lane,
+            "workspace_kind": "customer_workspace_anchor",
+            "source": "viewer_workspace_anchor",
+            "intake_submission_id": submission_id or None,
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+        result = families.insert_one(family_payload)
+        family_payload["_id"] = result.inserted_id
+        family_doc = family_payload
+
+    family_id = _normalize_value(family_doc.get("_id"))
+
+    if family_id and existing_family_id != family_id and project_object_id is not None:
+        projects.update_one(
+            {"_id": project_object_id},
+            {
+                "$set": {
+                    "family_id": family_id,
+                    "updated_at": _now(),
+                }
+            },
+        )
+        refreshed = projects.find_one({"_id": project_object_id})
+        if refreshed:
+            project = refreshed
+        else:
+            project = dict(project)
+            project["family_id"] = family_id
+
+    primary_member = None
+    if family_id:
+        member_query: dict[str, Any] = {"family_id": family_id}
+        owned_member_filters: list[dict[str, Any]] = []
+        if owner_user_id:
+            owned_member_filters.append({"owner_user_id": owner_user_id})
+        if owner_email:
+            owned_member_filters.append({"owner_email": owner_email})
+
+        if owned_member_filters:
+            primary_member = family_members.find_one(
+                {
+                    "$and": [
+                        member_query,
+                        {"$or": owned_member_filters},
+                    ]
+                },
+                sort=[("created_at", 1)],
+            )
+
+        if primary_member is None:
+            primary_member = family_members.find_one(member_query, sort=[("created_at", 1)])
+
+        if primary_member is None:
+            household = submission.get("household") if isinstance(submission, dict) else {}
+            primary_contact_name = _normalize_value(
+                household.get("primary_contact_name") if isinstance(household, dict) else ""
+            )
+            first_name, last_name = _split_name(primary_contact_name, owner_email)
+
+            member_payload = {
+                "family_id": family_id,
+                "first_name": first_name,
+                "last_name": last_name,
+                "generation": 1,
+                "bio": _build_anchor_description(
+                    lane=lane,
+                    project=project,
+                    submission=submission,
+                ),
+                "owner_user_id": owner_user_id,
+                "owner_email": owner_email,
+                "workspace_lane": lane,
+                "source": "viewer_workspace_anchor",
+                "intake_submission_id": submission_id or None,
+                "is_verified": False,
+                "verification_status": "unverified",
+                "created_at": _now(),
+                "updated_at": _now(),
+            }
+            result = family_members.insert_one(member_payload)
+            member_payload["_id"] = result.inserted_id
+            primary_member = member_payload
+
+    return family_doc, primary_member, project
+
+
+def _build_empty_state(
+    *,
+    lane: str,
+    family: dict[str, Any] | None,
+    project: dict[str, Any],
+) -> dict[str, Any]:
+    workspace_name = (
+        _normalize_value((family or {}).get("family_name"))
+        or _normalize_value(project.get("project_name") or project.get("name"))
+        or "Private Workspace"
+    )
+
+    if lane == "organization":
+        status = "Awaiting Command Portraits"
+        description = (
+            "Upload your first leadership or organization portrait in Verification Uploads to activate this cinematic workspace."
+        )
+    elif lane in {"household", "network"}:
+        status = "Awaiting Family Portraits"
+        description = (
+            "Upload portraits for yourself or your family members in Verification Uploads to populate this cinematic viewer automatically."
+        )
+    else:
+        status = "Awaiting Portrait Upload"
+        description = (
+            "Upload your portrait in Verification Uploads to activate your private cinematic viewer automatically."
+        )
+
+    return {
+        "id": "workspace-anchor",
+        "image": "",
+        "title": workspace_name,
+        "status": status,
+        "node": workspace_name,
+        "description": description,
+        "narration": description,
+        "left_state_id": None,
+        "right_state_id": None,
+        "eye_targets": DEFAULT_EYE_TARGETS,
+    }
+
+
+def _member_status(
+    *,
+    lane: str,
+    member: dict[str, Any],
+    primary_member_id: str,
+    anchor_generation: int | None,
+) -> str:
+    member_id = _normalize_value(member.get("_id"))
+    if member_id == primary_member_id:
+        if lane == "organization":
+            return "Command Anchor"
+        return "Anchor Portrait"
+
+    if lane == "organization":
+        return "Leadership Layer"
+
+    raw_generation = member.get("generation")
+    try:
+        generation = int(raw_generation)
+    except Exception:
+        generation = None
+
+    if anchor_generation is not None and generation is not None:
+        if generation < anchor_generation:
+            return "Earlier Generation"
+        if generation > anchor_generation:
+            return "Next Generation"
+
+    return "Parallel Branch"
+
+
+def _sequence_members_for_viewer(
+    *,
+    lane: str,
+    members: list[dict[str, Any]],
+    primary_member: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    members_with_photos = [
+        member
+        for member in _sort_members(members)
+        if _normalize_value(member.get("photo_upload_id"))
+    ]
+
+    primary_member_id = _normalize_value((primary_member or {}).get("_id"))
+
+    if primary_member_id:
+        for index, member in enumerate(members_with_photos):
+            if _normalize_value(member.get("_id")) == primary_member_id:
+                members_with_photos.insert(0, members_with_photos.pop(index))
+                break
+
+    if lane == "portrait" and primary_member_id:
+        primary_photo = [
+            member
+            for member in members_with_photos
+            if _normalize_value(member.get("_id")) == primary_member_id
+        ]
+        if primary_photo:
+            trailing = [
+                member
+                for member in members_with_photos
+                if _normalize_value(member.get("_id")) != primary_member_id
+            ]
+            return primary_photo + trailing
+
+    return members_with_photos
+
+
+def build_viewer_manifest(
+    *,
+    current_user: dict[str, Any],
+    project_id: str = "",
+    family_id: str = "",
+) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise ValueError("Database is not connected.")
+
+    project = resolve_project_for_viewer(
+        current_user=current_user,
+        project_id=project_id,
+        family_id=family_id,
+    )
+    if project is None:
+        raise ValueError("Viewer workspace could not be resolved for this account.")
+
+    submission = _find_submission_for_project(project)
+    family_doc, primary_member, project = ensure_project_workspace_anchor(
+        project=project,
+        submission=submission,
+    )
+
+    lane = _lane_from_project(project)
+    family_id_value = _normalize_value((family_doc or {}).get("_id") or project.get("family_id"))
+    members: list[dict[str, Any]] = []
+    if family_id_value:
+        members = list(db["family_members"].find({"family_id": family_id_value}))
+
+    ordered_members = _sequence_members_for_viewer(
+        lane=lane,
+        members=members,
+        primary_member=primary_member,
+    )
+
+    primary_member_id = _normalize_value((primary_member or {}).get("_id"))
+    anchor_generation = None
+    if primary_member and isinstance(primary_member.get("generation"), int):
+        anchor_generation = int(primary_member["generation"])
+
+    states: list[dict[str, Any]] = []
+    if ordered_members:
+        for index, member in enumerate(ordered_members):
+            member_id = _normalize_value(member.get("_id"))
+            upload_id = _normalize_value(member.get("photo_upload_id"))
+            title = _display_name(member)
+            status = _member_status(
+                lane=lane,
+                member=member,
+                primary_member_id=primary_member_id,
+                anchor_generation=anchor_generation,
+            )
+            description = (
+                f"Cinematic portrait view for {title} inside your private {lane} workspace."
+            )
+            if lane == "organization":
+                description = (
+                    f"Cinematic command portrait view for {title} inside your protected organization workspace."
+                )
+            states.append(
+                {
+                    "id": f"member-{member_id}",
+                    "member_id": member_id,
+                    "image": f"/uploads/{upload_id}/download" if upload_id else "",
+                    "title": title,
+                    "status": status,
+                    "node": title,
+                    "description": description,
+                    "narration": description,
+                    "left_state_id": f"member-{_normalize_value(ordered_members[index - 1].get('_id'))}" if index > 0 else None,
+                    "right_state_id": f"member-{_normalize_value(ordered_members[index + 1].get('_id'))}" if index + 1 < len(ordered_members) else None,
+                    "eye_targets": DEFAULT_EYE_TARGETS,
+                }
+            )
+    else:
+        states.append(
+            _build_empty_state(
+                lane=lane,
+                family=family_doc,
+                project=project,
+            )
+        )
+
+    package_name = _normalize_value(project.get("package_name")) or "Tomb of Light Package"
+    workspace_name = (
+        _normalize_value((family_doc or {}).get("family_name"))
+        or _normalize_value(project.get("project_name") or project.get("name"))
+        or "Private Workspace"
+    )
+
+    if lane == "organization":
+        hero_title = "Private Structure Viewer"
+        hero_body = (
+            "Move through the protected command portrait sequence attached to your organization workspace."
+        )
+        path_title = "Structure Flow"
+        nav_labels = {"left": "Previous Role", "right": "Next Role"}
+    elif lane in {"household", "network"}:
+        hero_title = "Private Family Viewer"
+        hero_body = (
+            "Move through the uploaded family portraits attached to your protected lineage workspace."
+        )
+        path_title = "Family Flow"
+        nav_labels = {"left": "Previous Portrait", "right": "Next Portrait"}
+    else:
+        hero_title = "Private Portrait Viewer"
+        hero_body = (
+            "Move through the portrait sequence attached to your protected legacy workspace."
+        )
+        path_title = "Portrait Flow"
+        nav_labels = {"left": "Previous Portrait", "right": "Next Portrait"}
+
+    path_items = [
+        f"{state['title']} — {state['status']}"
+        for state in states[:6]
+    ]
+
+    return {
+        "mode": "dynamic",
+        "navigation_mode": "sequence",
+        "hero_kicker": package_name,
+        "hero_title": hero_title,
+        "hero_body": hero_body,
+        "workspace_name": workspace_name,
+        "instructions": (
+            "Hold C, then click the left or right navigation marker. You can also use the controls below. "
+            "Use scroll, pinch, or the zoom buttons to adjust the photo scale. (Full viewer only)"
+        ),
+        "path_title": path_title,
+        "path_items": path_items,
+        "nav_labels": nav_labels,
+        "states": states,
+        "initial_state_id": states[0]["id"] if states else "",
+        "branch_options_by_state": {},
+        "project": _serialize_project_summary(project),
+        "family": _serialize_family_summary(family_doc) if family_doc else None,
+        "primary_member_id": primary_member_id or None,
+        "has_uploaded_portraits": any(_normalize_value(state.get("image")) for state in states),
+    }

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -629,6 +629,6 @@
       });
     </script>
 
-    <script src="verification-upload.js?v=20260328-7"></script>
+    <script src="verification-upload.js?v=20260329-1"></script>
   </body>
 </html>

--- a/verification-upload.js
+++ b/verification-upload.js
@@ -26,6 +26,10 @@
   let currentGraph = { members: [] };
   let families = [];
 
+  function normalizeValue(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
   function escapeHtml(value) {
     return String(value ?? "")
       .replaceAll("&", "&amp;")
@@ -161,6 +165,51 @@
 
   function getPreferredFamilyId(context) {
     return String(getFamilyIdFromUrl() || getFamilyIdFromContext(context) || "").trim();
+  }
+
+  async function ensureWorkspaceFamilyId(context) {
+    const existingFamilyId = getPreferredFamilyId(context);
+    if (existingFamilyId) {
+      return existingFamilyId;
+    }
+
+    const projectId = getProjectIdFromContext(context);
+    const lane = normalizeValue(
+      context?.packageLane || context?.activeProject?.project_lane,
+    );
+
+    if (!projectId || !lane) {
+      return existingFamilyId;
+    }
+
+    try {
+      const manifest = await app.apiRequest(
+        `/viewer/manifest?project_id=${encodeURIComponent(projectId)}`,
+        { method: "GET" },
+      );
+
+      const resolvedFamilyId = String(
+        manifest?.family?.id || manifest?.project?.family_id || "",
+      ).trim();
+
+      if (!resolvedFamilyId) {
+        return existingFamilyId;
+      }
+
+      if (context?.activeProject) {
+        context.activeProject.family_id = resolvedFamilyId;
+      }
+
+      if (context?.currentWorkspace?.activeProject) {
+        context.currentWorkspace.activeProject.family_id = resolvedFamilyId;
+      }
+
+      setFamilyIdInUrl(resolvedFamilyId);
+      return resolvedFamilyId;
+    } catch (error) {
+      console.warn("Unable to resolve workspace family via viewer manifest:", error);
+      return existingFamilyId;
+    }
   }
 
   function getDisplayName(member) {
@@ -757,7 +806,7 @@
         currentContext = null;
       }
 
-      const preferredFamilyId = getPreferredFamilyId(currentContext);
+      const preferredFamilyId = await ensureWorkspaceFamilyId(currentContext);
       updateNav(currentContext, preferredFamilyId);
       await loadFamilies(preferredFamilyId);
 

--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -262,6 +262,28 @@ a {
   transition: opacity 0.25s ease;
 }
 
+#viewerImage.is-empty {
+  opacity: 0;
+}
+
+.viewer-empty-note {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  z-index: 4;
+  width: min(82%, 420px);
+  padding: 18px 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(214, 176, 102, 0.18);
+  background: rgba(5, 9, 17, 0.82);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  color: var(--text);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  text-align: center;
+  transform: translate(-50%, -50%);
+  backdrop-filter: blur(10px);
+}
+
 .eye-hint {
   appearance: none;
   position: absolute;
@@ -340,6 +362,10 @@ a {
   background: rgba(4, 8, 15, 0.82);
   backdrop-filter: blur(12px);
   box-shadow: var(--shadow);
+}
+
+.branch-options:empty {
+  display: none;
 }
 
 /* -----------------------

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tomb of Light | Genesis Prototype</title>
+    <title>Tomb of Light | Viewer</title>
 
-    <link rel="stylesheet" href="css/style.css?v=20260329-2" />
+    <link rel="stylesheet" href="css/style.css?v=20260329-3" />
 
     <script>
       (function () {
@@ -178,9 +178,9 @@
         </div>
 
         <div class="viewer-header-copy">
-          <span class="viewer-kicker">Genesis Prototype</span>
-          <h1>Interactive Family Lineage</h1>
-          <p>
+          <span class="viewer-kicker" id="viewerHeaderKicker">Genesis Prototype</span>
+          <h1 id="viewerHeroTitle">Interactive Family Lineage</h1>
+          <p id="viewerHeroBody">
             Navigate through generations of the Moreland lineage and explore
             family branches through the Tomb of Light viewer.
           </p>
@@ -215,6 +215,9 @@
                 src="images/malik.jpg"
                 alt="Malik Moreland"
               />
+              <div class="viewer-empty-note" id="viewerEmptyState" hidden>
+                Upload portraits to activate your private cinematic viewer.
+              </div>
 
               <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
               <div class="eye-hint" id="eyeRight" aria-hidden="true"></div>
@@ -222,24 +225,14 @@
 
             <div id="narrationDisplay" class="narration-text"></div>
 
-            <div class="branch-options" id="branchOptions">
-              <button type="button" onclick="selectBranch('julian')">
-                Julian
-              </button>
-              <button type="button" onclick="selectBranch('malik')">
-                Malik
-              </button>
-              <button type="button" onclick="selectBranch('selah')">
-                Selah
-              </button>
-            </div>
+            <div class="branch-options" id="branchOptions"></div>
           </div>
 
           <div class="viewer-line"></div>
 
           <div class="controls" id="controls">
-            <button type="button" onclick="navigateParents()">Parents</button>
-            <button type="button" onclick="navigateDescendants()">
+            <button type="button" id="navLeftBtn" onclick="navigateParents()">Parents</button>
+            <button type="button" id="navRightBtn" onclick="navigateDescendants()">
               Descendants
             </button>
             <button type="button" onclick="zoomOut()">Zoom Out</button>
@@ -265,8 +258,8 @@
           </div>
 
           <div class="side-card">
-            <span class="panel-kicker">Lineage Flow</span>
-            <div class="path-list">
+            <span class="panel-kicker" id="pathListTitle">Lineage Flow</span>
+            <div class="path-list" id="pathList">
               <div class="path-item">Malik → Parents</div>
               <div class="path-item">Malik → Descendants</div>
               <div class="path-item">Imani → Descendants</div>
@@ -278,6 +271,8 @@
       </main>
     </div>
 
-    <script src="js/script.js?v=20260329-2"></script>
+    <script src="../config.js"></script>
+    <script src="../app.js"></script>
+    <script src="js/script.js?v=20260329-3"></script>
   </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -1,10 +1,13 @@
 // viewer/js/script.js
-// Tomb of Light — Cinematic Viewer Controls (Option 1: Explicit eye zones)
-// ✅ Full viewer: wheel + pinch zoom, hold "C" to reveal eye targets, click Left/Right eye to navigate
-// ✅ Embed mode (homepage preview): WATCH-ONLY (no controls, no C-click, no zoom)
+// Tomb of Light — Cinematic Viewer
+// Public mode keeps the Moreland demo.
+// Signed-in mode loads a customer-specific viewer manifest from the API.
 
 (() => {
+  const app = window.TOLApp || null;
+
   const viewerImage = document.getElementById("viewerImage");
+  const viewerEmptyState = document.getElementById("viewerEmptyState");
   const branchOptions = document.getElementById("branchOptions");
   const viewerTitle = document.getElementById("viewerTitle");
   const viewerStatus = document.getElementById("viewerStatus");
@@ -12,6 +15,15 @@
   const currentDescription = document.getElementById("currentDescription");
   const narrationDisplay = document.getElementById("narrationDisplay");
   const narrationToggleBtn = document.getElementById("narrationToggleBtn");
+  const viewerHeaderKicker = document.getElementById("viewerHeaderKicker");
+  const viewerHeroTitle = document.getElementById("viewerHeroTitle");
+  const viewerHeroBody = document.getElementById("viewerHeroBody");
+  const viewerInstructions = document.getElementById("viewerInstructions");
+  const pathListTitle = document.getElementById("pathListTitle");
+  const pathList = document.getElementById("pathList");
+  const navLeftBtn = document.getElementById("navLeftBtn");
+  const navRightBtn = document.getElementById("navRightBtn");
+  const backLink = document.getElementById("backLink");
 
   const stage = document.getElementById("viewerStage");
   const slideshow = document.getElementById("slideshow");
@@ -19,140 +31,359 @@
   const eyeLeft = document.getElementById("eyeLeft");
   const eyeRight = document.getElementById("eyeRight");
 
+  const params = new URLSearchParams(window.location.search);
+  const PREVIEW_MODE = params.get("preview") === "1";
   const EMBED_MODE =
-    new URLSearchParams(window.location.search).get("embed") === "1" ||
-    window.self !== window.top;
+    PREVIEW_MODE || params.get("embed") === "1" || window.self !== window.top;
 
-  // ----------------------------
-  // STATE GRAPH (your existing flow)
-  // ----------------------------
-  const states = {
-    malik: {
-      image: "images/malik.jpg",
-      title: "Malik Moreland",
-      status: "Anchor Portrait",
-      node: "Malik Moreland",
-      description: "Starting at the anchor portrait for the Genesis family line.",
-      narration:
-        "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations."
+  const DEMO_MANIFEST = {
+    mode: "demo",
+    navigation_mode: "branch",
+    hero_kicker: "Genesis Prototype",
+    hero_title: "Interactive Family Lineage",
+    hero_body:
+      "Navigate through generations of the Moreland lineage and explore family branches through the Tomb of Light viewer.",
+    instructions:
+      "Hold C, then click Left Eye (Parents) or Right Eye (Descendants). You can also use the navigation controls below. Use scroll, pinch, or the zoom buttons to adjust the photo scale. (Full viewer only)",
+    path_title: "Lineage Flow",
+    path_items: [
+      "Malik → Parents",
+      "Malik → Descendants",
+      "Imani → Descendants",
+      "Selah → Descendants",
+      "Julian → Parents",
+    ],
+    nav_labels: {
+      left: "Parents",
+      right: "Descendants",
     },
-    parents: {
-      image: "images/parents.jpg",
-      title: "Elias & Clara Moreland",
-      status: "Parent Structure",
-      node: "Parent Layer",
-      description: "Choose a family branch from the shared parent structure.",
-      narration:
-        "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge."
+    initial_state_id: "malik",
+    branch_options_by_state: {
+      parents: [
+        { label: "Julian", target_state_id: "julian" },
+        { label: "Malik", target_state_id: "malik" },
+        { label: "Selah", target_state_id: "selah" },
+      ],
     },
-    malik_descendants: {
-      image: "images/malik_descendants.jpg",
-      title: "Malik Descendants",
-      status: "Descendant Layer",
-      node: "Malik Descendants",
-      description: "Malik's line expands into the next generation.",
-      narration:
-        "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree."
-    },
-    imani: {
-      image: "images/imani.jpg",
-      title: "Imani Moreland",
-      status: "Next Generation Anchor",
-      node: "Imani Moreland",
-      description: "Imani becomes the next generation anchor portrait.",
-      narration:
-        "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters."
-    },
-    imani_descendants: {
-      image: "images/imani_descendants.jpg",
-      title: "Imani Descendants",
-      status: "Future Legacy Layer",
-      node: "Imani Descendants",
-      description: "Imani's descendants extend the family line forward.",
-      narration:
-        "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time."
-    },
-    julian: {
-      image: "images/julian.jpg",
-      title: "Julian Moreland",
-      status: "Sibling Branch",
-      node: "Julian Moreland",
-      description: "Julian is a sibling branch with no descendant layer.",
-      narration:
-        "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer."
-    },
-    selah: {
-      image: "images/selah.jpg",
-      title: "Selah Carter",
-      status: "Sibling Branch",
-      node: "Selah Carter",
-      description: "Selah is a sibling branch with her own descendants.",
-      narration:
-        "Selah Carter branches from the parent structure with her own distinct lineage and family tree."
-    },
-    selah_descendants: {
-      image: "images/selah_descendants.jpg",
-      title: "Selah Descendants",
-      status: "Descendant Layer",
-      node: "Selah Descendants",
-      description: "Selah's line expands into her descendant branch.",
-      narration:
-        "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure."
-    }
+    states: [
+      {
+        id: "malik",
+        image: "images/malik.jpg",
+        title: "Malik Moreland",
+        status: "Anchor Portrait",
+        node: "Malik Moreland",
+        description:
+          "Starting at the anchor portrait for the Genesis family line.",
+        narration:
+          "This is Malik Moreland, the anchor portrait of the Genesis family line. From here, the Moreland lineage unfolds across generations.",
+        left_state_id: "parents",
+        right_state_id: "malik_descendants",
+        eye_targets: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+      },
+      {
+        id: "parents",
+        image: "images/parents.jpg",
+        title: "Elias & Clara Moreland",
+        status: "Parent Structure",
+        node: "Parent Layer",
+        description:
+          "Choose a family branch from the shared parent structure.",
+        narration:
+          "Elias and Clara Moreland represent the foundational parent structure. From this layer, three distinct family branches emerge.",
+        left_state_id: "malik",
+        right_state_id: null,
+        eye_targets: { left: { x: 40, y: 31 }, right: { x: 60, y: 31 } },
+      },
+      {
+        id: "malik_descendants",
+        image: "images/malik_descendants.jpg",
+        title: "Malik Descendants",
+        status: "Descendant Layer",
+        node: "Malik Descendants",
+        description: "Malik's line expands into the next generation.",
+        narration:
+          "Malik's descendants extend his lineage forward, connecting to the next generation of the Moreland family tree.",
+        left_state_id: "malik",
+        right_state_id: "imani",
+        eye_targets: { left: { x: 42, y: 33 }, right: { x: 58, y: 33 } },
+      },
+      {
+        id: "imani",
+        image: "images/imani.jpg",
+        title: "Imani Moreland",
+        status: "Next Generation Anchor",
+        node: "Imani Moreland",
+        description: "Imani becomes the next generation anchor portrait.",
+        narration:
+          "Imani Moreland carries the anchor role for the next generation, continuing the Moreland lineage into new chapters.",
+        left_state_id: "malik_descendants",
+        right_state_id: "imani_descendants",
+        eye_targets: { left: { x: 44, y: 30 }, right: { x: 56, y: 30 } },
+      },
+      {
+        id: "imani_descendants",
+        image: "images/imani_descendants.jpg",
+        title: "Imani Descendants",
+        status: "Future Legacy Layer",
+        node: "Imani Descendants",
+        description: "Imani's descendants extend the family line forward.",
+        narration:
+          "Imani's descendants reach further into the future, extending the Moreland family legacy forward in time.",
+        left_state_id: "imani",
+        right_state_id: null,
+        eye_targets: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } },
+      },
+      {
+        id: "julian",
+        image: "images/julian.jpg",
+        title: "Julian Moreland",
+        status: "Sibling Branch",
+        node: "Julian Moreland",
+        description: "Julian is a sibling branch with no descendant layer.",
+        narration:
+          "Julian Moreland is a sibling branch. His path connects back through the shared parent structure without a descendant layer.",
+        left_state_id: "parents",
+        right_state_id: null,
+        eye_targets: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+      },
+      {
+        id: "selah",
+        image: "images/selah.jpg",
+        title: "Selah Carter",
+        status: "Sibling Branch",
+        node: "Selah Carter",
+        description: "Selah is a sibling branch with her own descendants.",
+        narration:
+          "Selah Carter branches from the parent structure with her own distinct lineage and family tree.",
+        left_state_id: "parents",
+        right_state_id: "selah_descendants",
+        eye_targets: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
+      },
+      {
+        id: "selah_descendants",
+        image: "images/selah_descendants.jpg",
+        title: "Selah Descendants",
+        status: "Descendant Layer",
+        node: "Selah Descendants",
+        description: "Selah's line expands into her descendant branch.",
+        narration:
+          "Selah's descendants form her unique branch, expanding the family line outward from the Moreland parent structure.",
+        left_state_id: "selah",
+        right_state_id: null,
+        eye_targets: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } },
+      },
+    ],
   };
 
-  // ----------------------------
-  // EYE TARGETS (explicit, per image)
-  // Values are % of the IMAGE AREA (not the browser).
-  // Tune these later per portrait; these are safe starters.
-  // ----------------------------
-  const eyeTargets = {
-    malik: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
-    parents: { left: { x: 40, y: 31 }, right: { x: 60, y: 31 } },
-    malik_descendants: { left: { x: 42, y: 33 }, right: { x: 58, y: 33 } },
-    imani: { left: { x: 44, y: 30 }, right: { x: 56, y: 30 } },
-    imani_descendants: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } },
-    julian: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
-    selah: { left: { x: 44, y: 31 }, right: { x: 56, y: 31 } },
-    selah_descendants: { left: { x: 43, y: 33 }, right: { x: 57, y: 33 } }
-  };
-
-  // ----------------------------
-  // NAV RULES FOR EYES
-  // Left eye = "ancestry / parents direction"
-  // Right eye = "descendants direction"
-  // ----------------------------
-  function goLeftEye() {
-    // ancestry direction
-    if (state === "malik") return applyState("parents");
-    if (state === "malik_descendants") return applyState("malik");
-    if (state === "imani") return applyState("malik_descendants");
-    if (state === "imani_descendants") return applyState("imani");
-    if (state === "julian") return applyState("parents");
-    if (state === "selah") return applyState("parents");
-    if (state === "selah_descendants") return applyState("selah");
-    if (state === "parents") return applyState("malik"); // collapse back to anchor
-  }
-
-  function goRightEye() {
-    // descendants direction
-    if (state === "malik") return applyState("malik_descendants");
-    if (state === "malik_descendants") return applyState("imani");
-    if (state === "imani") return applyState("imani_descendants");
-    if (state === "selah") return applyState("selah_descendants");
-    // parents: don’t use right-eye; branch buttons exist in full viewer
-  }
-
-  // ----------------------------
-  // Narration
-  // ----------------------------
   const NARRATION_DISPLAY_DURATION_MS = 4500;
   const AUTO_ADVANCE_INTERVAL_MS = 5000;
+  const DEFAULT_DYNAMIC_EYE_TARGETS = {
+    left: { x: 18, y: 50 },
+    right: { x: 82, y: 50 },
+  };
 
-  let state = "malik";
+  let currentManifest = null;
+  let statesById = {};
+  let stateOrder = [];
+  let state = "";
   let isPlaying = true;
   let narrationInterval = null;
   let narrationFadeTimeout = null;
+  let transitionLock = false;
+
+  let scale = 1;
+  const SCALE_MIN = 0.65;
+  const SCALE_MAX = 1.25;
+  const ZOOM_STEP = 0.12;
+
+  let pendingWheelDelta = 0;
+  let wheelRaf = null;
+
+  let pointers = new Map();
+  let startDist = 0;
+  let startScale = 1;
+
+  let isUserInteracting = false;
+  let interactionTimeout = null;
+  let cHeld = false;
+
+  function clamp(v, min, max) {
+    return Math.min(max, Math.max(min, v));
+  }
+
+  function setText(node, value) {
+    if (!node) return;
+    node.textContent = value || "";
+  }
+
+  function getApiBaseUrl() {
+    if (app && typeof app.getApiBaseUrl === "function") {
+      return app.getApiBaseUrl();
+    }
+    return "";
+  }
+
+  function resolveImageUrl(image) {
+    const source = String(image || "").trim();
+    if (!source) return "";
+    if (/^https?:\/\//i.test(source)) return source;
+    if (source.startsWith("/")) {
+      const base = getApiBaseUrl();
+      return base ? `${base}${source}` : source;
+    }
+    return source;
+  }
+
+  function normalizeManifest(manifest) {
+    const states = Array.isArray(manifest?.states) ? manifest.states : [];
+    const navigationMode =
+      String(manifest?.navigation_mode || "").trim() || "sequence";
+
+    const normalizedStates = states.map(function (rawState, index) {
+      const id = String(rawState?.id || `state-${index}`).trim();
+      const previousState = states[index - 1];
+      const nextState = states[index + 1];
+
+      return {
+        id,
+        image: resolveImageUrl(rawState?.image),
+        title: String(rawState?.title || "Private Workspace").trim(),
+        status: String(rawState?.status || "").trim(),
+        node: String(rawState?.node || rawState?.title || "Node").trim(),
+        description: String(rawState?.description || "").trim(),
+        narration: String(
+          rawState?.narration || rawState?.description || "",
+        ).trim(),
+        leftStateId:
+          rawState?.left_state_id ||
+          (navigationMode === "sequence" && previousState
+            ? String(previousState.id || "").trim()
+            : ""),
+        rightStateId:
+          rawState?.right_state_id ||
+          (navigationMode === "sequence" && nextState
+            ? String(nextState.id || "").trim()
+            : ""),
+        eyeTargets:
+          rawState?.eye_targets ||
+          (manifest?.mode === "dynamic"
+            ? DEFAULT_DYNAMIC_EYE_TARGETS
+            : DEFAULT_DYNAMIC_EYE_TARGETS),
+      };
+    });
+
+    const normalized = {
+      mode: String(manifest?.mode || "demo").trim() || "demo",
+      navigationMode,
+      heroKicker: String(manifest?.hero_kicker || "Genesis Prototype").trim(),
+      heroTitle: String(
+        manifest?.hero_title || "Interactive Family Lineage",
+      ).trim(),
+      heroBody: String(manifest?.hero_body || "").trim(),
+      instructions: String(manifest?.instructions || "").trim(),
+      pathTitle: String(manifest?.path_title || "Lineage Flow").trim(),
+      pathItems: Array.isArray(manifest?.path_items)
+        ? manifest.path_items.map(function (item) {
+            return String(item || "").trim();
+          }).filter(Boolean)
+        : [],
+      navLabels: {
+        left: String(manifest?.nav_labels?.left || "Parents").trim(),
+        right: String(manifest?.nav_labels?.right || "Descendants").trim(),
+      },
+      initialStateId: String(
+        manifest?.initial_state_id || normalizedStates[0]?.id || "",
+      ).trim(),
+      branchOptionsByState:
+        manifest && typeof manifest.branch_options_by_state === "object"
+          ? manifest.branch_options_by_state
+          : {},
+      states: normalizedStates,
+      project: manifest?.project || null,
+      family: manifest?.family || null,
+    };
+
+    normalized.stateMap = normalized.states.reduce(function (acc, item) {
+      acc[item.id] = item;
+      return acc;
+    }, {});
+    normalized.stateOrder = normalized.states.map(function (item) {
+      return item.id;
+    });
+
+    return normalized;
+  }
+
+  function renderPathList(manifest) {
+    if (!pathList) return;
+
+    const items =
+      manifest.pathItems.length
+        ? manifest.pathItems
+        : manifest.states.map(function (item) {
+            return `${item.title} — ${item.status || "Viewer Node"}`;
+          });
+
+    pathList.innerHTML = items
+      .map(function (item) {
+        return `<div class="path-item">${item}</div>`;
+      })
+      .join("");
+  }
+
+  function updateNavLabels() {
+    setText(navLeftBtn, currentManifest?.navLabels?.left || "Parents");
+    setText(
+      navRightBtn,
+      currentManifest?.navLabels?.right || "Descendants",
+    );
+  }
+
+  function updateHeaderCopy(manifest) {
+    setText(viewerHeaderKicker, manifest.heroKicker);
+    setText(viewerHeroTitle, manifest.heroTitle);
+    setText(viewerHeroBody, manifest.heroBody);
+    setText(viewerInstructions, manifest.instructions);
+    setText(pathListTitle, manifest.pathTitle);
+
+    if (backLink) {
+      if (manifest.mode === "dynamic") {
+        backLink.href = "../dashboard.html";
+        backLink.textContent = "← Back to Dashboard";
+      } else {
+        backLink.href = "../index.html";
+        backLink.textContent = "← Back to Tomb of Light";
+      }
+    }
+
+    if (manifest.mode === "dynamic") {
+      document.title = `Tomb of Light | ${manifest.heroTitle}`;
+    } else {
+      document.title = "Tomb of Light | Genesis Prototype";
+    }
+  }
+
+  function applyManifest(manifest) {
+    currentManifest = normalizeManifest(manifest || DEMO_MANIFEST);
+    statesById = currentManifest.stateMap;
+    stateOrder = currentManifest.stateOrder;
+    state = currentManifest.initialStateId || stateOrder[0] || "";
+
+    updateHeaderCopy(currentManifest);
+    updateNavLabels();
+    renderPathList(currentManifest);
+  }
+
+  function setEmptyState(copy) {
+    if (!viewerEmptyState) return;
+    if (copy) {
+      viewerEmptyState.hidden = false;
+      viewerEmptyState.textContent = copy;
+    } else {
+      viewerEmptyState.hidden = true;
+      viewerEmptyState.textContent = "";
+    }
+  }
 
   function showNarration(text) {
     if (!narrationDisplay) return;
@@ -170,34 +401,33 @@
     narrationDisplay.textContent = text;
     narrationDisplay.style.opacity = "1";
 
-    narrationFadeTimeout = setTimeout(() => {
+    narrationFadeTimeout = setTimeout(function () {
       narrationDisplay.style.opacity = "0";
     }, NARRATION_DISPLAY_DURATION_MS);
   }
 
+  function getNextAutoAdvanceStateId() {
+    const currentState = statesById[state];
+    if (!currentState) return "";
+    if (currentState.rightStateId) return currentState.rightStateId;
+
+    const currentIndex = stateOrder.indexOf(state);
+    if (currentIndex === -1 || stateOrder.length < 2) return "";
+
+    return stateOrder[(currentIndex + 1) % stateOrder.length] || "";
+  }
+
   function startNarrationAutoAdvance() {
-    if (EMBED_MODE) return; // watch-only
+    if (EMBED_MODE) return;
     if (narrationInterval) clearInterval(narrationInterval);
 
-    narrationInterval = setInterval(() => {
-      // narration mode can stay as-is or be upgraded later;
-      // keep it stable: only auto-advance if user is not currently zooming
+    narrationInterval = setInterval(function () {
       if (isUserInteracting) return;
 
-      // use the existing order you approved
-      const order = [
-        "malik",
-        "parents",
-        "malik_descendants",
-        "imani",
-        "imani_descendants",
-        "julian",
-        "selah",
-        "selah_descendants"
-      ];
-      const i = order.indexOf(state);
-      const next = order[(i + 1) % order.length];
-      applyState(next);
+      const next = getNextAutoAdvanceStateId();
+      if (next && next !== state) {
+        applyState(next);
+      }
     }, AUTO_ADVANCE_INTERVAL_MS);
   }
 
@@ -214,194 +444,51 @@
   }
 
   function toggleNarration() {
-    if (EMBED_MODE) return; // watch-only preview
+    if (EMBED_MODE) return;
     isPlaying = !isPlaying;
     if (narrationToggleBtn) {
-      narrationToggleBtn.textContent = isPlaying ? "Narration: ON" : "Narration: OFF";
+      narrationToggleBtn.textContent = isPlaying
+        ? "Narration: ON"
+        : "Narration: OFF";
     }
     if (isPlaying) {
-      showNarration(states[state].narration);
+      showNarration(statesById[state]?.narration || "");
       startNarrationAutoAdvance();
     } else {
       stopNarrationAutoAdvance();
     }
   }
 
-  // ----------------------------
-  // Transition lock (prevents shaking / double triggers)
-  // ----------------------------
-  let transitionLock = false;
-
-  function applyState(nextState) {
-    if (transitionLock) return;
-    const config = states[nextState];
-    if (!config) return;
-
-    transitionLock = true;
-    state = nextState;
-
-    // reset zoom whenever we change states (prevents weird carry-over)
-    setZoom(1, false);
-
-    if (viewerImage) viewerImage.style.opacity = "0.25";
-
-    setTimeout(() => {
-      if (viewerImage) {
-        viewerImage.src = config.image;
-        viewerImage.alt = config.node;
-        viewerImage.style.opacity = "1";
-      }
-
-      if (viewerTitle) viewerTitle.textContent = config.title;
-      if (viewerStatus) viewerStatus.textContent = config.status;
-      if (currentNode) currentNode.textContent = config.node;
-      if (currentDescription) currentDescription.textContent = config.description;
-
-      showNarration(config.narration);
-      placeEyeHints();
-
-      if (branchOptions) {
-        if (!EMBED_MODE && nextState === "parents") branchOptions.style.display = "flex";
-        else branchOptions.style.display = "none";
-      }
-
-      setTimeout(() => {
-        transitionLock = false;
-      }, 140);
-    }, 160);
-  }
-
-  // ----------------------------
-  // BRANCH SELECT (full viewer only)
-  // ----------------------------
-  function selectBranch(branch) {
-    if (EMBED_MODE) return;
-    if (branch === "julian") return applyState("julian");
-    if (branch === "malik") return applyState("malik");
-    if (branch === "selah") return applyState("selah");
-  }
-  window.selectBranch = selectBranch;
-
-  // ----------------------------
-  // ZOOM (Wheel + Pinch)
-  // Applies transform to the IMAGE so it feels continuous.
-  // ----------------------------
-  let scale = 1;
-  const SCALE_MIN = 0.65;
-  const SCALE_MAX = 1.25;
-  const ZOOM_STEP = 0.12;
-
-  function clamp(v, min, max) {
-    return Math.min(max, Math.max(min, v));
-  }
-
   function setZoom(nextScale, smooth = true) {
     if (!viewerImage) return;
     scale = clamp(nextScale, SCALE_MIN, SCALE_MAX);
-
-    // Use translateZ to stabilize GPU and reduce jitter
     viewerImage.style.transition = smooth ? "transform 120ms ease" : "none";
     viewerImage.style.transform = `translateZ(0) scale(${scale})`;
   }
 
-  // Smooth wheel handling (prevents trackpad bursts from shaking)
-  let pendingWheelDelta = 0;
-  let wheelRaf = null;
-
-  function onWheel(e) {
-    if (EMBED_MODE) return;
-    e.preventDefault();
-
-    pendingWheelDelta += e.deltaY;
-
-    if (!wheelRaf) {
-      wheelRaf = requestAnimationFrame(() => {
-        const delta = pendingWheelDelta;
-        pendingWheelDelta = 0;
-        wheelRaf = null;
-
-        // Smaller factor = smoother trackpads
-        const zoomChange = -delta * 0.0007;
-        setZoom(scale + zoomChange, true);
-
-        markInteraction();
-      });
-    }
-  }
-
-  // Pinch zoom using Pointer Events (best cross-device)
-  let pointers = new Map();
-  let startDist = 0;
-  let startScale = 1;
-
-  function getDist(a, b) {
-    const dx = a.clientX - b.clientX;
-    const dy = a.clientY - b.clientY;
-    return Math.hypot(dx, dy);
-  }
-
-  function onPointerDown(e) {
-    if (EMBED_MODE) return;
-    if (!stage) return;
-    stage.setPointerCapture(e.pointerId);
-    pointers.set(e.pointerId, e);
-    markInteraction();
-
-    if (pointers.size === 2) {
-      const [p1, p2] = Array.from(pointers.values());
-      startDist = getDist(p1, p2);
-      startScale = scale;
-    }
-  }
-
-  function onPointerMove(e) {
-    if (EMBED_MODE) return;
-    if (!pointers.has(e.pointerId)) return;
-    pointers.set(e.pointerId, e);
-
-    if (pointers.size === 2) {
-      const [p1, p2] = Array.from(pointers.values());
-      const dist = getDist(p1, p2);
-      if (startDist > 0) {
-        const ratio = dist / startDist;
-        setZoom(startScale * ratio, false);
-        markInteraction();
-      }
-    }
-  }
-
-  function onPointerUp(e) {
-    if (!pointers.has(e.pointerId)) return;
-    pointers.delete(e.pointerId);
-    if (pointers.size < 2) startDist = 0;
-  }
-
-  // Tracks whether user is actively interacting (used to pause narration auto-advance)
-  let isUserInteracting = false;
-  let interactionTimeout = null;
-
   function markInteraction() {
     isUserInteracting = true;
     if (interactionTimeout) clearTimeout(interactionTimeout);
-    interactionTimeout = setTimeout(() => {
+    interactionTimeout = setTimeout(function () {
       isUserInteracting = false;
     }, 900);
   }
 
-  // ----------------------------
-  // EYE HINTS + HOLD "C" TO REVEAL
-  // ----------------------------
-  let cHeld = false;
-
   function placeEyeHints() {
     if (!eyeLeft || !eyeRight || !slideshow) return;
 
-    const t = eyeTargets[state] || eyeTargets["malik"];
-    eyeLeft.style.left = `${t.left.x}%`;
-    eyeLeft.style.top = `${t.left.y}%`;
+    const config = statesById[state];
+    const targets =
+      config?.eyeTargets ||
+      (currentManifest?.mode === "dynamic"
+        ? DEFAULT_DYNAMIC_EYE_TARGETS
+        : DEFAULT_DYNAMIC_EYE_TARGETS);
 
-    eyeRight.style.left = `${t.right.x}%`;
-    eyeRight.style.top = `${t.right.y}%`;
+    eyeLeft.style.left = `${targets.left.x}%`;
+    eyeLeft.style.top = `${targets.left.y}%`;
+
+    eyeRight.style.left = `${targets.right.x}%`;
+    eyeRight.style.top = `${targets.right.y}%`;
   }
 
   function setEyeHintsVisible(visible) {
@@ -429,31 +516,128 @@
     }
   }
 
+  function resolveLeftTarget() {
+    return statesById[state]?.leftStateId || "";
+  }
+
+  function resolveRightTarget() {
+    return statesById[state]?.rightStateId || "";
+  }
+
   function onEyeLeftClick() {
-    if (EMBED_MODE) return;
-    if (!cHeld) return; // must hold C
-    goLeftEye();
+    if (EMBED_MODE || !cHeld) return;
+    const next = resolveLeftTarget();
+    if (next) applyState(next);
   }
 
   function onEyeRightClick() {
-    if (EMBED_MODE) return;
-    if (!cHeld) return; // must hold C
-    goRightEye();
+    if (EMBED_MODE || !cHeld) return;
+    const next = resolveRightTarget();
+    if (next) applyState(next);
   }
 
-  // ----------------------------
-  // Existing button controls still work (full viewer only)
-  // ----------------------------
+  function selectBranch(targetStateId) {
+    if (EMBED_MODE || !targetStateId) return;
+    markInteraction();
+    applyState(targetStateId);
+  }
+
+  function renderBranchOptions() {
+    if (!branchOptions) return;
+
+    const branchOptionsForState = Array.isArray(
+      currentManifest?.branchOptionsByState?.[state],
+    )
+      ? currentManifest.branchOptionsByState[state]
+      : [];
+
+    branchOptions.innerHTML = branchOptionsForState
+      .map(function (option) {
+        const label = String(option?.label || "").trim();
+        const targetStateId = String(option?.target_state_id || "").trim();
+        return label && targetStateId
+          ? `<button type="button" data-target-state="${targetStateId}">${label}</button>`
+          : "";
+      })
+      .join("");
+
+    branchOptions.style.display = branchOptionsForState.length ? "flex" : "none";
+  }
+
+  async function swapViewerImage(imageUrl, altText) {
+    if (!viewerImage) return;
+
+    const resolved = String(imageUrl || "").trim();
+    viewerImage.style.opacity = "0.25";
+
+    if (!resolved) {
+      viewerImage.classList.add("is-empty");
+      viewerImage.removeAttribute("src");
+      viewerImage.alt = altText || "";
+      viewerImage.style.opacity = "0";
+      return;
+    }
+
+    await new Promise(function (resolve) {
+      const preloaded = new Image();
+
+      preloaded.onload = function () {
+        viewerImage.src = resolved;
+        viewerImage.alt = altText || "";
+        viewerImage.classList.remove("is-empty");
+        viewerImage.style.opacity = "1";
+        resolve();
+      };
+
+      preloaded.onerror = function () {
+        viewerImage.src = resolved;
+        viewerImage.alt = altText || "";
+        viewerImage.classList.remove("is-empty");
+        viewerImage.style.opacity = "1";
+        resolve();
+      };
+
+      preloaded.src = resolved;
+    });
+  }
+
+  async function applyState(nextState) {
+    if (transitionLock) return;
+    const config = statesById[nextState];
+    if (!config) return;
+
+    transitionLock = true;
+    state = nextState;
+    setZoom(1, false);
+
+    await swapViewerImage(config.image, config.node);
+
+    setText(viewerTitle, config.title);
+    setText(viewerStatus, config.status);
+    setText(currentNode, config.node);
+    setText(currentDescription, config.description);
+    setEmptyState(config.image ? "" : config.description);
+    showNarration(config.narration);
+    placeEyeHints();
+    renderBranchOptions();
+
+    setTimeout(function () {
+      transitionLock = false;
+    }, 140);
+  }
+
   function navigateParents() {
     if (EMBED_MODE) return;
     markInteraction();
-    goLeftEye();
+    const next = resolveLeftTarget();
+    if (next) applyState(next);
   }
 
   function navigateDescendants() {
     if (EMBED_MODE) return;
     markInteraction();
-    goRightEye();
+    const next = resolveRightTarget();
+    if (next) applyState(next);
   }
 
   function zoomIn() {
@@ -471,48 +655,145 @@
   function resetViewer() {
     if (EMBED_MODE) return;
     setZoom(1, false);
-    applyState("malik");
+    applyState(currentManifest?.initialStateId || stateOrder[0] || "");
     if (isPlaying) startNarrationAutoAdvance();
   }
 
+  function onWheel(e) {
+    if (EMBED_MODE) return;
+    e.preventDefault();
+
+    pendingWheelDelta += e.deltaY;
+
+    if (!wheelRaf) {
+      wheelRaf = requestAnimationFrame(function () {
+        const delta = pendingWheelDelta;
+        pendingWheelDelta = 0;
+        wheelRaf = null;
+
+        const zoomChange = -delta * 0.0007;
+        setZoom(scale + zoomChange, true);
+        markInteraction();
+      });
+    }
+  }
+
+  function getDist(a, b) {
+    const dx = a.clientX - b.clientX;
+    const dy = a.clientY - b.clientY;
+    return Math.hypot(dx, dy);
+  }
+
+  function onPointerDown(e) {
+    if (EMBED_MODE || !stage) return;
+    stage.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, e);
+    markInteraction();
+
+    if (pointers.size === 2) {
+      const activePointers = Array.from(pointers.values());
+      startDist = getDist(activePointers[0], activePointers[1]);
+      startScale = scale;
+    }
+  }
+
+  function onPointerMove(e) {
+    if (EMBED_MODE || !pointers.has(e.pointerId)) return;
+    pointers.set(e.pointerId, e);
+
+    if (pointers.size === 2) {
+      const activePointers = Array.from(pointers.values());
+      const dist = getDist(activePointers[0], activePointers[1]);
+      if (startDist > 0) {
+        const ratio = dist / startDist;
+        setZoom(startScale * ratio, false);
+        markInteraction();
+      }
+    }
+  }
+
+  function onPointerUp(e) {
+    if (!pointers.has(e.pointerId)) return;
+    pointers.delete(e.pointerId);
+    if (pointers.size < 2) startDist = 0;
+  }
+
+  async function loadDynamicManifest() {
+    if (EMBED_MODE) return null;
+    if (!app || typeof app.apiRequest !== "function") return null;
+    if (!app.getToken || !app.getToken()) return null;
+
+    const query = new URLSearchParams();
+    const projectId = params.get("project_id");
+    const familyId = params.get("family_id");
+
+    if (projectId) query.set("project_id", projectId);
+    if (familyId) query.set("family_id", familyId);
+
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+
+    try {
+      const manifest = await app.apiRequest(`/viewer/manifest${suffix}`, {
+        method: "GET",
+      });
+      if (manifest && Array.isArray(manifest.states) && manifest.states.length) {
+        return manifest;
+      }
+    } catch (error) {
+      console.warn("Viewer manifest fallback to demo:", error);
+    }
+
+    return null;
+  }
+
+  function bindEvents() {
+    if (EMBED_MODE) {
+      stopNarrationAutoAdvance();
+      if (branchOptions) branchOptions.style.display = "none";
+      setEyeHintsVisible(false);
+      return;
+    }
+
+    if (stage) stage.addEventListener("wheel", onWheel, { passive: false });
+
+    if (stage) {
+      stage.addEventListener("pointerdown", onPointerDown);
+      stage.addEventListener("pointermove", onPointerMove);
+      stage.addEventListener("pointerup", onPointerUp);
+      stage.addEventListener("pointercancel", onPointerUp);
+      stage.addEventListener("pointerleave", onPointerUp);
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+
+    if (eyeLeft) eyeLeft.addEventListener("click", onEyeLeftClick);
+    if (eyeRight) eyeRight.addEventListener("click", onEyeRightClick);
+
+    if (branchOptions) {
+      branchOptions.addEventListener("click", function (event) {
+        const button = event.target.closest("[data-target-state]");
+        if (!button) return;
+        selectBranch(button.getAttribute("data-target-state"));
+      });
+    }
+  }
+
+  async function boot() {
+    const liveManifest = await loadDynamicManifest();
+    applyManifest(liveManifest || DEMO_MANIFEST);
+    bindEvents();
+    await applyState(currentManifest.initialStateId || stateOrder[0] || "");
+    startNarrationAutoAdvance();
+  }
+
+  window.selectBranch = selectBranch;
   window.navigateParents = navigateParents;
   window.navigateDescendants = navigateDescendants;
   window.zoomIn = zoomIn;
   window.zoomOut = zoomOut;
   window.resetViewer = resetViewer;
   window.toggleNarration = toggleNarration;
-
-  // ----------------------------
-  // BOOT
-  // ----------------------------
-  function boot() {
-    // Embed mode: remove any chance of interaction
-    if (EMBED_MODE) {
-      stopNarrationAutoAdvance();
-      if (branchOptions) branchOptions.style.display = "none";
-      setEyeHintsVisible(false);
-    } else {
-      // Full viewer handlers
-      if (stage) stage.addEventListener("wheel", onWheel, { passive: false });
-
-      if (stage) {
-        stage.addEventListener("pointerdown", onPointerDown);
-        stage.addEventListener("pointermove", onPointerMove);
-        stage.addEventListener("pointerup", onPointerUp);
-        stage.addEventListener("pointercancel", onPointerUp);
-        stage.addEventListener("pointerleave", onPointerUp);
-      }
-
-      window.addEventListener("keydown", onKeyDown);
-      window.addEventListener("keyup", onKeyUp);
-
-      if (eyeLeft) eyeLeft.addEventListener("click", onEyeLeftClick);
-      if (eyeRight) eyeRight.addEventListener("click", onEyeRightClick);
-    }
-
-    applyState("malik");
-    startNarrationAutoAdvance();
-  }
 
   boot();
 })();

--- a/viewer/viewer-preview.html
+++ b/viewer/viewer-preview.html
@@ -13,7 +13,7 @@
   <main class="viewer-preview-shell">
     <div class="viewer-preview-stage">
       <iframe
-        src="index.html?embed=1&v=20260329-2"
+        src="index.html?embed=1&v=20260329-3"
         title="Tomb of Light Viewer Preview"
         loading="lazy"
         allowfullscreen>


### PR DESCRIPTION
The backend has a new live manifest route at viewer_manifest.py (line 11) backed by viewer_manifest_service.py (line 268) and viewer_manifest_service.py (line 535). That layer resolves the signed-in customer’s current project, backfills a hidden workspace family/member anchor when portrait or organization packages do not have one yet, and builds the viewer sequence from real uploaded member photos. I also hooked that same anchor step into intake provisioning in intake_pipeline_service.py (line 339) so new workspaces stop shipping without upload/viewer context.

On the frontend, viewer/index.html (line 180), viewer/js/script.js (line 721), and viewer/css/style.css (line 260) now switch the full viewer into live customer mode when someone is signed in, while keeping the Moreland demo for public/embed preview. The upload page also now auto-resolves that workspace family before loading selectors in verification-upload.js (line 170) and verification-upload.js (line 809), so portrait customers can upload and populate their viewer automatically instead of getting stuck without a family context.

Verification: git diff --check passed, and the touched Python backend files compiled with python3 -m py_compile. I couldn’t run a live browser or JS runtime test here because this machine does not have node, bun, or deno installed.

One honest limitation remains: organization packages now work as an automated protected portrait/leadership sequence, but a true org-chart-specific cinematic structure flow still needs its own dedicated manifest logic later.