### PR TITLE
Add mutual link-key handshakes, password recovery/admin reset tools, …

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Account Security | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Reset or change your Tomb of Light password through the protected account security layer."
+    />
+    <link rel="stylesheet" href="styles.css?v=20260331-2" />
+  </head>
+  <body class="portal-dashboard-body">
+    <div class="page-wrap">
+      <header class="site-header" role="banner">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="billing.html">Billing</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="signin.html">Sign In</a>
+            <button class="btn btn-secondary" type="button" data-logout-btn>
+              Log Out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" role="main">
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Account Security</span>
+              <h1>Password recovery and protected account changes.</h1>
+              <p data-account-security-page-status>
+                Tomb of Light can issue secure reset requests, accept one-time
+                reset tokens, and let signed-in users change their password
+                directly inside the portal.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell portal-account-grid">
+            <div class="form-panel" id="reset-request">
+              <span class="eyebrow">Reset Request</span>
+              <p class="card-copy">
+                Enter the email attached to your Tomb of Light account. If it
+                exists, a secure password reset request will be created. In the
+                current protected flow, support or an internal admin can help
+                deliver the recovery link if needed.
+              </p>
+
+              <form class="form-grid" data-password-reset-request-form novalidate>
+                <label>
+                  Email Address
+                  <input
+                    type="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    autocomplete="email"
+                    required
+                  />
+                </label>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button class="btn btn-primary" type="submit">
+                    Request Password Reset
+                  </button>
+                </div>
+              </form>
+
+              <div
+                class="helper"
+                data-password-reset-request-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+
+            <div class="form-panel" id="reset-confirm">
+              <span class="eyebrow">Use Reset Token</span>
+              <p class="card-copy">
+                If Tomb of Light or an internal admin gave you a one-time reset
+                token or reset link, enter it here to set a new password.
+              </p>
+
+              <form class="form-grid" data-password-reset-confirm-form novalidate>
+                <label>
+                  Reset Token
+                  <input
+                    type="text"
+                    name="token"
+                    placeholder="Paste your secure reset token"
+                    autocomplete="off"
+                    required
+                  />
+                </label>
+
+                <label>
+                  New Password
+                  <input
+                    type="password"
+                    name="new_password"
+                    placeholder="Create a new password"
+                    autocomplete="new-password"
+                    required
+                  />
+                </label>
+
+                <label>
+                  Confirm New Password
+                  <input
+                    type="password"
+                    name="confirm_new_password"
+                    placeholder="Re-enter your new password"
+                    autocomplete="new-password"
+                    required
+                  />
+                </label>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button class="btn btn-primary" type="submit">
+                    Apply New Password
+                  </button>
+                </div>
+              </form>
+
+              <div
+                class="helper"
+                data-password-reset-confirm-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+
+            <div class="form-panel" data-password-change-panel>
+              <span class="eyebrow">Change Password</span>
+              <p class="card-copy" data-password-change-intro>
+                Sign in to change your password from inside the protected
+                workspace.
+              </p>
+
+              <form class="form-grid" data-password-change-form novalidate>
+                <label>
+                  Current Password
+                  <input
+                    type="password"
+                    name="current_password"
+                    placeholder="Enter your current password"
+                    autocomplete="current-password"
+                    required
+                  />
+                </label>
+
+                <label>
+                  New Password
+                  <input
+                    type="password"
+                    name="new_password"
+                    placeholder="Create a new password"
+                    autocomplete="new-password"
+                    required
+                  />
+                </label>
+
+                <label>
+                  Confirm New Password
+                  <input
+                    type="password"
+                    name="confirm_new_password"
+                    placeholder="Re-enter your new password"
+                    autocomplete="new-password"
+                    required
+                  />
+                </label>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button class="btn btn-primary" type="submit">
+                    Change Password
+                  </button>
+                </div>
+              </form>
+
+              <div
+                class="helper"
+                data-password-change-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer" role="contentinfo">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">
+                  Tomb of Light<span class="brand-symbol">™</span>
+                </div>
+                <p class="footer-copy">
+                  Protected lineage access with account recovery and private
+                  workspace security controls.
+                </p>
+              </div>
+            </div>
+
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+              <span>Protected account operations remain private by design.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="config.js?v=20260331-2"></script>
+    <script src="app.js?v=20260331-2"></script>
+    <script src="auth.js?v=20260331-2"></script>
+    <script src="account-security.js?v=20260331-2"></script>
+  </body>
+</html>

--- a/account-security.js
+++ b/account-security.js
@@ -1,0 +1,197 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") {
+    return;
+  }
+
+  function query(name) {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return String(params.get(name) || "").trim();
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function getErrorMessage(error) {
+    return String((error && error.message) || error || "Unknown error");
+  }
+
+  async function populateSignedInState() {
+    const introNode = document.querySelector("[data-password-change-intro]");
+    try {
+      const me = await app.fetchCurrentUser();
+      if (introNode) {
+        introNode.textContent =
+          "You are signed in. Use this form to change your Tomb of Light password directly inside the protected workspace.";
+      }
+      return me;
+    } catch (_error) {
+      if (introNode) {
+        introNode.textContent =
+          "Sign in first if you want to change your password from inside the protected workspace. Reset requests and one-time reset tokens still work here without a live session.";
+      }
+      return null;
+    }
+  }
+
+  function setupResetRequestForm() {
+    const form = document.querySelector("[data-password-reset-request-form]");
+    if (!form) return;
+    const statusNode = document.querySelector(
+      "[data-password-reset-request-status]",
+    );
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      app.clearStatus(statusNode);
+
+      const formData = new FormData(form);
+      const email = String(formData.get("email") || "")
+        .trim()
+        .toLowerCase();
+
+      if (!email) {
+        app.setStatus(statusNode, "Email address is required.", "error");
+        return;
+      }
+
+      try {
+        const payload = await app.apiRequest("/auth/password-reset/request", {
+          method: "POST",
+          body: JSON.stringify({ email }),
+        });
+        const message = String(
+          (payload && payload.message) ||
+            "Password reset request created successfully.",
+        );
+        const resetUrl = String((payload && payload.reset_url) || "").trim();
+        app.setStatus(statusNode, message, "success");
+        if (resetUrl) {
+          window.prompt("Local reset preview link:", resetUrl);
+        }
+        form.reset();
+      } catch (error) {
+        app.setStatus(
+          statusNode,
+          getErrorMessage(error) || "Unable to request password reset.",
+          "error",
+        );
+      }
+    });
+  }
+
+  function setupResetConfirmForm() {
+    const form = document.querySelector("[data-password-reset-confirm-form]");
+    if (!form) return;
+    const statusNode = document.querySelector(
+      "[data-password-reset-confirm-status]",
+    );
+
+    const tokenField = form.querySelector('input[name="token"]');
+    if (tokenField) {
+      tokenField.value = query("token");
+    }
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      app.clearStatus(statusNode);
+
+      const formData = new FormData(form);
+      const token = String(formData.get("token") || "").trim();
+      const newPassword = String(formData.get("new_password") || "").trim();
+      const confirmPassword = String(
+        formData.get("confirm_new_password") || "",
+      ).trim();
+
+      if (!token || !newPassword || !confirmPassword) {
+        app.setStatus(statusNode, "Please complete all reset fields.", "error");
+        return;
+      }
+
+      if (newPassword !== confirmPassword) {
+        app.setStatus(statusNode, "New passwords do not match.", "error");
+        return;
+      }
+
+      try {
+        await app.apiRequest("/auth/password-reset/confirm", {
+          method: "POST",
+          body: JSON.stringify({
+            token,
+            new_password: newPassword,
+          }),
+        });
+        app.setStatus(
+          statusNode,
+          "Password reset completed successfully. You can sign in now.",
+          "success",
+        );
+        form.reset();
+      } catch (error) {
+        app.setStatus(
+          statusNode,
+          getErrorMessage(error) || "Unable to apply password reset.",
+          "error",
+        );
+      }
+    });
+  }
+
+  function setupPasswordChangeForm() {
+    const form = document.querySelector("[data-password-change-form]");
+    if (!form) return;
+    const statusNode = document.querySelector("[data-password-change-status]");
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      app.clearStatus(statusNode);
+
+      const formData = new FormData(form);
+      const currentPassword = String(
+        formData.get("current_password") || "",
+      ).trim();
+      const newPassword = String(formData.get("new_password") || "").trim();
+      const confirmPassword = String(
+        formData.get("confirm_new_password") || "",
+      ).trim();
+
+      if (!currentPassword || !newPassword || !confirmPassword) {
+        app.setStatus(statusNode, "Please complete all password fields.", "error");
+        return;
+      }
+
+      if (newPassword !== confirmPassword) {
+        app.setStatus(statusNode, "New passwords do not match.", "error");
+        return;
+      }
+
+      try {
+        await app.apiRequest("/auth/password-change", {
+          method: "POST",
+          body: JSON.stringify({
+            current_password: currentPassword,
+            new_password: newPassword,
+          }),
+        });
+        app.setStatus(statusNode, "Password changed successfully.", "success");
+        form.reset();
+      } catch (error) {
+        app.setStatus(
+          statusNode,
+          getErrorMessage(error) || "Unable to change password.",
+          "error",
+        );
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", async function () {
+    await populateSignedInState();
+    setupResetRequestForm();
+    setupResetConfirmForm();
+    setupPasswordChangeForm();
+  });
+})();

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -130,6 +130,15 @@
     return Boolean(allowed && allowed.has(currentRoleKey));
   }
 
