### PR TITLE
Harden workspace privacy boundaries, public token safety, upload scop…

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -147,7 +147,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("POSTER_BASE_URL"),
     )
     public_token_external_base_url: str = Field(
-        default="https://tomboflight.com/token",
+        default="https://tomboflight-api.onrender.com/tokens",
         validation_alias=AliasChoices(
             "PUBLIC_TOKEN_EXTERNAL_BASE_URL",
             "NFT_DEFAULT_EXTERNAL_URL",

--- a/backend/app/routes/family_graph.py
+++ b/backend/app/routes/family_graph.py
@@ -4,7 +4,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.database import get_database
-from app.dependencies.auth import get_current_user
+from app.dependencies.auth import get_current_user, has_internal_admin_access
 from app.services.viewer_manifest_service import ensure_project_workspace_anchor
 from app.services.workspace_access_service import require_workspace_capability
 
@@ -134,6 +134,7 @@ def get_family_graph(
         raise HTTPException(status_code=500, detail="Database is not connected.")
     family = context["family"]
     project = context["project"]
+    is_internal_admin = has_internal_admin_access(current_user)
     resolved_family_id = str(family.get("_id"))
 
     member_query = {"family_id": {"$in": _family_id_candidates(resolved_family_id)}}
@@ -181,17 +182,22 @@ def get_family_graph(
                 "spouse_id": member.get("spouse_id"),
                 "bio": member.get("bio"),
                 "created_at": member.get("created_at"),
-                "updated_at": member.get("updated_at"),
-                "created_by": member.get("created_by"),
-                "updated_by": member.get("updated_by"),
                 "is_verified": bool(member.get("is_verified", False)),
                 "verification_status": member.get("verification_status"),
-                "verification_method": member.get("verification_method"),
-                "verified_by": member.get("verified_by"),
-                "verified_at": member.get("verified_at"),
-                "verification_notes": member.get("verification_notes"),
             }
         )
+        if is_internal_admin:
+            members[-1].update(
+                {
+                    "updated_at": member.get("updated_at"),
+                    "created_by": member.get("created_by"),
+                    "updated_by": member.get("updated_by"),
+                    "verification_method": member.get("verification_method"),
+                    "verified_by": member.get("verified_by"),
+                    "verified_at": member.get("verified_at"),
+                    "verification_notes": member.get("verification_notes"),
+                }
+            )
 
     relationships = []
     for rel in relationships_raw:
@@ -234,9 +240,15 @@ def get_family_graph(
             "created_by": family.get("created_by"),
             "description": family.get("description"),
             "created_at": family.get("created_at"),
-            "owner_user_id": family.get("owner_user_id"),
-            "owner_email": family.get("owner_email"),
             "visibility": family.get("visibility", "private"),
+            **(
+                {
+                    "owner_user_id": family.get("owner_user_id"),
+                    "owner_email": family.get("owner_email"),
+                }
+                if is_internal_admin
+                else {}
+            ),
         },
         "members": members,
         "relationships": relationships,

--- a/backend/app/routes/mint_records.py
+++ b/backend/app/routes/mint_records.py
@@ -420,7 +420,6 @@ def get_public_token_landing_payload(public_token_id: str):
     return {
         "public_token_id": manifest["public_token_id"],
         "metadata_uri": manifest["metadata_uri"],
-        "project_id": manifest["project_id"],
         "version_number": manifest["version_number"],
         "poster_image_uri_public": manifest["poster_image_uri_public"],
         "approval_status": manifest["approval_status"],

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -288,6 +288,7 @@ def _public_upload_record(record: dict[str, Any]) -> dict[str, Any]:
     serialized.pop("relative_path", None)
     serialized.pop("absolute_path", None)
     serialized.pop("storage_path", None)
+    serialized.pop("uploaded_by_user_id", None)
     return serialized
 
 
@@ -656,12 +657,14 @@ def list_member_uploads(
 
     member = context["member"]
     family = context["family"]
+    project = context["project"]
 
     normalized_category = _validate_category_filter(category)
 
     query: dict[str, Any] = {
         "member_id": str(member.get("_id")),
         "family_id": _normalize_value((family or {}).get("_id")),
+        "project_id": _normalize_value((project or {}).get("_id")),
     }
     if normalized_category:
         query["category"] = normalized_category
@@ -692,9 +695,13 @@ def list_family_uploads(
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
     family = context["family"]
+    project = context["project"]
     normalized_category = _validate_category_filter(category)
 
-    query: dict[str, Any] = {"family_id": _normalize_value((family or {}).get("_id"))}
+    query: dict[str, Any] = {
+        "family_id": _normalize_value((family or {}).get("_id")),
+        "project_id": _normalize_value((project or {}).get("_id")),
+    }
     if normalized_category:
         query["category"] = normalized_category
 

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import stripe
 from bson import ObjectId
@@ -53,6 +54,26 @@ def _require_stripe_secret_key() -> str:
         raise RuntimeError("STRIPE_SECRET_KEY is not configured.")
     stripe.api_key = secret_key
     return secret_key
+
+
+def _validate_portal_return_url(return_url: str | None) -> str:
+    normalized = _normalize_text(return_url)
+    fallback = (
+        settings.stripe_billing_portal_return_url_clean
+        or "https://tomboflight.com/billing.html"
+    )
+    if not normalized:
+        return fallback
+
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return fallback
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    if origin not in set(settings.allowed_origins_list):
+        return fallback
+
+    return normalized
 
 
 def _stripe_to_dict(value: Any) -> dict[str, Any]:
@@ -146,14 +167,18 @@ def _ensure_stripe_customer_for_user(user: dict[str, Any]) -> dict[str, Any]:
         except Exception:
             pass
 
-    created_customer = stripe.Customer.create(
-        email=email or None,
-        name=full_name or None,
-        metadata={
+    create_payload: dict[str, Any] = {
+        "metadata": {
             "user_id": user_id,
             "platform": "tomboflight",
         },
-    )
+    }
+    if email:
+        create_payload["email"] = email
+    if full_name:
+        create_payload["name"] = full_name
+
+    created_customer = stripe.Customer.create(**create_payload)
     customer_dict = _stripe_to_dict(created_customer)
     customer_id = _normalize_text(customer_dict.get("id"))
     if customer_id:
@@ -391,11 +416,7 @@ def create_billing_portal_session_for_user(
 ) -> dict[str, Any]:
     _require_stripe_secret_key()
     customer_id = _customer_id_for_user(user)
-    resolved_return_url = (
-        _normalize_text(return_url)
-        or settings.stripe_billing_portal_return_url_clean
-        or "https://tomboflight.com/billing.html"
-    )
+    resolved_return_url = _validate_portal_return_url(return_url)
 
     kwargs: dict[str, Any] = {
         "customer": customer_id,

--- a/backend/app/services/nft_runtime_validation_service.py
+++ b/backend/app/services/nft_runtime_validation_service.py
@@ -89,8 +89,10 @@ def validate_nft_runtime_configuration_on_startup() -> None:
         ("NFT_CONTRACT_ADDRESS", settings.nft_contract_address),
         ("NFT_CONTRACT_ABI_JSON", settings.nft_contract_abi_json),
         ("NFT_MINTER_PRIVATE_KEY", settings.nft_minter_private_key),
+        ("HASH_SALT", settings.hash_salt),
         ("METADATA_BASE_URL", settings.metadata_base_url),
         ("POSTER_BASE_URL", settings.poster_base_url),
+        ("PUBLIC_TOKEN_EXTERNAL_BASE_URL", settings.public_token_external_base_url),
     ):
         if not _normalize(value):
             missing.append(field_name)
@@ -111,6 +113,10 @@ def validate_nft_runtime_configuration_on_startup() -> None:
         settings.poster_base_url_clean,
         field_name="POSTER_BASE_URL",
         require_v1_path=True,
+    )
+    _validate_http_url(
+        settings.public_token_external_base_url_clean,
+        field_name="PUBLIC_TOKEN_EXTERNAL_BASE_URL",
     )
     _validate_contract_address()
     _validate_private_key()

--- a/backend/app/services/public_manifest_service.py
+++ b/backend/app/services/public_manifest_service.py
@@ -112,7 +112,12 @@ def _hash_sha256(value: str) -> str:
 
 
 def _hash_salt() -> str:
-    return _normalize(settings.hash_salt) or _normalize(settings.secret_key) or "change-me"
+    salt = _normalize(settings.hash_salt)
+    if salt:
+        return salt
+    raise RuntimeError(
+        "HASH_SALT must be configured before Tomb of Light can generate public-safe anchor hashes."
+    )
 
 
 def _project_document(project_id: str) -> dict[str, Any]:
@@ -204,7 +209,7 @@ def _default_description() -> str:
 
 
 def _token_external_url(public_token_id: str) -> str:
-    return f"{settings.public_token_external_base_url.rstrip('/')}/{public_token_id}"
+    return f"{settings.public_token_external_base_url_clean}/{public_token_id}"
 
 
 def _attributes_for_manifest(

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -465,8 +465,8 @@ def count_workspace_uploads(
     project_id: str = "",
 ) -> int:
     db = _require_database()
-    if family_id:
-        return int(db["uploaded_files"].count_documents({"family_id": family_id}))
     if project_id:
         return int(db["uploaded_files"].count_documents({"project_id": project_id}))
+    if family_id:
+        return int(db["uploaded_files"].count_documents({"family_id": family_id}))
     return 0


### PR DESCRIPTION
…ing, and billing portal redirects

This patch is a production hardening pass across Tomb of Light’s highest-risk customer and admin surfaces.

It tightens workspace isolation for upload listing/counting so stale family/member records do not bleed across project boundaries, removes internal uploader IDs from customer-facing upload payloads, and limits family graph responses so owner fields and verification-review details are only exposed to internal admins.

It also fixes a public-safe NFT boundary issue by removing internal project references from the public token landing payload, makes public anchor hashing fail fast when HASH_SALT is missing, and strengthens startup validation for live mint configuration and public token URL settings.

On the billing side, it closes a redirect risk by validating Stripe billing portal return URLs against allowed origins and falling back safely when a supplied return target is invalid.

Validation completed locally with:

python3 -m py_compile
git diff --check
app import sanity from backend/app/main.py