### PR TITLE
Harden on-chain anchor storage, mint execution safeguards, and viewer…

### DIFF
--- a/IMPLEMENTATION_CHECKLIST.md
+++ b/IMPLEMENTATION_CHECKLIST.md
@@ -3,6 +3,7 @@
 Purpose: Convert the platform blueprint into an ordered execution plan that product, engineering, operations, and legal can work through together.
 
 Related blueprint: [PLATFORM_BLUEPRINT.md](/Users/ok/Documents/GitHub/tomboflight/PLATFORM_BLUEPRINT.md)
+Detailed on-chain backend reference: [ONCHAIN_ANCHOR_BACKEND_SPEC.md](/Users/ok/Documents/GitHub/tomboflight/ONCHAIN_ANCHOR_BACKEND_SPEC.md)
 
 ## How to use this file
 
@@ -335,6 +336,8 @@ Acceptance criteria:
 ## Phase 7: Blockchain and Certificate Boundary
 
 Goal: Keep proof on-chain while keeping private family content off-chain.
+
+Detailed implementation reference: [ONCHAIN_ANCHOR_BACKEND_SPEC.md](/Users/ok/Documents/GitHub/tomboflight/ONCHAIN_ANCHOR_BACKEND_SPEC.md)
 
 ### 7.1 Certificate issuance boundary
 

--- a/ONCHAIN_ANCHOR_BACKEND_SPEC.md
+++ b/ONCHAIN_ANCHOR_BACKEND_SPEC.md
@@ -1,0 +1,705 @@
+# Tomb of Light On-Chain Anchor Backend Spec
+
+Status: Proposed production backend spec
+
+Purpose: Define the exact backend architecture for public-safe NFT anchor issuance, metadata generation, poster generation, mint jobs, and dashboard display without exposing private family archive data.
+
+Related documents:
+
+- [PLATFORM_BLUEPRINT.md](/Users/ok/Documents/GitHub/tomboflight/PLATFORM_BLUEPRINT.md)
+- [IMPLEMENTATION_CHECKLIST.md](/Users/ok/Documents/GitHub/tomboflight/IMPLEMENTATION_CHECKLIST.md)
+
+## 1. Launch rule
+
+Tomb of Light should use the smallest public-safe proof on-chain and keep the real archive off-chain.
+
+Core rule:
+
+1. No mint at checkout.
+2. No mint at upload.
+3. No mint at intake submission.
+4. Mint only after final approved public-safe manifest.
+
+This means the live operational flow is:
+
+1. payment confirmed
+2. workspace provisioned
+3. intake completed
+4. uploads and build completed
+5. admin final approval
+6. customer public-safe approval when required
+7. metadata and poster generated
+8. mint job executed
+9. mint record stored
+10. dashboard updated
+
+## 2. Package mint policy
+
+Launch v1 policy:
+
+- `legacy_snapshot`: no automatic mint
+- `legacy_portrait_intro`: no automatic mint
+- `digital_legacy_portrait`: automatic `portrait_anchor`
+- `household_foundation`: automatic `household_anchor`
+- `heirloom_legacy_tree`: automatic `household_anchor`
+- `legacy_plus`: automatic `household_anchor`
+- `family_estate_concierge`: automatic `branch_anchor`, up to 3 included
+- `command_structure_network`: opt-in only for launch, `organization_anchor`
+
+Policy rules:
+
+- Lowest two portrait packages stay off-chain by default.
+- Organization minting is disabled by default until public-title and privacy handling is finalized.
+- Customer opt-in is required before using an approved portrait as public poster art.
+- Public title is opt-in only.
+
+## 3. Public/private boundary
+
+### 3.1 On-chain
+
+Blockchain exposes or derives:
+
+- `token_id`
+- `contract_address`
+- `chain`
+- `tx_hash`
+- `owner_wallet`
+- `token_uri`
+
+### 3.2 Public metadata JSON
+
+Token metadata may include only public-safe fields:
+
+- generic token name
+- generic description
+- poster image URI
+- external URL
+- public-safe attributes
+- hashed references
+- approval timestamp
+- version number
+- package code and lane
+
+### 3.3 Private vault only
+
+Never publish these to chain or public metadata:
+
+- names of living people unless explicitly opted in
+- names of minors
+- dates of birth
+- addresses, emails, phone numbers
+- private photos, videos, audio
+- IDs and civil records
+- raw family-tree JSON
+- admin notes
+- correction notes
+- signed download URLs
+
+## 4. Environment variables
+
+Add these environment variables:
+
+- `NFT_CHAIN=base-mainnet`
+- `NFT_CONTRACT_ADDRESS=...`
+- `NFT_MINTER_PRIVATE_KEY=...`
+- `HASH_SALT=...`
+- `METADATA_BASE_URL=https://metadata.tomboflight.com/v1`
+- `POSTER_BASE_URL=https://metadata.tomboflight.com/v1/posters`
+- `NFT_MINT_ENABLED=false`
+- `NFT_ORG_MINT_ENABLED=false`
+- `NFT_RPC_URL=...`
+
+Optional:
+
+- `IPFS_MIRROR_ENABLED=false`
+- `IPFS_GATEWAY_BASE_URL=...`
+- `PINATA_JWT=...`
+
+## 5. Storage zones
+
+Use three storage zones:
+
+1. Private archive bucket
+   - source portraits
+   - family documents
+   - certificates
+   - narration and media
+
+2. Public metadata bucket
+   - token JSON
+   - optional metadata versions
+
+3. Public poster bucket
+   - abstract covers
+   - symbolic covers
+   - approved public-safe poster art
+
+## 6. MongoDB collection design
+
+### 6.1 `mint_records`
+
+Purpose: permanent internal record of every minted or attempted anchor.
+
+```json
+{
+  "_id": "ObjectId",
+  "project_id": "string",
+  "household_id": "string|null",
+  "family_id": "string|null",
+  "user_id": "string",
+  "package_code": "string",
+  "package_lane": "string",
+  "token_type": "portrait_anchor|household_anchor|branch_anchor|organization_anchor",
+  "chain": "base-mainnet",
+  "contract_address": "0x...",
+  "token_id": "string|null",
+  "tx_hash": "0x...|null",
+  "metadata_uri": "string",
+  "project_ref_hash": "sha256:...",
+  "household_ref_hash": "sha256:...|null",
+  "build_hash": "sha256:...",
+  "certificate_hash": "sha256:...|null",
+  "version_number": 1,
+  "poster_image_uri_public": "string",
+  "poster_style": "abstract_cover|symbolic_cover|approved_poster",
+  "mint_status": "pending_approval|approved|queued|minting|minted|failed|superseded|cancelled",
+  "approved_at": "datetime|null",
+  "minted_at": "datetime|null",
+  "failed_at": "datetime|null",
+  "customer_wallet": "0x...|null",
+  "minted_by": "system|admin_email|user_id",
+  "public_title_opt_in": false,
+  "public_title": "string|null",
+  "public_title_kind": "none|household_title|project_title|organization_title",
+  "error_code": "string|null",
+  "error_message": "string|null",
+  "created_at": "datetime",
+  "updated_at": "datetime"
+}
+```
+
+Indexes:
+
+- `project_id_1_version_number_-1`
+- `mint_status_1_created_at_-1`
+- `tx_hash_1`
+- `token_id_1_contract_address_1`
+
+### 6.2 `mint_jobs`
+
+Purpose: queue and execution state for metadata generation, poster generation, and minting.
+
+```json
+{
+  "_id": "ObjectId",
+  "project_id": "string",
+  "mint_record_id": "string",
+  "job_type": "prepare_manifest|generate_poster|mint_anchor|sync_receipt",
+  "status": "queued|running|succeeded|failed|cancelled",
+  "attempt_count": 0,
+  "max_attempts": 5,
+  "priority": 50,
+  "run_after": "datetime",
+  "locked_by": "worker-id|null",
+  "locked_at": "datetime|null",
+  "started_at": "datetime|null",
+  "finished_at": "datetime|null",
+  "payload": {
+    "project_id": "string",
+    "mint_record_id": "string",
+    "version_number": 1
+  },
+  "result": {
+    "metadata_uri": "string|null",
+    "poster_image_uri_public": "string|null",
+    "tx_hash": "string|null"
+  },
+  "error_code": "string|null",
+  "error_message": "string|null",
+  "created_at": "datetime",
+  "updated_at": "datetime"
+}
+```
+
+Indexes:
+
+- `status_1_run_after_1_priority_-1`
+- `project_id_1_created_at_-1`
+- `mint_record_id_1`
+
+### 6.3 `public_metadata_manifests`
+
+Purpose: canonical public-safe metadata versions before and after mint.
+
+```json
+{
+  "_id": "ObjectId",
+  "project_id": "string",
+  "mint_record_id": "string",
+  "version_number": 1,
+  "schema_version": "tol-nft-1.0",
+  "public_token_id": "TOL-2026-000123",
+  "metadata_uri": "string",
+  "poster_image_uri_public": "string",
+  "payload": {
+    "name": "string",
+    "description": "string",
+    "image": "string",
+    "external_url": "string",
+    "attributes": [],
+    "tol": {}
+  },
+  "build_hash": "sha256:...",
+  "certificate_hash": "sha256:...|null",
+  "approval_status": "draft|approved|superseded",
+  "approved_by": "string|null",
+  "approved_at": "datetime|null",
+  "created_at": "datetime",
+  "updated_at": "datetime"
+}
+```
+
+Indexes:
+
+- `project_id_1_version_number_-1`
+- `public_token_id_1`
+- `mint_record_id_1`
+
+### 6.4 `mint_approvals`
+
+Purpose: store admin/customer approval checkpoints before mint.
+
+```json
+{
+  "_id": "ObjectId",
+  "project_id": "string",
+  "mint_record_id": "string",
+  "approval_type": "admin_final|customer_public_safe",
+  "status": "pending|approved|rejected|cancelled",
+  "approved_by_user_id": "string|null",
+  "approved_by_email": "string|null",
+  "notes": "string|null",
+  "consent_snapshot": {
+    "public_title_opt_in": false,
+    "approved_poster_opt_in": false,
+    "wallet_address": "string|null"
+  },
+  "created_at": "datetime",
+  "updated_at": "datetime"
+}
+```
+
+Indexes:
+
+- `project_id_1_approval_type_1_status_1`
+- `mint_record_id_1`
+
+## 7. Hash rules
+
+Use these exact rules:
+
+- `project_ref_hash = "sha256:" + SHA256(HASH_SALT + ":" + project_id)`
+- `household_ref_hash = "sha256:" + SHA256(HASH_SALT + ":" + household_id)` when household exists
+- `build_hash = "sha256:" + SHA256(canonical_build_manifest_json)`
+- `certificate_hash = "sha256:" + SHA256(canonical_certificate_payload_json)` when certificate exists
+
+Rules:
+
+- `HASH_SALT` must be secret and environment-backed.
+- Never hash with a public salt.
+- Canonical JSON must be stable-key-sorted before hashing.
+
+## 8. Public-safe NFT metadata schema
+
+The token URI should point to:
+
+- `https://metadata.tomboflight.com/v1/tokens/{public_token_id}.json`
+
+Required shape:
+
+- `name`
+- `description`
+- `image`
+- `external_url`
+- `attributes`
+- `tol`
+
+Required `tol` fields:
+
+- `schema_version`
+- `token_type`
+- `package_code`
+- `package_lane`
+- `project_ref_hash`
+- `build_hash`
+- `version_number`
+- `approval_timestamp`
+- `privacy_mode`
+- `poster_style`
+- `public_title_opt_in`
+
+Optional `tol` fields:
+
+- `household_ref_hash`
+- `certificate_hash`
+- `public_title`
+- `public_title_kind`
+
+Rules:
+
+- Default token name is generic, not a personal name.
+- `public_title` is null unless explicitly approved.
+- Poster art defaults to abstract or symbolic art.
+- Approved portrait poster use is opt-in only.
+
+## 9. Backend service modules
+
+Add these backend services under `backend/app/services/`:
+
+### 9.1 `mint_policy_service.py`
+
+Responsibilities:
+
+- decide whether a package auto-mints
+- decide token type from package
+- enforce launch toggles
+- enforce org opt-in behavior
+
+Core functions:
+
+- `get_package_mint_policy(package_code)`
+- `project_is_mint_eligible(project_id)`
+- `resolve_token_type(project)`
+
+### 9.2 `public_manifest_service.py`
+
+Responsibilities:
+
+- read project/family/certificate state
+- filter to allowlisted public-safe fields
+- build canonical metadata JSON
+- compute hashes
+- write metadata payload to public storage
+
+Core functions:
+
+- `build_public_manifest(project_id, version_number)`
+- `compute_build_hash(project_id)`
+- `compute_certificate_hash(project_id)`
+- `write_public_metadata(public_token_id, payload)`
+
+### 9.3 `poster_asset_service.py`
+
+Responsibilities:
+
+- generate or select poster style
+- enforce poster privacy policy
+- write poster asset to public storage
+
+Core functions:
+
+- `resolve_poster_policy(project_id)`
+- `generate_abstract_cover(project_id, version_number)`
+- `generate_symbolic_cover(project_id, version_number)`
+- `export_approved_public_poster(project_id, version_number)`
+
+### 9.4 `mint_record_service.py`
+
+Responsibilities:
+
+- create and version internal mint records
+- persist approvals
+- track mint status changes
+- prevent duplicate active versions
+
+Core functions:
+
+- `create_mint_record(project_id)`
+- `get_latest_mint_record(project_id)`
+- `mark_mint_approved(mint_record_id, ...)`
+- `mark_mint_minted(mint_record_id, ...)`
+- `mark_mint_failed(mint_record_id, ...)`
+
+### 9.5 `blockchain_mint_service.py`
+
+Responsibilities:
+
+- submit mint transaction to Base
+- poll or confirm receipt
+- capture token id and tx hash
+
+Core functions:
+
+- `mint_anchor(metadata_uri, recipient_wallet, token_type)`
+- `sync_mint_receipt(tx_hash)`
+
+### 9.6 `mint_job_service.py`
+
+Responsibilities:
+
+- enqueue jobs
+- claim jobs
+- retry failures
+- execute prepare/poster/mint stages
+
+Core functions:
+
+- `enqueue_prepare_manifest(project_id, mint_record_id)`
+- `enqueue_generate_poster(project_id, mint_record_id)`
+- `enqueue_mint_anchor(project_id, mint_record_id)`
+- `run_next_job(worker_id)`
+
+## 10. API endpoint list
+
+Add these backend routes under `backend/app/routes/`:
+
+### 10.1 Policy and eligibility
+
+- `GET /mint-policy/packages`
+  - public/admin-safe package mint policy list
+
+- `GET /projects/{project_id}/mint-eligibility`
+  - customer/admin
+  - returns whether project can mint, token type, missing approvals, missing build state
+
+### 10.2 Preparation and approval
+
+- `POST /projects/{project_id}/mint-records/prepare`
+  - admin only
+  - creates or versions a draft `mint_record`
+  - generates draft public manifest
+
+- `POST /projects/{project_id}/mint-records/{mint_record_id}/approve-admin`
+  - admin only
+  - marks admin final approval
+
+- `POST /projects/{project_id}/mint-records/{mint_record_id}/approve-customer`
+  - customer owner or authorized collaborator
+  - records public-safe consent, wallet, poster opt-in, title opt-in
+
+### 10.3 Execution
+
+- `POST /projects/{project_id}/mint-records/{mint_record_id}/queue`
+  - admin only
+  - queues prepare poster + mint jobs
+
+- `POST /mint-jobs/run-next`
+  - internal worker only
+  - claims and runs the next queued job
+
+- `POST /mint-records/{mint_record_id}/sync`
+  - internal/admin
+  - syncs mint receipt and final token state
+
+### 10.4 Retrieval
+
+- `GET /projects/{project_id}/mint-records`
+  - customer/admin
+  - returns all mint versions for that project
+
+- `GET /projects/{project_id}/mint-status`
+  - customer/admin
+  - returns current status block for dashboard
+
+- `GET /tokens/{public_token_id}`
+  - public-safe landing page payload
+  - does not expose private archive data
+
+## 11. Route request/response contracts
+
+### 11.1 `GET /projects/{project_id}/mint-eligibility`
+
+Response:
+
+```json
+{
+  "project_id": "string",
+  "package_code": "digital_legacy_portrait",
+  "package_lane": "portrait",
+  "mint_policy": {
+    "auto_mint_enabled": true,
+    "token_type": "portrait_anchor",
+    "requires_customer_public_safe_approval": true
+  },
+  "eligible": true,
+  "reasons": [],
+  "latest_mint_record_id": "string|null"
+}
+```
+
+### 11.2 `POST /projects/{project_id}/mint-records/prepare`
+
+Request:
+
+```json
+{
+  "version_strategy": "new_version_if_needed",
+  "poster_style": "abstract_cover",
+  "public_title_opt_in": false,
+  "public_title": null
+}
+```
+
+Response:
+
+```json
+{
+  "mint_record_id": "string",
+  "version_number": 1,
+  "status": "pending_approval",
+  "metadata_uri": "https://metadata.tomboflight.com/v1/tokens/TOL-2026-000123.json",
+  "poster_image_uri_public": "https://metadata.tomboflight.com/v1/posters/TOL-2026-000123.jpg"
+}
+```
+
+### 11.3 `GET /projects/{project_id}/mint-status`
+
+Response:
+
+```json
+{
+  "project_id": "string",
+  "mint_enabled": true,
+  "latest": {
+    "mint_record_id": "string",
+    "mint_status": "minted",
+    "token_type": "portrait_anchor",
+    "version_number": 1,
+    "chain": "base-mainnet",
+    "contract_address": "0x...",
+    "token_id": "123",
+    "tx_hash": "0x...",
+    "metadata_uri": "https://metadata.tomboflight.com/v1/tokens/TOL-2026-000123.json",
+    "poster_image_uri_public": "https://metadata.tomboflight.com/v1/posters/TOL-2026-000123.jpg",
+    "minted_at": "2026-03-29T18:25:05Z"
+  },
+  "history": []
+}
+```
+
+## 12. Job state machine
+
+Mint record states:
+
+- `pending_approval`
+- `approved`
+- `queued`
+- `minting`
+- `minted`
+- `failed`
+- `superseded`
+- `cancelled`
+
+Job states:
+
+- `queued`
+- `running`
+- `succeeded`
+- `failed`
+- `cancelled`
+
+Execution sequence:
+
+1. prepare manifest
+2. generate poster
+3. mint anchor
+4. sync receipt
+5. update dashboard-facing status
+
+Retry rules:
+
+- receipt sync retries allowed
+- mint transaction submission retries only before tx hash is produced
+- failed jobs keep error codes and messages
+
+## 13. Dashboard display contract
+
+Customer dashboard NFT panel should show:
+
+- token type
+- version number
+- mint status
+- chain
+- contract address
+- token id
+- tx hash
+- metadata link
+- poster preview
+- wallet address if connected
+
+Suggested front-end API source:
+
+- `GET /projects/{project_id}/mint-status`
+
+UI states:
+
+- `not_included`
+- `eligible_waiting_for_build`
+- `waiting_for_approval`
+- `queued`
+- `minting`
+- `minted`
+- `failed`
+
+## 14. Versioning rules
+
+Use these version rules:
+
+- typo fix in private data only: no remint
+- major approved public-safe update: new version only when explicitly chosen
+- previous token remains historical record
+- latest mint record becomes dashboard primary version
+
+## 15. Security and approval rules
+
+Required rules:
+
+- admin final approval required before queueing mint
+- customer public-safe approval required when public title, poster opt-in, or wallet assignment is involved
+- customer cannot mint without an entitled project
+- customer cannot mint another customer’s project
+- private files never leave protected storage for public metadata generation
+- public manifest service must use an explicit allowlist, never a blacklist
+
+## 16. Proposed file layout
+
+Add these files:
+
+- `backend/app/services/mint_policy_service.py`
+- `backend/app/services/public_manifest_service.py`
+- `backend/app/services/poster_asset_service.py`
+- `backend/app/services/mint_record_service.py`
+- `backend/app/services/blockchain_mint_service.py`
+- `backend/app/services/mint_job_service.py`
+- `backend/app/routes/mint_policy.py`
+- `backend/app/routes/mint_records.py`
+- `backend/app/routes/mint_jobs.py`
+- `backend/app/schemas/mint_record.py`
+- `backend/app/schemas/public_manifest.py`
+- `backend/app/schemas/mint_job.py`
+
+## 17. Implementation order
+
+Build order:
+
+1. collection schemas and indexes
+2. mint policy service
+3. public manifest generator
+4. poster asset generator
+5. mint record service
+6. approval endpoints
+7. job queue and worker route
+8. blockchain mint service
+9. dashboard NFT panel
+10. legal copy alignment
+
+## 18. Done criteria
+
+This spec is complete when:
+
+- metadata generation is public-safe by allowlist
+- approved packages mint only according to policy
+- no private archive fields appear in public metadata
+- minting is versioned and auditable
+- dashboard shows mint state and history correctly
+- Stripe checkout metadata can target an existing project for upgrades

