### PR TITLE
Harden workspace authorization, upload isolation, and in-place packag…

### DIFF
--- a/backend/app/routes/families.py
+++ b/backend/app/routes/families.py
@@ -10,6 +10,10 @@ from app.dependencies.auth import (
     require_any_package_capability,
 )
 from app.schemas.family import FamilyCreate, FamilyResponse, build_family_response
+from app.services.workspace_access_service import (
+    list_accessible_families_for_user,
+    require_workspace_capability,
+)
 
 router = APIRouter(prefix="/families", tags=["Families"])
 
@@ -107,10 +111,6 @@ def get_families(user: dict[str, Any] = Depends(get_current_user)):
     db = get_database()
     families_collection = db["families"]
 
-    current_user_id = _current_user_id(user)
-    current_user_email = _current_user_email(user)
-    current_user_name = _current_user_display_name(user)
-
     docs = list(families_collection.find().sort("created_at", -1))
 
     results: list[FamilyResponse] = []
@@ -122,16 +122,10 @@ def get_families(user: dict[str, Any] = Depends(get_current_user)):
                 results.append(built)
         return results
 
-    for family in docs:
-        if _family_is_visible_to_user(
-            family=family,
-            current_user_id=current_user_id,
-            current_user_email=current_user_email,
-            current_user_name=current_user_name,
-        ):
-            built = _safe_build_family_response(family)
-            if built is not None:
-                results.append(built)
+    for family in list_accessible_families_for_user(user):
+        built = _safe_build_family_response(family)
+        if built is not None:
+            results.append(built)
 
     return results
 
@@ -147,22 +141,17 @@ def create_family_route(
     payload: FamilyCreate,
     user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include family build access.",
-    )
-
     db = get_database()
     families_collection = db["families"]
 
     current_user_id = _current_user_id(user)
     current_user_email = _current_user_email(user)
+    is_admin = _is_admin(user)
 
     family_name = str(payload.family_name).strip()
     created_by = str(payload.created_by).strip() if payload.created_by else ""
     description = str(payload.description).strip() if payload.description else None
+    project_id = str(payload.project_id or "").strip()
 
     if not family_name:
         raise HTTPException(
@@ -173,10 +162,50 @@ def create_family_route(
     if not created_by:
         created_by = str(user.get("full_name") or current_user_email).strip()
 
+    project = None
+    if is_admin:
+        if project_id:
+            context = require_workspace_capability(
+                user,
+                project_id=project_id,
+                capabilities=("can_build_family_tree", "can_open_family_intake"),
+                detail="This workspace does not support family build access.",
+            )
+            project = context["project"]
+    else:
+        if not project_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="project_id is required to create a family inside a workspace.",
+            )
+        context = require_workspace_capability(
+            user,
+            project_id=project_id,
+            capabilities=("can_build_family_tree", "can_open_family_intake"),
+            detail="Your active package does not include family build access.",
+        )
+        project = context["project"]
+
+    if project is not None:
+        existing_project_family_id = str(project.get("family_id") or "").strip()
+        existing_project_family = (
+            families_collection.find_one({"project_id": str(project.get("_id"))})
+            if not existing_project_family_id
+            else None
+        )
+        if existing_project_family_id or existing_project_family is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "This workspace already has a family root. "
+                    "Use the existing family workspace instead of creating a new root."
+                ),
+            )
+
     existing = families_collection.find_one(
         {
             "family_name": family_name,
-            "owner_user_id": current_user_id,
+            "owner_user_id": current_user_id if not is_admin else str(project.get("owner_user_id") or current_user_id) if project is not None else current_user_id,
         }
     )
     if existing:
@@ -189,15 +218,24 @@ def create_family_route(
         "family_name": family_name,
         "created_by": created_by,
         "description": description,
-        "owner_user_id": current_user_id,
-        "owner_email": current_user_email,
+        "project_id": str(project.get("_id")) if project is not None else None,
+        "owner_user_id": str(project.get("owner_user_id") or current_user_id) if project is not None else current_user_id,
+        "owner_email": str(project.get("owner_email") or current_user_email).strip().lower() if project is not None else current_user_email,
         "visibility": "private",
         "shared_with_user_ids": [],
         "shared_with_emails": [],
+        "package_code": str(project.get("package_code") or "").strip() if project is not None else None,
+        "package_name": str(project.get("package_name") or "").strip() if project is not None else None,
         "created_at": datetime.now(UTC),
     }
 
     result = families_collection.insert_one(family_doc)
     family_doc["_id"] = result.inserted_id
+
+    if project is not None:
+        db["projects"].update_one(
+            {"_id": project["_id"]},
+            {"$set": {"family_id": str(result.inserted_id), "updated_at": datetime.now(UTC)}},
+        )
 
     return build_family_response(family_doc)

--- a/backend/app/routes/family_graph.py
+++ b/backend/app/routes/family_graph.py
@@ -4,7 +4,8 @@ from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.database import get_database
-from app.dependencies.auth import get_current_user, require_any_package_capability
+from app.dependencies.auth import get_current_user
+from app.services.workspace_access_service import require_workspace_capability
 
 router = APIRouter(prefix="/families", tags=["Family Graph"])
 
@@ -109,42 +110,25 @@ def get_family_graph(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
-        "can_upload_verification_docs",
-        "can_upload_portraits",
+        family_id=family_id,
+        capabilities=(
+            "can_build_family_tree",
+            "can_upload_verification_docs",
+            "can_upload_portraits",
+        ),
         detail="Your active package does not include access to this family workspace.",
     )
 
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
+    family = context["family"]
+    resolved_family_id = str(family.get("_id"))
 
-    if not ObjectId.is_valid(family_id):
-        raise HTTPException(status_code=400, detail="Invalid family id.")
-
-    family = db.families.find_one({"_id": ObjectId(family_id)})
-    if not family:
-        raise HTTPException(status_code=404, detail="Family not found.")
-
-    current_user_id = _current_user_id(current_user)
-    current_user_email = _current_user_email(current_user)
-    current_user_name = _current_user_display_name(current_user)
-
-    if not _is_admin(current_user) and not _family_is_visible_to_user(
-        family=family,
-        current_user_id=current_user_id,
-        current_user_email=current_user_email,
-        current_user_name=current_user_name,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to access this family graph.",
-        )
-
-    members_cursor = db.family_members.find({"family_id": family_id}).sort("generation", 1)
-    relationships_cursor = db.relationships.find({"family_id": family_id})
+    members_cursor = db.family_members.find({"family_id": resolved_family_id}).sort("generation", 1)
+    relationships_cursor = db.relationships.find({"family_id": resolved_family_id})
 
     members = []
     for member in members_cursor:

--- a/backend/app/routes/family_members.py
+++ b/backend/app/routes/family_members.py
@@ -5,9 +5,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.core.metadata import apply_create_metadata, apply_update_metadata
 from app.database import get_database