+  SECTION_ACCESS.users = new Set([
+    "operations_admin",
+    "operations",
+    "finance_admin",
+    "finance",
+    "marketing_admin",
+    "marketing",
+  ]);
+
   function getSearchValue() {
     const node = document.querySelector("[data-admin-control-search]");
     return String((node && node.value) || "").trim();
@@ -373,10 +382,18 @@
     return `
       <div class="family-record-card">
         <div class="card-number">U</div>
-        <h3>${escapeHtml(`${item.first_name || ""} ${item.last_name || ""}`.trim() || item.email || "User")}</h3>
+        <h3>${escapeHtml(item.full_name || `${item.first_name || ""} ${item.last_name || ""}`.trim() || item.email || "User")}</h3>
         <p class="card-copy"><strong>Email:</strong> ${escapeHtml(item.email || "—")}</p>
         <p class="card-copy"><strong>Role:</strong> ${escapeHtml(item.role || "—")}</p>
+        <p class="card-copy"><strong>Status:</strong> ${escapeHtml(item.status || "—")}</p>
+        <p class="card-copy"><strong>Last Login:</strong> ${escapeHtml(formatDate(item.last_login_at))}</p>
+        <p class="card-copy"><strong>Reset Requested:</strong> ${escapeHtml(formatDate(item.password_reset_requested_at))}</p>
         <p class="card-copy"><strong>Created:</strong> ${escapeHtml(formatDate(item.created_at))}</p>
+        <div class="inline-actions" style="margin-top: 1rem;">
+          <button class="btn btn-secondary" type="button" data-admin-password-reset="${escapeHtml(item.id || "")}">
+            Issue Reset Link
+          </button>
+        </div>
       </div>
     `;
   }
@@ -533,11 +550,13 @@
       const items = await fetchJson("/users/");
       const filtered = Array.isArray(items)
         ? items.filter(function (item) {
-            const haystack = [
+          const haystack = [
+              item.full_name,
               item.first_name,
               item.last_name,
               item.email,
               item.role,
+              item.status,
             ]
               .join(" ")
               .toLowerCase();
@@ -723,6 +742,40 @@
         {},
         "Syncing mint receipt...",
       );
+      return;
+    }
+
+    const passwordResetButton = event.target.closest("[data-admin-password-reset]");
+    if (passwordResetButton) {
+      const userId = passwordResetButton.getAttribute("data-admin-password-reset");
+      if (!userId) return;
+      try {
+        setPageStatus("Issuing password reset link...", "info");
+        const payload = await app.apiRequest(
+          `/auth/admin/users/${encodeURIComponent(userId)}/password-reset`,
+          {
+            method: "POST",
+          },
+        );
+        const resetUrl = String(payload && payload.reset_url ? payload.reset_url : "").trim();
+        if (resetUrl && navigator.clipboard && navigator.clipboard.writeText) {
+          try {
+            await navigator.clipboard.writeText(resetUrl);
+            setPageStatus("Password reset link issued and copied to clipboard.", "success");
+          } catch (_error) {
+            setPageStatus("Password reset link issued. Copy it from the dialog.", "success");
+          }
+        } else {
+          setPageStatus("Password reset link issued successfully.", "success");
+        }
+
+        if (resetUrl) {
+          window.prompt("Share this secure reset link with the user:", resetUrl);
+        }
+        await loadUsers();
+      } catch (error) {
+        setPageStatus(error.message || "Unable to issue password reset link.", "error");
+      }
     }
   }
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,9 +48,37 @@ class Settings(BaseSettings):
         default="",
         validation_alias=AliasChoices("STRIPE_SECRET_KEY"),
     )
+    stripe_publishable_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("STRIPE_PUBLISHABLE_KEY"),
+    )
     stripe_webhook_secret: str = Field(
         default="",
         validation_alias=AliasChoices("STRIPE_WEBHOOK_SECRET"),
+    )
+    stripe_billing_portal_configuration_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("STRIPE_BILLING_PORTAL_CONFIGURATION_ID"),
+    )
+    stripe_billing_portal_return_url: str = Field(
+        default="https://tomboflight.com/billing.html",
+        validation_alias=AliasChoices("STRIPE_BILLING_PORTAL_RETURN_URL"),
+    )
+    stripe_payment_method_max_cards: int = Field(
+        default=3,
+        validation_alias=AliasChoices("STRIPE_PAYMENT_METHOD_MAX_CARDS"),
+    )
+    password_reset_token_expire_minutes: int = Field(
+        default=30,
+        validation_alias=AliasChoices("PASSWORD_RESET_TOKEN_EXPIRE_MINUTES"),
+    )
+    password_reset_base_url: str = Field(
+        default="https://tomboflight.com/account-security.html",
+        validation_alias=AliasChoices("PASSWORD_RESET_BASE_URL"),
+    )
+    password_reset_preview_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("PASSWORD_RESET_PREVIEW_ENABLED"),
     )
 
     nft_chain: str = Field(
@@ -331,6 +359,14 @@ class Settings(BaseSettings):
     @property
     def public_token_external_base_url_clean(self) -> str:
         return str(self.public_token_external_base_url or "").strip().rstrip("/")
+
+    @property
+    def stripe_billing_portal_return_url_clean(self) -> str:
+        return str(self.stripe_billing_portal_return_url or "").strip().rstrip("/")
+
+    @property
+    def password_reset_base_url_clean(self) -> str:
+        return str(self.password_reset_base_url or "").strip().rstrip("/")
 
 
 @lru_cache

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.routes.admin_intake_submissions import (
 )
 from app.routes.audit_logs import router as audit_logs_router
 from app.routes.auth import router as auth_router
+from app.routes.billing import router as billing_router
 from app.routes.canonical_persons import router as canonical_persons_router
 from app.routes.certificate_versions import router as certificate_versions_router
 from app.routes.consistency import router as consistency_router
@@ -136,6 +137,7 @@ async def add_security_headers(request: Request, call_next):
 # ----------------------------
 app.include_router(health_router)
 app.include_router(auth_router)
+app.include_router(billing_router)
 app.include_router(intake_router)
 app.include_router(intake_submissions_router)
 app.include_router(admin_intake_submissions_router)
@@ -216,6 +218,9 @@ def root():
             "/auth/login",
             "/auth/logout",
             "/auth/me",
+            "/auth/password-reset/request",
+            "/auth/password-reset/confirm",
+            "/auth/password-change",
             "/intake",
             "/intake-submissions",
             "/intake-submissions/my-latest",
@@ -247,6 +252,12 @@ def root():
             "/orders/record-checkout",
             "/orders/my-orders",
             "/orders/health",
+            "/billing/config",
+            "/billing/overview",
+            "/billing/setup-intent",
+            "/billing/payment-methods/{payment_method_id}/default",
+            "/billing/payment-methods/{payment_method_id}",
+            "/billing/portal-session",
             "/audit-logs",
             "/docs",
         ],

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -3,9 +3,26 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.config import settings
-from app.dependencies.auth import COOKIE_NAME, get_current_user
-from app.schemas.auth import TokenResponse, UserCreate, UserLogin, UserResponse
-from app.services.auth_service import authenticate_user, build_user_response, register_user
+from app.dependencies.auth import COOKIE_NAME, get_current_user, require_admin
+from app.schemas.auth import (
+    PasswordChangeRequest,
+    PasswordResetConfirm,
+    PasswordResetRequest,
+    PasswordResetResponse,
+    TokenResponse,
+    UserCreate,
+    UserLogin,
+    UserResponse,
+)
+from app.services.auth_service import (
+    admin_issue_password_reset,
+    authenticate_user,
+    build_user_response,
+    change_password,
+    register_user,
+    request_password_reset,
+    reset_password_with_token,
+)
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
@@ -89,3 +106,77 @@ def logout(request: Request, response: Response):
 def me(response: Response, current_user: dict = Depends(get_current_user)):
     _apply_no_store(response)
     return build_user_response(current_user)