--- a/PLATFORM_BLUEPRINT.md
+++ b/PLATFORM_BLUEPRINT.md
@@ -5,6 +5,7 @@ Status: Working blueprint
 Purpose: Turn Tomb of Light from a working prototype into a controlled production platform for private family archives, lineage verification, premium package fulfillment, and limited on-chain proof anchoring.
 
 Execution companion: See [IMPLEMENTATION_CHECKLIST.md](/Users/ok/Documents/GitHub/tomboflight/IMPLEMENTATION_CHECKLIST.md) for the ordered build sequence.
+On-chain backend spec: See [ONCHAIN_ANCHOR_BACKEND_SPEC.md](/Users/ok/Documents/GitHub/tomboflight/ONCHAIN_ANCHOR_BACKEND_SPEC.md) for the detailed minting, metadata, and dashboard architecture.
 
 ## 1. Product model
 
@@ -266,6 +267,8 @@ Developer machines should only be used for:
 - internal operations
 
 ### 3.9 Blockchain and NFT boundary
+
+Detailed implementation reference: [ONCHAIN_ANCHOR_BACKEND_SPEC.md](/Users/ok/Documents/GitHub/tomboflight/ONCHAIN_ANCHOR_BACKEND_SPEC.md)
 
 The platform should keep sensitive family data off-chain.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from pathlib import Path
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,6 +19,152 @@ class Settings(BaseSettings):
 
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
+
+    nft_chain: str = Field(
+        default="base-mainnet",
+        validation_alias=AliasChoices("NFT_CHAIN"),
+    )
+    nft_contract_address: str = Field(
+        default="",
+        validation_alias=AliasChoices("NFT_CONTRACT_ADDRESS"),
+    )
+    nft_contract_abi_json: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "NFT_CONTRACT_ABI_JSON",
+            "NFT_CONTRACT_ABI",
+            "NFT_ABI_JSON",
+        ),
+    )
+    nft_mint_function_name: str = Field(
+        default="mintAnchor",
+        validation_alias=AliasChoices("NFT_MINT_FUNCTION_NAME"),
+    )
+    nft_minter_private_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("NFT_MINTER_PRIVATE_KEY"),
+    )
+    nft_default_recipient_wallet: str = Field(
+        default="",
+        validation_alias=AliasChoices("NFT_DEFAULT_RECIPIENT_WALLET"),
+    )
+    nft_rpc_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("NFT_RPC_URL"),
+    )
+    nft_mint_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("NFT_MINTING_ENABLED", "NFT_MINT_ENABLED"),
+    )
+    nft_org_mint_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("NFT_ORG_MINT_ENABLED"),
+    )
+    hash_salt: str = Field(
+        default="",
+        validation_alias=AliasChoices("HASH_SALT"),
+    )
+    metadata_base_url: str = Field(
+        default="https://metadata.tomboflight.com/v1",
+        validation_alias=AliasChoices("METADATA_BASE_URL"),
+    )
+    poster_base_url: str = Field(
+        default="https://metadata.tomboflight.com/v1/posters",
+        validation_alias=AliasChoices("POSTER_BASE_URL"),
+    )
+    public_token_external_base_url: str = Field(
+        default="https://tomboflight.com/token",
+        validation_alias=AliasChoices("PUBLIC_TOKEN_EXTERNAL_BASE_URL"),
+    )
+    ipfs_mirror_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("IPFS_MIRROR_ENABLED"),
+    )
+    ipfs_gateway_base_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("IPFS_GATEWAY_BASE_URL"),
+    )
+    pinata_jwt: str = Field(
+        default="",
+        validation_alias=AliasChoices("PINATA_JWT"),
+    )
+
+    r2_account_id: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_ACCOUNT_ID",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "R2_ACCOUNT",
+        ),
+    )
+    r2_access_key_id: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_ACCESS_KEY_ID",
+            "R2_ACCESS_KEY",
+            "CLOUDFLARE_R2_ACCESS_KEY_ID",
+            "AWS_ACCESS_KEY_ID",
+        ),
+    )
+    r2_secret_access_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_SECRET_ACCESS_KEY",
+            "R2_SECRET_KEY",
+            "CLOUDFLARE_R2_SECRET_ACCESS_KEY",
+            "AWS_SECRET_ACCESS_KEY",
+        ),
+    )
+    r2_endpoint_url: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_ENDPOINT_URL",
+            "R2_S3_ENDPOINT",
+            "R2_ENDPOINT",
+            "CLOUDFLARE_R2_ENDPOINT_URL",
+            "AWS_S3_ENDPOINT",
+        ),
+    )
+    r2_region: str = Field(
+        default="auto",
+        validation_alias=AliasChoices("R2_REGION", "AWS_REGION"),
+    )
+    r2_bucket: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_BUCKET",
+            "R2_BUCKET_NAME",
+            "CLOUDFLARE_R2_BUCKET",
+        ),
+    )
+    r2_private_bucket: str = Field(
+        default="",
+        validation_alias=AliasChoices("R2_PRIVATE_BUCKET"),
+    )
+    r2_metadata_bucket: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_METADATA_BUCKET",
+            "R2_PUBLIC_METADATA_BUCKET",
+            "R2_METADATA_BUCKET_NAME",
+        ),
+    )
+    r2_poster_bucket: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "R2_POSTER_BUCKET",
+            "R2_PUBLIC_POSTER_BUCKET",
+            "R2_POSTER_BUCKET_NAME",
+        ),
+    )
+    r2_force_path_style: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("R2_FORCE_PATH_STYLE"),
+    )
+    public_storage_dir: str = Field(
+        default="storage/public",
+        validation_alias=AliasChoices("PUBLIC_STORAGE_DIR"),
+    )
 
     allowed_origins: str = (
         "http://127.0.0.1:5500,"
@@ -94,6 +241,25 @@ class Settings(BaseSettings):
         if mount_path:
             return str(Path(mount_path) / "uploads")
         return str(Path(self.upload_storage_dir))
+
+    @property
+    def r2_resolved_endpoint_url(self) -> str:
+        explicit = str(self.r2_endpoint_url or "").strip().rstrip("/")
+        if explicit:
+            return explicit
+
+        account_id = str(self.r2_account_id or "").strip()
+        if account_id:
+            return f"https://{account_id}.r2.cloudflarestorage.com"
+
+        return ""
+
+    @property
+    def public_storage_root_path(self) -> str:
+        mount_path = str(self.render_disk_mount_path or "").strip().rstrip("/")
+        if mount_path:
+            return str(Path(mount_path) / "public")
+        return str(Path(self.public_storage_dir))
 
 
 @lru_cache

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,9 @@ from app.routes.link_keys import router as link_keys_router
 from app.routes.link_requests import router as link_requests_router
 from app.routes.match_candidates import router as match_candidates_router
 from app.routes.match_generation import router as match_generation_router
+from app.routes.mint_jobs import router as mint_jobs_router
+from app.routes.mint_policy import router as mint_policy_router
+from app.routes.mint_records import router as mint_records_router
 from app.routes.narrative_records import router as narrative_records_router
 from app.routes.orders import router as orders_router
 from app.routes.package_catalog import router as package_catalog_router
@@ -150,6 +153,9 @@ app.include_router(orders_router)
 app.include_router(package_catalog_router)
 app.include_router(uploads_router)
 app.include_router(viewer_manifest_router)
+app.include_router(mint_policy_router)
+app.include_router(mint_records_router)
+app.include_router(mint_jobs_router)
 
 # Stripe Webhooks
 app.include_router(stripe_webhooks_router)
@@ -216,6 +222,13 @@ def root():
             "/uploads/family/{family_id}",
             "/uploads/{upload_id}/download",
             "/viewer/manifest",
+            "/mint-policy/packages",
+            "/projects/{project_id}/mint-eligibility",
+            "/projects/{project_id}/mint-records/prepare",
+            "/projects/{project_id}/mint-records",
+            "/projects/{project_id}/mint-status",
+            "/mint-jobs/run-next",
+            "/tokens/{public_token_id}",
             "/link-keys/my-list",
             "/link-keys/my-active?project_id={project_id}",
             "/link-keys/project/{project_id}/generate",

--- a/backend/app/routes/mint_jobs.py
+++ b/backend/app/routes/mint_jobs.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies.auth import require_admin
+from app.schemas.mint_job import RunNextMintJobPayload
+from app.services.mint_job_service import ensure_mint_job_indexes, run_next_job
+
+router = APIRouter(prefix="/mint-jobs", tags=["Mint Jobs"])
+
+
+@router.on_event("startup")
+def startup_mint_job_indexes():
+    ensure_mint_job_indexes()
+
+
+@router.post("/run-next")
+def run_next_mint_job(
+    payload: RunNextMintJobPayload,
+    current_user: dict = Depends(require_admin),
+):
+    del current_user
+    return run_next_job(payload.worker_id)

--- a/backend/app/routes/mint_policy.py
+++ b/backend/app/routes/mint_policy.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.services.mint_policy_service import list_package_mint_policies
+
+router = APIRouter(prefix="/mint-policy", tags=["Mint Policy"])
+
+
+@router.get("/packages")
+def get_package_mint_policy_list():
+    return {
+        "packages": list_package_mint_policies(),
+    }

--- a/backend/app/routes/mint_records.py
+++ b/backend/app/routes/mint_records.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies.auth import get_current_user, require_admin
+from app.schemas.mint_record import (
+    AdminMintApprovalPayload,
+    CustomerMintApprovalPayload,
+    PrepareMintRecordPayload,
+)
+from app.services.mint_job_service import queue_mint_pipeline, sync_receipt_for_mint_record
+from app.services.mint_policy_service import describe_project_mint_eligibility
+from app.services.mint_record_service import (
+    approve_admin_mint_record,
+    approve_customer_mint_record,
+    build_mint_status,
+    create_mint_record,
+    ensure_mint_record_indexes,
+    get_latest_mint_record,
+    get_mint_record,
+    list_mint_records,
+)
+from app.services.public_manifest_service import get_public_manifest_by_token_id
+from app.services.workspace_access_service import resolve_workspace_context
+
+router = APIRouter(tags=["Mint Records"])
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return _normalize(raw_email).lower()
+
+
+def _project_context(
+    current_user: dict[str, Any],
+    project_id: str,
+) -> dict[str, Any]:
+    try:
+        return resolve_workspace_context(current_user, project_id=project_id)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+
+def _project_for_request(current_user: dict[str, Any], project_id: str) -> dict[str, Any]:
+    context = _project_context(current_user, project_id)
+    project = context.get("project")
+    if not isinstance(project, dict):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found.",
+        )
+    return project
+
+
+def _require_project_match(project_id: str, mint_record_id: str) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mint record not found.",
+        )
+    if record["project_id"] != _normalize(project_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Mint record does not belong to the requested project.",
+        )
+    return record
+
+
+@router.on_event("startup")
+def startup_mint_record_indexes():
+    ensure_mint_record_indexes()
+
+
+@router.get("/projects/{project_id}/mint-eligibility")
+def get_project_mint_eligibility(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    project = _project_for_request(current_user, project_id)
+    eligibility = describe_project_mint_eligibility(project)
+    latest = get_latest_mint_record(project_id)
+    eligibility["latest_mint_record_id"] = (latest or {}).get("id")
+    return eligibility
+
+
+@router.post("/projects/{project_id}/mint-records/prepare")
+def prepare_project_mint_record(
+    project_id: str,
+    payload: PrepareMintRecordPayload,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    _project_for_request(current_user, project_id)
+
+    try:
+        record = create_mint_record(
+            project_id,
+            version_strategy=payload.version_strategy,
+            poster_style=payload.poster_style,
+            public_title_opt_in=payload.public_title_opt_in,
+            public_title=payload.public_title,
+            public_title_kind=payload.public_title_kind,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return {
+        "mint_record_id": record["id"],
+        "version_number": record["version_number"],
+        "status": record["mint_status"],
+        "metadata_uri": record["metadata_uri"],
+        "poster_image_uri_public": record["poster_image_uri_public"],
+    }
+
+
+@router.post("/projects/{project_id}/mint-records/{mint_record_id}/approve-admin")
+def approve_project_mint_record_admin(
+    project_id: str,
+    mint_record_id: str,
+    payload: AdminMintApprovalPayload,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    _project_for_request(current_user, project_id)
+    _require_project_match(project_id, mint_record_id)
+
+    try:
+        return approve_admin_mint_record(
+            mint_record_id,
+            approved_by_email=_current_user_email(current_user),
+            notes=payload.notes,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/projects/{project_id}/mint-records/{mint_record_id}/approve-customer")
+def approve_project_mint_record_customer(
+    project_id: str,
+    mint_record_id: str,
+    payload: CustomerMintApprovalPayload,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _project_for_request(current_user, project_id)
+    _require_project_match(project_id, mint_record_id)
+
+    try:
+        return approve_customer_mint_record(
+            mint_record_id,
+            approved_by_user_id=_current_user_id(current_user),
+            approved_by_email=_current_user_email(current_user),
+            notes=payload.notes,
+            wallet_address=payload.wallet_address,
+            approved_poster_opt_in=payload.approved_poster_opt_in,
+            public_title_opt_in=payload.public_title_opt_in,
+            public_title=payload.public_title,
+            public_title_kind=payload.public_title_kind,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/projects/{project_id}/mint-records/{mint_record_id}/queue")
+def queue_project_mint_record(
+    project_id: str,
+    mint_record_id: str,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    _project_for_request(current_user, project_id)
+    _require_project_match(project_id, mint_record_id)
+
+    try:
+        return {
+            "jobs": queue_mint_pipeline(
+                project_id,
+                mint_record_id,
+                queued_by=_current_user_email(current_user),
+            )
+        }
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("/projects/{project_id}/mint-records")
+def list_project_mint_records(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _project_for_request(current_user, project_id)
+    return {
+        "items": list_mint_records(project_id),
+    }
+
+
+@router.get("/projects/{project_id}/mint-status")
+def get_project_mint_status(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _project_for_request(current_user, project_id)
+    return build_mint_status(project_id)
+
+
+@router.post("/mint-records/{mint_record_id}/sync")
+def sync_project_mint_record(
+    mint_record_id: str,
+    current_user: dict[str, Any] = Depends(require_admin),
+):
+    del current_user
+
+    try:
+        return sync_receipt_for_mint_record(mint_record_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("/tokens/{public_token_id}")
+def get_public_token_landing_payload(public_token_id: str):
+    manifest = get_public_manifest_by_token_id(public_token_id)
+    if manifest is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Public token record not found.",
+        )
+    if manifest["approval_status"] != "approved":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Public token record is not available yet.",
+        )
+
+    return {
+        "public_token_id": manifest["public_token_id"],
+        "metadata_uri": manifest["metadata_uri"],
+        "project_id": manifest["project_id"],
+        "version_number": manifest["version_number"],
+        "poster_image_uri_public": manifest["poster_image_uri_public"],
+        "approval_status": manifest["approval_status"],
+        "payload": manifest["payload"],
+    }

--- a/backend/app/schemas/mint_job.py
+++ b/backend/app/schemas/mint_job.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RunNextMintJobPayload(BaseModel):
+    worker_id: str = Field(default="api-worker", min_length=1)
+
+
+class MintJobResponse(BaseModel):
+    id: str
+    project_id: str
+    mint_record_id: str
+    job_type: str
+    status: str
+    attempt_count: int
+    max_attempts: int
+    priority: int
+    run_after: datetime
+    locked_by: str | None = None
+    locked_at: datetime | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    result: dict[str, Any] = Field(default_factory=dict)
+    error_code: str | None = None
+    error_message: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/schemas/mint_record.py
+++ b/backend/app/schemas/mint_record.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class MintPolicyItem(BaseModel):
+    package_code: str
+    package_name: str
+    package_lane: str
+    token_type: str | None = None
+    product_includes_onchain_anchor: bool
+    auto_mint_enabled: bool
+    opt_in_only: bool = False
+    requires_customer_public_safe_approval: bool = False
+    included_anchor_count: int = 0
+    runtime_enabled: bool = False
+
+
+class MintEligibilityResponse(BaseModel):
+    project_id: str
+    package_code: str
+    package_lane: str
+    mint_policy: MintPolicyItem
+    eligible: bool
+    reasons: list[str] = Field(default_factory=list)
+    latest_mint_record_id: str | None = None
+
+
+class PrepareMintRecordPayload(BaseModel):
+    version_strategy: str = Field(default="new_version_if_needed")
+    poster_style: str = Field(default="abstract_cover")
+    public_title_opt_in: bool = False
+    public_title: str | None = None
+    public_title_kind: str = Field(default="none")
+
+
+class AdminMintApprovalPayload(BaseModel):
+    notes: str = ""
+
+
+class CustomerMintApprovalPayload(BaseModel):
+    notes: str = ""
+    wallet_address: str | None = None
+    approved_poster_opt_in: bool = False
+    public_title_opt_in: bool = False
+    public_title: str | None = None
+    public_title_kind: str = Field(default="none")
+
+
+class MintRecordResponse(BaseModel):
+    id: str
+    project_id: str
+    household_id: str | None = None
+    family_id: str | None = None
+    user_id: str
+    package_code: str
+    package_lane: str
+    token_type: str | None = None
+    chain: str
+    contract_address: str
+    token_id: str | None = None
+    tx_hash: str | None = None
+    metadata_uri: str
+    project_ref_hash: str
+    household_ref_hash: str | None = None
+    build_hash: str
+    certificate_hash: str | None = None
+    version_number: int
+    poster_image_uri_public: str
+    poster_style: str
+    mint_status: str
+    approved_at: datetime | None = None
+    minted_at: datetime | None = None
+    failed_at: datetime | None = None
+    customer_wallet: str | None = None
+    minted_by: str | None = None
+    public_title_opt_in: bool = False
+    public_title: str | None = None
+    public_title_kind: str = "none"
+    error_code: str | None = None
+    error_message: str | None = None
+    pending_approvals: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class MintStatusResponse(BaseModel):
+    project_id: str
+    mint_enabled: bool
+    latest: MintRecordResponse | None = None
+    history: list[MintRecordResponse] = Field(default_factory=list)

--- a/backend/app/schemas/public_manifest.py
+++ b/backend/app/schemas/public_manifest.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PublicMetadataPayload(BaseModel):
+    name: str
+    description: str
+    image: str
+    external_url: str
+    attributes: list[dict[str, Any]] = Field(default_factory=list)
+    tol: dict[str, Any] = Field(default_factory=dict)
+
+
+class PublicManifestResponse(BaseModel):
+    id: str
+    project_id: str
+    mint_record_id: str
+    version_number: int
+    schema_version: str
+    public_token_id: str
+    metadata_uri: str
+    poster_image_uri_public: str
+    payload: PublicMetadataPayload | dict[str, Any]
+    build_hash: str
+    certificate_hash: str | None = None
+    approval_status: str
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PublicTokenLandingResponse(BaseModel):
+    public_token_id: str
+    metadata_uri: str
+    project_id: str
+    version_number: int
+    poster_image_uri_public: str
+    approval_status: str
+    payload: PublicMetadataPayload | dict[str, Any]

--- a/backend/app/services/blockchain_mint_service.py
+++ b/backend/app/services/blockchain_mint_service.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.config import settings
+
+TRANSFER_EVENT_SIGNATURE = (
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _lazy_web3():
+    try:
+        from eth_account import Account
+        from web3 import Web3
+    except ImportError as exc:
+        raise RuntimeError(
+            "web3 and eth-account are required for live blockchain minting. "
+            "Install backend requirements before enabling NFT mint jobs."
+        ) from exc
+
+    return Web3, Account
+
+
+def _require_mint_runtime() -> None:
+    if not settings.nft_mint_enabled:
+        raise RuntimeError("NFT minting is disabled by configuration.")
+
+    missing = [
+        name
+        for name, value in (
+            ("NFT_CONTRACT_ADDRESS", settings.nft_contract_address),
+            ("NFT_CONTRACT_ABI_JSON", settings.nft_contract_abi_json),
+            ("NFT_MINTER_PRIVATE_KEY", settings.nft_minter_private_key),
+            ("NFT_RPC_URL", settings.nft_rpc_url),
+        )
+        if not _normalize(value)
+    ]
+    if missing:
+        missing_joined = ", ".join(missing)
+        raise RuntimeError(
+            f"NFT minting is not fully configured. Missing: {missing_joined}."
+        )
+
+
+def _web3_client():
+    Web3, _Account = _lazy_web3()
+    client = Web3(Web3.HTTPProvider(_normalize(settings.nft_rpc_url)))
+    if not client.is_connected():
+        raise RuntimeError("Unable to connect to the configured NFT RPC endpoint.")
+    return client
+
+
+def _contract_abi() -> list[dict[str, Any]]:
+    raw = _normalize(settings.nft_contract_abi_json)
+    if not raw:
+        raise RuntimeError("NFT contract ABI is not configured.")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("NFT contract ABI JSON is invalid.") from exc
+    if not isinstance(parsed, list):
+        raise RuntimeError("NFT contract ABI must be a JSON array.")
+    return parsed
+
+
+def _account():
+    _Web3, Account = _lazy_web3()
+    return Account.from_key(_normalize(settings.nft_minter_private_key))
+
+
+def _checksum_address(address: str) -> str:
+    Web3, _Account = _lazy_web3()
+    return Web3.to_checksum_address(_normalize(address))
+
+
+def _recipient_wallet(recipient_wallet: str | None) -> str:
+    preferred = _normalize(recipient_wallet) or _normalize(settings.nft_default_recipient_wallet)
+    if preferred:
+        return _checksum_address(preferred)
+    raise RuntimeError(
+        "A recipient wallet is required before minting. "
+        "Provide a customer wallet or configure NFT_DEFAULT_RECIPIENT_WALLET."
+    )
+
+
+def _token_type_argument(token_type: str, input_type: str) -> Any:
+    normalized_token_type = _normalize(token_type)
+    normalized_input_type = _normalize(input_type).lower()
+
+    if normalized_input_type.startswith("string"):
+        return normalized_token_type
+
+    if normalized_input_type.startswith("uint") or normalized_input_type.startswith("int"):
+        token_map = {
+            "portrait_anchor": 1,
+            "household_anchor": 2,
+            "branch_anchor": 3,
+            "organization_anchor": 4,
+        }
+        if normalized_token_type.isdigit():
+            return int(normalized_token_type)
+        if normalized_token_type in token_map:
+            return token_map[normalized_token_type]
+        raise RuntimeError(
+            f"Token type '{normalized_token_type}' cannot be converted to numeric contract input."
+        )
+
+    if normalized_input_type == "bytes32":
+        raw = normalized_token_type.encode("utf-8")
+        if len(raw) > 32:
+            raise RuntimeError("Token type is too long for bytes32 contract input.")
+        return raw.ljust(32, b"\x00")
+
+    raise RuntimeError(
+        f"Unsupported token type input '{normalized_input_type}' in mint contract."
+    )
+
+
+def _contract_function(contract: Any, *, recipient: str, metadata_uri: str, token_type: str):
+    function_name = _normalize(settings.nft_mint_function_name) or "mintAnchor"
+    candidate = getattr(contract.functions, function_name, None)
+    if candidate is None:
+        raise RuntimeError(f"Mint function '{function_name}' was not found in the contract ABI.")
+
+    functions_abi = [
+        item
+        for item in _contract_abi()
+        if item.get("type") == "function" and item.get("name") == function_name
+    ]
+    if not functions_abi:
+        raise RuntimeError(f"Mint function '{function_name}' was not found in the ABI.")
+
+    abi = functions_abi[0]
+    arguments: list[Any] = []
+    string_index = 0
+    token_type_consumed = False
+
+    for input_item in abi.get("inputs", []):
+        input_type = _normalize(input_item.get("type")).lower()
+        if input_type == "address":
+            arguments.append(recipient)
+            continue
+        if input_type.startswith("string"):
+            if string_index == 0:
+                arguments.append(metadata_uri)
+            else:
+                arguments.append(_token_type_argument(token_type, input_type))
+                token_type_consumed = True
+            string_index += 1
+            continue
+        if input_type.startswith("uint") or input_type.startswith("int") or input_type == "bytes32":
+            arguments.append(_token_type_argument(token_type, input_type))
+            token_type_consumed = True
+            continue
+        raise RuntimeError(
+            f"Unsupported mint function input type '{input_type}'. "
+            "Expected address, string, uint, int, or bytes32 parameters only."
+        )
+
+    if not token_type_consumed:
+        raise RuntimeError(
+            "Mint function ABI does not expose a token type argument. "
+            "Update NFT_MINT_FUNCTION_NAME or contract ABI configuration."
+        )
+
+    return candidate(*arguments)
+
+
+def _gas_fields(client: Any) -> dict[str, int]:
+    gas_price = int(client.eth.gas_price)
+    try:
+        priority_fee = int(client.eth.max_priority_fee)
+    except Exception:
+        priority_fee = max(gas_price // 10, 1)
+
+    return {
+        "maxPriorityFeePerGas": priority_fee,
+        "maxFeePerGas": max(gas_price + priority_fee, gas_price),
+    }
+
+
+def _extract_token_id_from_receipt(receipt: Any) -> str | None:
+    logs = getattr(receipt, "logs", None) or receipt.get("logs") or []
+    for log in logs:
+        topics = list(getattr(log, "topics", None) or log.get("topics") or [])
+        if len(topics) < 4:
+            continue
+        first_topic = topics[0]
+        topic_hex = first_topic.hex() if hasattr(first_topic, "hex") else str(first_topic)
+        if not topic_hex.lower().startswith(TRANSFER_EVENT_SIGNATURE):
+            continue
+        token_topic = topics[3]
+        token_hex = token_topic.hex() if hasattr(token_topic, "hex") else str(token_topic)
+        try:
+            return str(int(token_hex, 16))
+        except Exception:
+            continue
+    return None
+
+
+def mint_anchor(
+    *,
+    metadata_uri: str,
+    recipient_wallet: str | None,
+    token_type: str,
+) -> dict[str, Any]:
+    _require_mint_runtime()
+
+    client = _web3_client()
+    contract = client.eth.contract(
+        address=_checksum_address(settings.nft_contract_address),
+        abi=_contract_abi(),
+    )
+    signer = _account()
+    recipient = _recipient_wallet(recipient_wallet)
+    contract_function = _contract_function(
+        contract,
+        recipient=recipient,
+        metadata_uri=metadata_uri,
+        token_type=token_type,
+    )
+
+    transaction = contract_function.build_transaction(
+        {
+            "from": signer.address,
+            "nonce": client.eth.get_transaction_count(signer.address),
+            "chainId": int(client.eth.chain_id),
+            **_gas_fields(client),
+        }
+    )
+
+    if not transaction.get("gas"):
+        estimated_gas = contract_function.estimate_gas({"from": signer.address})
+        transaction["gas"] = int(estimated_gas * 1.2)
+
+    signed = client.eth.account.sign_transaction(
+        transaction,
+        private_key=_normalize(settings.nft_minter_private_key),
+    )
+    tx_hash = client.eth.send_raw_transaction(signed.raw_transaction)
+    tx_hash_hex = tx_hash.hex()
+
+    receipt = None
+    try:
+        receipt = client.eth.wait_for_transaction_receipt(tx_hash, timeout=180)
+    except Exception as exc:
+        if exc.__class__.__name__ not in {"TimeExhausted", "TimeoutError"}:
+            raise
+
+    if receipt is not None and int(receipt.status) != 1:
+        raise RuntimeError("Mint transaction was mined but reverted on-chain.")
+
+    token_id = _extract_token_id_from_receipt(receipt) if receipt is not None else None
+
+    return {
+        "status": "submitted",
+        "chain": _normalize(settings.nft_chain),
+        "contract_address": _checksum_address(settings.nft_contract_address),
+        "tx_hash": tx_hash_hex,
+        "token_id": token_id,
+        "recipient_wallet": recipient,
+        "block_number": int(receipt.blockNumber) if receipt is not None else None,
+    }
+
+
+def sync_mint_receipt(tx_hash: str) -> dict[str, Any]:
+    _require_mint_runtime()
+
+    client = _web3_client()
+    try:
+        receipt = client.eth.get_transaction_receipt(_normalize(tx_hash))
+    except Exception as exc:
+        if exc.__class__.__name__ == "TransactionNotFound":
+            return {
+                "status": "pending",
+                "chain": _normalize(settings.nft_chain),
+                "contract_address": _checksum_address(settings.nft_contract_address),
+                "tx_hash": _normalize(tx_hash),
+                "token_id": None,
+                "block_number": None,
+            }
+        raise
+    token_id = _extract_token_id_from_receipt(receipt)
+
+    return {
+        "status": "confirmed" if int(receipt.status) == 1 else "failed",
+        "chain": _normalize(settings.nft_chain),
+        "contract_address": _checksum_address(settings.nft_contract_address),
+        "tx_hash": _normalize(tx_hash),
+        "token_id": token_id,
+        "block_number": int(receipt.blockNumber),
+    }

--- a/backend/app/services/db_bootstrap_service.py
+++ b/backend/app/services/db_bootstrap_service.py
@@ -1,4 +1,4 @@
-from pymongo import ASCENDING
+from pymongo import ASCENDING, DESCENDING
 from pymongo.errors import OperationFailure
 
 from app.database import get_database
@@ -103,6 +103,65 @@ CORE_COLLECTIONS: dict[str, list[tuple[list[tuple[str, int]], dict]]] = {
     "certificate_versions": [
         ([("family_id", ASCENDING)], {"name": "idx_certificate_versions_family_id"}),
         ([("version", ASCENDING)], {"name": "idx_certificate_versions_version"}),
+    ],
+    "mint_records": [
+        (
+            [("project_id", ASCENDING), ("version_number", DESCENDING)],
+            {"name": "idx_mint_records_project_id_1_version_number_-1"},
+        ),
+        (
+            [("mint_status", ASCENDING), ("created_at", DESCENDING)],
+            {"name": "idx_mint_records_mint_status_1_created_at_-1"},
+        ),
+        ([("tx_hash", ASCENDING)], {"name": "idx_mint_records_tx_hash_1"}),
+        (
+            [("token_id", ASCENDING), ("contract_address", ASCENDING)],
+            {"name": "idx_mint_records_token_id_1_contract_address_1"},
+        ),
+    ],
+    "mint_jobs": [
+        (
+            [("status", ASCENDING), ("run_after", ASCENDING), ("priority", DESCENDING)],
+            {"name": "idx_mint_jobs_status_1_run_after_1_priority_-1"},
+        ),
+        (
+            [("project_id", ASCENDING), ("created_at", DESCENDING)],
+            {"name": "idx_mint_jobs_project_id_1_created_at_-1"},
+        ),
+        (
+            [("mint_record_id", ASCENDING)],
+            {"name": "idx_mint_jobs_mint_record_id_1"},
+        ),
+    ],
+    "public_metadata_manifests": [
+        (
+            [("project_id", ASCENDING), ("version_number", DESCENDING)],
+            {"name": "idx_public_metadata_manifests_project_id_1_version_number_-1"},
+        ),
+        (
+            [("public_token_id", ASCENDING)],
+            {
+                "name": "idx_public_metadata_manifests_public_token_id_1",
+                "unique": True,
+                "partialFilterExpression": {
+                    "public_token_id": {"$type": "string"}
+                },
+            },
+        ),
+        (
+            [("mint_record_id", ASCENDING)],
+            {"name": "idx_public_metadata_manifests_mint_record_id_1"},
+        ),
+    ],
+    "mint_approvals": [
+        (
+            [("project_id", ASCENDING), ("approval_type", ASCENDING), ("status", ASCENDING)],
+            {"name": "idx_mint_approvals_project_id_1_approval_type_1_status_1"},
+        ),
+        (
+            [("mint_record_id", ASCENDING)],
+            {"name": "idx_mint_approvals_mint_record_id_1"},
+        ),
     ],
 }
 

--- a/backend/app/services/mint_job_service.py
+++ b/backend/app/services/mint_job_service.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from bson import ObjectId
+from pymongo import ReturnDocument
+from pymongo.collection import Collection
+from pymongo.errors import OperationFailure
+
+from app.database import get_database
+from app.services.blockchain_mint_service import mint_anchor, sync_mint_receipt
+from app.services.mint_record_service import (
+    get_mint_record,
+    get_latest_mint_record,
+    mark_mint_failed,
+    mark_mint_minted,
+    mark_mint_minting,
+    mark_mint_queued,
+)
+from app.services.poster_asset_service import build_poster_asset
+from app.services.public_manifest_service import (
+    build_public_manifest,
+    get_public_manifest_for_mint_record,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["mint_jobs"])
+
+
+def _records_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["mint_records"])
+
+
+def ensure_mint_job_indexes() -> None:
+    collection = _collection()
+    existing = collection.index_information()
+    definitions = [
+        (
+            [("status", 1), ("run_after", 1), ("priority", -1)],
+            "status_1_run_after_1_priority_-1",
+        ),
+        ([("project_id", 1), ("created_at", -1)], "project_id_1_created_at_-1"),
+        ([("mint_record_id", 1)], "mint_record_id_1"),
+    ]
+
+    for keys, name in definitions:
+        if name in existing:
+            continue
+        try:
+            collection.create_index(keys, name=name)
+        except OperationFailure:
+            continue
+
+
+def _serialize_job(document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize(document.get("_id")),
+        "project_id": _normalize(document.get("project_id")),
+        "mint_record_id": _normalize(document.get("mint_record_id")),
+        "job_type": _normalize(document.get("job_type")),
+        "status": _normalize(document.get("status")) or "queued",
+        "attempt_count": int(document.get("attempt_count") or 0),
+        "max_attempts": int(document.get("max_attempts") or 5),
+        "priority": int(document.get("priority") or 50),
+        "run_after": document.get("run_after") or _now(),
+        "locked_by": _normalize(document.get("locked_by")) or None,
+        "locked_at": document.get("locked_at"),
+        "started_at": document.get("started_at"),
+        "finished_at": document.get("finished_at"),
+        "payload": document.get("payload") or {},
+        "result": document.get("result") or {},
+        "error_code": _normalize(document.get("error_code")) or None,
+        "error_message": _normalize(document.get("error_message")) or None,
+        "created_at": document.get("created_at") or _now(),
+        "updated_at": document.get("updated_at") or _now(),
+    }
+
+
+def enqueue_job(
+    *,
+    project_id: str,
+    mint_record_id: str,
+    job_type: str,
+    priority: int = 50,
+    run_after: datetime | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = _now()
+    document = {
+        "project_id": _normalize(project_id),
+        "mint_record_id": _normalize(mint_record_id),
+        "job_type": _normalize(job_type),
+        "status": "queued",
+        "attempt_count": 0,
+        "max_attempts": 5,
+        "priority": priority,
+        "run_after": run_after or now,
+        "locked_by": None,
+        "locked_at": None,
+        "started_at": None,
+        "finished_at": None,
+        "payload": payload or {},
+        "result": {},
+        "error_code": None,
+        "error_message": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    existing = _collection().find_one(
+        {
+            "project_id": document["project_id"],
+            "mint_record_id": document["mint_record_id"],
+            "job_type": document["job_type"],
+            "status": {"$in": ["queued", "running"]},
+        }
+    )
+    if existing is not None:
+        return _serialize_job(existing)
+
+    result = _collection().insert_one(document)
+    saved = _collection().find_one({"_id": result.inserted_id}) or document
+    return _serialize_job(saved)
+
+
+def queue_mint_pipeline(
+    project_id: str,
+    mint_record_id: str,
+    *,
+    queued_by: str = "system",
+) -> list[dict[str, Any]]:
+    del queued_by
+    now = _now()
+
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+    if record["project_id"] != _normalize(project_id):
+        raise ValueError("Mint record does not belong to the requested project.")
+
+    mark_mint_queued(mint_record_id)
+
+    return [
+        enqueue_job(
+            project_id=project_id,
+            mint_record_id=mint_record_id,
+            job_type="prepare_manifest",
+            priority=90,
+            payload={"version_number": record["version_number"]},
+        ),
+        enqueue_job(
+            project_id=project_id,
+            mint_record_id=mint_record_id,
+            job_type="generate_poster",
+            priority=80,
+            payload={"version_number": record["version_number"]},
+        ),
+        enqueue_job(
+            project_id=project_id,
+            mint_record_id=mint_record_id,
+            job_type="mint_anchor",
+            priority=70,
+            payload={"version_number": record["version_number"]},
+        ),
+        enqueue_job(
+            project_id=project_id,
+            mint_record_id=mint_record_id,
+            job_type="sync_receipt",
+            priority=60,
+            run_after=now + timedelta(seconds=45),
+            payload={"version_number": record["version_number"]},
+        ),
+    ]
+
+
+def _execute_prepare_manifest(job: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    manifest = build_public_manifest(
+        record["project_id"],
+        record["version_number"],
+        mint_record_id=record["id"],
+        poster_style=record["poster_style"],
+        public_title_opt_in=bool(record["public_title_opt_in"]),
+        public_title=record.get("public_title"),
+        public_title_kind=record.get("public_title_kind") or "none",
+        approved_poster_opt_in=record["poster_style"] == "approved_poster",
+        approval_timestamp=record.get("approved_at"),
+    )
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(record["id"])},
+        {
+            "$set": {
+                "metadata_uri": manifest["metadata_uri"],
+                "poster_image_uri_public": manifest["poster_image_uri_public"],
+                "build_hash": manifest["build_hash"],
+                "certificate_hash": manifest["certificate_hash"],
+                "updated_at": _now(),
+            }
+        },
+    )
+
+    return {
+        "metadata_uri": manifest["metadata_uri"],
+        "poster_image_uri_public": manifest["poster_image_uri_public"],
+    }
+
+
+def _execute_generate_poster(job: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    manifest = get_public_manifest_for_mint_record(record["id"])
+    public_token_id = _normalize((manifest or {}).get("public_token_id"))
+    if not public_token_id:
+        public_token_id = f"TOL-{_now().year}-{record['project_id'][-6:].upper()}-V{record['version_number']:02d}"
+
+    poster_asset = build_poster_asset(
+        project_id=record["project_id"],
+        version_number=record["version_number"],
+        public_token_id=public_token_id,
+        requested_style=record["poster_style"],
+        approved_poster_opt_in=record["poster_style"] == "approved_poster",
+    )
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(record["id"])},
+        {
+            "$set": {
+                "poster_style": poster_asset["poster_style"],
+                "poster_image_uri_public": poster_asset["poster_image_uri_public"],
+                "updated_at": _now(),
+            }
+        },
+    )
+
+    return poster_asset
+
+
+def _execute_mint_anchor(job: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    del job
+
+    manifest = get_public_manifest_for_mint_record(record["id"])
+    if manifest is None:
+        raise RuntimeError("Public manifest is missing for this mint record.")
+
+    mark_mint_minting(record["id"])
+    mint_result = mint_anchor(
+        metadata_uri=manifest["metadata_uri"],
+        recipient_wallet=record.get("customer_wallet"),
+        token_type=record.get("token_type") or "portrait_anchor",
+    )
+
+    token_id = _normalize(mint_result.get("token_id"))
+    tx_hash = _normalize(mint_result.get("tx_hash"))
+    if tx_hash:
+        mark_mint_minting(record["id"], tx_hash=tx_hash)
+    if token_id and tx_hash:
+        mark_mint_minted(
+            record["id"],
+            token_id=token_id,
+            tx_hash=tx_hash,
+            minted_by="system",
+            contract_address=mint_result.get("contract_address"),
+            chain=mint_result.get("chain"),
+        )
+
+    return mint_result
+
+
+def sync_receipt_for_mint_record(mint_record_id: str) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+    tx_hash = _normalize(record.get("tx_hash"))
+    if not tx_hash:
+        return {
+            "mint_record_id": mint_record_id,
+            "status": "pending",
+            "message": "Mint transaction hash is not available yet.",
+        }
+
+    receipt = sync_mint_receipt(tx_hash)
+    token_id = _normalize(receipt.get("token_id"))
+    synced_tx_hash = _normalize(receipt.get("tx_hash")) or tx_hash
+
+    if token_id:
+        return mark_mint_minted(
+            mint_record_id,
+            token_id=token_id,
+            tx_hash=synced_tx_hash,
+            minted_by="system",
+            contract_address=receipt.get("contract_address"),
+            chain=receipt.get("chain"),
+        )
+
+    return {
+        "mint_record_id": mint_record_id,
+        "tx_hash": synced_tx_hash,
+        "status": "pending",
+    }
+
+
+def _finish_job(
+    job_id: ObjectId,
+    *,
+    status: str,
+    result: dict[str, Any] | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> dict[str, Any]:
+    _collection().update_one(
+        {"_id": job_id},
+        {
+            "$set": {
+                "status": status,
+                "result": result or {},
+                "error_code": _normalize(error_code) or None,
+                "error_message": _normalize(error_message) or None,
+                "finished_at": _now(),
+                "updated_at": _now(),
+            }
+        },
+    )
+    saved = _collection().find_one({"_id": job_id})
+    return _serialize_job(saved or {"_id": job_id})
+
+
+def run_next_job(worker_id: str) -> dict[str, Any]:
+    now = _now()
+    job = _collection().find_one_and_update(
+        {
+            "status": "queued",
+            "run_after": {"$lte": now},
+        },
+        {
+            "$set": {
+                "status": "running",
+                "locked_by": _normalize(worker_id) or "api-worker",
+                "locked_at": now,
+                "started_at": now,
+                "updated_at": now,
+            },
+            "$inc": {"attempt_count": 1},
+        },
+        sort=[("priority", -1), ("created_at", 1)],
+        return_document=ReturnDocument.AFTER,
+    )
+
+    if job is None:
+        return {
+            "status": "idle",
+            "message": "No mint jobs are queued.",
+        }
+
+    serialized_job = _serialize_job(job)
+    record = get_mint_record(serialized_job["mint_record_id"])
+    if record is None:
+        return _finish_job(
+            job["_id"],
+            status="failed",
+            error_code="mint_record_missing",
+            error_message="Mint record was not found.",
+        )
+
+    try:
+        if serialized_job["job_type"] == "prepare_manifest":
+            result = _execute_prepare_manifest(serialized_job, record)
+        elif serialized_job["job_type"] == "generate_poster":
+            result = _execute_generate_poster(serialized_job, record)
+        elif serialized_job["job_type"] == "mint_anchor":
+            result = _execute_mint_anchor(serialized_job, record)
+        elif serialized_job["job_type"] == "sync_receipt":
+            result = sync_receipt_for_mint_record(record["id"])
+        else:
+            raise RuntimeError("Unsupported mint job type.")
+
+        return _finish_job(
+            job["_id"],
+            status="succeeded",
+            result=result,
+        )
+    except Exception as exc:
+        mark_mint_failed(
+            record["id"],
+            error_code="mint_job_failed",
+            error_message=str(exc),
+        )
+        retry_delay = now + timedelta(minutes=5)
+        _collection().update_one(
+            {"_id": job["_id"]},
+            {
+                "$set": {
+                    "status": "failed",
+                    "run_after": retry_delay,
+                    "error_code": "mint_job_failed",
+                    "error_message": str(exc),
+                    "finished_at": _now(),
+                    "updated_at": _now(),
+                }
+            },
+        )
+        saved = _collection().find_one({"_id": job["_id"]}) or job
+        return _serialize_job(saved)

--- a/backend/app/services/mint_policy_service.py
+++ b/backend/app/services/mint_policy_service.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bson import ObjectId
+
+from app.config import settings
+from app.core.package_catalog import get_package, get_package_catalog
+from app.database import get_database
+
+BUILD_READY_STATUSES = {
+    "build_ready",
+    "in_production",
+    "qa_review",
+    "client_review",
+    "delivered",
+    "archived",
+}
+BUILD_READY_PHASES = {
+    "intake_approved",
+    "in_production",
+    "qa_review",
+    "client_review",
+    "delivered",
+    "archived",
+}
+
+PACKAGE_MINT_POLICIES: dict[str, dict[str, Any]] = {
+    "legacy_snapshot": {
+        "product_includes_onchain_anchor": False,
+        "auto_mint_enabled": False,
+        "opt_in_only": False,
+        "token_type": None,
+        "included_anchor_count": 0,
+        "requires_customer_public_safe_approval": False,
+    },
+    "legacy_portrait_intro": {
+        "product_includes_onchain_anchor": False,
+        "auto_mint_enabled": False,
+        "opt_in_only": False,
+        "token_type": None,
+        "included_anchor_count": 0,
+        "requires_customer_public_safe_approval": False,
+    },
+    "digital_legacy_portrait": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": True,
+        "opt_in_only": False,
+        "token_type": "portrait_anchor",
+        "included_anchor_count": 1,
+        "requires_customer_public_safe_approval": True,
+    },
+    "household_foundation": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": True,
+        "opt_in_only": False,
+        "token_type": "household_anchor",
+        "included_anchor_count": 1,
+        "requires_customer_public_safe_approval": True,
+    },
+    "heirloom_legacy_tree": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": True,
+        "opt_in_only": False,
+        "token_type": "household_anchor",
+        "included_anchor_count": 1,
+        "requires_customer_public_safe_approval": True,
+    },
+    "legacy_plus": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": True,
+        "opt_in_only": False,
+        "token_type": "household_anchor",
+        "included_anchor_count": 1,
+        "requires_customer_public_safe_approval": True,
+    },
+    "family_estate_concierge": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": True,
+        "opt_in_only": False,
+        "token_type": "branch_anchor",
+        "included_anchor_count": 3,
+        "requires_customer_public_safe_approval": True,
+    },
+    "command_structure_network": {
+        "product_includes_onchain_anchor": True,
+        "auto_mint_enabled": False,
+        "opt_in_only": True,
+        "token_type": "organization_anchor",
+        "included_anchor_count": 1,
+        "requires_customer_public_safe_approval": True,
+    },
+}
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _get_project(project_id: str) -> dict[str, Any] | None:
+    db = get_database()
+    if db is None or not ObjectId.is_valid(project_id):
+        return None
+    return db["projects"].find_one({"_id": ObjectId(project_id)})
+
+
+def _package_code_from_project(project: dict[str, Any]) -> str:
+    package = get_package(
+        _normalize(
+            project.get("package_code")
+            or project.get("package_slug")
+            or project.get("package_type")
+        )
+    )
+    return _normalize((package or {}).get("package_code")) or _normalize(
+        project.get("package_code")
+        or project.get("package_slug")
+        or project.get("package_type")
+    )
+
+
+def _package_lane_from_project(project: dict[str, Any]) -> str:
+    package = get_package(_package_code_from_project(project))
+    return _normalize((package or {}).get("package_lane")) or _normalize(
+        project.get("project_lane")
+    )
+
+
+def _runtime_enabled(token_type: str | None) -> bool:
+    if not token_type:
+        return False
+    if token_type == "organization_anchor":
+        return bool(settings.nft_mint_enabled and settings.nft_org_mint_enabled)
+    return bool(settings.nft_mint_enabled)
+
+
+def _project_has_build_state(project: dict[str, Any]) -> bool:
+    status_value = _normalize(project.get("status")).lower()
+    phase_value = _normalize(project.get("phase")).lower()
+    return (
+        status_value in BUILD_READY_STATUSES or phase_value in BUILD_READY_PHASES
+    )
+
+
+def get_package_mint_policy(package_code: str) -> dict[str, Any]:
+    package = get_package(package_code)
+    normalized_code = _normalize((package or {}).get("package_code")) or _normalize(
+        package_code
+    )
+    package_name = _normalize((package or {}).get("display_name")) or normalized_code
+    package_lane = _normalize((package or {}).get("package_lane"))
+
+    base_policy = PACKAGE_MINT_POLICIES.get(
+        normalized_code,
+        {
+            "product_includes_onchain_anchor": False,
+            "auto_mint_enabled": False,
+            "opt_in_only": False,
+            "token_type": None,
+            "included_anchor_count": 0,
+            "requires_customer_public_safe_approval": False,
+        },
+    )
+
+    token_type = base_policy.get("token_type")
+
+    return {
+        "package_code": normalized_code,
+        "package_name": package_name,
+        "package_lane": package_lane,
+        "token_type": token_type,
+        "product_includes_onchain_anchor": bool(
+            base_policy.get("product_includes_onchain_anchor")
+        ),
+        "auto_mint_enabled": bool(base_policy.get("auto_mint_enabled")),
+        "opt_in_only": bool(base_policy.get("opt_in_only")),
+        "requires_customer_public_safe_approval": bool(
+            base_policy.get("requires_customer_public_safe_approval")
+        ),
+        "included_anchor_count": int(base_policy.get("included_anchor_count") or 0),
+        "runtime_enabled": _runtime_enabled(token_type),
+    }
+
+
+def list_package_mint_policies() -> list[dict[str, Any]]:
+    policies: list[dict[str, Any]] = []
+    for package_code in get_package_catalog():
+        policies.append(get_package_mint_policy(package_code))
+    return policies
+
+
+def resolve_token_type(project: dict[str, Any]) -> str | None:
+    policy = get_package_mint_policy(_package_code_from_project(project))
+    return str(policy.get("token_type") or "").strip() or None
+
+
+def describe_project_mint_eligibility(project: dict[str, Any]) -> dict[str, Any]:
+    package_code = _package_code_from_project(project)
+    package_lane = _package_lane_from_project(project)
+    policy = get_package_mint_policy(package_code)
+    reasons: list[str] = []
+
+    if not policy.get("product_includes_onchain_anchor"):
+        reasons.append("package_not_included")
+
+    if not _project_has_build_state(project):
+        reasons.append("build_not_ready")
+
+    if (
+        policy.get("product_includes_onchain_anchor")
+        and not policy.get("runtime_enabled")
+    ):
+        reasons.append("mint_runtime_disabled")
+
+    return {
+        "project_id": _normalize(project.get("_id") or project.get("id")),
+        "package_code": package_code,
+        "package_lane": package_lane,
+        "mint_policy": policy,
+        "eligible": len(reasons) == 0,
+        "reasons": reasons,
+    }
+
+
+def project_is_mint_eligible(project_id: str) -> dict[str, Any]:
+    project = _get_project(project_id)
+    if project is None:
+        raise ValueError("Project not found.")
+    return describe_project_mint_eligibility(project)

--- a/backend/app/services/mint_record_service.py
+++ b/backend/app/services/mint_record_service.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from bson import ObjectId
+from pymongo.collection import Collection
+from pymongo.errors import OperationFailure
+
+from app.config import settings
+from app.core.package_catalog import get_package
+from app.database import get_database
+from app.services.mint_policy_service import get_package_mint_policy
+from app.services.public_manifest_service import (
+    build_public_manifest,
+    compute_build_hash,
+    compute_certificate_hash,
+    compute_household_ref_hash,
+    compute_project_ref_hash,
+    ensure_public_manifest_indexes,
+    get_public_manifest_for_mint_record,
+)
+
+ADMIN_APPROVAL_TYPE = "admin_final"
+CUSTOMER_APPROVAL_TYPE = "customer_public_safe"
+ACTIVE_MINT_RECORD_STATUSES = {"pending_approval", "approved", "queued", "minting"}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _records_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["mint_records"])
+
+
+def _approvals_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["mint_approvals"])
+
+
+def _projects_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["projects"])
+
+
+def ensure_mint_record_indexes() -> None:
+    records = _records_collection()
+    approvals = _approvals_collection()
+
+    record_definitions = [
+        ([("project_id", 1), ("version_number", -1)], "project_id_1_version_number_-1"),
+        ([("mint_status", 1), ("created_at", -1)], "mint_status_1_created_at_-1"),
+        ([("tx_hash", 1)], "tx_hash_1"),
+        ([("token_id", 1), ("contract_address", 1)], "token_id_1_contract_address_1"),
+    ]
+    approval_definitions = [
+        ([("project_id", 1), ("approval_type", 1), ("status", 1)], "project_id_1_approval_type_1_status_1"),
+        ([("mint_record_id", 1)], "mint_record_id_1"),
+    ]
+
+    existing_record_indexes = records.index_information()
+    for keys, name in record_definitions:
+        if name in existing_record_indexes:
+            continue
+        try:
+            records.create_index(keys, name=name)
+        except OperationFailure:
+            continue
+
+    existing_approval_indexes = approvals.index_information()
+    for keys, name in approval_definitions:
+        if name in existing_approval_indexes:
+            continue
+        try:
+            approvals.create_index(keys, name=name)
+        except OperationFailure:
+            continue
+
+    ensure_public_manifest_indexes()
+
+
+def _project_document(project_id: str) -> dict[str, Any]:
+    oid = _to_object_id(project_id)
+    if oid is None:
+        raise ValueError("Project not found.")
+
+    project = _projects_collection().find_one({"_id": oid})
+    if project is None:
+        raise ValueError("Project not found.")
+    return project
+
+
+def _package_fields(project: dict[str, Any]) -> tuple[str, str]:
+    package = get_package(
+        _normalize(
+            project.get("package_code")
+            or project.get("package_slug")
+            or project.get("package_type")
+        )
+    )
+    if not package:
+        return (
+            _normalize(project.get("package_code") or project.get("package_slug")),
+            _normalize(project.get("project_lane")),
+        )
+    return (
+        _normalize(package.get("package_code")),
+        _normalize(package.get("package_lane")),
+    )
+
+
+def _requires_customer_approval(
+    policy: dict[str, Any],
+    *,
+    poster_style: str,
+    public_title_opt_in: bool,
+    customer_wallet: str | None = None,
+) -> bool:
+    return bool(
+        policy.get("requires_customer_public_safe_approval")
+        or _normalize(poster_style).lower() == "approved_poster"
+        or public_title_opt_in
+        or _normalize(customer_wallet)
+    )
+
+
+def _serialize_record(document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize(document.get("_id")),
+        "project_id": _normalize(document.get("project_id")),
+        "household_id": _normalize(document.get("household_id")) or None,
+        "family_id": _normalize(document.get("family_id")) or None,
+        "user_id": _normalize(document.get("user_id")),
+        "package_code": _normalize(document.get("package_code")),
+        "package_lane": _normalize(document.get("package_lane")),
+        "token_type": _normalize(document.get("token_type")) or None,
+        "chain": _normalize(document.get("chain")) or settings.nft_chain,
+        "contract_address": _normalize(document.get("contract_address"))
+        or settings.nft_contract_address,
+        "token_id": _normalize(document.get("token_id")) or None,
+        "tx_hash": _normalize(document.get("tx_hash")) or None,
+        "metadata_uri": _normalize(document.get("metadata_uri")),
+        "project_ref_hash": _normalize(document.get("project_ref_hash")),
+        "household_ref_hash": _normalize(document.get("household_ref_hash")) or None,
+        "build_hash": _normalize(document.get("build_hash")),
+        "certificate_hash": _normalize(document.get("certificate_hash")) or None,
+        "version_number": int(document.get("version_number") or 1),
+        "poster_image_uri_public": _normalize(document.get("poster_image_uri_public")),
+        "poster_style": _normalize(document.get("poster_style")) or "abstract_cover",
+        "mint_status": _normalize(document.get("mint_status")) or "pending_approval",
+        "approved_at": document.get("approved_at"),
+        "minted_at": document.get("minted_at"),
+        "failed_at": document.get("failed_at"),
+        "customer_wallet": _normalize(document.get("customer_wallet")) or None,
+        "minted_by": _normalize(document.get("minted_by")) or None,
+        "public_title_opt_in": bool(document.get("public_title_opt_in")),
+        "public_title": _normalize(document.get("public_title")) or None,
+        "public_title_kind": _normalize(document.get("public_title_kind")) or "none",
+        "error_code": _normalize(document.get("error_code")) or None,
+        "error_message": _normalize(document.get("error_message")) or None,
+        "pending_approvals": list_pending_approvals(
+            _normalize(document.get("_id"))
+        ),
+        "created_at": document.get("created_at") or _now(),
+        "updated_at": document.get("updated_at") or _now(),
+    }
+
+
+def get_mint_record(mint_record_id: str) -> dict[str, Any] | None:
+    oid = _to_object_id(mint_record_id)
+    if oid is None:
+        return None
+    document = _records_collection().find_one({"_id": oid})
+    if document is None:
+        return None
+    return _serialize_record(document)
+
+
+def get_latest_mint_record(project_id: str) -> dict[str, Any] | None:
+    document = _records_collection().find_one(
+        {"project_id": _normalize(project_id)},
+        sort=[("version_number", -1), ("created_at", -1)],
+    )
+    if document is None:
+        return None
+    return _serialize_record(document)
+
+
+def list_mint_records(project_id: str) -> list[dict[str, Any]]:
+    cursor = _records_collection().find({"project_id": _normalize(project_id)}).sort(
+        [("version_number", -1), ("created_at", -1)]
+    )
+    return [_serialize_record(document) for document in cursor]
+
+
+def list_pending_approvals(mint_record_id: str) -> list[str]:
+    cursor = _approvals_collection().find(
+        {"mint_record_id": _normalize(mint_record_id), "status": "pending"}
+    )
+    return [_normalize(document.get("approval_type")) for document in cursor]
+
+
+def _ensure_approval_record(
+    *,
+    project_id: str,
+    mint_record_id: str,
+    approval_type: str,
+    status: str = "pending",
+    approved_by_user_id: str | None = None,
+    approved_by_email: str | None = None,
+    notes: str | None = None,
+    consent_snapshot: dict[str, Any] | None = None,
+) -> None:
+    now = _now()
+    query = {
+        "project_id": _normalize(project_id),
+        "mint_record_id": _normalize(mint_record_id),
+        "approval_type": _normalize(approval_type),
+    }
+    existing = _approvals_collection().find_one(query)
+    document = {
+        "project_id": _normalize(project_id),
+        "mint_record_id": _normalize(mint_record_id),
+        "approval_type": _normalize(approval_type),
+        "status": _normalize(status) or "pending",
+        "approved_by_user_id": _normalize(approved_by_user_id) or None,
+        "approved_by_email": _normalize(approved_by_email) or None,
+        "notes": _normalize(notes) or None,
+        "consent_snapshot": consent_snapshot or {},
+        "updated_at": now,
+    }
+
+    if existing is None:
+        document["created_at"] = now
+        _approvals_collection().insert_one(document)
+    else:
+        _approvals_collection().update_one({"_id": existing["_id"]}, {"$set": document})
+
+
+def _delete_approval_record(mint_record_id: str, approval_type: str) -> None:
+    _approvals_collection().delete_many(
+        {
+            "mint_record_id": _normalize(mint_record_id),
+            "approval_type": _normalize(approval_type),
+        }
+    )
+
+
+def _refresh_manifest(mint_record_id: str, approval_timestamp: datetime | None = None) -> None:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+
+    manifest = build_public_manifest(
+        record["project_id"],
+        record["version_number"],
+        mint_record_id=mint_record_id,
+        poster_style=record["poster_style"],
+        public_title_opt_in=bool(record["public_title_opt_in"]),
+        public_title=record.get("public_title"),
+        public_title_kind=record.get("public_title_kind") or "none",
+        approved_poster_opt_in=record["poster_style"] == "approved_poster",
+        approval_timestamp=approval_timestamp,
+    )
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "metadata_uri": manifest["metadata_uri"],
+                "poster_image_uri_public": manifest["poster_image_uri_public"],
+                "build_hash": manifest["build_hash"],
+                "certificate_hash": manifest["certificate_hash"],
+                "updated_at": _now(),
+            }
+        },
+    )
+
+
+def _next_version_number(project_id: str) -> int:
+    latest = get_latest_mint_record(project_id)
+    return int((latest or {}).get("version_number") or 0) + 1
+
+
+def create_mint_record(
+    project_id: str,
+    *,
+    version_strategy: str = "new_version_if_needed",
+    poster_style: str = "abstract_cover",
+    public_title_opt_in: bool = False,
+    public_title: str | None = None,
+    public_title_kind: str = "none",
+) -> dict[str, Any]:
+    project = _project_document(project_id)
+    package_code, package_lane = _package_fields(project)
+    policy = get_package_mint_policy(package_code)
+
+    if not policy.get("product_includes_onchain_anchor"):
+        raise ValueError("This package does not include an on-chain legacy anchor.")
+
+    existing = get_latest_mint_record(project_id)
+    if (
+        version_strategy == "new_version_if_needed"
+        and existing is not None
+        and existing.get("mint_status") in ACTIVE_MINT_RECORD_STATUSES
+    ):
+        return existing
+
+    version_number = _next_version_number(project_id)
+    project_doc_id = _normalize(project.get("_id"))
+    now = _now()
+
+    document: dict[str, Any] = {
+        "project_id": project_doc_id,
+        "household_id": _normalize(project.get("household_id")) or None,
+        "family_id": _normalize(project.get("family_id")) or None,
+        "user_id": _normalize(project.get("owner_user_id")),
+        "package_code": package_code,
+        "package_lane": package_lane,
+        "token_type": _normalize(policy.get("token_type")) or None,
+        "chain": settings.nft_chain,
+        "contract_address": settings.nft_contract_address,
+        "token_id": None,
+        "tx_hash": None,
+        "metadata_uri": "",
+        "project_ref_hash": compute_project_ref_hash(project_doc_id),
+        "household_ref_hash": compute_household_ref_hash(project.get("household_id")),
+        "build_hash": compute_build_hash(project_doc_id),
+        "certificate_hash": compute_certificate_hash(project_doc_id),
+        "version_number": version_number,
+        "poster_image_uri_public": "",
+        "poster_style": _normalize(poster_style).lower() or "abstract_cover",
+        "mint_status": "pending_approval",
+        "approved_at": None,
+        "minted_at": None,
+        "failed_at": None,
+        "customer_wallet": None,
+        "minted_by": None,
+        "public_title_opt_in": bool(public_title_opt_in),
+        "public_title": _normalize(public_title) or None,
+        "public_title_kind": _normalize(public_title_kind) or "none",
+        "error_code": None,
+        "error_message": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    result = _records_collection().insert_one(document)
+    mint_record_id = _normalize(result.inserted_id)
+
+    _ensure_approval_record(
+        project_id=project_doc_id,
+        mint_record_id=mint_record_id,
+        approval_type=ADMIN_APPROVAL_TYPE,
+        status="pending",
+    )
+
+    if _requires_customer_approval(
+        policy,
+        poster_style=document["poster_style"],
+        public_title_opt_in=bool(document["public_title_opt_in"]),
+    ):
+        _ensure_approval_record(
+            project_id=project_doc_id,
+            mint_record_id=mint_record_id,
+            approval_type=CUSTOMER_APPROVAL_TYPE,
+            status="pending",
+            consent_snapshot={
+                "public_title_opt_in": bool(document["public_title_opt_in"]),
+                "approved_poster_opt_in": document["poster_style"] == "approved_poster",
+                "wallet_address": None,
+            },
+        )
+
+    _refresh_manifest(mint_record_id)
+    return get_mint_record(mint_record_id) or _serialize_record(document)
+
+
+def _recompute_mint_approval_state(mint_record_id: str) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+
+    pending = list_pending_approvals(mint_record_id)
+    approved_at = record.get("approved_at")
+    next_status = "approved" if not pending else "pending_approval"
+
+    if next_status == "approved" and approved_at is None:
+        approved_at = _now()
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "mint_status": next_status,
+                "approved_at": approved_at,
+                "updated_at": _now(),
+            }
+        },
+    )
+    _refresh_manifest(mint_record_id, approval_timestamp=approved_at)
+    updated = get_mint_record(mint_record_id)
+    if updated is None:
+        raise ValueError("Mint record not found.")
+    return updated
+
+
+def approve_admin_mint_record(
+    mint_record_id: str,
+    *,
+    approved_by_email: str,
+    notes: str = "",
+) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+
+    _ensure_approval_record(
+        project_id=record["project_id"],
+        mint_record_id=mint_record_id,
+        approval_type=ADMIN_APPROVAL_TYPE,
+        status="approved",
+        approved_by_email=approved_by_email,
+        notes=notes,
+    )
+    return _recompute_mint_approval_state(mint_record_id)
+
+
+def approve_customer_mint_record(
+    mint_record_id: str,
+    *,
+    approved_by_user_id: str,
+    approved_by_email: str,
+    notes: str = "",
+    wallet_address: str | None = None,
+    approved_poster_opt_in: bool = False,
+    public_title_opt_in: bool = False,
+    public_title: str | None = None,
+    public_title_kind: str = "none",
+) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+
+    next_poster_style = record["poster_style"]
+    if next_poster_style == "approved_poster" and not approved_poster_opt_in:
+        next_poster_style = "abstract_cover"
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "customer_wallet": _normalize(wallet_address) or None,
+                "poster_style": next_poster_style,
+                "public_title_opt_in": bool(public_title_opt_in),
+                "public_title": _normalize(public_title) or None,
+                "public_title_kind": _normalize(public_title_kind) or "none",
+                "updated_at": _now(),
+            }
+        },
+    )
+
+    _ensure_approval_record(
+        project_id=record["project_id"],
+        mint_record_id=mint_record_id,
+        approval_type=CUSTOMER_APPROVAL_TYPE,
+        status="approved",
+        approved_by_user_id=approved_by_user_id,
+        approved_by_email=approved_by_email,
+        notes=notes,
+        consent_snapshot={
+            "public_title_opt_in": bool(public_title_opt_in),
+            "approved_poster_opt_in": bool(approved_poster_opt_in),
+            "wallet_address": _normalize(wallet_address) or None,
+        },
+    )
+    return _recompute_mint_approval_state(mint_record_id)
+
+
+def mark_mint_queued(mint_record_id: str) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+    if record["mint_status"] not in {"approved", "queued"}:
+        raise ValueError("Mint record must be approved before queueing.")
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {"$set": {"mint_status": "queued", "updated_at": _now()}},
+    )
+    updated = get_mint_record(mint_record_id)
+    if updated is None:
+        raise ValueError("Mint record not found.")
+    return updated
+
+
+def mark_mint_minting(mint_record_id: str, *, tx_hash: str | None = None) -> dict[str, Any]:
+    record = get_mint_record(mint_record_id)
+    if record is None:
+        raise ValueError("Mint record not found.")
+
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "mint_status": "minting",
+                "tx_hash": _normalize(tx_hash) or record.get("tx_hash"),
+                "updated_at": _now(),
+            }
+        },
+    )
+    updated = get_mint_record(mint_record_id)
+    if updated is None:
+        raise ValueError("Mint record not found.")
+    return updated
+
+
+def mark_mint_minted(
+    mint_record_id: str,
+    *,
+    token_id: str,
+    tx_hash: str,
+    minted_by: str = "system",
+    contract_address: str | None = None,
+    chain: str | None = None,
+) -> dict[str, Any]:
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "mint_status": "minted",
+                "token_id": _normalize(token_id),
+                "tx_hash": _normalize(tx_hash),
+                "minted_by": _normalize(minted_by) or "system",
+                "contract_address": _normalize(contract_address) or settings.nft_contract_address,
+                "chain": _normalize(chain) or settings.nft_chain,
+                "minted_at": _now(),
+                "failed_at": None,
+                "error_code": None,
+                "error_message": None,
+                "updated_at": _now(),
+            }
+        },
+    )
+    updated = get_mint_record(mint_record_id)
+    if updated is None:
+        raise ValueError("Mint record not found.")
+    return updated
+
+
+def mark_mint_failed(
+    mint_record_id: str,
+    *,
+    error_code: str,
+    error_message: str,
+) -> dict[str, Any]:
+    _records_collection().update_one(
+        {"_id": _to_object_id(mint_record_id)},
+        {
+            "$set": {
+                "mint_status": "failed",
+                "failed_at": _now(),
+                "error_code": _normalize(error_code) or "mint_failed",
+                "error_message": _normalize(error_message) or "Mint job failed.",
+                "updated_at": _now(),
+            }
+        },
+    )
+    updated = get_mint_record(mint_record_id)
+    if updated is None:
+        raise ValueError("Mint record not found.")
+    return updated
+
+
+def build_mint_status(project_id: str) -> dict[str, Any]:
+    project = _project_document(project_id)
+    package_code, _package_lane = _package_fields(project)
+    history = list_mint_records(project_id)
+    latest = history[0] if history else None
+    manifest = (
+        get_public_manifest_for_mint_record(latest["id"])
+        if latest is not None
+        else None
+    )
+    mint_policy = get_package_mint_policy(package_code)
+
+    if latest is not None and manifest is not None:
+        latest = {
+            **latest,
+            "metadata_uri": manifest["metadata_uri"],
+            "poster_image_uri_public": manifest["poster_image_uri_public"],
+        }
+
+    return {
+        "project_id": _normalize(project_id),
+        "mint_enabled": bool(mint_policy.get("product_includes_onchain_anchor")),
+        "latest": latest,
+        "history": history,
+    }