-from app.dependencies.auth import get_current_user, require_any_package_capability
+from app.dependencies.auth import get_current_user
 from app.services.audit_log_service import create_audit_log
 from app.services.matching import generate_match_candidates_for_member
+from app.services.workspace_access_service import (
+    list_accessible_families_for_user,
+    require_workspace_capability,
+)
 
 router = APIRouter(prefix="/family-members", tags=["family_members"])
 
@@ -195,14 +199,6 @@ def _display_name(member: dict[str, Any]) -> str:
 
 @router.get("-index")
 def list_family_members_index(current_user: dict[str, Any] = Depends(get_current_user)):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_upload_verification_docs",
-        "can_upload_portraits",
-        detail="Your active package does not include family member access.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
@@ -211,21 +207,13 @@ def list_family_members_index(current_user: dict[str, Any] = Depends(get_current
         cursor = db.family_members.find().sort("created_at", 1)
         return [_serialize_member(member) for member in cursor]
 
-    current_user_id = _current_user_id(current_user)
-    current_user_email = _current_user_email(current_user)
-    current_user_name = _current_user_display_name(current_user)
-
-    visible_family_ids: list[str] = []
-    family_cursor = db.families.find()
-
-    for family in family_cursor:
-        if _family_is_visible_to_user(
-            family=family,
-            current_user_id=current_user_id,
-            current_user_email=current_user_email,
-            current_user_name=current_user_name,
-        ):
-            visible_family_ids.append(str(family.get("_id")))
+    visible_family_ids = [
+        str(family.get("_id"))
+        for family in list_accessible_families_for_user(
+            current_user,
+            capabilities=("can_build_family_tree", "can_open_family_intake"),
+        )
+    ]
 
     if not visible_family_ids:
         return []
@@ -242,24 +230,22 @@ def create_family_member(
     payload: Dict[str, Any],
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include family member editing.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
     family_id = str(payload.get("family_id") or "").strip()
-    _require_family_access_by_family_id(family_id, current_user)
+    context = require_workspace_capability(
+        current_user,
+        family_id=family_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
+        detail="Your active package does not include family member editing.",
+    )
 
     user_id = _current_user_id(current_user)
 
     payload = dict(payload)
-    payload["family_id"] = family_id
+    payload["family_id"] = str(context["family"].get("_id"))
 
     payload = apply_create_metadata(payload, user_id)
     result = db.family_members.insert_one(payload)
@@ -272,7 +258,7 @@ def create_family_member(
         entity_type="family_member",
         entity_id=member_id,
         details={
-            "family_id": family_id,
+            "family_id": payload["family_id"],
             "payload_keys": list(payload.keys()),
         },
     )
@@ -292,18 +278,17 @@ def update_family_member(
     payload: Dict[str, Any],
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include family member editing.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    existing, _family = _require_family_access_for_member(member_id, current_user)
+    context = require_workspace_capability(
+        current_user,
+        member_id=member_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
+        detail="Your active package does not include family member editing.",
+    )
+    existing = context["member"]
 
     if "family_id" in payload:
         incoming_family_id = str(payload.get("family_id") or "").strip()
@@ -345,18 +330,17 @@ def delete_family_member(
     member_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include family member editing.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    existing, _family = _require_family_access_for_member(member_id, current_user)
+    context = require_workspace_capability(
+        current_user,
+        member_id=member_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
+        detail="Your active package does not include family member editing.",
+    )
+    existing = context["member"]
 
     relationship_count = db.relationships.count_documents(
         {

--- a/backend/app/routes/lineage_certificate.py
+++ b/backend/app/routes/lineage_certificate.py
@@ -6,11 +6,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.database import get_database
 from app.dependencies.auth import (
     get_current_user,
-    has_internal_admin_access,
-    require_package_capability,
 )
 from app.schemas.lineage_certificate import LineageCertificateResponse
 from app.services.lineage_certificate_service import LineageCertificateService
+from app.services.workspace_access_service import require_workspace_capability
 
 router = APIRouter(
     prefix="/lineage-certificate",
@@ -45,113 +44,21 @@ def _current_user_display_name(user: dict[str, Any]) -> str:
     return str(raw_name).strip()
 
 
-def _is_admin(user: dict[str, Any]) -> bool:
-    return has_internal_admin_access(user)
-
-
-def _family_is_visible_to_user(
-    family: dict[str, Any],
-    current_user_id: str,
-    current_user_email: str,
-    current_user_name: str,
-) -> bool:
-    owner_user_id = str(family.get("owner_user_id") or "").strip()
-    owner_email = str(family.get("owner_email") or "").strip().lower()
-
-    shared_with_user_ids = [
-        str(value).strip()
-        for value in (family.get("shared_with_user_ids") or [])
-        if value is not None
-    ]
-    shared_with_emails = [
-        str(value).strip().lower()
-        for value in (family.get("shared_with_emails") or [])
-        if value is not None
-    ]
-
-    if owner_user_id and owner_user_id == current_user_id:
-        return True
-
-    if owner_email and owner_email == current_user_email:
-        return True
-
-    if current_user_id in shared_with_user_ids:
-        return True
-
-    if current_user_email in shared_with_emails:
-        return True
-
-    # Backward-compatible fallback for older family records
-    if not owner_user_id and not owner_email:
-        created_by = str(family.get("created_by") or "").strip()
-        if created_by and (
-            created_by == current_user_name or created_by.lower() == current_user_email
-        ):
-            return True
-
-    return False
-
-
-def _require_family_access(
-    family_id: str,
-    current_user: dict[str, Any],
-) -> dict[str, Any]:
-    db = get_database()
-    if db is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Database is not connected.",
-        )
-
-    if not ObjectId.is_valid(family_id):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid family id.",
-        )
-
-    family = db.families.find_one({"_id": ObjectId(family_id)})
-    if not family:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Family not found.",
-        )
-
-    if _is_admin(current_user):
-        return family
-
-    current_user_id = _current_user_id(current_user)
-    current_user_email = _current_user_email(current_user)
-    current_user_name = _current_user_display_name(current_user)
-
-    if not _family_is_visible_to_user(
-        family=family,
-        current_user_id=current_user_id,
-        current_user_email=current_user_email,
-        current_user_name=current_user_name,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to access this lineage certificate.",
-        )
-
-    return family
-
-
 @router.get("/{family_id}", response_model=LineageCertificateResponse)
 def get_lineage_certificate(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_use_lineage_certificate",
+        family_id=family_id,
+        capabilities=("can_use_lineage_certificate",),
         detail="Your active package does not include lineage certificates.",
     )
-
-    _require_family_access(family_id, current_user)
+    resolved_family_id = str(context["family"].get("_id"))
 
     try:
-        return service.build_certificate(family_id)
+        return service.build_certificate(resolved_family_id)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/routes/relationships.py
+++ b/backend/app/routes/relationships.py
@@ -6,10 +6,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from app.dependencies.auth import (
     get_current_user,
     has_internal_admin_access,
-    require_any_package_capability,
 )
 from app.schemas.relationship import RelationshipCreate, RelationshipResponse
 from app.services.relationship_guardrails import RelationshipGuardrailService
+from app.services.workspace_access_service import require_workspace_capability
 
 router = APIRouter(prefix="/relationships", tags=["Relationships"])
 
@@ -151,9 +151,13 @@ def _require_relationship_access(
     if not relationship:
         raise HTTPException(status_code=404, detail="Relationship not found")
 
-    family_id = str(relationship.get("family_id") or "").strip()
-    family = _require_family_access_by_family_id(family_id, db, current_user)
-    return relationship, family
+    context = require_workspace_capability(
+        current_user,
+        family_id=str(relationship.get("family_id") or "").strip(),
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
+        detail="Your active package does not include relationship editing.",
+    )
+    return relationship, context
 
 
 @router.post("", response_model=RelationshipResponse, status_code=status.HTTP_201_CREATED)
@@ -162,17 +166,15 @@ async def create_relationship(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include relationship editing.",
-    )
-
     db = request.app.state.db
     service = RelationshipGuardrailService(db)
-
-    _require_family_access_by_family_id(payload.family_id, db, current_user)
+    context = require_workspace_capability(
+        current_user,
+        family_id=payload.family_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
+        detail="Your active package does not include relationship editing.",
+    )
+    resolved_family_id = str(context["family"].get("_id"))
 
     created_by = (
         current_user.get("email")
@@ -184,7 +186,7 @@ async def create_relationship(
     )
 
     guarded_payload = RelationshipCreate(
-        family_id=payload.family_id,
+        family_id=resolved_family_id,
         source_member_id=payload.source_member_id,
         target_member_id=payload.target_member_id,
         relationship_type=payload.relationship_type,
@@ -224,19 +226,17 @@ async def get_family_relationships(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    db = request.app.state.db
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
+        family_id=family_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include relationship access.",
     )
-
-    db = request.app.state.db
-
-    _require_family_access_by_family_id(family_id, db, current_user)
+    resolved_family_id = str(context["family"].get("_id"))
 
     relationships = []
-    cursor = db["relationships"].find({"family_id": family_id})
+    cursor = db["relationships"].find({"family_id": resolved_family_id})
 
     for rel in cursor:
         relationships.append(
@@ -253,7 +253,7 @@ async def get_family_relationships(
         )
 
     return {
-        "family_id": family_id,
+        "family_id": resolved_family_id,
         "count": len(relationships),
         "relationships": relationships,
     }
@@ -265,16 +265,13 @@ async def get_member_relationships(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    db = request.app.state.db
+    require_workspace_capability(
         current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
+        member_id=member_id,
+        capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include relationship access.",
     )
-
-    db = request.app.state.db
-
-    _member, _family = _require_member_access(member_id, db, current_user)
 
     relationships = []
     cursor = db["relationships"].find(
@@ -313,13 +310,6 @@ async def delete_relationship(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_build_family_tree",
-        "can_open_family_intake",
-        detail="Your active package does not include relationship editing.",
-    )
-
     db = request.app.state.db
 
     relationship, _family = _require_relationship_access(relationship_id, db, current_user)

--- a/backend/app/routes/tree.py
+++ b/backend/app/routes/tree.py
@@ -6,9 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.database import get_database
 from app.dependencies.auth import (
     get_current_user,
-    has_internal_admin_access,
-    require_package_capability,
 )
+from app.services.workspace_access_service import require_workspace_capability
 from app.services.tree_service import get_family_tree, get_filtered_family_tree
 
 router = APIRouter(prefix="/tree", tags=["Tree"])
@@ -39,100 +38,20 @@ def _current_user_display_name(user: dict[str, Any]) -> str:
     return str(raw_name).strip()
 
 
-def _is_admin(user: dict[str, Any]) -> bool:
-    return has_internal_admin_access(user)
-
-
-def _family_is_visible_to_user(
-    family: dict[str, Any],
-    current_user_id: str,
-    current_user_email: str,
-    current_user_name: str,
-) -> bool:
-    owner_user_id = str(family.get("owner_user_id") or "").strip()
-    owner_email = str(family.get("owner_email") or "").strip().lower()
-
-    shared_with_user_ids = [
-        str(value).strip()
-        for value in (family.get("shared_with_user_ids") or [])
-        if value is not None
-    ]
-    shared_with_emails = [
-        str(value).strip().lower()
-        for value in (family.get("shared_with_emails") or [])
-        if value is not None
-    ]
-
-    if owner_user_id and owner_user_id == current_user_id:
-        return True
-
-    if owner_email and owner_email == current_user_email:
-        return True
-
-    if current_user_id in shared_with_user_ids:
-        return True
-
-    if current_user_email in shared_with_emails:
-        return True
-
-    # Temporary backward-compatible fallback for older family records
-    if not owner_user_id and not owner_email:
-        created_by = str(family.get("created_by") or "").strip()
-        if created_by and (
-            created_by == current_user_name or created_by.lower() == current_user_email
-        ):
-            return True
-
-    return False
-
-
-def _require_family_access(family_id: str, current_user: dict[str, Any]) -> dict[str, Any]:
-    db = get_database()
-    if db is None:
-        raise HTTPException(status_code=500, detail="Database is not connected.")
-
-    if not ObjectId.is_valid(family_id):
-        raise HTTPException(status_code=400, detail="Invalid family id.")
-
-    family = db.families.find_one({"_id": ObjectId(family_id)})
-    if not family:
-        raise HTTPException(status_code=404, detail="Family not found.")
-
-    if _is_admin(current_user):
-        return family
-
-    current_user_id = _current_user_id(current_user)
-    current_user_email = _current_user_email(current_user)
-    current_user_name = _current_user_display_name(current_user)
-
-    if not _family_is_visible_to_user(
-        family=family,
-        current_user_id=current_user_id,
-        current_user_email=current_user_email,
-        current_user_name=current_user_name,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to access this family tree.",
-        )
-
-    return family
-
-
 @router.get("/{family_id}")
 def get_tree(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
+        family_id=family_id,
+        capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
+    resolved_family_id = str(context["family"].get("_id"))
 
-    _require_family_access(family_id, current_user)
-
-    tree = get_family_tree(family_id)
+    tree = get_family_tree(resolved_family_id)
 
     if not tree["members"] and not tree["nodes"] and not tree["relationships"]:
         raise HTTPException(status_code=404, detail="Family tree not found.")
@@ -145,13 +64,13 @@ def get_verified_tree(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
+        family_id=family_id,
+        capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    _require_family_access(family_id, current_user)
-    tree = get_filtered_family_tree(family_id, "verified")
+    tree = get_filtered_family_tree(str(context["family"].get("_id")), "verified")
     return tree
 
 
@@ -160,13 +79,13 @@ def get_narrative_tree(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
+        family_id=family_id,
+        capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    _require_family_access(family_id, current_user)
-    tree = get_filtered_family_tree(family_id, "narrative")
+    tree = get_filtered_family_tree(str(context["family"].get("_id")), "narrative")
     return tree
 
 
@@ -175,11 +94,11 @@ def get_private_tree(
     family_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_build_family_tree",
+        family_id=family_id,
+        capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    _require_family_access(family_id, current_user)
-    tree = get_filtered_family_tree(family_id, "private")
+    tree = get_filtered_family_tree(str(context["family"].get("_id")), "private")
     return tree

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -18,11 +18,16 @@ from fastapi.responses import FileResponse
 
 from app.config import settings
 from app.database import get_database
-from app.dependencies.auth import get_current_user, require_any_package_capability
+from app.dependencies.auth import get_current_user
 from app.services.upload_service import (
     serialize_upload_record,
     store_member_photo_upload,
     store_verification_evidence_upload,
+)
+from app.services.workspace_access_service import (
+    count_workspace_uploads,
+    require_workspace_capability,
+    resolve_workspace_context,
 )
 
 router = APIRouter(prefix="/uploads", tags=["Uploads"])
@@ -244,6 +249,8 @@ def _require_upload_access(
     upload_id: str,
     db: Any,
     current_user: dict[str, Any],
+    *,
+    detail: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if not ObjectId.is_valid(upload_id):
         raise HTTPException(status_code=400, detail="Invalid upload id.")
@@ -253,8 +260,26 @@ def _require_upload_access(
         raise HTTPException(status_code=404, detail="Upload not found.")
 
     family_id = _normalize_value(upload_record.get("family_id"))
-    family = _require_family_access_by_family_id(family_id, db, current_user)
-    return upload_record, family
+    project_id = _normalize_value(upload_record.get("project_id"))
+    context = require_workspace_capability(
+        current_user,
+        project_id=project_id,
+        family_id=family_id,
+        capabilities=("can_upload_portraits", "can_upload_verification_docs"),
+        detail=detail,
+    )
+
+    if (
+        not context.get("is_admin")
+        and project_id
+        and _normalize_value(context["project"].get("_id")) != project_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Upload does not belong to the current workspace.",
+        )
+
+    return upload_record, context
 
 
 def _public_upload_record(record: dict[str, Any]) -> dict[str, Any]:
@@ -360,6 +385,32 @@ def _validate_upload_file(
     upload.file.seek(0)
 
 
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _enforce_workspace_upload_limit(context: dict[str, Any]) -> None:
+    entitlements = context.get("resolved_entitlements") or {}
+    max_uploads = _as_int(entitlements.get("max_uploads"), 0)
+    if max_uploads <= 0:
+        return
+
+    family_id = _normalize_value((context.get("family") or {}).get("_id"))
+    project_id = _normalize_value((context.get("project") or {}).get("_id"))
+    current_count = count_workspace_uploads(family_id=family_id, project_id=project_id)
+    if current_count >= max_uploads:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "This workspace has reached its upload limit for the active package. "
+                "Upgrade or add upload capacity before uploading more files."
+            ),
+        )
+
+
 @router.post("/member-photo")
 async def upload_member_photo(
     family_id: str = Form(...),
@@ -367,10 +418,11 @@ async def upload_member_photo(
     file: UploadFile = File(...),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_upload_portraits",
-        "can_upload_verification_docs",
+        family_id=family_id,
+        member_id=member_id,
+        capabilities=("can_upload_portraits",),
         detail="Your active package does not include upload access.",
     )
 
@@ -386,7 +438,7 @@ async def upload_member_photo(
         label="member photo",
     )
 
-    member, _family = _require_member_access(member_id, db, current_user)
+    member = context["member"]
     actual_family_id = _normalize_value(member.get("family_id"))
 
     if _normalize_value(family_id) != actual_family_id:
@@ -395,8 +447,11 @@ async def upload_member_photo(
             detail="family_id does not match the selected member.",
         )
 
+    _enforce_workspace_upload_limit(context)
+
     upload_record = await store_member_photo_upload(
         db=db,
+        project_id=_normalize_value(context["project"].get("_id")),
         family_id=actual_family_id,
         member_id=member_id,
         upload=file,
@@ -421,10 +476,11 @@ async def upload_verification_evidence(
     file: UploadFile = File(...),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_upload_verification_docs",
-        "can_upload_portraits",
+        family_id=family_id,
+        member_id=member_id,
+        capabilities=("can_upload_verification_docs",),
         detail="Your active package does not include upload access.",
     )
 
@@ -449,7 +505,7 @@ async def upload_verification_evidence(
         label="verification evidence",
     )
 
-    member, _family = _require_member_access(member_id, db, current_user)
+    member = context["member"]
     actual_family_id = _normalize_value(member.get("family_id"))
 
     if _normalize_value(family_id) != actual_family_id:
@@ -458,8 +514,11 @@ async def upload_verification_evidence(
             detail="family_id does not match the selected member.",
         )
 
+    _enforce_workspace_upload_limit(context)
+
     upload_record = await store_verification_evidence_upload(
         db=db,
+        project_id=_normalize_value(context["project"].get("_id")),
         family_id=actual_family_id,
         member_id=member_id,
         verification_type=normalized_verification_type,
@@ -483,10 +542,10 @@ def list_member_uploads(
     category: Optional[str] = Query(default=None),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_upload_verification_docs",
-        "can_upload_portraits",
+        member_id=member_id,
+        capabilities=("can_upload_verification_docs", "can_upload_portraits"),
         detail="Your active package does not include upload access.",
     )
 
@@ -494,11 +553,15 @@ def list_member_uploads(
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    member, _family = _require_member_access(member_id, db, current_user)
+    member = context["member"]
+    family = context["family"]
 
     normalized_category = _validate_category_filter(category)
 
-    query: dict[str, Any] = {"member_id": str(member.get("_id"))}
+    query: dict[str, Any] = {
+        "member_id": str(member.get("_id")),
+        "family_id": _normalize_value((family or {}).get("_id")),
+    }
     if normalized_category:
         query["category"] = normalized_category
 
@@ -516,10 +579,10 @@ def list_family_uploads(
     category: Optional[str] = Query(default=None),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
+    context = require_workspace_capability(
         current_user,
-        "can_upload_verification_docs",
-        "can_upload_portraits",
+        family_id=family_id,
+        capabilities=("can_upload_verification_docs", "can_upload_portraits"),
         detail="Your active package does not include upload access.",
     )
 
@@ -527,16 +590,16 @@ def list_family_uploads(
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    _require_family_access_by_family_id(family_id, db, current_user)
+    family = context["family"]
     normalized_category = _validate_category_filter(category)
 
-    query: dict[str, Any] = {"family_id": family_id}
+    query: dict[str, Any] = {"family_id": _normalize_value((family or {}).get("_id"))}
     if normalized_category:
         query["category"] = normalized_category
 
     records = list(db["uploaded_files"].find(query).sort("created_at", -1))
     return {
-        "family_id": family_id,
+        "family_id": _normalize_value((family or {}).get("_id")),
         "count": len(records),
         "uploads": _serialize_uploads(records),
     }
@@ -547,18 +610,16 @@ def download_upload(
     upload_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_upload_verification_docs",
-        "can_upload_portraits",
-        detail="Your active package does not include upload access.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    upload_record, _family = _require_upload_access(upload_id, db, current_user)
+    upload_record, _context = _require_upload_access(
+        upload_id,
+        db,
+        current_user,
+        detail="Your active package does not include upload access.",
+    )
 
     relative_path = _normalize_value(upload_record.get("relative_path"))
     if not relative_path:
@@ -585,18 +646,16 @@ def delete_upload(
     upload_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    require_any_package_capability(
-        current_user,
-        "can_upload_verification_docs",
-        "can_upload_portraits",
-        detail="Your active package does not include upload access.",
-    )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    upload_record, _family = _require_upload_access(upload_id, db, current_user)
+    upload_record, _context = _require_upload_access(
+        upload_id,
+        db,
+        current_user,
+        detail="Your active package does not include upload access.",
+    )
 
     relative_path = _normalize_value(upload_record.get("relative_path"))
     if relative_path:

--- a/backend/app/schemas/family.py
+++ b/backend/app/schemas/family.py
@@ -8,6 +8,7 @@ class FamilyCreate(BaseModel):
     family_name: str = Field(..., min_length=1, max_length=150)
     created_by: str = Field(..., min_length=1)
     description: str | None = None
+    project_id: str | None = None
 
 
 class FamilyResponse(BaseModel):
@@ -16,9 +17,12 @@ class FamilyResponse(BaseModel):
     created_by: str
     description: str | None = None
     created_at: datetime
+    project_id: str | None = None
     owner_user_id: str | None = None
     owner_email: str | None = None
     visibility: str | None = None
+    package_code: str | None = None
+    package_name: str | None = None
 
 
 def _to_string(value: Any, default: str = "") -> str:
@@ -59,7 +63,10 @@ def build_family_response(data: dict[str, Any]) -> FamilyResponse:
         created_by=created_by,
         description=data.get("description"),
         created_at=_to_datetime(data.get("created_at")),
+        project_id=_to_string(data.get("project_id")) or None,
         owner_user_id=_to_string(data.get("owner_user_id")) or None,
         owner_email=_to_string(data.get("owner_email")).lower() or None,
         visibility=_to_string(data.get("visibility")) or None,
+        package_code=_to_string(data.get("package_code")) or None,
+        package_name=_to_string(data.get("package_name")) or None,
     )

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -13,6 +13,7 @@ class OrderCreate(BaseModel):
     billing_plan: str = Field(default="one_time")
     source: str = Field(default="stripe_payment_link")
     order_status: str = Field(default="paid")
+    project_id: Optional[str] = None
     stripe_session_id: Optional[str] = None
     stripe_payment_link_id: Optional[str] = None
 

--- a/backend/app/services/intake_pipeline_service.py
+++ b/backend/app/services/intake_pipeline_service.py
@@ -343,6 +343,18 @@ def provision_build_from_submission(
 
     project_id = str(project_doc["_id"])
 
+    resolved_family_id = str(project_doc.get("family_id") or family_root_id or "").strip()
+    if resolved_family_id and ObjectId.is_valid(resolved_family_id):
+        families.update_one(
+            {"_id": ObjectId(resolved_family_id)},
+            {
+                "$set": {
+                    "project_id": project_id,
+                    "updated_at": _now(),
+                }
+            },
+        )
+
     submission_set: dict[str, Any] = {
         "status": "build_ready",
         "review_locked": True,

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -9,7 +9,10 @@ from pymongo.database import Database
 from pymongo.errors import OperationFailure
 
 from app.database import get_database
-from app.services.project_service import create_project_from_paid_order
+from app.services.project_service import (
+    apply_package_purchase_to_project,
+    create_project_from_paid_order,
+)
 
 
 def _get_orders_collection() -> Collection:
@@ -153,13 +156,24 @@ def create_order_for_user(user: dict[str, Any], payload: Any) -> dict[str, Any]:
     order_doc["_id"] = result.inserted_id
 
     if order_doc["item_type"] == "package":
-        project = create_project_from_paid_order(
-            user=user,
-            package_code=package_code,
-            package_name=payload.package_name,
-            stripe_session_id=payload.stripe_session_id,
-            stripe_payment_link_id=payload.stripe_payment_link_id,
-        )
+        target_project_id = _normalize(getattr(payload, "project_id", None))
+        if target_project_id:
+            project = apply_package_purchase_to_project(
+                user=user,
+                project_id=target_project_id,
+                package_code=package_code,
+                package_name=payload.package_name,
+                stripe_session_id=payload.stripe_session_id,
+                stripe_payment_link_id=payload.stripe_payment_link_id,
+            )
+        else:
+            project = create_project_from_paid_order(
+                user=user,
+                package_code=package_code,
+                package_name=payload.package_name,
+                stripe_session_id=payload.stripe_session_id,
+                stripe_payment_link_id=payload.stripe_payment_link_id,
+            )
         if project:
             orders.update_one(
                 {"_id": result.inserted_id},
@@ -316,6 +330,16 @@ def _format_price_label(amount_subtotal: Any, billing_plan: str) -> str:
         return f"${amount:,.2f}/year"
 
     return f"${amount:,.2f}"
+
+
+def _extract_target_project_id(session: dict[str, Any]) -> str:
+    metadata = session.get("metadata") or {}
+    return _normalize(
+        metadata.get("project_id")
+        or metadata.get("upgrade_project_id")
+        or metadata.get("existing_project_id")
+        or metadata.get("target_project_id")
+    )
 
 
 def _infer_purchase_fields(session: dict[str, Any]) -> tuple[str, str, str, str, str]:
@@ -539,13 +563,24 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
     order_doc["_id"] = result.inserted_id
 
     if item_type == "package":
-        project = create_project_from_paid_order(
-            user=user,
-            package_code=package_code,
-            package_name=package_name,
-            stripe_session_id=session_id,
-            stripe_payment_link_id=session.get("payment_link"),
-        )
+        target_project_id = _extract_target_project_id(session)
+        if target_project_id:
+            project = apply_package_purchase_to_project(
+                user=user,
+                project_id=target_project_id,
+                package_code=package_code,
+                package_name=package_name,
+                stripe_session_id=session_id,
+                stripe_payment_link_id=session.get("payment_link"),
+            )
+        else:
+            project = create_project_from_paid_order(
+                user=user,
+                package_code=package_code,
+                package_name=package_name,
+                stripe_session_id=session_id,
+                stripe_payment_link_id=session.get("payment_link"),
+            )
         if project:
             orders.update_one(
                 {"_id": result.inserted_id},

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,10 +1,16 @@
 from datetime import UTC, datetime
 from typing import Any
 
+from bson import ObjectId
+
 from app.core.package_catalog import get_package
 from app.database import get_database
 from app.schemas.project import ProjectCreate
-from app.services.project_entitlement_service import upsert_project_entitlement
+from app.services.entitlement_service import can_upgrade
+from app.services.project_entitlement_service import (
+    get_project_entitlement,
+    upsert_project_entitlement,
+)
 
 
 def _now() -> datetime:
@@ -141,3 +147,99 @@ def create_project_from_paid_order(
         pass
 
     return project_doc
+
+
+def apply_package_purchase_to_project(
+    *,
+    user: dict[str, Any],
+    project_id: str,
+    package_code: str,
+    package_name: str,
+    stripe_session_id: str | None = None,
+    stripe_payment_link_id: str | None = None,
+) -> dict[str, Any] | None:
+    db = get_database()
+    if db is None:
+        return None
+
+    if not ObjectId.is_valid(project_id):
+        return None
+
+    package = get_package(package_code)
+    if not package:
+        return None
+
+    project = db.projects.find_one({"_id": ObjectId(project_id)})
+    if not project:
+        return None
+
+    user_id = str(user.get("_id") or user.get("id") or user.get("user_id") or "").strip()
+    owner_user_id = str(project.get("owner_user_id") or "").strip()
+    owner_email = str(project.get("owner_email") or "").strip().lower()
+    user_email = str(user.get("email") or "").strip().lower()
+
+    if user_id and owner_user_id and owner_user_id != user_id:
+        return None
+    if user_email and owner_email and owner_email != user_email:
+        return None
+
+    current_entitlement = get_project_entitlement(project_id) or {}
+    current_package_code = str(
+        current_entitlement.get("package_code")
+        or project.get("package_code")
+        or project.get("package_slug")
+        or project.get("package_type")
+        or ""
+    ).strip()
+    if (
+        current_package_code
+        and current_package_code != package_code
+        and not can_upgrade(current_package_code, package_code)
+    ):
+        return None
+
+    now = _now()
+    updated_fields: dict[str, Any] = {
+        "project_lane": str(package.get("package_lane") or project.get("project_lane") or "").strip().lower() or project.get("project_lane"),
+        "package_code": package_code,
+        "package_slug": package_code,
+        "package_type": package_code,
+        "package_name": package_name,
+        "item_type": "package",
+        "billing_plan": "one_time",
+        "status": project.get("status") or "purchased",
+        "phase": project.get("phase") or "checkout_completed",
+        "source": project.get("source") or "stripe_webhook",
+        "updated_at": now,
+    }
+
+    if stripe_session_id:
+        updated_fields["stripe_session_id"] = stripe_session_id
+    if stripe_payment_link_id:
+        updated_fields["stripe_payment_link_id"] = stripe_payment_link_id
+
+    db.projects.update_one(
+        {"_id": ObjectId(project_id)},
+        {"$set": updated_fields},
+    )
+
+    refreshed = db.projects.find_one({"_id": ObjectId(project_id)}) or project
+
+    existing_addons = list(current_entitlement.get("active_addons") or [])
+    maintenance_plan = str(current_entitlement.get("maintenance_plan") or "not_started")
+    delivered_at = current_entitlement.get("delivered_at")
+
+    try:
+        upsert_project_entitlement(
+            project_id=project_id,
+            user_id=owner_user_id or user_id,
+            package_code=package_code,
+            active_addons=existing_addons,
+            maintenance_plan=maintenance_plan,
+            delivered_at=delivered_at,
+            status="active",
+        )
+    except Exception:
+        pass
+
+    return refreshed

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -98,6 +98,7 @@ def serialize_upload_record(record: dict[str, Any]) -> dict[str, Any]:
     record_id = str(record.get("_id") or record.get("id") or "")
     return {
         "id": record_id,
+        "project_id": record.get("project_id"),
         "family_id": record.get("family_id"),
         "member_id": record.get("member_id"),
         "category": record.get("category"),
@@ -117,6 +118,7 @@ def serialize_upload_record(record: dict[str, Any]) -> dict[str, Any]:
 async def store_member_photo_upload(
     *,
     db: Any,
+    project_id: str,
     family_id: str,
     member_id: str,
     upload: UploadFile,
@@ -149,6 +151,7 @@ async def store_member_photo_upload(
     now_iso = datetime.now(UTC).isoformat()
 
     upload_record = {
+        "project_id": project_id,
         "family_id": family_id,
         "member_id": member_id,
         "category": "member_photo",
@@ -192,6 +195,7 @@ async def store_member_photo_upload(
 async def store_verification_evidence_upload(
     *,
     db: Any,
+    project_id: str,
     family_id: str,
     member_id: str,
     verification_type: str,
@@ -233,6 +237,7 @@ async def store_verification_evidence_upload(
     now_iso = datetime.now(UTC).isoformat()
 
     upload_record = {
+        "project_id": project_id,
         "family_id": family_id,
         "member_id": member_id,
         "category": "verification_evidence",

--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -348,6 +348,22 @@ def ensure_project_workspace_anchor(
 
     family_id = _normalize_value(family_doc.get("_id"))
 
+    if project_id and family_id:
+        family_project_id = _normalize_value(family_doc.get("project_id"))
+        if family_project_id != project_id and ObjectId.is_valid(family_id):
+            families.update_one(
+                {"_id": ObjectId(family_id)},
+                {
+                    "$set": {
+                        "project_id": project_id,
+                        "updated_at": _now(),
+                    }
+                },
+            )
+            refreshed_family = families.find_one({"_id": ObjectId(family_id)})
+            if refreshed_family is not None:
+                family_doc = refreshed_family
+
     if family_id and existing_family_id != family_id and project_object_id is not None:
         projects.update_one(
             {"_id": project_object_id},

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from bson import ObjectId
+from fastapi import HTTPException, status
+
+from app.core.package_catalog import get_package
+from app.database import get_database
+from app.dependencies.auth import has_internal_admin_access
+from app.services.entitlement_service import resolve_project_entitlements
+
+PAID_PACKAGE_STATUSES = {
+    "paid",
+    "complete",
+    "completed",
+    "succeeded",
+}
+
+
+def _normalize_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: Any) -> str:
+    return _normalize_value(value).lower()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    return _normalize_value(user.get("id") or user.get("_id") or user.get("user_id"))
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    return _normalize_email(user.get("email"))
+
+
+def _current_user_name(user: dict[str, Any]) -> str:
+    return _normalize_value(user.get("full_name") or user.get("name"))
+
+
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _project_id_candidates(project_id: str) -> list[Any]:
+    values: list[Any] = [str(project_id)]
+    oid = _to_object_id(project_id)
+    if oid is not None:
+        values.append(oid)
+    return values
+
+
+def _family_is_visible_to_user(
+    family: dict[str, Any],
+    *,
+    current_user_id: str,
+    current_user_email: str,
+    current_user_name: str,
+) -> bool:
+    owner_user_id = _normalize_value(family.get("owner_user_id"))
+    owner_email = _normalize_email(family.get("owner_email"))
+
+    shared_with_user_ids = [
+        _normalize_value(value)
+        for value in (family.get("shared_with_user_ids") or [])
+        if value is not None
+    ]
+    shared_with_emails = [
+        _normalize_email(value)
+        for value in (family.get("shared_with_emails") or [])
+        if value is not None
+    ]
+
+    if owner_user_id and owner_user_id == current_user_id:
+        return True
+
+    if owner_email and owner_email == current_user_email:
+        return True
+
+    if current_user_id in shared_with_user_ids:
+        return True
+
+    if current_user_email in shared_with_emails:
+        return True
+
+    if not owner_user_id and not owner_email:
+        created_by = _normalize_value(family.get("created_by"))
+        if created_by and (
+            created_by == current_user_name or created_by.lower() == current_user_email
+        ):
+            return True
+
+    return False
+
+
+def _require_database():
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database is not connected.",
+        )
+    return db
+
+
+def _find_project_by_id(project_id: str) -> dict[str, Any] | None:
+    oid = _to_object_id(project_id)
+    if oid is None:
+        return None
+    return _require_database()["projects"].find_one({"_id": oid})
+
+
+def _find_family_by_id(family_id: str) -> dict[str, Any] | None:
+    oid = _to_object_id(family_id)
+    if oid is None:
+        return None
+    return _require_database()["families"].find_one({"_id": oid})
+
+
+def _find_member_by_id(member_id: str) -> dict[str, Any] | None:
+    oid = _to_object_id(member_id)
+    if oid is None:
+        return None
+    return _require_database()["family_members"].find_one({"_id": oid})
+
+
+def _find_project_for_family(family: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not family:
+        return None
+
+    db = _require_database()
+    project_id = _normalize_value(family.get("project_id"))
+    if project_id:
+        project = _find_project_by_id(project_id)
+        if project is not None:
+            return project
+
+    family_id = _normalize_value(family.get("_id") or family.get("id"))
+    if family_id:
+        project = db["projects"].find_one(
+            {"family_id": family_id},
+            sort=[("updated_at", -1), ("created_at", -1)],
+        )
+        if project is not None:
+            return project
+
+    intake_submission_id = _normalize_value(family.get("intake_submission_id"))
+    if intake_submission_id:
+        project = db["projects"].find_one(
+            {"intake_submission_id": intake_submission_id},
+            sort=[("updated_at", -1), ("created_at", -1)],
+        )
+        if project is not None:
+            return project
+
+    return None
+
+
+def _find_family_for_project(project: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not project:
+        return None
+
+    db = _require_database()
+    family_id = _normalize_value(project.get("family_id"))
+    if family_id:
+        family = _find_family_by_id(family_id)
+        if family is not None:
+            return family
+
+    project_id = _normalize_value(project.get("_id") or project.get("id"))
+    if project_id:
+        family = db["families"].find_one(
+            {"project_id": project_id},
+            sort=[("updated_at", -1), ("created_at", -1)],
+        )
+        if family is not None:
+            return family
+
+    intake_submission_id = _normalize_value(project.get("intake_submission_id"))
+    if intake_submission_id:
+        family = db["families"].find_one(
+            {"intake_submission_id": intake_submission_id},
+            sort=[("updated_at", -1), ("created_at", -1)],
+        )
+        if family is not None:
+            return family
+
+    return None
+
+
+def _is_paid_package_order(order: dict[str, Any] | None) -> bool:
+    if not isinstance(order, dict):
+        return False
+
+    item_type = _normalize_value(order.get("item_type") or "package").lower()
+    status_value = _normalize_value(order.get("status")).lower()
+
+    return item_type == "package" and status_value in PAID_PACKAGE_STATUSES
+
+
+def _get_paid_package_order_for_project(project_id: str) -> dict[str, Any] | None:
+    db = _require_database()
+    cursor = db["orders"].find(
+        {"project_id": {"$in": _project_id_candidates(project_id)}}
+    ).sort("created_at", -1)
+
+    for order in cursor:
+        if _is_paid_package_order(order):
+            return order
+
+    return None
+
+
+def _get_active_project_entitlement(project_id: str) -> dict[str, Any] | None:
+    db = _require_database()
+    entitlements = db["project_entitlements"]
+    return entitlements.find_one(
+        {"project_id": str(project_id), "status": "active"}
+    ) or entitlements.find_one({"project_id": str(project_id)})
+
+
+def _resolve_project_entitlement_map(project: dict[str, Any]) -> dict[str, Any]:
+    project_id = _normalize_value(project.get("_id") or project.get("id"))
+    entitlement_doc = _get_active_project_entitlement(project_id)
+    paid_order = _get_paid_package_order_for_project(project_id)
+
+    package_code = _normalize_value(
+        (entitlement_doc or {}).get("package_code")
+        or (paid_order or {}).get("package_code")
+        or (paid_order or {}).get("package_slug")
+        or project.get("package_code")
+        or project.get("package_slug")
+        or project.get("package_type")
+    )
+    active_addons = list((entitlement_doc or {}).get("active_addons") or [])
+
+    resolved_entitlements: dict[str, Any] = {}
+    if package_code:
+        try:
+            resolved_entitlements = resolve_project_entitlements(
+                package_code,
+                active_addons,
+            )
+        except Exception:
+            resolved_entitlements = dict(get_package(package_code) or {})
+
+    return {
+        "package_code": package_code,
+        "active_addons": active_addons,
+        "resolved_entitlements": resolved_entitlements,
+        "entitlement": entitlement_doc,
+        "paid_order": paid_order,
+    }
+
+
+def _project_is_visible_to_user(
+    project: dict[str, Any],
+    family: dict[str, Any] | None,
+    current_user: dict[str, Any],
+) -> bool:
+    if has_internal_admin_access(current_user):
+        return True
+
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+    current_user_name = _current_user_name(current_user)
+
+    owner_user_ids = {
+        _normalize_value(project.get("owner_user_id")),
+        _normalize_value((family or {}).get("owner_user_id")),
+    }
+    owner_emails = {
+        _normalize_email(project.get("owner_email")),
+        _normalize_email((family or {}).get("owner_email")),
+    }
+
+    if current_user_id and current_user_id in owner_user_ids:
+        return True
+
+    if current_user_email and current_user_email in owner_emails:
+        return True
+
+    if family is not None and not any(value for value in owner_user_ids | owner_emails):
+        return _family_is_visible_to_user(
+            family,
+            current_user_id=current_user_id,
+            current_user_email=current_user_email,
+            current_user_name=current_user_name,
+        )
+
+    return False
+
+
+def resolve_workspace_context(
+    current_user: dict[str, Any],
+    *,
+    project_id: str = "",
+    family_id: str = "",
+    member_id: str = "",
+) -> dict[str, Any]:
+    normalized_project_id = _normalize_value(project_id)
+    normalized_family_id = _normalize_value(family_id)
+    normalized_member_id = _normalize_value(member_id)
+
+    member = None
+    if normalized_member_id:
+        if not ObjectId.is_valid(normalized_member_id):
+            raise HTTPException(status_code=400, detail="Invalid member id.")
+        member = _find_member_by_id(normalized_member_id)
+        if member is None:
+            raise HTTPException(status_code=404, detail="Family member not found.")
+        if not normalized_family_id:
+            normalized_family_id = _normalize_value(member.get("family_id"))
+
+    family = None
+    if normalized_family_id:
+        if not ObjectId.is_valid(normalized_family_id):
+            raise HTTPException(status_code=400, detail="Invalid family id.")
+        family = _find_family_by_id(normalized_family_id)
+        if family is None:
+            raise HTTPException(status_code=404, detail="Family not found.")
+
+    project = None
+    if normalized_project_id:
+        if not ObjectId.is_valid(normalized_project_id):
+            raise HTTPException(status_code=400, detail="Invalid project id.")
+        project = _find_project_by_id(normalized_project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found.")
+
+    if project is None and family is not None:
+        project = _find_project_for_family(family)
+
+    if family is None and project is not None:
+        family = _find_family_for_project(project)
+
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Workspace project could not be resolved.",
+        )
+
+    if family is not None:
+        family_doc_id = _normalize_value(family.get("_id") or family.get("id"))
+        family_project_id = _normalize_value(family.get("project_id"))
+        project_doc_id = _normalize_value(project.get("_id") or project.get("id"))
+        project_family_id = _normalize_value(project.get("family_id"))
+
+        if family_project_id and family_project_id != project_doc_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Family does not belong to the requested workspace.",
+            )
+
+        if project_family_id and family_doc_id and project_family_id != family_doc_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Requested family does not match the current workspace.",
+            )
+
+        if member is not None and _normalize_value(member.get("family_id")) != family_doc_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Family member does not belong to the requested family.",
+            )
+
+    if not _project_is_visible_to_user(project, family, current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this workspace.",
+        )
+
+    entitlement_map = _resolve_project_entitlement_map(project)
+    return {
+        "project": project,
+        "family": family,
+        "member": member,
+        "package_code": entitlement_map.get("package_code"),
+        "active_addons": entitlement_map.get("active_addons") or [],
+        "resolved_entitlements": entitlement_map.get("resolved_entitlements") or {},
+        "entitlement": entitlement_map.get("entitlement"),
+        "paid_order": entitlement_map.get("paid_order"),
+        "is_admin": has_internal_admin_access(current_user),
+    }
+
+
+def require_workspace_capability(
+    current_user: dict[str, Any],
+    *,
+    project_id: str = "",
+    family_id: str = "",
+    member_id: str = "",
+    capabilities: Iterable[str],
+    detail: str,
+) -> dict[str, Any]:
+    context = resolve_workspace_context(
+        current_user,
+        project_id=project_id,
+        family_id=family_id,
+        member_id=member_id,
+    )
+
+    if context.get("is_admin"):
+        return context
+
+    resolved_entitlements = context.get("resolved_entitlements") or {}
+    normalized_capabilities = [
+        _normalize_value(capability).lower()
+        for capability in capabilities
+        if _normalize_value(capability)
+    ]
+
+    if not any(bool(resolved_entitlements.get(capability)) for capability in normalized_capabilities):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=detail,
+        )
+
+    return context
+
+
+def list_accessible_families_for_user(
+    current_user: dict[str, Any],
+    *,
+    capabilities: Iterable[str] = (),
+) -> list[dict[str, Any]]:
+    db = _require_database()
+    if has_internal_admin_access(current_user):
+        return list(db["families"].find().sort("created_at", -1))
+
+    normalized_capabilities = [
+        _normalize_value(capability).lower()
+        for capability in capabilities
+        if _normalize_value(capability)
+    ]
+
+    families: list[dict[str, Any]] = []
+    cursor = db["families"].find().sort("created_at", -1)
+    for family in cursor:
+        family_id = _normalize_value(family.get("_id"))
+        try:
+            context = resolve_workspace_context(current_user, family_id=family_id)
+        except HTTPException:
+            continue
+
+        if normalized_capabilities:
+            resolved_entitlements = context.get("resolved_entitlements") or {}
+            if not any(
+                bool(resolved_entitlements.get(capability))
+                for capability in normalized_capabilities
+            ):
+                continue
+
+        families.append(family)
+
+    return families
+
+
+def count_workspace_uploads(
+    *,
+    family_id: str = "",
+    project_id: str = "",
+) -> int:
+    db = _require_database()
+    if family_id:
+        return int(db["uploaded_files"].count_documents({"family_id": family_id}))
+    if project_id:
+        return int(db["uploaded_files"].count_documents({"project_id": project_id}))
+    return 0

--- a/family.js
+++ b/family.js
@@ -15,11 +15,18 @@
       return;
     }
 
+    let currentContext = null;
+
     try {
       const me = await window.TOLAuth.apiRequest('/auth/me', { method: 'GET' });
 
       if (createdByInput && !createdByInput.value.trim()) {
         createdByInput.value = me.full_name || me.email || '';
+      }
+
+      if (window.TOLAuthPages && typeof window.TOLAuthPages.fetchOrders === 'function' && typeof window.TOLAuthPages.getDashboardContextForCurrentPage === 'function') {
+        const orders = await window.TOLAuthPages.fetchOrders();
+        currentContext = await window.TOLAuthPages.getDashboardContextForCurrentPage(me, orders);
       }
     } catch (error) {
       window.TOLAuth.clearSession();
@@ -44,14 +51,15 @@
       const payload = {
         family_name: String(formData.get('family_name') || '').trim(),
         created_by: String(formData.get('created_by') || '').trim(),
-        description: String(formData.get('description') || '').trim() || null
+        description: String(formData.get('description') || '').trim() || null,
+        project_id: String(currentContext?.activeProject?.id || currentContext?.activeProject?._id || '').trim() || null
       };
 
-      if (!payload.family_name || !payload.created_by) {
+      if (!payload.family_name || !payload.created_by || !payload.project_id) {
         if (statusNode) {
           statusNode.style.display = 'block';
           statusNode.style.color = '#ffb3b3';
-          statusNode.textContent = 'Please complete the required fields.';
+          statusNode.textContent = 'Please open this page from an active family-capable workspace.';
         }
         return;
       }


### PR DESCRIPTION
…e upgrade handling across the Tomb of Light backend.

This update replaces broad account-level package checks with project-specific workspace authorization for the main customer-facing family routes. Tree access, lineage certificates, family graph data, family member editing, relationship editing, and upload actions now resolve the active workspace first and then enforce the entitlements attached to that exact purchased project.

It also strengthens file isolation by attaching uploads to project_id as well as family_id, enforcing per-workspace upload limits, and refusing access when uploads do not belong to the resolved workspace. Family/workspace linkage is now persisted more reliably during provisioning and viewer backfill so customer data stays pinned to the correct project.

The order path was extended to support in-place project upgrades when checkout metadata includes the target project_id, allowing a purchased upgrade to update the existing workspace instead of creating a duplicate project. The legacy family-creation flow was also bound to the active workspace so customers cannot create extra family roots outside their purchased package scope.