### PR TITLE
 backend/app/services/viewer_manifest_service.py viewer/css/style.css…

### DIFF
--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -629,21 +629,21 @@ def build_viewer_manifest(
             "Move through the protected command portrait sequence attached to your organization workspace."
         )
         path_title = "Structure Flow"
-        nav_labels = {"left": "Previous Role", "right": "Next Role"}
+        nav_labels = {"left": "Foundations", "right": "Next Role"}
     elif lane in {"household", "network"}:
         hero_title = "Private Family Viewer"
         hero_body = (
             "Move through the uploaded family portraits attached to your protected lineage workspace."
         )
         path_title = "Family Flow"
-        nav_labels = {"left": "Previous Portrait", "right": "Next Portrait"}
+        nav_labels = {"left": "Origins", "right": "Forward Line"}
     else:
         hero_title = "Private Portrait Viewer"
         hero_body = (
             "Move through the portrait sequence attached to your protected legacy workspace."
         )
         path_title = "Portrait Flow"
-        nav_labels = {"left": "Previous Portrait", "right": "Next Portrait"}
+        nav_labels = {"left": "Origins", "right": "Forward View"}
 
     path_items = [
         f"{state['title']} — {state['status']}"
@@ -658,8 +658,8 @@ def build_viewer_manifest(
         "hero_body": hero_body,
         "workspace_name": workspace_name,
         "instructions": (
-            "Hold C, then click the left or right navigation marker. You can also use the controls below. "
-            "Use scroll, pinch, or the zoom buttons to adjust the photo scale. (Full viewer only)"
+            "Hold C to reveal the lineage portals. Hover a portal and scroll in to enter that line, or scroll out to return. "
+            "Use the zoom buttons below only when you want a closer look at the portrait. (Full viewer only)"
         ),
         "path_title": path_title,
         "path_items": path_items,

--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -287,6 +287,7 @@ a {
 .eye-hint {
   appearance: none;
   position: absolute;
+  z-index: 4;
   width: 44px;
   height: 44px;
   padding: 0;
@@ -301,7 +302,8 @@ a {
     opacity var(--transition),
     transform var(--transition),
     box-shadow var(--transition),
-    background var(--transition);
+    background var(--transition),
+    border-color var(--transition);
 }
 
 .eye-hint.is-visible {
@@ -310,10 +312,12 @@ a {
   cursor: pointer;
 }
 
-.eye-hint.is-visible:hover {
+.eye-hint.is-visible:hover,
+.eye-hint.is-visible.is-active {
   transform: translate(-50%, -50%) scale(1.05);
   box-shadow: 0 0 0 6px rgba(214, 176, 102, 0.14);
   background: rgba(214, 176, 102, 0.14);
+  border-color: rgba(214, 176, 102, 0.8);
 }
 
 .eye-hint.is-visible:focus-visible {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tomb of Light | Viewer</title>
 
-    <link rel="stylesheet" href="css/style.css?v=20260329-3" />
+    <link rel="stylesheet" href="css/style.css?v=20260329-4" />
 
     <script>
       (function () {
@@ -186,11 +186,10 @@
           </p>
 
           <p class="viewer-instructions" id="viewerInstructions">
-            Hold <strong>C</strong>, then click
-            <strong>Left Eye</strong> (Parents) or
-            <strong>Right Eye</strong> (Descendants). You can also use the
-            navigation controls below. Use scroll, pinch, or the zoom buttons
-            to adjust the photo scale. (Full viewer only)
+            Hold <strong>C</strong> to reveal the lineage portals. Hover a
+            portal and scroll in to enter that line, or scroll out to return.
+            Use the zoom buttons below only when you want a closer look at the
+            portrait. (Full viewer only)
           </p>
         </div>
       </header>
@@ -219,8 +218,20 @@
                 Upload portraits to activate your private cinematic viewer.
               </div>
 
-              <div class="eye-hint" id="eyeLeft" aria-hidden="true"></div>
-              <div class="eye-hint" id="eyeRight" aria-hidden="true"></div>
+              <button
+                class="eye-hint"
+                id="eyeLeft"
+                type="button"
+                aria-hidden="true"
+                aria-label="Origins portal"
+              ></button>
+              <button
+                class="eye-hint"
+                id="eyeRight"
+                type="button"
+                aria-hidden="true"
+                aria-label="Future line portal"
+              ></button>
             </div>
 
             <div id="narrationDisplay" class="narration-text"></div>
@@ -231,9 +242,9 @@
           <div class="viewer-line"></div>
 
           <div class="controls" id="controls">
-            <button type="button" id="navLeftBtn" onclick="navigateParents()">Parents</button>
+            <button type="button" id="navLeftBtn" onclick="navigateParents()">Origins</button>
             <button type="button" id="navRightBtn" onclick="navigateDescendants()">
-              Descendants
+              Future Line
             </button>
             <button type="button" onclick="zoomOut()">Zoom Out</button>
             <button type="button" onclick="zoomIn()">Zoom In</button>
@@ -273,6 +284,6 @@
 
     <script src="../config.js"></script>
     <script src="../app.js"></script>
-    <script src="js/script.js?v=20260329-3"></script>
+    <script src="js/script.js?v=20260329-4"></script>
   </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -44,7 +44,7 @@
     hero_body:
       "Navigate through generations of the Moreland lineage and explore family branches through the Tomb of Light viewer.",
     instructions:
-      "Hold C, then click Left Eye (Parents) or Right Eye (Descendants). You can also use the navigation controls below. Use scroll, pinch, or the zoom buttons to adjust the photo scale. (Full viewer only)",
+      "Hold C to reveal the lineage portals. Hover a portal and scroll in to enter that line, or scroll out to return. Use the zoom buttons below only when you want a closer look at the portrait. (Full viewer only)",
     path_title: "Lineage Flow",
     path_items: [
       "Malik → Parents",
@@ -54,8 +54,8 @@
       "Julian → Parents",
     ],
     nav_labels: {
-      left: "Parents",
-      right: "Descendants",
+      left: "Origins",
+      right: "Future Line",
     },
     initial_state_id: "malik",
     branch_options_by_state: {
@@ -198,10 +198,8 @@
 
   let pendingWheelDelta = 0;
   let wheelRaf = null;
-
-  let pointers = new Map();
-  let startDist = 0;
-  let startScale = 1;
+  let hoveredPortalSide = "";
+  let gestureNavigationLock = false;
 
   let isUserInteracting = false;
   let interactionTimeout = null;
@@ -501,6 +499,16 @@
     eyeRight.setAttribute("aria-hidden", visible ? "false" : "true");
   }
 
+  function setHoveredPortal(side) {
+    hoveredPortalSide = side || "";
+    if (eyeLeft) {
+      eyeLeft.classList.toggle("is-active", hoveredPortalSide === "left");
+    }
+    if (eyeRight) {
+      eyeRight.classList.toggle("is-active", hoveredPortalSide === "right");
+    }
+  }
+
   function onKeyDown(e) {
     if (EMBED_MODE) return;
     if (e.key === "c" || e.key === "C") {
@@ -513,6 +521,7 @@
     if (e.key === "c" || e.key === "C") {
       cHeld = false;
       setEyeHintsVisible(false);
+      setHoveredPortal("");
     }
   }
 
@@ -524,16 +533,51 @@
     return statesById[state]?.rightStateId || "";
   }
 
+  function portalCanInteract(node) {
+    return Boolean(node && node.classList.contains("is-visible"));
+  }
+
+  async function animatePortalTransition(side, nextState) {
+    if (!nextState || !viewerImage || gestureNavigationLock) return;
+
+    gestureNavigationLock = true;
+
+    const config = statesById[state];
+    const targets =
+      config?.eyeTargets ||
+      DEFAULT_DYNAMIC_EYE_TARGETS;
+    const target = side === "left" ? targets.left : targets.right;
+    const shiftX = clamp((50 - Number(target?.x || 50)) * 0.45, -20, 20);
+    const shiftY = clamp((50 - Number(target?.y || 50)) * 0.3, -14, 14);
+
+    viewerImage.style.transition =
+      "transform 240ms cubic-bezier(0.22, 1, 0.36, 1), opacity 0.25s ease";
+    viewerImage.style.transform = `translate(${shiftX}%, ${shiftY}%) scale(1.24)`;
+
+    await new Promise(function (resolve) {
+      window.setTimeout(resolve, 210);
+    });
+
+    await applyState(nextState);
+    gestureNavigationLock = false;
+  }
+
   function onEyeLeftClick() {
-    if (EMBED_MODE || !cHeld) return;
+    if (EMBED_MODE || !portalCanInteract(eyeLeft)) return;
     const next = resolveLeftTarget();
-    if (next) applyState(next);
+    if (next) {
+      markInteraction();
+      animatePortalTransition("left", next);
+    }
   }
 
   function onEyeRightClick() {
-    if (EMBED_MODE || !cHeld) return;
+    if (EMBED_MODE || !portalCanInteract(eyeRight)) return;
     const next = resolveRightTarget();
-    if (next) applyState(next);
+    if (next) {
+      markInteraction();
+      animatePortalTransition("right", next);
+    }
   }
 
   function selectBranch(targetStateId) {
@@ -630,14 +674,14 @@
     if (EMBED_MODE) return;
     markInteraction();
     const next = resolveLeftTarget();
-    if (next) applyState(next);
+    if (next) animatePortalTransition("left", next);
   }
 
   function navigateDescendants() {
     if (EMBED_MODE) return;
     markInteraction();
     const next = resolveRightTarget();
-    if (next) applyState(next);
+    if (next) animatePortalTransition("right", next);
   }
 
   function zoomIn() {
@@ -671,51 +715,42 @@
         pendingWheelDelta = 0;
         wheelRaf = null;
 
-        const zoomChange = -delta * 0.0007;
-        setZoom(scale + zoomChange, true);
+        if (Math.abs(delta) < 12 || gestureNavigationLock) return;
+
         markInteraction();
+
+        if (delta < 0) {
+          const side =
+            hoveredPortalSide ||
+            (resolveRightTarget() ? "right" : resolveLeftTarget() ? "left" : "");
+          const next =
+            side === "left" ? resolveLeftTarget() : resolveRightTarget();
+          if (next) {
+            animatePortalTransition(side || "right", next);
+          }
+          return;
+        }
+
+        const backTarget = resolveLeftTarget();
+        if (backTarget) {
+          animatePortalTransition("left", backTarget);
+        }
       });
     }
   }
 
-  function getDist(a, b) {
-    const dx = a.clientX - b.clientX;
-    const dy = a.clientY - b.clientY;
-    return Math.hypot(dx, dy);
-  }
-
   function onPointerDown(e) {
     if (EMBED_MODE || !stage) return;
-    stage.setPointerCapture(e.pointerId);
-    pointers.set(e.pointerId, e);
     markInteraction();
-
-    if (pointers.size === 2) {
-      const activePointers = Array.from(pointers.values());
-      startDist = getDist(activePointers[0], activePointers[1]);
-      startScale = scale;
-    }
   }
 
   function onPointerMove(e) {
-    if (EMBED_MODE || !pointers.has(e.pointerId)) return;
-    pointers.set(e.pointerId, e);
-
-    if (pointers.size === 2) {
-      const activePointers = Array.from(pointers.values());
-      const dist = getDist(activePointers[0], activePointers[1]);
-      if (startDist > 0) {
-        const ratio = dist / startDist;
-        setZoom(startScale * ratio, false);
-        markInteraction();
-      }
-    }
+    if (EMBED_MODE) return;
+    markInteraction();
   }
 
   function onPointerUp(e) {
-    if (!pointers.has(e.pointerId)) return;
-    pointers.delete(e.pointerId);
-    if (pointers.size < 2) startDist = 0;
+    if (EMBED_MODE) return;
   }
 
   async function loadDynamicManifest() {
@@ -760,8 +795,6 @@
       stage.addEventListener("pointerdown", onPointerDown);
       stage.addEventListener("pointermove", onPointerMove);
       stage.addEventListener("pointerup", onPointerUp);
-      stage.addEventListener("pointercancel", onPointerUp);
-      stage.addEventListener("pointerleave", onPointerUp);
     }
 
     window.addEventListener("keydown", onKeyDown);
@@ -769,6 +802,22 @@
 
     if (eyeLeft) eyeLeft.addEventListener("click", onEyeLeftClick);
     if (eyeRight) eyeRight.addEventListener("click", onEyeRightClick);
+    if (eyeLeft) {
+      eyeLeft.addEventListener("pointerenter", function () {
+        setHoveredPortal("left");
+      });
+      eyeLeft.addEventListener("pointerleave", function () {
+        if (hoveredPortalSide === "left") setHoveredPortal("");
+      });
+    }
+    if (eyeRight) {
+      eyeRight.addEventListener("pointerenter", function () {
+        setHoveredPortal("right");
+      });
+      eyeRight.addEventListener("pointerleave", function () {
+        if (hoveredPortalSide === "right") setHoveredPortal("");
+      });
+    }
 
     if (branchOptions) {
       branchOptions.addEventListener("click", function (event) {

--- a/viewer/viewer-preview.html
+++ b/viewer/viewer-preview.html
@@ -13,7 +13,7 @@
   <main class="viewer-preview-shell">
     <div class="viewer-preview-stage">
       <iframe
-        src="index.html?embed=1&v=20260329-3"
+        src="index.html?embed=1&v=20260329-4"
         title="Tomb of Light Viewer Preview"
         loading="lazy"
         allowfullscreen>


### PR DESCRIPTION
… viewer/index.html viewer/js/script.js viewer/viewer-preview.html

I reworked the prototype viewer so the wheel gesture now behaves like lineage travel instead of portrait zoom. In script.js (line 540), scrolling in over a revealed portal now triggers a short zoom-into-portal transition and moves into that line, while scrolling out backs out through the left/origin path. The actual portrait zoom is now reserved for the bottom Zoom In and Zoom Out buttons only. I also made the portal circles real buttons in index.html (line 222), added stronger hover/active styling in style.css (line 282), and changed the wording away from Parents / Descendants.

The better interaction model is the one you were describing: treat those circles as lineage portals, not tiny literal eye click targets. That’s more reliable, especially on group portraits like your screenshot. I set the demo viewer to use Origins and Future Line, and the live customer viewer now uses softer labels too in viewer_manifest_service.py (line 632). If you want to push it further, my next recommendation would be adding tiny portal captions directly beside the circles, like Origins on the left and Future Line on the right, so users do not have to guess.

Verification: git diff --check passed, and the touched Python files compiled with python3 -m py_compile. I still could not run a live browser execution test here, so the next thing to check in Render is:

hold C shows the portals
hover a portal and scroll up enters that line
scroll down backs out
bottom zoom buttons still only zoom the portrait