--- a/backend/app/services/poster_asset_service.py
+++ b/backend/app/services/poster_asset_service.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from pymongo.collection import Collection
+
+from app.config import settings
+from app.database import get_database
+from app.services.r2_storage_service import ZONE_POSTER, upload_bytes
+
+ALLOWED_POSTER_STYLES = {
+    "abstract_cover",
+    "symbolic_cover",
+    "approved_poster",
+}
+
+SVG_CONTENT_TYPE = "image/svg+xml"
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _poster_url(filename: str) -> str:
+    base = settings.poster_base_url.rstrip("/")
+    return f"{base}/{filename}"
+
+
+def _uploads_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["uploaded_files"])
+
+
+def resolve_poster_policy(
+    project_id: str,
+    *,
+    requested_style: str,
+    approved_poster_opt_in: bool = False,
+) -> dict[str, str]:
+    del project_id
+
+    style = _normalize(requested_style).lower()
+    if style not in ALLOWED_POSTER_STYLES:
+        style = "abstract_cover"
+
+    if style == "approved_poster" and not approved_poster_opt_in:
+        style = "abstract_cover"
+
+    return {
+        "poster_style": style,
+    }
+
+
+def _build_svg_cover(
+    *,
+    title: str,
+    subtitle: str,
+    accent_start: str,
+    accent_end: str,
+    token_label: str,
+) -> str:
+    safe_title = title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    safe_subtitle = subtitle.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    safe_token = token_label.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1600" viewBox="0 0 1600 1600" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="160" y1="80" x2="1440" y2="1520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#07101B"/>
+      <stop offset="0.5" stop-color="#0D1E2E"/>
+      <stop offset="1" stop-color="#04080F"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="420" y1="340" x2="1180" y2="1260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="{accent_start}"/>
+      <stop offset="1" stop-color="{accent_end}"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 760) rotate(90) scale(460)">
+      <stop stop-color="{accent_start}" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="{accent_end}" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="1600" fill="url(#bg)"/>
+  <circle cx="800" cy="760" r="460" fill="url(#glow)"/>
+  <circle cx="800" cy="760" r="330" stroke="url(#ring)" stroke-opacity="0.3" stroke-width="2"/>
+  <circle cx="800" cy="760" r="230" stroke="url(#ring)" stroke-opacity="0.6" stroke-width="3"/>
+  <circle cx="800" cy="760" r="140" fill="#071320" stroke="url(#ring)" stroke-width="4"/>
+  <path d="M800 604V916" stroke="url(#ring)" stroke-width="3" stroke-linecap="round"/>
+  <path d="M644 760H956" stroke="url(#ring)" stroke-width="3" stroke-linecap="round"/>
+  <text x="800" y="250" fill="#F3EFE7" font-size="62" font-family="Georgia, 'Times New Roman', serif" text-anchor="middle" letter-spacing="10">TOMB OF LIGHT</text>
+  <text x="800" y="1160" fill="#FFFFFF" font-size="92" font-family="Georgia, 'Times New Roman', serif" text-anchor="middle">{safe_title}</text>
+  <text x="800" y="1240" fill="#BFCBDD" font-size="34" font-family="Arial, sans-serif" text-anchor="middle" letter-spacing="2">{safe_subtitle}</text>
+  <text x="800" y="1360" fill="{accent_start}" font-size="26" font-family="Arial, sans-serif" text-anchor="middle" letter-spacing="6">{safe_token}</text>
+</svg>"""
+
+
+def _upload_svg_poster(
+    *,
+    svg_text: str,
+    filename: str,
+    publish: bool,
+) -> dict[str, Any]:
+    uploaded = upload_bytes(
+        zone=ZONE_POSTER,
+        key=f"posters/{filename}",
+        body=svg_text.encode("utf-8"),
+        content_type=SVG_CONTENT_TYPE,
+        cache_control="public, max-age=86400",
+        publish=publish,
+    )
+    return {
+        "poster_image_uri_public": _poster_url(filename),
+        "poster_filename": filename,
+        "poster_storage_key": uploaded["key"],
+        "poster_storage_bucket": uploaded.get("bucket"),
+        "poster_storage_provider": uploaded["storage_provider"],
+    }
+
+
+def generate_abstract_cover(
+    project_id: str,
+    version_number: int,
+    public_token_id: str,
+    *,
+    publish: bool = True,
+) -> dict[str, Any]:
+    del project_id
+    filename = f"{public_token_id}-abstract-cover.svg"
+    svg_text = _build_svg_cover(
+        title="Legacy Anchor",
+        subtitle=f"Version {version_number}",
+        accent_start="#E7A45A",
+        accent_end="#7AC8FF",
+        token_label=public_token_id,
+    )
+    return _upload_svg_poster(svg_text=svg_text, filename=filename, publish=publish)
+
+
+def generate_symbolic_cover(
+    project_id: str,
+    version_number: int,
+    public_token_id: str,
+    *,
+    publish: bool = True,
+) -> dict[str, Any]:
+    del project_id
+    filename = f"{public_token_id}-symbolic-cover.svg"
+    svg_text = _build_svg_cover(
+        title="Protected Lineage",
+        subtitle=f"Approved build version {version_number}",
+        accent_start="#C8C0FF",
+        accent_end="#7EE7C4",
+        token_label=public_token_id,
+    )
+    return _upload_svg_poster(svg_text=svg_text, filename=filename, publish=publish)
+
+
+def _best_uploaded_portrait(project_id: str) -> dict[str, Any] | None:
+    return _uploads_collection().find_one(
+        {
+            "project_id": _normalize(project_id),
+            "category": "member_photo",
+        },
+        sort=[("created_at", -1)],
+    )
+
+
+def _read_local_upload_bytes(upload_record: dict[str, Any]) -> tuple[bytes, str, str] | None:
+    relative_path = _normalize(upload_record.get("relative_path"))
+    if not relative_path:
+        return None
+
+    absolute_path = Path(settings.upload_root_path) / relative_path
+    if not absolute_path.exists() or not absolute_path.is_file():
+        return None
+
+    content_type = _normalize(upload_record.get("content_type")) or "application/octet-stream"
+    suffix = Path(_normalize(upload_record.get("stored_filename")) or absolute_path.name).suffix or ".bin"
+    return absolute_path.read_bytes(), content_type, suffix
+
+
+def export_approved_public_poster(
+    project_id: str,
+    version_number: int,
+    public_token_id: str,
+    *,
+    publish: bool = True,
+) -> dict[str, Any]:
+    upload_record = _best_uploaded_portrait(project_id)
+    if upload_record is None:
+        return generate_abstract_cover(
+            project_id,
+            version_number,
+            public_token_id,
+            publish=publish,
+        )
+
+    source = _read_local_upload_bytes(upload_record)
+    if source is None:
+        return generate_abstract_cover(
+            project_id,
+            version_number,
+            public_token_id,
+            publish=publish,
+        )
+
+    body, content_type, suffix = source
+    filename = f"{public_token_id}-approved-poster{suffix}"
+    uploaded = upload_bytes(
+        zone=ZONE_POSTER,
+        key=f"posters/{filename}",
+        body=body,
+        content_type=content_type,
+        cache_control="public, max-age=86400",
+        publish=publish,
+    )
+
+    return {
+        "poster_image_uri_public": _poster_url(filename),
+        "poster_filename": filename,
+        "poster_storage_key": uploaded["key"],
+        "poster_storage_bucket": uploaded.get("bucket"),
+        "poster_storage_provider": uploaded["storage_provider"],
+    }
+
+
+def build_poster_asset(
+    *,
+    project_id: str,
+    version_number: int,
+    public_token_id: str,
+    requested_style: str,
+    approved_poster_opt_in: bool = False,
+    publish: bool = True,
+) -> dict[str, Any]:
+    policy = resolve_poster_policy(
+        project_id,
+        requested_style=requested_style,
+        approved_poster_opt_in=approved_poster_opt_in,
+    )
+    poster_style = policy["poster_style"]
+
+    if poster_style == "symbolic_cover":
+        asset = generate_symbolic_cover(
+            project_id,
+            version_number,
+            public_token_id,
+            publish=publish,
+        )
+    elif poster_style == "approved_poster":
+        asset = export_approved_public_poster(
+            project_id,
+            version_number,
+            public_token_id,
+            publish=publish,
+        )
+    else:
+        asset = generate_abstract_cover(
+            project_id,
+            version_number,
+            public_token_id,
+            publish=publish,
+        )
+
+    return {
+        "poster_style": poster_style,
+        **asset,
+    }

--- a/backend/app/services/public_manifest_service.py
+++ b/backend/app/services/public_manifest_service.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from bson import ObjectId
+from pymongo.collection import Collection
+from pymongo.errors import OperationFailure
+
+from app.config import settings
+from app.core.package_catalog import get_package
+from app.database import get_database
+from app.services.mint_policy_service import get_package_mint_policy
+from app.services.poster_asset_service import build_poster_asset
+from app.services.r2_storage_service import ZONE_METADATA, upload_json
+
+SCHEMA_VERSION = "tol-nft-1.0"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _to_object_id(value: str) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["public_metadata_manifests"])
+
+
+def _projects_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["projects"])
+
+
+def _certificates_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["issued_certificates"])
+
+
+def ensure_public_manifest_indexes() -> None:
+    collection = _collection()
+    existing = collection.index_information()
+
+    definitions = [
+        (
+            [("project_id", 1), ("version_number", -1)],
+            "project_id_1_version_number_-1",
+            False,
+            None,
+        ),
+        (
+            [("public_token_id", 1)],
+            "public_token_id_1",
+            True,
+            {"public_token_id": {"$type": "string"}},
+        ),
+        (
+            [("mint_record_id", 1)],
+            "mint_record_id_1",
+            False,
+            None,
+        ),
+    ]
+
+    for keys, name, unique, partial in definitions:
+        if name in existing:
+            continue
+        options: dict[str, Any] = {"name": name, "unique": unique}
+        if partial is not None:
+            options["partialFilterExpression"] = partial
+        try:
+            collection.create_index(keys, **options)
+        except OperationFailure:
+            continue
+
+
+def _serialize_value(value: Any) -> Any:
+    if isinstance(value, ObjectId):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_serialize_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialize_value(item) for key, item in value.items()}
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _serialize_value(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _hash_sha256(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest().upper()}"
+
+
+def _hash_salt() -> str:
+    return _normalize(settings.hash_salt) or _normalize(settings.secret_key) or "change-me"
+
+
+def _project_document(project_id: str) -> dict[str, Any]:
+    oid = _to_object_id(project_id)
+    if oid is None:
+        raise ValueError("Project not found.")
+    project = _projects_collection().find_one({"_id": oid})
+    if project is None:
+        raise ValueError("Project not found.")
+    return project
+
+
+def _latest_certificate(project: dict[str, Any]) -> dict[str, Any] | None:
+    family_id = _normalize(project.get("family_id"))
+    project_id = _normalize(project.get("_id") or project.get("id"))
+
+    if family_id:
+        certificate = _certificates_collection().find_one(
+            {"family_id": family_id},
+            sort=[("version", -1), ("issued_at", -1), ("created_at", -1)],
+        )
+        if certificate is not None:
+            return certificate
+
+    if project_id:
+        certificate = _certificates_collection().find_one(
+            {"project_id": project_id},
+            sort=[("version", -1), ("issued_at", -1), ("created_at", -1)],
+        )
+        if certificate is not None:
+            return certificate
+
+    return None
+
+
+def compute_project_ref_hash(project_id: str) -> str:
+    return _hash_sha256(f"{_hash_salt()}:{_normalize(project_id)}")
+
+
+def compute_household_ref_hash(household_id: str | None) -> str | None:
+    normalized = _normalize(household_id)
+    if not normalized:
+        return None
+    return _hash_sha256(f"{_hash_salt()}:{normalized}")
+
+
+def compute_build_hash(project_id: str) -> str:
+    project = _project_document(project_id)
+    payload = {
+        "project_id": _normalize(project.get("_id")),
+        "package_code": _normalize(
+            project.get("package_code")
+            or project.get("package_slug")
+            or project.get("package_type")
+        ),
+        "project_lane": _normalize(project.get("project_lane")),
+        "family_id": _normalize(project.get("family_id")) or None,
+        "household_id": _normalize(project.get("household_id")) or None,
+        "organization_id": _normalize(project.get("organization_id")) or None,
+        "status": _normalize(project.get("status")),
+        "phase": _normalize(project.get("phase")),
+        "updated_at": _serialize_value(project.get("updated_at") or project.get("created_at")),
+    }
+    return _hash_sha256(_canonical_json(payload))
+
+
+def compute_certificate_hash(project_id: str) -> str | None:
+    project = _project_document(project_id)
+    certificate = _latest_certificate(project)
+    if certificate is None:
+        return None
+    return _hash_sha256(_canonical_json(certificate))
+
+
+def _build_public_token_id(project_id: str, version_number: int) -> str:
+    suffix = (_normalize(project_id)[-6:] or "000000").upper()
+    return f"TOL-{_now().year}-{suffix}-V{version_number:02d}"
+
+
+def _default_name(public_token_id: str) -> str:
+    return f"Tomb of Light Legacy Anchor #{public_token_id}"
+
+
+def _default_description() -> str:
+    return (
+        "A public-safe onchain legacy anchor issued by Tomb of Light for an approved "
+        "digital lineage build. Private family records remain off-chain in protected storage."
+    )
+
+
+def _token_external_url(public_token_id: str) -> str:
+    return f"{settings.public_token_external_base_url.rstrip('/')}/{public_token_id}"
+
+
+def _attributes_for_manifest(
+    *,
+    package_name: str,
+    package_lane: str,
+    token_type: str,
+    version_number: int,
+    poster_style: str,
+) -> list[dict[str, Any]]:
+    return [
+        {"trait_type": "Package", "value": package_name},
+        {"trait_type": "Lane", "value": package_lane},
+        {"trait_type": "Token Type", "value": token_type},
+        {"trait_type": "Version", "value": version_number},
+        {"trait_type": "Privacy", "value": "public-safe"},
+        {"trait_type": "Poster Style", "value": poster_style},
+    ]
+
+
+def _serialize_manifest(document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize(document.get("_id")),
+        "project_id": _normalize(document.get("project_id")),
+        "mint_record_id": _normalize(document.get("mint_record_id")),
+        "version_number": int(document.get("version_number") or 1),
+        "schema_version": _normalize(document.get("schema_version")) or SCHEMA_VERSION,
+        "public_token_id": _normalize(document.get("public_token_id")),
+        "metadata_uri": _normalize(document.get("metadata_uri")),
+        "poster_image_uri_public": _normalize(document.get("poster_image_uri_public")),
+        "payload": document.get("payload") or {},
+        "build_hash": _normalize(document.get("build_hash")),
+        "certificate_hash": _normalize(document.get("certificate_hash")) or None,
+        "approval_status": _normalize(document.get("approval_status")) or "draft",
+        "approved_by": _normalize(document.get("approved_by")) or None,
+        "approved_at": document.get("approved_at"),
+        "storage_provider": _normalize(document.get("storage_provider")) or None,
+        "storage_bucket": _normalize(document.get("storage_bucket")) or None,
+        "storage_key": _normalize(document.get("storage_key")) or None,
+        "created_at": document.get("created_at") or _now(),
+        "updated_at": document.get("updated_at") or _now(),
+    }
+
+
+def write_public_metadata(
+    *,
+    project_id: str,
+    mint_record_id: str,
+    version_number: int,
+    public_token_id: str,
+    metadata_uri: str,
+    poster_image_uri_public: str,
+    payload: dict[str, Any],
+    build_hash: str,
+    certificate_hash: str | None,
+    approval_status: str = "draft",
+    approved_by: str | None = None,
+    approved_at: datetime | None = None,
+) -> dict[str, Any]:
+    collection = _collection()
+    now = _now()
+    publish = _normalize(approval_status).lower() == "approved"
+    storage_write = upload_json(
+        zone=ZONE_METADATA,
+        key=f"tokens/{public_token_id}.json",
+        payload=payload,
+        publish=publish,
+    )
+
+    document: dict[str, Any] = {
+        "project_id": project_id,
+        "mint_record_id": mint_record_id,
+        "version_number": version_number,
+        "schema_version": SCHEMA_VERSION,
+        "public_token_id": public_token_id,
+        "metadata_uri": metadata_uri,
+        "poster_image_uri_public": poster_image_uri_public,
+        "payload": payload,
+        "build_hash": build_hash,
+        "certificate_hash": certificate_hash,
+        "approval_status": approval_status,
+        "approved_by": approved_by,
+        "approved_at": approved_at,
+        "storage_provider": storage_write.get("storage_provider"),
+        "storage_bucket": storage_write.get("bucket"),
+        "storage_key": storage_write.get("key"),
+        "updated_at": now,
+    }
+
+    existing = collection.find_one(
+        {"mint_record_id": mint_record_id, "version_number": version_number}
+    )
+
+    if existing is not None:
+        collection.update_one(
+            {"_id": existing["_id"]},
+            {"$set": document},
+        )
+        saved = collection.find_one({"_id": existing["_id"]}) or existing
+    else:
+        document["created_at"] = now
+        result = collection.insert_one(document)
+        saved = collection.find_one({"_id": result.inserted_id}) or document
+
+    return _serialize_manifest(saved)
+
+
+def build_public_manifest(
+    project_id: str,
+    version_number: int,
+    *,
+    mint_record_id: str = "",
+    poster_style: str = "abstract_cover",
+    public_title_opt_in: bool = False,
+    public_title: str | None = None,
+    public_title_kind: str = "none",
+    approved_poster_opt_in: bool = False,
+    approval_timestamp: datetime | None = None,
+) -> dict[str, Any]:
+    project = _project_document(project_id)
+    package = get_package(
+        _normalize(
+            project.get("package_code")
+            or project.get("package_slug")
+            or project.get("package_type")
+        )
+    )
+    if not package:
+        raise ValueError("Project package could not be resolved.")
+
+    package_code = _normalize(package.get("package_code"))
+    package_name = _normalize(package.get("display_name")) or package_code
+    package_lane = _normalize(package.get("package_lane")) or _normalize(
+        project.get("project_lane")
+    )
+    policy = get_package_mint_policy(package_code)
+    token_type = _normalize(policy.get("token_type")) or "portrait_anchor"
+    public_token_id = _build_public_token_id(project_id, version_number)
+
+    poster_asset = build_poster_asset(
+        project_id=project_id,
+        version_number=version_number,
+        public_token_id=public_token_id,
+        requested_style=poster_style,
+        approved_poster_opt_in=approved_poster_opt_in,
+        publish=approval_timestamp is not None,
+    )
+    resolved_poster_style = poster_asset["poster_style"]
+    poster_image_uri_public = poster_asset["poster_image_uri_public"]
+
+    metadata_uri = (
+        f"{settings.metadata_base_url.rstrip('/')}/tokens/{public_token_id}.json"
+    )
+    project_ref_hash = compute_project_ref_hash(project_id)
+    household_ref_hash = compute_household_ref_hash(project.get("household_id"))
+    build_hash = compute_build_hash(project_id)
+    certificate_hash = compute_certificate_hash(project_id)
+    final_title = (
+        _normalize(public_title)
+        if public_title_opt_in and _normalize(public_title)
+        else None
+    )
+    resolved_approval_timestamp = approval_timestamp or _now()
+
+    payload = {
+        "name": final_title or _default_name(public_token_id),
+        "description": _default_description(),
+        "image": poster_image_uri_public,
+        "external_url": _token_external_url(public_token_id),
+        "attributes": _attributes_for_manifest(
+            package_name=package_name,
+            package_lane=package_lane,
+            token_type=token_type,
+            version_number=version_number,
+            poster_style=resolved_poster_style,
+        ),
+        "tol": {
+            "schema_version": SCHEMA_VERSION,
+            "token_type": token_type,
+            "package_code": package_code,
+            "package_lane": package_lane,
+            "project_ref_hash": project_ref_hash,
+            "household_ref_hash": household_ref_hash,
+            "certificate_hash": certificate_hash,
+            "build_hash": build_hash,
+            "version_number": version_number,
+            "approval_timestamp": resolved_approval_timestamp.isoformat(),
+            "privacy_mode": "public-safe",
+            "poster_style": resolved_poster_style,
+            "public_title_opt_in": bool(public_title_opt_in),
+            "public_title": final_title,
+            "public_title_kind": _normalize(public_title_kind) or "none",
+        },
+    }
+
+    return write_public_metadata(
+        project_id=project_id,
+        mint_record_id=mint_record_id,
+        version_number=version_number,
+        public_token_id=public_token_id,
+        metadata_uri=metadata_uri,
+        poster_image_uri_public=poster_image_uri_public,
+        payload=payload,
+        build_hash=build_hash,
+        certificate_hash=certificate_hash,
+        approval_status="draft" if approval_timestamp is None else "approved",
+        approved_at=approval_timestamp,
+    )
+
+
+def get_public_manifest_for_mint_record(mint_record_id: str) -> dict[str, Any] | None:
+    document = _collection().find_one(
+        {"mint_record_id": mint_record_id},
+        sort=[("version_number", -1), ("updated_at", -1)],
+    )
+    if document is None:
+        return None
+    return _serialize_manifest(document)
+
+
+def get_public_manifest_by_token_id(public_token_id: str) -> dict[str, Any] | None:
+    document = _collection().find_one({"public_token_id": public_token_id})
+    if document is None:
+        return None
+    return _serialize_manifest(document)

--- a/backend/app/services/r2_storage_service.py
+++ b/backend/app/services/r2_storage_service.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.config import settings
+
+ZONE_METADATA = "metadata"
+ZONE_POSTER = "poster"
+ZONE_PRIVATE = "private"
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _public_storage_root() -> Path:
+    root = Path(settings.public_storage_root_path)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _metadata_bucket() -> str:
+    return (
+        _normalize(settings.r2_metadata_bucket)
+        or _normalize(settings.r2_bucket)
+    )
+
+
+def _poster_bucket() -> str:
+    return (
+        _normalize(settings.r2_poster_bucket)
+        or _normalize(settings.r2_bucket)
+    )
+
+
+def _private_bucket() -> str:
+    return (
+        _normalize(settings.r2_private_bucket)
+        or _normalize(settings.r2_bucket)
+    )
+
+
+def _has_any_r2_config() -> bool:
+    return any(
+        (
+            _normalize(settings.r2_account_id),
+            _normalize(settings.r2_access_key_id),
+            _normalize(settings.r2_secret_access_key),
+            _normalize(settings.r2_endpoint_url),
+            _normalize(settings.r2_bucket),
+            _normalize(settings.r2_metadata_bucket),
+            _normalize(settings.r2_poster_bucket),
+            _normalize(settings.r2_private_bucket),
+        )
+    )
+
+
+def r2_is_configured() -> bool:
+    return all(
+        (
+            _normalize(settings.r2_access_key_id),
+            _normalize(settings.r2_secret_access_key),
+            _normalize(settings.r2_resolved_endpoint_url),
+            _metadata_bucket() or _poster_bucket() or _private_bucket(),
+        )
+    )
+
+
+def _allow_local_fallback() -> bool:
+    environment = _normalize(settings.environment).lower()
+    if _has_any_r2_config():
+        return False
+    return environment in {"", "development", "dev", "local", "test", "testing"}
+
+
+def _bucket_for_zone(zone: str) -> str:
+    normalized = _normalize(zone).lower()
+    if normalized == ZONE_METADATA:
+        return _metadata_bucket()
+    if normalized == ZONE_POSTER:
+        return _poster_bucket()
+    if normalized == ZONE_PRIVATE:
+        return _private_bucket()
+    return _normalize(settings.r2_bucket)
+
+
+def _lazy_s3_client():
+    try:
+        import boto3
+        from botocore.config import Config
+    except ImportError as exc:
+        raise RuntimeError(
+            "boto3 is required for R2 storage writes. Install backend requirements "
+            "before enabling R2-backed metadata or poster storage."
+        ) from exc
+
+    endpoint_url = _normalize(settings.r2_resolved_endpoint_url)
+    if not endpoint_url:
+        raise RuntimeError("R2 endpoint is not configured.")
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        region_name=_normalize(settings.r2_region) or "auto",
+        aws_access_key_id=_normalize(settings.r2_access_key_id),
+        aws_secret_access_key=_normalize(settings.r2_secret_access_key),
+        config=Config(
+            signature_version="s3v4",
+            s3={"addressing_style": "path" if settings.r2_force_path_style else "virtual"},
+        ),
+    )
+
+
+def _local_fallback_write(
+    *,
+    zone: str,
+    key: str,
+    body: bytes,
+) -> dict[str, Any]:
+    destination = _public_storage_root() / _normalize(zone).lower() / key
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(body)
+
+    return {
+        "storage_provider": "local_disk",
+        "bucket": None,
+        "key": key,
+        "size_bytes": len(body),
+        "local_path": str(destination),
+    }
+
+
+def upload_bytes(
+    *,
+    zone: str,
+    key: str,
+    body: bytes,
+    content_type: str,
+    cache_control: str = "public, max-age=300",
+    publish: bool = True,
+    metadata: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    normalized_key = key.lstrip("/")
+    storage_key = normalized_key if publish else f"draft/{normalized_key}"
+    bucket = _bucket_for_zone(zone)
+
+    if not r2_is_configured() or not bucket:
+        if _allow_local_fallback():
+            return _local_fallback_write(zone=zone, key=storage_key, body=body)
+        raise RuntimeError(
+            "R2 storage is not fully configured for this environment. "
+            "Refusing to fall back to local public storage."
+        )
+
+    client = _lazy_s3_client()
+    client.put_object(
+        Bucket=bucket,
+        Key=storage_key,
+        Body=body,
+        ContentType=content_type,
+        CacheControl=cache_control,
+        Metadata=metadata or {},
+    )
+
+    return {
+        "storage_provider": "r2",
+        "bucket": bucket,
+        "key": storage_key,
+        "size_bytes": len(body),
+        "content_type": content_type,
+    }
+
+
+def upload_json(
+    *,
+    zone: str,
+    key: str,
+    payload: dict[str, Any],
+    publish: bool = True,
+) -> dict[str, Any]:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=True, indent=2).encode("utf-8")
+    return upload_bytes(
+        zone=zone,
+        key=key,
+        body=encoded,
+        content_type="application/json",
+        cache_control="public, max-age=300",
+        publish=publish,
+    )
+
+
+def upload_text(
+    *,
+    zone: str,
+    key: str,
+    text: str,
+    content_type: str,
+    publish: bool = True,
+) -> dict[str, Any]:
+    return upload_bytes(
+        zone=zone,
+        key=key,
+        body=text.encode("utf-8"),
+        content_type=content_type,
+        cache_control="public, max-age=300",
+        publish=publish,
+    )

--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -102,6 +102,15 @@ def _sort_members(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(members, key=_generation)
 
 
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
 def _lane_from_project(project: dict[str, Any]) -> str:
     lane = _normalize_value(project.get("project_lane")).lower()
     if lane:
@@ -174,6 +183,15 @@ def resolve_project_for_viewer(
         for project in sorted_projects:
             if _normalize_value(project.get("family_id")) == normalized_family_id:
                 return project
+        db = get_database()
+        if db is not None and ObjectId.is_valid(normalized_family_id):
+            family_doc = db["families"].find_one({"_id": ObjectId(normalized_family_id)})
+            family_project_id = _normalize_value((family_doc or {}).get("project_id"))
+            if family_project_id:
+                for project in sorted_projects:
+                    candidate_id = _normalize_value(project.get("_id") or project.get("id"))
+                    if candidate_id == family_project_id:
+                        return project
         return None
 
     return sorted_projects[0] if sorted_projects else None
@@ -538,14 +556,59 @@ def _sequence_members_for_viewer(
             if _normalize_value(member.get("_id")) == primary_member_id
         ]
         if primary_photo:
-            trailing = [
-                member
-                for member in members_with_photos
-                if _normalize_value(member.get("_id")) != primary_member_id
-            ]
-            return primary_photo + trailing
+            return primary_photo
 
     return members_with_photos
+
+
+def _resolve_member_photo_upload(
+    *,
+    db: Any,
+    member: dict[str, Any],
+    project_id: str,
+    family_id: str,
+) -> dict[str, Any] | None:
+    uploads = db["uploaded_files"]
+    member_id = _normalize_value(member.get("_id"))
+    candidate_upload_ids: list[str] = []
+
+    primary_upload_id = _normalize_value(member.get("photo_upload_id"))
+    if primary_upload_id:
+        candidate_upload_ids.append(primary_upload_id)
+
+    fallback_cursor = uploads.find(
+        {
+            "project_id": project_id,
+            "family_id": family_id,
+            "member_id": member_id,
+            "category": "member_photo",
+        }
+    ).sort("created_at", -1)
+
+    for upload in fallback_cursor:
+        upload_id = _normalize_value(upload.get("_id"))
+        if upload_id and upload_id not in candidate_upload_ids:
+            candidate_upload_ids.append(upload_id)
+
+    for upload_id in candidate_upload_ids:
+        if not ObjectId.is_valid(upload_id):
+            continue
+        upload = uploads.find_one({"_id": ObjectId(upload_id)})
+        if upload is None:
+            continue
+        if _normalize_value(upload.get("category")) != "member_photo":
+            continue
+        if _normalize_value(upload.get("project_id")) != project_id:
+            continue
+        if _normalize_value(upload.get("family_id")) != family_id:
+            continue
+        if _normalize_value(upload.get("member_id")) != member_id:
+            continue
+        if not _normalize_value(upload.get("relative_path")):
+            continue
+        return upload
+
+    return None
 
 
 def build_viewer_manifest(
@@ -585,15 +648,25 @@ def build_viewer_manifest(
     )
 
     primary_member_id = _normalize_value((primary_member or {}).get("_id"))
-    anchor_generation = None
-    if primary_member and isinstance(primary_member.get("generation"), int):
-        anchor_generation = int(primary_member["generation"])
+    anchor_generation = _coerce_int((primary_member or {}).get("generation"))
 
     states: list[dict[str, Any]] = []
     if ordered_members:
-        for index, member in enumerate(ordered_members):
+        project_id_value = _normalize_value(project.get("_id") or project.get("id"))
+        valid_member_views: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        for member in ordered_members:
+            upload_record = _resolve_member_photo_upload(
+                db=db,
+                member=member,
+                project_id=project_id_value,
+                family_id=family_id_value,
+            )
+            if upload_record is not None:
+                valid_member_views.append((member, upload_record))
+
+        for index, (member, upload_record) in enumerate(valid_member_views):
             member_id = _normalize_value(member.get("_id"))
-            upload_id = _normalize_value(member.get("photo_upload_id"))
+            upload_id = _normalize_value(upload_record.get("_id"))
             title = _display_name(member)
             status = _member_status(
                 lane=lane,
@@ -618,12 +691,13 @@ def build_viewer_manifest(
                     "node": title,
                     "description": description,
                     "narration": description,
-                    "left_state_id": f"member-{_normalize_value(ordered_members[index - 1].get('_id'))}" if index > 0 else None,
-                    "right_state_id": f"member-{_normalize_value(ordered_members[index + 1].get('_id'))}" if index + 1 < len(ordered_members) else None,
+                    "left_state_id": f"member-{_normalize_value(valid_member_views[index - 1][0].get('_id'))}" if index > 0 else None,
+                    "right_state_id": f"member-{_normalize_value(valid_member_views[index + 1][0].get('_id'))}" if index + 1 < len(valid_member_views) else None,
                     "eye_targets": DEFAULT_EYE_TARGETS,
                 }
             )
-    else:
+
+    if not states:
         states.append(
             _build_empty_state(
                 lane=lane,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,8 @@ annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.1
 bcrypt==4.0.1
+boto3==1.40.18
+botocore==1.40.18
 cachetools==5.5.2
 certifi==2025.8.3
 charset-normalizer==3.4.3
@@ -35,4 +37,5 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.5.0
 uvicorn==0.42.0
+web3==7.13.0
 python-multipart==0.0.22

--- a/contracts/Tomb of Light Legacy Anchor.sol
+++ b/contracts/Tomb of Light Legacy Anchor.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts ^5.6.0
+pragma solidity ^0.8.27;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Pausable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Pausable.sol";
+import {ERC721URIStorage} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+
+contract TombOfLightLegacyAnchor is ERC721, ERC721URIStorage, ERC721Pausable, Ownable {
+    uint256 private _nextTokenId;
+
+    constructor(address initialOwner)
+        ERC721("Tomb of Light Legacy Anchor", "TOLA")
+        Ownable(initialOwner)
+    {}
+
+    function pause() public onlyOwner {
+        _pause();
+    }
+
+    function unpause() public onlyOwner {
+        _unpause();
+    }
+
+    function safeMint(address to, string memory uri)
+        public
+        onlyOwner
+        returns (uint256)
+    {
+        uint256 tokenId = _nextTokenId++;
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri);
+        return tokenId;
+    }
+
+    // The following functions are overrides required by Solidity.
+
+    function _update(address to, uint256 tokenId, address auth)
+        internal
+        override(ERC721, ERC721Pausable)
+        returns (address)
+    {
+        return super._update(to, tokenId, auth);
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override(ERC721, ERC721URIStorage)
+        returns (string memory)
+    {
+        return super.tokenURI(tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721, ERC721URIStorage)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}


### PR DESCRIPTION
… workspace validation.

This update closes the remaining backend gaps in the on-chain anchor scaffold by adding a real R2 storage service, tightening blockchain mint execution rules, and fixing viewer manifest integrity checks.

Public metadata JSON and poster assets now route through a dedicated R2/local-public storage layer instead of only resolving placeholder URLs in Mongo. The storage path is stricter as well: partial R2 configuration no longer silently falls back to local public files, while local fallback remains available only for development-style environments.

The blockchain mint service was upgraded from a stub into a guarded live execution path that supports contract ABI loading, wallet validation, transaction submission, and receipt syncing while still respecting NFT_MINTING_ENABLED / NFT_MINT_ENABLED. It now requires an explicit recipient wallet (or configured default), handles multiple token-type argument shapes, and treats mined-but-reverted transactions as failures instead of false positives.

The viewer manifest service was also hardened so cinematic portrait states are built only from uploads that actually belong to the current project and family. This prevents stale or mismatched portrait links from leaking across workspaces and fixes navigation sequences so left/right lineage travel only points to valid visible states.