+
+
+def _current_user_id(user: dict) -> str:
+    raw_value = user.get("id") or user.get("_id") or user.get("user_id")
+    return str(raw_value or "").strip()
+
+
+def _current_user_display(user: dict) -> str:
+    return (
+        str(user.get("full_name") or user.get("name") or user.get("email") or "").strip()
+        or "Tomb of Light Admin"
+    )
+
+
+@router.post("/password-reset/request", response_model=PasswordResetResponse)
+def password_reset_request_route(payload: PasswordResetRequest, response: Response):
+    result = request_password_reset(payload.email)
+    _apply_no_store(response)
+    return result
+
+
+@router.post("/password-reset/confirm", response_model=PasswordResetResponse)
+def password_reset_confirm_route(
+    payload: PasswordResetConfirm,
+    response: Response,
+):
+    try:
+        result = reset_password_with_token(payload.token, payload.new_password)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    _apply_no_store(response)
+    return result
+
+
+@router.post("/password-change", response_model=PasswordResetResponse)
+def password_change_route(
+    payload: PasswordChangeRequest,
+    response: Response,
+    current_user: dict = Depends(get_current_user),
+):
+    try:
+        result = change_password(
+            _current_user_id(current_user),
+            current_password=payload.current_password,
+            new_password=payload.new_password,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    _apply_no_store(response)
+    return result
+
+
+@router.post(
+    "/admin/users/{user_id}/password-reset",
+    response_model=PasswordResetResponse,
+)
+def admin_issue_password_reset_route(
+    user_id: str,
+    response: Response,
+    current_user: dict = Depends(require_admin),
+):
+    try:
+        result = admin_issue_password_reset(
+            user_id,
+            admin_user_id=_current_user_id(current_user),
+            admin_display=_current_user_display(current_user),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    _apply_no_store(response)
+    return result

--- a/backend/app/routes/billing.py
+++ b/backend/app/routes/billing.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.dependencies.auth import get_current_user
+from app.schemas.billing import (
+    BillingConfigResponse,
+    BillingOverviewResponse,
+    BillingPortalSessionResponse,
+    PaymentMethodActionResponse,
+    SetupIntentResponse,
+    build_payment_method_summary,
+    build_subscription_summary,
+)
+from app.services.billing_service import (
+    create_billing_portal_session_for_user,
+    create_setup_intent_for_user,
+    detach_payment_method_for_user,
+    get_billing_config,
+    get_billing_overview,
+    set_default_payment_method_for_user,
+)
+
+router = APIRouter(prefix="/billing", tags=["Billing"])
+
+
+class BillingPortalRequest(BaseModel):
+    return_url: str | None = Field(default=None, max_length=500)
+
+
+@router.get("/config", response_model=BillingConfigResponse)
+def billing_config_route(current_user: dict[str, Any] = Depends(get_current_user)):
+    del current_user
+    return get_billing_config()
+
+
+@router.get("/overview", response_model=BillingOverviewResponse)
+def billing_overview_route(current_user: dict[str, Any] = Depends(get_current_user)):
+    try:
+        payload = get_billing_overview(current_user)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return BillingOverviewResponse(
+        customer_id=payload.get("customer_id"),
+        max_cards=int(payload.get("max_cards") or 3),
+        cards_on_file=int(payload.get("cards_on_file") or 0),
+        can_add_card=bool(payload.get("can_add_card")),
+        default_payment_method_id=payload.get("default_payment_method_id"),
+        payment_methods=[
+            build_payment_method_summary(
+                item,
+                default_payment_method_id=payload.get("default_payment_method_id"),
+            )
+            for item in payload.get("payment_methods") or []
+        ],
+        subscriptions=[
+            build_subscription_summary(item)
+            for item in payload.get("subscriptions") or []
+        ],
+    )
+
+
+@router.post("/setup-intent", response_model=SetupIntentResponse)
+def create_setup_intent_route(
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        return create_setup_intent_for_user(current_user)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post(
+    "/payment-methods/{payment_method_id}/default",
+    response_model=PaymentMethodActionResponse,
+)
+def set_default_payment_method_route(
+    payment_method_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        return set_default_payment_method_for_user(current_user, payment_method_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/payment-methods/{payment_method_id}",
+    response_model=PaymentMethodActionResponse,
+)
+def detach_payment_method_route(
+    payment_method_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        return detach_payment_method_for_user(current_user, payment_method_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/portal-session", response_model=BillingPortalSessionResponse)
+def create_billing_portal_session_route(
+    payload: BillingPortalRequest | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        return create_billing_portal_session_for_user(
+            current_user,
+            return_url=payload.return_url if payload else None,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -25,6 +25,29 @@ class UserLogin(BaseModel):
     password: str = Field(..., min_length=8, max_length=128)
 
 
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class PasswordResetConfirm(BaseModel):
+    token: str = Field(..., min_length=16, max_length=512)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+
+class PasswordChangeRequest(BaseModel):
+    current_password: str = Field(..., min_length=8, max_length=128)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+
+class PasswordResetResponse(BaseModel):
+    success: bool = True
+    message: str
+    expires_at: Optional[str] = None
+    reset_token: Optional[str] = None
+    reset_url: Optional[str] = None
+    delivery_mode: Optional[str] = None
+
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"

--- a/backend/app/schemas/billing.py
+++ b/backend/app/schemas/billing.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class BillingConfigResponse(BaseModel):
+    publishable_key: str
+    max_cards: int = Field(default=3, ge=1, le=10)
+    portal_return_url: str | None = None
+
+
+class PaymentMethodSummaryResponse(BaseModel):
+    id: str
+    brand: str | None = None
+    last4: str | None = None
+    exp_month: int | None = None
+    exp_year: int | None = None
+    funding: str | None = None
+    is_default: bool = False
+    created_at: str | None = None
+
+
+class SubscriptionSummaryResponse(BaseModel):
+    id: str
+    status: str
+    collection_method: str | None = None
+    cancel_at_period_end: bool = False
+    current_period_end: str | None = None
+    default_payment_method_id: str | None = None
+    product_names: list[str] = Field(default_factory=list)
+
+
+class BillingOverviewResponse(BaseModel):
+    customer_id: str | None = None
+    chain_label: str | None = None
+    max_cards: int = Field(default=3, ge=1, le=10)
+    cards_on_file: int = 0
+    can_add_card: bool = True
+    default_payment_method_id: str | None = None
+    payment_methods: list[PaymentMethodSummaryResponse] = Field(default_factory=list)
+    subscriptions: list[SubscriptionSummaryResponse] = Field(default_factory=list)
+
+
+class SetupIntentResponse(BaseModel):
+    client_secret: str
+    customer_id: str
+    max_cards: int = Field(default=3, ge=1, le=10)
+
+
+class BillingPortalSessionResponse(BaseModel):
+    url: str
+
+
+class PaymentMethodActionResponse(BaseModel):
+    success: bool = True
+    message: str
+    payment_method_id: str | None = None
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def build_payment_method_summary(
+    item: dict[str, Any],
+    *,
+    default_payment_method_id: str | None = None,
+) -> PaymentMethodSummaryResponse:
+    card = item.get("card") or {}
+    item_id = _normalize_text(item.get("id"))
+    return PaymentMethodSummaryResponse(
+        id=item_id,
+        brand=_normalize_text(card.get("brand")) or None,
+        last4=_normalize_text(card.get("last4")) or None,
+        exp_month=card.get("exp_month"),
+        exp_year=card.get("exp_year"),
+        funding=_normalize_text(card.get("funding")) or None,
+        is_default=bool(item_id and item_id == _normalize_text(default_payment_method_id)),
+        created_at=_normalize_text(item.get("created")) or None,
+    )
+
+
+def build_subscription_summary(item: dict[str, Any]) -> SubscriptionSummaryResponse:
+    product_names: list[str] = []
+    items = (((item.get("items") or {}).get("data")) or []) if isinstance(item, dict) else []
+    for entry in items:
+        price = (entry or {}).get("price") or {}
+        product = price.get("product") or {}
+        name = _normalize_text(product.get("name"))
+        if name:
+            product_names.append(name)
+
+    default_payment_method = item.get("default_payment_method")
+    if isinstance(default_payment_method, dict):
+        default_payment_method_id = _normalize_text(default_payment_method.get("id")) or None
+    else:
+        default_payment_method_id = _normalize_text(default_payment_method) or None
+
+    return SubscriptionSummaryResponse(
+        id=_normalize_text(item.get("id")),
+        status=_normalize_text(item.get("status")) or "unknown",
+        collection_method=_normalize_text(item.get("collection_method")) or None,
+        cancel_at_period_end=bool(item.get("cancel_at_period_end")),
+        current_period_end=_to_datetime_string(item.get("current_period_end")),
+        default_payment_method_id=default_payment_method_id,
+        product_names=product_names,
+    )
+
+
+def _to_datetime_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), UTC).isoformat()
+    except Exception:
+        normalized = _normalize_text(value)
+        return normalized or None

--- a/backend/app/schemas/link_request.py
+++ b/backend/app/schemas/link_request.py
@@ -32,6 +32,14 @@ class LinkRequestResponse(BaseModel):
     target_project_name: str | None = None
     target_owner_email: str | None = None
     notes: str | None = None
+    handshake_state: str | None = None
+    source_handshake_at: str | None = None
+    source_handshake_by: str | None = None
+    source_handshake_user_id: str | None = None
+    target_handshake_at: str | None = None
+    target_handshake_by: str | None = None
+    target_handshake_user_id: str | None = None
+    handshake_completed_at: str | None = None
     approved_by: str | None = None
     approved_at: str | None = None
     approval_notes: str | None = None
@@ -112,6 +120,26 @@ def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
             else None
         ),
         notes=data.get("notes"),
+        handshake_state=(
+            str(data.get("handshake_state"))
+            if data.get("handshake_state")
+            else None
+        ),
+        source_handshake_at=data.get("source_handshake_at"),
+        source_handshake_by=data.get("source_handshake_by"),
+        source_handshake_user_id=(
+            str(data.get("source_handshake_user_id"))
+            if data.get("source_handshake_user_id") is not None
+            else None
+        ),
+        target_handshake_at=data.get("target_handshake_at"),
+        target_handshake_by=data.get("target_handshake_by"),
+        target_handshake_user_id=(
+            str(data.get("target_handshake_user_id"))
+            if data.get("target_handshake_user_id") is not None
+            else None
+        ),
+        handshake_completed_at=data.get("handshake_completed_at"),
         approved_by=data.get("approved_by"),
         approved_at=data.get("approved_at"),
         approval_notes=data.get("approval_notes"),

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -16,6 +16,11 @@ class UserResponse(BaseModel):
     email: str
     role: str
     created_at: str
+    status: str | None = None
+    full_name: str | None = None
+    last_login_at: str | None = None
+    password_reset_requested_at: str | None = None
+    password_reset_expires_at: str | None = None
 
 
 def _normalize_text(value: object) -> str:
@@ -62,4 +67,13 @@ def build_user_response(data: dict) -> UserResponse:
         email=_normalize_text(data.get("email")) or "—",
         role=_normalize_text(data.get("role")) or "client",
         created_at=_serialize_created_at(data.get("created_at")),
+        status=_normalize_text(data.get("status")) or None,
+        full_name=_normalize_text(data.get("full_name")) or None,
+        last_login_at=_normalize_text(data.get("last_login_at")) or None,
+        password_reset_requested_at=(
+            _normalize_text(data.get("password_reset_requested_at")) or None
+        ),
+        password_reset_expires_at=(
+            _normalize_text(data.get("password_reset_expires_at")) or None
+        ),
     )

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,16 +1,80 @@
-from datetime import UTC, datetime
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+from urllib.parse import quote
 
 from bson import ObjectId
 
+from app.config import settings
 from app.core.security import create_access_token, hash_password, verify_password
 from app.database import get_database
 from app.schemas.auth import UserCreate
+from app.services.audit_log_service import create_audit_log
 
 PUBLIC_SIGNUP_ROLE = "user"
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _current_user_id_from_doc(user: dict) -> str:
+    raw_value = user.get("_id") or user.get("id") or user.get("user_id")
+    return _normalize_text(raw_value)
+
+
+def _password_reset_expiry_iso() -> str:
+    expire_at = _now() + timedelta(
+        minutes=max(5, int(settings.password_reset_token_expire_minutes or 30))
+    )
+    return expire_at.isoformat()
+
+
+def _hash_password_reset_token(token: str) -> str:
+    payload = f"{settings.secret_key}:{_normalize_text(token)}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _build_password_reset_url(token: str, email: str) -> str:
+    base_url = (
+        settings.password_reset_base_url_clean
+        or "https://tomboflight.com/account-security.html"
+    )
+    encoded_token = quote(_normalize_text(token), safe="")
+    encoded_email = quote(_normalize_text(email).lower(), safe="")
+    joiner = "&" if "?" in base_url else "?"
+    return f"{base_url}{joiner}mode=reset&token={encoded_token}&email={encoded_email}"
+
+
+def _should_expose_password_reset_preview() -> bool:
+    if bool(settings.password_reset_preview_enabled):
+        return True
+
+    return _normalize_text(settings.environment).lower() in {
+        "development",
+        "dev",
+        "local",
+        "test",
+    }
+
+
+def _clear_password_reset_fields() -> dict[str, object]:
+    return {
+        "password_reset_token_hash": None,
+        "password_reset_expires_at": None,
+        "password_reset_requested_at": None,
+        "password_reset_requested_via": None,
+        "password_reset_requested_by": None,
+        "password_reset_requested_by_user_id": None,
+    }
 
 
 def build_user_response(user: dict) -> dict:
@@ -65,7 +129,11 @@ def register_user(payload: UserCreate) -> dict | None:
         "role": PUBLIC_SIGNUP_ROLE,
         "status": "active",
         "password_hash": hash_password(payload.password),
+        "password_updated_at": now_iso,
         "created_at": now_iso,
+        "last_login_at": None,
+        **_clear_password_reset_fields(),
+        "password_reset_used_at": None,
         "policy_version": payload.policy_version,
         "terms_accepted_at": now_iso,
         "privacy_accepted_at": now_iso,
@@ -91,6 +159,17 @@ def authenticate_user(email: str, password: str) -> str | None:
 
     if not verify_password(password, user["password_hash"]):
         return None
+
+    now_iso = _now_iso()
+    db.users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "last_login_at": now_iso,
+                **_clear_password_reset_fields(),
+            }
+        },
+    )
 
     return create_access_token(
         {
@@ -120,3 +199,202 @@ def get_user_by_id(user_id: str) -> dict | None:
         return None
 
     return db.users.find_one({"_id": object_id})
+
+
+def request_password_reset(
+    email: str,
+    *,
+    requested_via: str = "self_service",
+    requested_by_user_id: str | None = None,
+    requested_by: str | None = None,
+    expose_token: bool = False,
+) -> dict[str, object]:
+    normalized_email = _normalize_text(email).lower()
+    generic_message = (
+        "If this account exists, Tomb of Light created a secure password reset request."
+    )
+    generic_response: dict[str, object] = {
+        "success": True,
+        "message": generic_message,
+        "delivery_mode": "admin_assisted",
+    }
+
+    db = get_database()
+    if db is None:
+        return generic_response
+
+    user = db.users.find_one({"email": normalized_email})
+    if user is None:
+        return generic_response
+
+    now_iso = _now_iso()
+    expires_at = _password_reset_expiry_iso()
+    token = secrets.token_urlsafe(32)
+    token_hash = _hash_password_reset_token(token)
+
+    db.users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "password_reset_token_hash": token_hash,
+                "password_reset_expires_at": expires_at,
+                "password_reset_requested_at": now_iso,
+                "password_reset_requested_via": _normalize_text(requested_via)
+                or "self_service",
+                "password_reset_requested_by": _normalize_text(requested_by) or None,
+                "password_reset_requested_by_user_id": _normalize_text(
+                    requested_by_user_id
+                )
+                or None,
+                "password_reset_used_at": None,
+            }
+        },
+    )
+
+    try:
+        create_audit_log(
+            "password_reset_requested",
+            requested_by_user_id or _current_user_id_from_doc(user) or None,
+            "user",
+            _current_user_id_from_doc(user),
+            {
+                "email": normalized_email,
+                "requested_via": _normalize_text(requested_via) or "self_service",
+                "admin_assisted": bool(expose_token),
+            },
+        )
+    except Exception:
+        pass
+
+    should_expose = bool(expose_token) or _should_expose_password_reset_preview()
+    if should_expose:
+        generic_response["reset_token"] = token
+        generic_response["reset_url"] = _build_password_reset_url(token, normalized_email)
+        generic_response["expires_at"] = expires_at
+
+    return generic_response
+
+
+def reset_password_with_token(token: str, new_password: str) -> dict[str, object]:
+    normalized_token = _normalize_text(token)
+    if not normalized_token:
+        raise ValueError("Password reset token is required.")
+
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    token_hash = _hash_password_reset_token(normalized_token)
+    user = db.users.find_one({"password_reset_token_hash": token_hash})
+    if user is None:
+        raise ValueError("Password reset token is invalid or expired.")
+
+    expires_at = _normalize_text(user.get("password_reset_expires_at"))
+    if not expires_at:
+        raise ValueError("Password reset token is invalid or expired.")
+
+    try:
+        expires_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except Exception as exc:
+        raise ValueError("Password reset token is invalid or expired.") from exc
+
+    if expires_dt < _now():
+        raise ValueError("Password reset token is invalid or expired.")
+
+    if _normalize_text(user.get("status")).lower() not in {"", "active"}:
+        raise ValueError("This account is not active.")
+
+    now_iso = _now_iso()
+    update_fields = {
+        "password_hash": hash_password(new_password),
+        "password_updated_at": now_iso,
+        "password_reset_used_at": now_iso,
+        **_clear_password_reset_fields(),
+    }
+    db.users.update_one({"_id": user["_id"]}, {"$set": update_fields})
+
+    try:
+        create_audit_log(
+            "password_reset_completed",
+            _current_user_id_from_doc(user) or None,
+            "user",
+            _current_user_id_from_doc(user),
+            {
+                "email": _normalize_text(user.get("email")).lower(),
+            },
+        )
+    except Exception:
+        pass
+
+    return {
+        "success": True,
+        "message": "Password reset completed successfully.",
+    }
+
+
+def change_password(
+    user_id: str,
+    *,
+    current_password: str,
+    new_password: str,
+) -> dict[str, object]:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    user = get_user_by_id(user_id)
+    if user is None:
+        raise ValueError("User account not found.")
+
+    password_hash = _normalize_text(user.get("password_hash"))
+    if not verify_password(current_password, password_hash):
+        raise ValueError("Current password is incorrect.")
+
+    now_iso = _now_iso()
+    db.users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "password_hash": hash_password(new_password),
+                "password_updated_at": now_iso,
+                **_clear_password_reset_fields(),
+            }
+        },
+    )
+
+    try:
+        create_audit_log(
+            "password_changed",
+            user_id,
+            "user",
+            user_id,
+            {"email": _normalize_text(user.get("email")).lower()},
+        )
+    except Exception:
+        pass
+
+    return {
+        "success": True,
+        "message": "Password updated successfully.",
+    }
+
+
+def admin_issue_password_reset(
+    user_id: str,
+    *,
+    admin_user_id: str,
+    admin_display: str,
+) -> dict[str, object]:
+    user = get_user_by_id(user_id)
+    if user is None:
+        raise ValueError("User account not found.")
+
+    response = request_password_reset(
+        _normalize_text(user.get("email")).lower(),
+        requested_via="admin_assist",
+        requested_by_user_id=admin_user_id,
+        requested_by=admin_display,
+        expose_token=True,
+    )
+    response["message"] = "Admin password reset issued successfully."
+    return response

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import stripe
+from bson import ObjectId
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from app.config import settings
+from app.database import get_database
+from app.services.audit_log_service import create_audit_log
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _db() -> Database:
+    db = cast(Database | None, get_database())
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    return db
+
+
+def _users_collection() -> Collection:
+    return _db().get_collection("users")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_value = user.get("_id") or user.get("id") or user.get("user_id")
+    return _normalize_text(raw_value)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    return _normalize_text(user.get("email")).lower()
+
+
+def _current_user_name(user: dict[str, Any]) -> str:
+    return _normalize_text(
+        user.get("full_name") or user.get("name") or user.get("display_name")
+    )
+
+
+def _require_stripe_secret_key() -> str:
+    secret_key = _normalize_text(settings.stripe_secret_key)
+    if not secret_key:
+        raise RuntimeError("STRIPE_SECRET_KEY is not configured.")
+    stripe.api_key = secret_key
+    return secret_key
+
+
+def _stripe_to_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "to_dict_recursive"):
+        return cast(dict[str, Any], value.to_dict_recursive())
+    if isinstance(value, dict):
+        return value
+    return cast(dict[str, Any], dict(value))
+
+
+def _user_lookup_query(user_id: str) -> dict[str, Any]:
+    try:
+        return {"_id": ObjectId(user_id)}
+    except Exception:
+        return {"_id": user_id}
+
+
+def _get_user_document(user: dict[str, Any]) -> dict[str, Any]:
+    user_id = _current_user_id(user)
+    if not user_id:
+        raise ValueError("Authenticated user id is missing.")
+
+    document = _users_collection().find_one(_user_lookup_query(user_id))
+    if document is None:
+        raise ValueError("User account not found.")
+    return document
+
+
+def _save_customer_id_to_user(user_id: str, customer_id: str) -> None:
+    _users_collection().update_one(
+        _user_lookup_query(user_id),
+        {
+            "$set": {
+                "stripe_customer_id": _normalize_text(customer_id),
+                "stripe_customer_updated_at": _now_iso(),
+            }
+        },
+    )
+
+
+def store_stripe_customer_reference(
+    *,
+    user_id: str | None = None,
+    email: str | None = None,
+    customer_id: str,
+) -> None:
+    normalized_customer_id = _normalize_text(customer_id)
+    if not normalized_customer_id:
+        return
+
+    users = _users_collection()
+    if user_id:
+        users.update_one(
+            _user_lookup_query(user_id),
+            {
+                "$set": {
+                    "stripe_customer_id": normalized_customer_id,
+                    "stripe_customer_updated_at": _now_iso(),
+                }
+            },
+        )
+        return
+
+    normalized_email = _normalize_text(email).lower()
+    if normalized_email:
+        users.update_one(
+            {"email": normalized_email},
+            {
+                "$set": {
+                    "stripe_customer_id": normalized_customer_id,
+                    "stripe_customer_updated_at": _now_iso(),
+                }
+            },
+        )
+
+
+def _ensure_stripe_customer_for_user(user: dict[str, Any]) -> dict[str, Any]:
+    _require_stripe_secret_key()
+    document = _get_user_document(user)
+    user_id = _current_user_id(document)
+    email = _current_user_email(document)
+    full_name = _current_user_name(document)
+
+    existing_customer_id = _normalize_text(document.get("stripe_customer_id"))
+    if existing_customer_id:
+        try:
+            existing_customer = stripe.Customer.retrieve(existing_customer_id)
+            customer_dict = _stripe_to_dict(existing_customer)
+            if not bool(customer_dict.get("deleted")):
+                return customer_dict
+        except Exception:
+            pass
+
+    created_customer = stripe.Customer.create(
+        email=email or None,
+        name=full_name or None,
+        metadata={
+            "user_id": user_id,
+            "platform": "tomboflight",
+        },
+    )
+    customer_dict = _stripe_to_dict(created_customer)
+    customer_id = _normalize_text(customer_dict.get("id"))
+    if customer_id:
+        _save_customer_id_to_user(user_id, customer_id)
+
+    return customer_dict
+
+
+def _customer_id_for_user(user: dict[str, Any]) -> str:
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize_text(customer.get("id"))
+    if not customer_id:
+        raise RuntimeError("Stripe customer could not be resolved.")
+    return customer_id
+
+
+def _list_payment_methods(customer_id: str) -> list[dict[str, Any]]:
+    _require_stripe_secret_key()
+    result = stripe.PaymentMethod.list(
+        customer=customer_id,
+        type="card",
+        limit=10,
+    )
+    payload = _stripe_to_dict(result)
+    items = payload.get("data") or []
+    return [cast(dict[str, Any], _stripe_to_dict(item)) for item in items]
+
+
+def _default_payment_method_id(customer: dict[str, Any]) -> str | None:
+    invoice_settings = customer.get("invoice_settings") or {}
+    default_payment_method = invoice_settings.get("default_payment_method")
+    if isinstance(default_payment_method, dict):
+        return _normalize_text(default_payment_method.get("id")) or None
+    return _normalize_text(default_payment_method) or None
+
+
+def _serialize_card_created(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), UTC).isoformat()
+    except Exception:
+        return _normalize_text(value) or None
+
+
+def get_billing_overview(user: dict[str, Any]) -> dict[str, Any]:
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize_text(customer.get("id"))
+    default_payment_method_id = _default_payment_method_id(customer)
+    payment_methods = _list_payment_methods(customer_id)
+
+    for item in payment_methods:
+        item["created"] = _serialize_card_created(item.get("created"))
+
+    subscriptions_result = stripe.Subscription.list(
+        customer=customer_id,
+        status="all",
+        limit=10,
+        expand=["data.default_payment_method", "data.items.data.price.product"],
+    )
+    subscriptions_payload = _stripe_to_dict(subscriptions_result)
+    subscriptions = subscriptions_payload.get("data") or []
+
+    max_cards = max(1, int(settings.stripe_payment_method_max_cards or 3))
+
+    return {
+        "customer_id": customer_id or None,
+        "max_cards": max_cards,
+        "cards_on_file": len(payment_methods),
+        "can_add_card": len(payment_methods) < max_cards,
+        "default_payment_method_id": default_payment_method_id,
+        "payment_methods": payment_methods,
+        "subscriptions": [
+            cast(dict[str, Any], _stripe_to_dict(item)) for item in subscriptions
+        ],
+    }
+
+
+def get_billing_config() -> dict[str, Any]:
+    return {
+        "publishable_key": _normalize_text(settings.stripe_publishable_key),
+        "max_cards": max(1, int(settings.stripe_payment_method_max_cards or 3)),
+        "portal_return_url": settings.stripe_billing_portal_return_url_clean or None,
+    }
+
+
+def create_setup_intent_for_user(user: dict[str, Any]) -> dict[str, Any]:
+    _require_stripe_secret_key()
+    overview = get_billing_overview(user)
+    max_cards = max(1, int(settings.stripe_payment_method_max_cards or 3))
+    if int(overview.get("cards_on_file") or 0) >= max_cards:
+        raise ValueError(f"You can store up to {max_cards} cards on file.")
+
+    customer_id = _normalize_text(overview.get("customer_id"))
+    if not customer_id:
+        raise RuntimeError("Stripe customer could not be resolved.")
+
+    setup_intent = stripe.SetupIntent.create(
+        customer=customer_id,
+        usage="off_session",
+        payment_method_types=["card"],
+        metadata={
+            "platform": "tomboflight",
+            "user_id": _current_user_id(user),
+        },
+    )
+    payload = _stripe_to_dict(setup_intent)
+    client_secret = _normalize_text(payload.get("client_secret"))
+    if not client_secret:
+        raise RuntimeError("Stripe setup intent did not return a client secret.")
+
+    try:
+        create_audit_log(
+            "billing_setup_intent_created",
+            _current_user_id(user) or None,
+            "stripe_customer",
+            customer_id,
+            {"max_cards": max_cards},
+        )
+    except Exception:
+        pass
+
+    return {
+        "client_secret": client_secret,
+        "customer_id": customer_id,
+        "max_cards": max_cards,
+    }
+
+
+def _ensure_payment_method_belongs_to_customer(
+    customer_id: str,
+    payment_method_id: str,
+) -> dict[str, Any]:
+    _require_stripe_secret_key()
+    payment_method = stripe.PaymentMethod.retrieve(payment_method_id)
+    payload = _stripe_to_dict(payment_method)
+    owner = payload.get("customer")
+    if isinstance(owner, dict):
+        owner_id = _normalize_text(owner.get("id"))
+    else:
+        owner_id = _normalize_text(owner)
+
+    if owner_id != _normalize_text(customer_id):
+        raise ValueError("Payment method does not belong to this customer.")
+
+    return payload
+
+
+def set_default_payment_method_for_user(
+    user: dict[str, Any],
+    payment_method_id: str,
+) -> dict[str, Any]:
+    customer_id = _customer_id_for_user(user)
+    normalized_payment_method_id = _normalize_text(payment_method_id)
+    if not normalized_payment_method_id:
+        raise ValueError("Payment method id is required.")
+
+    _ensure_payment_method_belongs_to_customer(customer_id, normalized_payment_method_id)
+    stripe.Customer.modify(
+        customer_id,
+        invoice_settings={"default_payment_method": normalized_payment_method_id},
+    )
+
+    try:
+        create_audit_log(
+            "billing_default_payment_method_set",
+            _current_user_id(user) or None,
+            "stripe_customer",
+            customer_id,
+            {"payment_method_id": normalized_payment_method_id},
+        )
+    except Exception:
+        pass
+
+    return {
+        "success": True,
+        "message": "Default payment method updated successfully.",
+        "payment_method_id": normalized_payment_method_id,
+    }
+
+
+def detach_payment_method_for_user(
+    user: dict[str, Any],
+    payment_method_id: str,
+) -> dict[str, Any]:
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize_text(customer.get("id"))
+    normalized_payment_method_id = _normalize_text(payment_method_id)
+    if not normalized_payment_method_id:
+        raise ValueError("Payment method id is required.")
+
+    _ensure_payment_method_belongs_to_customer(customer_id, normalized_payment_method_id)
+
+    payment_methods = _list_payment_methods(customer_id)
+    default_payment_method_id = _default_payment_method_id(customer)
+
+    replacement_default_id = ""
+    if normalized_payment_method_id == default_payment_method_id:
+        for item in payment_methods:
+            candidate_id = _normalize_text((item or {}).get("id"))
+            if candidate_id and candidate_id != normalized_payment_method_id:
+                replacement_default_id = candidate_id
+                break
+
+    stripe.PaymentMethod.detach(normalized_payment_method_id)
+    stripe.Customer.modify(
+        customer_id,
+        invoice_settings={
+            "default_payment_method": replacement_default_id or "",
+        },
+    )
+
+    try:
+        create_audit_log(
+            "billing_payment_method_detached",
+            _current_user_id(user) or None,
+            "stripe_customer",
+            customer_id,
+            {"payment_method_id": normalized_payment_method_id},
+        )
+    except Exception:
+        pass
+
+    return {
+        "success": True,
+        "message": "Payment method removed successfully.",
+        "payment_method_id": normalized_payment_method_id,
+    }
+
+
+def create_billing_portal_session_for_user(
+    user: dict[str, Any],
+    *,
+    return_url: str | None = None,
+) -> dict[str, Any]:
+    _require_stripe_secret_key()
+    customer_id = _customer_id_for_user(user)
+    resolved_return_url = (
+        _normalize_text(return_url)
+        or settings.stripe_billing_portal_return_url_clean
+        or "https://tomboflight.com/billing.html"
+    )
+
+    kwargs: dict[str, Any] = {
+        "customer": customer_id,
+        "return_url": resolved_return_url,
+    }
+
+    configuration_id = _normalize_text(settings.stripe_billing_portal_configuration_id)
+    if configuration_id:
+        kwargs["configuration"] = configuration_id
+
+    session = stripe.billing_portal.Session.create(**kwargs)
+    payload = _stripe_to_dict(session)
+    url = _normalize_text(payload.get("url"))
+    if not url:
+        raise RuntimeError("Stripe billing portal did not return a URL.")
+
+    try:
+        create_audit_log(
+            "billing_portal_session_created",
+            _current_user_id(user) or None,
+            "stripe_customer",
+            customer_id,
+            {},
+        )
+    except Exception:
+        pass
+
+    return {"url": url}

--- a/backend/app/services/link_request_service.py
+++ b/backend/app/services/link_request_service.py
@@ -7,6 +7,7 @@ from bson import ObjectId
 
 from app.database import get_database
 from app.schemas.link_request import LinkRequestCreate
+from app.services.audit_log_service import create_audit_log
 from app.services.link_key_service import (
     get_active_key_doc_for_project,
     get_key_doc_by_value,
@@ -41,6 +42,10 @@ def _household_links_collection():
 def _projects_collection():
     db = get_database()
     return db["projects"]
+
+
+def _normalize_value(value: Any) -> str:
+    return str(value or "").strip()
 
 
 def _enrich_request(document: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -179,6 +184,14 @@ def create_link_request(
         "requested_by": str(requested_by or "").strip() or "Unknown User",
         "requested_by_user_id": str(requested_by_user_id or "").strip(),
         "notes": payload.notes,
+        "handshake_state": "awaiting_target_consent",
+        "source_handshake_at": _utcnow_iso(),
+        "source_handshake_by": str(requested_by or "").strip() or "Unknown User",
+        "source_handshake_user_id": str(requested_by_user_id or "").strip() or None,
+        "target_handshake_at": None,
+        "target_handshake_by": None,
+        "target_handshake_user_id": None,
+        "handshake_completed_at": None,
         "source_package_code": source_project.get("package_code"),
         "source_package_name": source_project.get("package_name"),
         "target_package_code": target_project.get("package_code"),
@@ -189,6 +202,20 @@ def create_link_request(
 
     result = _requests_collection().insert_one(data)
     data["_id"] = result.inserted_id
+    try:
+        create_audit_log(
+            "link_request_created",
+            str(requested_by_user_id or "").strip() or None,
+            "link_request",
+            str(result.inserted_id),
+            {
+                "source_project_id": source_project_id,
+                "target_project_id": target_project_id,
+                "handshake_state": "awaiting_target_consent",
+            },
+        )
+    except Exception:
+        pass
     return _enrich_request(data) or data
 
 
@@ -214,6 +241,32 @@ def _can_manage_request(request: dict[str, Any], user_id: str, *, side: str) -> 
     )
 
 
+def _validate_active_handshake_keys(request: dict[str, Any]) -> None:
+    source_project_id = _normalize_value(request.get("source_project_id"))
+    target_project_id = _normalize_value(request.get("target_project_id"))
+    source_key = _normalize_value(request.get("source_key"))
+    target_key = _normalize_value(request.get("target_key"))
+
+    active_source_key = get_active_key_doc_for_project(source_project_id)
+    active_target_key = get_active_key_doc_for_project(target_project_id)
+
+    if (
+        active_source_key is None
+        or _normalize_value(active_source_key.get("key_value")) != source_key
+    ):
+        raise ValueError(
+            "The requesting workspace must still present the same active link key to complete the handshake."
+        )
+
+    if (
+        active_target_key is None
+        or _normalize_value(active_target_key.get("key_value")) != target_key
+    ):
+        raise ValueError(
+            "The receiving workspace must still present the same active link key to complete the handshake."
+        )
+
+
 def approve_link_request(
     request_id: str,
     *,
@@ -236,12 +289,19 @@ def approve_link_request(
     if str(request.get("status") or "").strip().lower() == "approved":
         return _enrich_request(request)
 
+    _validate_active_handshake_keys(request)
+
     now = _utcnow_iso()
     _requests_collection().update_one(
         {"_id": object_id},
         {
             "$set": {
                 "status": "approved",
+                "handshake_state": "complete",
+                "target_handshake_at": now,
+                "target_handshake_by": approved_by,
+                "target_handshake_user_id": approver_user_id,
+                "handshake_completed_at": now,
                 "approved_by": approved_by,
                 "approved_at": now,
                 "approval_notes": approval_notes,
@@ -285,6 +345,20 @@ def approve_link_request(
             )
 
     updated = _requests_collection().find_one({"_id": object_id})
+    try:
+        create_audit_log(
+            "link_request_approved",
+            str(approver_user_id or "").strip() or None,
+            "link_request",
+            str(object_id),
+            {
+                "source_project_id": _normalize_value(request.get("source_project_id")),
+                "target_project_id": _normalize_value(request.get("target_project_id")),
+                "handshake_state": "complete",
+            },
+        )
+    except Exception:
+        pass
     return _enrich_request(updated)
 
 
@@ -317,6 +391,7 @@ def reject_link_request(
         {
             "$set": {
                 "status": "rejected",
+                "handshake_state": "rejected",
                 "rejected_by": rejected_by,
                 "rejected_at": now,
                 "rejection_notes": rejection_notes,
@@ -326,6 +401,19 @@ def reject_link_request(
     )
 
     updated = _requests_collection().find_one({"_id": object_id})
+    try:
+        create_audit_log(
+            "link_request_rejected",
+            str(rejector_user_id or "").strip() or None,
+            "link_request",
+            str(object_id),
+            {
+                "source_project_id": _normalize_value(request.get("source_project_id")),
+                "target_project_id": _normalize_value(request.get("target_project_id")),
+            },
+        )
+    except Exception:
+        pass
     return _enrich_request(updated)
 
 
@@ -358,6 +446,7 @@ def revoke_link_request(
         {
             "$set": {
                 "status": "revoked",
+                "handshake_state": "revoked",
                 "revoked_by": revoked_by,
                 "revoked_at": now,
                 "revoke_notes": revoke_notes,
@@ -386,4 +475,17 @@ def revoke_link_request(
         )
 
     updated = _requests_collection().find_one({"_id": object_id})
+    try:
+        create_audit_log(
+            "link_request_revoked",
+            str(revoker_user_id or "").strip() or None,
+            "link_request",
+            str(object_id),
+            {
+                "source_project_id": _normalize_value(request.get("source_project_id")),
+                "target_project_id": _normalize_value(request.get("target_project_id")),
+            },
+        )
+    except Exception:
+        pass
     return _enrich_request(updated)

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -9,6 +9,7 @@ from pymongo.database import Database
 from pymongo.errors import OperationFailure
 
 from app.database import get_database
+from app.services.billing_service import store_stripe_customer_reference
 from app.services.project_service import (
     apply_package_purchase_to_project,
     create_project_from_paid_order,
@@ -559,6 +560,17 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "session_id": session_id,
             "email": email,
         }
+
+    customer_id = _normalize(session.get("customer"))
+    if customer_id:
+        try:
+            store_stripe_customer_reference(
+                user_id=str(user.get("_id") or ""),
+                email=email,
+                customer_id=customer_id,
+            )
+        except Exception:
+            pass
 
     orders = _get_orders_collection()
 

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -16,6 +16,16 @@ def create_user(payload: UserCreate) -> dict:
     db = get_database()
     data = payload.model_dump()
     data["created_at"] = datetime.now(UTC).isoformat()
+    data["full_name"] = f"{payload.first_name} {payload.last_name}".strip()
+    data["status"] = data.get("status") or "active"
+    data["last_login_at"] = None
+    data["password_reset_requested_at"] = None
+    data["password_reset_expires_at"] = None
+    data["password_reset_token_hash"] = None
+    data["password_reset_requested_via"] = None
+    data["password_reset_requested_by"] = None
+    data["password_reset_requested_by_user_id"] = None
+    data["password_reset_used_at"] = None
 
     if db is None:
         data["_id"] = "local-user-preview"

--- a/billing.html
+++ b/billing.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Billing & Cards | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Manage Tomb of Light billing, payment methods, maintenance subscriptions, and saved cards."
+    />
+    <link rel="stylesheet" href="styles.css?v=20260331-2" />
+  </head>
+  <body class="portal-dashboard-body">
+    <div class="page-wrap">
+      <header class="site-header" role="banner">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="account-security.html">Account Security</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="dashboard.html">
+              Back to Dashboard
+            </a>
+            <button class="btn btn-secondary" type="button" data-logout-btn>
+              Log Out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" role="main">
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Billing Control</span>
+              <h1>Saved cards, subscription payments, and maintenance access.</h1>
+              <p data-billing-page-status>
+                Loading your Tomb of Light billing profile...
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell portal-account-grid">
+            <div class="form-panel">
+              <span class="eyebrow">Subscription Actions</span>
+              <p class="card-copy" data-billing-subscriptions-status>
+                Loading subscriptions...
+              </p>
+
+              <div class="inline-actions" style="margin-top: 1rem">
+                <button class="btn btn-primary" type="button" data-open-billing-portal>
+                  Open Billing Portal
+                </button>
+                <a
+                  class="btn btn-secondary"
+                  href="#"
+                  data-maintenance-monthly-link
+                  style="display: none"
+                >
+                  Start Monthly Maintenance
+                </a>
+                <a
+                  class="btn btn-secondary"
+                  href="#"
+                  data-maintenance-yearly-link
+                  style="display: none"
+                >
+                  Start Yearly Maintenance
+                </a>
+              </div>
+
+              <div class="grid-3" style="margin-top: 1rem" data-billing-subscriptions-list></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Cards on File</span>
+              <p class="card-copy" data-billing-cards-status>
+                Loading saved cards...
+              </p>
+              <div class="grid-3" data-billing-cards-list></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Add Card</span>
+              <p class="card-copy" data-billing-add-card-copy>
+                You can store up to three cards on file for Tomb of Light billing.
+              </p>
+
+              <form class="form-grid" data-billing-card-form novalidate>
+                <label>
+                  Card Details
+                  <div class="stripe-card-mount" data-stripe-card-element></div>
+                </label>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button class="btn btn-primary" type="submit" data-billing-save-card>
+                    Save Card
+                  </button>
+                </div>
+              </form>
+
+              <div
+                class="helper"
+                data-billing-card-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer" role="contentinfo">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">
+                  Tomb of Light<span class="brand-symbol">™</span>
+                </div>
+                <p class="footer-copy">
+                  Protected billing management for maintenance subscriptions,
+                  saved cards, and private workspace continuity.
+                </p>
+              </div>
+            </div>
+
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+              <span>Billing identity and private family records remain separate.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="config.js?v=20260331-2"></script>
+    <script src="app.js?v=20260331-2"></script>
+    <script src="auth.js?v=20260331-2"></script>
+    <script src="billing.js?v=20260331-2"></script>
+  </body>
+</html>

--- a/billing.js
+++ b/billing.js
@@ -1,0 +1,352 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  const authPages = window.TOLAuthPages || {};
+
+  if (!app || typeof app.apiRequest !== "function") {
+    return;
+  }
+
+  let currentUser = null;
+  let currentContext = null;
+  let stripeClient = null;
+  let stripeCardElement = null;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function formatDate(value) {
+    if (!value) return "—";
+    try {
+      return new Date(value).toLocaleString();
+    } catch (_error) {
+      return String(value);
+    }
+  }
+
+  function getErrorMessage(error) {
+    return String((error && error.message) || error || "Unknown error");
+  }
+
+  function buildSubscriptionCard(item) {
+    const productNames = Array.isArray(item.product_names)
+      ? item.product_names.join(", ")
+      : "";
+
+    return `
+      <div class="family-record-card">
+        <div class="card-number">S</div>
+        <h3>${escapeHtml(productNames || item.id || "Subscription")}</h3>
+        <p class="card-copy"><strong>Status:</strong> ${escapeHtml(item.status || "—")}</p>
+        <p class="card-copy"><strong>Collection:</strong> ${escapeHtml(item.collection_method || "—")}</p>
+        <p class="card-copy"><strong>Renews:</strong> ${escapeHtml(formatDate(item.current_period_end))}</p>
+      </div>
+    `;
+  }
+
+  function buildCardCard(item) {
+    return `
+      <div class="family-record-card">
+        <div class="card-number">C</div>
+        <h3>${escapeHtml((item.brand || "Card").toUpperCase())} •••• ${escapeHtml(item.last4 || "—")}</h3>
+        <p class="card-copy"><strong>Expires:</strong> ${escapeHtml(`${item.exp_month || "—"}/${item.exp_year || "—"}`)}</p>
+        <p class="card-copy"><strong>Funding:</strong> ${escapeHtml(item.funding || "—")}</p>
+        <p class="card-copy"><strong>Default:</strong> ${escapeHtml(item.is_default ? "Yes" : "No")}</p>
+        <div class="inline-actions" style="margin-top: 1rem;">
+          ${
+            item.is_default
+              ? ""
+              : `<button class="btn btn-secondary" type="button" data-billing-set-default="${escapeHtml(item.id || "")}">Set Default</button>`
+          }
+          <button class="btn btn-secondary" type="button" data-billing-remove-card="${escapeHtml(item.id || "")}">Remove</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderMaintenanceLinks() {
+    const monthlyLink = document.querySelector("[data-maintenance-monthly-link]");
+    const yearlyLink = document.querySelector("[data-maintenance-yearly-link]");
+    const paymentLinks = (window.TOL_CONFIG && window.TOL_CONFIG.PAYMENT_LINKS) || {};
+    const packageCode = String((currentContext && currentContext.packageCode) || "").trim();
+    const monthlyHref = paymentLinks[`${packageCode}_maintenance_monthly`] || "";
+    const yearlyHref = paymentLinks[`${packageCode}_maintenance_yearly`] || "";
+
+    if (monthlyLink) {
+      monthlyLink.style.display = monthlyHref ? "" : "none";
+      if (monthlyHref) monthlyLink.href = monthlyHref;
+    }
+    if (yearlyLink) {
+      yearlyLink.style.display = yearlyHref ? "" : "none";
+      if (yearlyHref) yearlyLink.href = yearlyHref;
+    }
+  }
+
+  async function loadContext() {
+    const orders = authPages.fetchOrders ? await authPages.fetchOrders() : [];
+    currentContext =
+      typeof authPages.getDashboardContextForCurrentPage === "function"
+        ? await authPages.getDashboardContextForCurrentPage(currentUser, orders)
+        : authPages.getDashboardContext
+          ? await authPages.getDashboardContext(currentUser, orders)
+          : null;
+    renderMaintenanceLinks();
+  }
+
+  async function refreshOverview() {
+    const pageStatus = document.querySelector("[data-billing-page-status]");
+    const cardsStatus = document.querySelector("[data-billing-cards-status]");
+    const cardsList = document.querySelector("[data-billing-cards-list]");
+    const subscriptionsStatus = document.querySelector("[data-billing-subscriptions-status]");
+    const subscriptionsList = document.querySelector("[data-billing-subscriptions-list]");
+    const addCardCopy = document.querySelector("[data-billing-add-card-copy]");
+    const saveCardButton = document.querySelector("[data-billing-save-card]");
+
+    try {
+      const payload = await app.apiRequest("/billing/overview", { method: "GET" });
+      const paymentMethods = Array.isArray(payload && payload.payment_methods)
+        ? payload.payment_methods
+        : [];
+      const subscriptions = Array.isArray(payload && payload.subscriptions)
+        ? payload.subscriptions
+        : [];
+      const maxCards = Number(payload && payload.max_cards ? payload.max_cards : 3);
+      const cardsOnFile = Number(payload && payload.cards_on_file ? payload.cards_on_file : paymentMethods.length);
+      const canAddCard = Boolean(payload && payload.can_add_card);
+
+      if (pageStatus) {
+        pageStatus.textContent = `Billing profile connected. ${cardsOnFile} of ${maxCards} saved cards currently on file.`;
+      }
+
+      if (cardsStatus) {
+        cardsStatus.textContent = paymentMethods.length
+          ? "Saved cards are shown below."
+          : "No saved cards are on file yet.";
+      }
+
+      if (cardsList) {
+        cardsList.innerHTML = paymentMethods.length
+          ? paymentMethods.map(buildCardCard).join("")
+          : `
+              <div class="family-record-card">
+                <div class="card-number">•</div>
+                <h3>No cards saved</h3>
+                <p class="card-copy">Add a card below to store up to three payment methods for Tomb of Light billing.</p>
+              </div>
+            `;
+      }
+
+      if (subscriptionsStatus) {
+        subscriptionsStatus.textContent = subscriptions.length
+          ? "Your Stripe subscriptions and billing records are shown below."
+          : "No active or historical Stripe subscriptions were found for this customer profile yet.";
+      }
+
+      if (subscriptionsList) {
+        subscriptionsList.innerHTML = subscriptions.length
+          ? subscriptions.map(buildSubscriptionCard).join("")
+          : `
+              <div class="family-record-card">
+                <div class="card-number">•</div>
+                <h3>No subscriptions found</h3>
+                <p class="card-copy">Use the maintenance links above or your billing portal to begin a continuity plan.</p>
+              </div>
+            `;
+      }
+
+      if (addCardCopy) {
+        addCardCopy.textContent = canAddCard
+          ? `You can store up to ${maxCards} cards on file for Tomb of Light billing.`
+          : `You already have the maximum of ${maxCards} cards on file. Remove one before adding another.`;
+      }
+
+      if (saveCardButton) {
+        saveCardButton.disabled = !canAddCard;
+        saveCardButton.style.opacity = canAddCard ? "" : "0.45";
+      }
+    } catch (error) {
+      if (pageStatus) {
+        pageStatus.textContent = getErrorMessage(error) || "Billing profile could not be loaded.";
+      }
+      if (cardsStatus) {
+        cardsStatus.textContent = "Saved cards could not be loaded.";
+      }
+      if (subscriptionsStatus) {
+        subscriptionsStatus.textContent = "Subscription records could not be loaded.";
+      }
+    }
+  }
+
+  async function ensureStripeClient() {
+    if (stripeClient && stripeCardElement) return true;
+
+    const mountNode = document.querySelector("[data-stripe-card-element]");
+    const statusNode = document.querySelector("[data-billing-card-status]");
+    if (!mountNode || typeof window.Stripe !== "function") {
+      app.setStatus(statusNode, "Stripe card entry is not available in this browser.", "error");
+      return false;
+    }
+
+    const config = await app.apiRequest("/billing/config", { method: "GET" });
+    if (!config || !config.publishable_key) {
+      app.setStatus(statusNode, "Stripe publishable key is not configured yet.", "error");
+      return false;
+    }
+
+    stripeClient = window.Stripe(config.publishable_key);
+    const elements = stripeClient.elements();
+    stripeCardElement = elements.create("card", {
+      style: {
+        base: {
+          color: "#f3f5ff",
+          fontFamily: "inherit",
+          fontSize: "16px",
+          "::placeholder": {
+            color: "rgba(243,245,255,0.48)",
+          },
+        },
+      },
+    });
+    stripeCardElement.mount(mountNode);
+    return true;
+  }
+
+  async function handleCardSave(event) {
+    event.preventDefault();
+    const statusNode = document.querySelector("[data-billing-card-status]");
+    app.clearStatus(statusNode);
+
+    const ready = await ensureStripeClient();
+    if (!ready) return;
+
+    try {
+      const payload = await app.apiRequest("/billing/setup-intent", {
+        method: "POST",
+      });
+      const clientSecret = String((payload && payload.client_secret) || "").trim();
+      if (!clientSecret) {
+        throw new Error("Stripe setup intent is missing a client secret.");
+      }
+
+      app.setStatus(statusNode, "Saving card...", "info");
+      const result = await stripeClient.confirmCardSetup(clientSecret, {
+        payment_method: {
+          card: stripeCardElement,
+          billing_details: {
+            email: currentUser && currentUser.email ? currentUser.email : undefined,
+            name: currentUser && currentUser.full_name ? currentUser.full_name : undefined,
+          },
+        },
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Stripe could not save the card.");
+      }
+
+      app.setStatus(statusNode, "Card saved successfully.", "success");
+      if (stripeCardElement) {
+        stripeCardElement.clear();
+      }
+      await refreshOverview();
+    } catch (error) {
+      app.setStatus(
+        statusNode,
+        getErrorMessage(error) || "Unable to save card.",
+        "error",
+      );
+    }
+  }
+
+  async function openBillingPortal() {
+    const pageStatus = document.querySelector("[data-billing-page-status]");
+    try {
+      app.setStatus(pageStatus, "Opening billing portal...", "info");
+      const payload = await app.apiRequest("/billing/portal-session", {
+        method: "POST",
+        body: JSON.stringify({ return_url: window.location.href }),
+      });
+      const url = String((payload && payload.url) || "").trim();
+      if (!url) {
+        throw new Error("Billing portal session did not return a URL.");
+      }
+      window.location.href = url;
+    } catch (error) {
+      app.setStatus(
+        pageStatus,
+        getErrorMessage(error) || "Unable to open billing portal.",
+        "error",
+      );
+    }
+  }
+
+  async function runCardAction(path, successMessage) {
+    const statusNode = document.querySelector("[data-billing-card-status]");
+    try {
+      app.setStatus(statusNode, "Updating card settings...", "info");
+      await app.apiRequest(path, { method: path.includes("/default") ? "POST" : "DELETE" });
+      app.setStatus(statusNode, successMessage, "success");
+      await refreshOverview();
+    } catch (error) {
+      app.setStatus(
+        statusNode,
+        getErrorMessage(error) || "Unable to update card.",
+        "error",
+      );
+    }
+  }
+
+  function bindInteractions() {
+    const form = document.querySelector("[data-billing-card-form]");
+    if (form) {
+      form.addEventListener("submit", handleCardSave);
+    }
+
+    const portalButton = document.querySelector("[data-open-billing-portal]");
+    if (portalButton) {
+      portalButton.addEventListener("click", openBillingPortal);
+    }
+
+    document.addEventListener("click", async function (event) {
+      const setDefaultButton = event.target.closest("[data-billing-set-default]");
+      if (setDefaultButton) {
+        const paymentMethodId = setDefaultButton.getAttribute("data-billing-set-default");
+        if (!paymentMethodId) return;
+        await runCardAction(
+          `/billing/payment-methods/${encodeURIComponent(paymentMethodId)}/default`,
+          "Default card updated successfully.",
+        );
+        return;
+      }
+
+      const removeButton = event.target.closest("[data-billing-remove-card]");
+      if (removeButton) {
+        const paymentMethodId = removeButton.getAttribute("data-billing-remove-card");
+        if (!paymentMethodId) return;
+        if (!window.confirm("Remove this saved card from Tomb of Light billing?")) {
+          return;
+        }
+        await runCardAction(
+          `/billing/payment-methods/${encodeURIComponent(paymentMethodId)}`,
+          "Card removed successfully.",
+        );
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", async function () {
+    currentUser = await app.requireSession("signin.html");
+    if (!currentUser) return;
+
+    bindInteractions();
+    await loadContext();
+    await ensureStripeClient();
+    await refreshOverview();
+  });
+})();

--- a/dashboard.html
+++ b/dashboard.html
@@ -273,6 +273,15 @@
                   <p class="card-copy" data-user-role></p>
                 </div>
               </div>
+
+              <div class="inline-actions" style="margin-top: 1.5rem">
+                <a class="btn btn-secondary" href="account-security.html">
+                  Account Security
+                </a>
+                <a class="btn btn-secondary" href="billing.html">
+                  Billing &amp; Cards
+                </a>
+              </div>
             </div>
 
             <div

--- a/link-keys.html
+++ b/link-keys.html
@@ -102,6 +102,8 @@
               <div class="helper" style="margin-bottom: 1rem">
                 Generate a link key for your current eligible workspace. Share
                 this key with the other person or branch you want to connect.
+                A link is only completed when both sides present active keys and
+                the receiving side accepts the handshake by choice.
               </div>
 
               <label>
@@ -149,6 +151,11 @@
 
             <div class="form-panel" data-link-request-panel>
               <span class="eyebrow">Request a Link</span>
+              <div class="helper" style="margin-bottom: 1rem">
+                Tomb of Light records this as a trust handshake: your workspace
+                shares its active key first, then the other workspace must
+                accept with its own active key before the link becomes live.
+              </div>
 
               <form class="form-grid" data-link-request-form novalidate>
                 <label>

--- a/link-keys.js
+++ b/link-keys.js
@@ -42,6 +42,17 @@
       .join(" ");
   }
 
+  function handshakeLabel(item) {
+    const normalized = normalizeValue(item && item.handshake_state);
+    if (normalized === "complete") return "Handshake Complete";
+    if (normalized === "awaiting_target_consent") {
+      return "Awaiting Other Side";
+    }
+    if (normalized === "revoked") return "Handshake Revoked";
+    if (normalized === "rejected") return "Handshake Rejected";
+    return "Handshake Pending";
+  }
+
   function setStatus(node, message, type) {
     if (!node) return;
 
@@ -235,9 +246,22 @@
     const lines = [
       `<p class="card-copy"><strong>Workspace:</strong> ${escapeHtml(label)}</p>`,
       `<p class="card-copy"><strong>Status:</strong> ${escapeHtml(humanizeStatus(item.status))}</p>`,
+      `<p class="card-copy"><strong>Trust Handshake:</strong> ${escapeHtml(handshakeLabel(item))}</p>`,
       `<p class="card-copy"><strong>Requested By:</strong> ${escapeHtml(item.requested_by || "—")}</p>`,
       `<p class="card-copy"><strong>Created:</strong> ${escapeHtml(item.created_at || "—")}</p>`,
     ];
+
+    if (item.source_handshake_at) {
+      lines.push(
+        `<p class="card-copy"><strong>Requesting Side Key Shared:</strong> ${escapeHtml(item.source_handshake_at)}</p>`,
+      );
+    }
+
+    if (item.target_handshake_at) {
+      lines.push(
+        `<p class="card-copy"><strong>Receiving Side Accepted:</strong> ${escapeHtml(item.target_handshake_at)}</p>`,
+      );
+    }
 
     if (item.notes) {
       lines.push(
@@ -668,7 +692,7 @@
       if (workspaceStatusNode) {
         setStatus(
           workspaceStatusNode,
-          "This workspace can generate a project link key, send link requests, and manage active links.",
+          "This workspace can generate a project link key, exchange keys with another workspace, and complete a mutual trust handshake only when both sides choose to link.",
           "success",
         );
       }

--- a/signin.html
+++ b/signin.html
@@ -175,6 +175,15 @@
                     Start Your Legacy Build
                   </a>
                 </div>
+
+                <div class="inline-actions" style="margin-top: 0.75rem">
+                  <a class="btn btn-secondary" href="account-security.html#reset-request">
+                    Forgot Password
+                  </a>
+                  <a class="btn btn-secondary" href="account-security.html#reset-confirm">
+                    Use Reset Token
+                  </a>
+                </div>
               </form>
 
               <div class="portal-access-footer">

--- a/styles.css
+++ b/styles.css
@@ -2081,6 +2081,20 @@ textarea {
   gap: 16px;
 }
 
+.portal-account-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.stripe-card-mount {
+  min-height: 56px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(138, 169, 213, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
 .portal-priority-panel {
   border-color: rgba(120, 217, 255, 0.22) !important;
   box-shadow:


### PR DESCRIPTION
…and customer billing/card management

This update turns several account and trust flows into real platform features instead of partial plumbing.

Link keys now behave like an explicit mutual trust handshake. A link request records the requesting side’s key presentation, requires the receiving side to accept with its own still-active key, and stores handshake state and timestamps so link creation is clearly shown as a two-sided choice rather than a silent backend action.

Authentication now includes full password recovery support. Customers can request password resets, complete one-time token resets, and change their password while signed in. Internal admins can also issue customer reset links from the control center, which makes recovery and support possible without direct database intervention.

Billing is now exposed as a customer-facing management layer. The new billing routes and UI connect each user to a Stripe customer profile, show saved cards and subscription state, allow customers to save up to three cards on file, set a default card, remove cards, and open the Stripe billing portal. The dashboard and sign-in flow were also updated to surface the new account security and billing areas directly inside the Tomb of Light portal.

This work also adds the supporting config, schema, and webhook-side customer reference handling needed to keep Stripe customer identity aligned with Tomb of Light user accounts.