### PR TITLE
Repair admin console permissions and account visibility

### DIFF
--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -20,7 +20,12 @@
 
   const state = {
     currentUser: null,
+    accessProfile: null,
     roleKey: "",
+    allowedQueues: [],
+    allowedTabs: [],
+    allowedActions: [],
+    allowedBulkActions: [],
     queue: "overview",
     selectedCaseId: "",
     selectedTab: "identity",
@@ -130,6 +135,49 @@
     if (direct) return direct;
     if (typeof app.isInternalRole === "function" && app.isInternalRole(me)) return "admin";
     return "";
+  }
+
+  function normalizeAccessList(values) {
+    return Array.isArray(values)
+      ? values.map(normalizeLower).filter(Boolean)
+      : [];
+  }
+
+  function isAllowedQueue(queue) {
+    const normalized = normalizeLower(queue);
+    return state.allowedQueues.includes(normalized);
+  }
+
+  function isAllowedTab(tab) {
+    const normalized = normalizeLower(tab);
+    return state.allowedTabs.includes(normalized);
+  }
+
+  function isAllowedCaseAction(action) {
+    const normalized = normalizeLower(action);
+    return state.allowedActions.includes(normalized);
+  }
+
+  function isAllowedBulkAction(action) {
+    const normalized = normalizeLower(action);
+    return state.allowedBulkActions.includes(normalized);
+  }
+
+  async function loadAccessProfile() {
+    const profile = await fetchJson("/admin/control-center/access-profile");
+    state.accessProfile = profile || {};
+    state.roleKey = normalizeLower(profile && profile.role_key) || state.roleKey || "admin";
+    state.allowedQueues = normalizeAccessList(profile && profile.allowed_queues);
+    state.allowedTabs = normalizeAccessList(profile && profile.allowed_tabs);
+    state.allowedActions = normalizeAccessList(profile && profile.allowed_actions);
+    state.allowedBulkActions = normalizeAccessList(profile && profile.allowed_bulk_actions);
+
+    if (!isAllowedQueue(state.queue)) {
+      state.queue = state.allowedQueues[0] || "overview";
+    }
+    if (!isAllowedTab(state.selectedTab)) {
+      state.selectedTab = state.allowedTabs[0] || "identity";
+    }
   }
 
   function shortId(value) {
@@ -349,6 +397,7 @@
     const node = document.querySelector("[data-admin-case-list]");
     if (!node) return;
     const cases = Array.isArray(state.cases) ? state.cases : [];
+    const canRepairSelected = isAllowedBulkAction("repair-selected-records");
     if (!cases.length) {
       node.innerHTML = `
         <div class="admin-empty-state">
@@ -368,9 +417,13 @@
         const isSelected = state.selectedCaseId === item.case_id;
         return `
           <article class="admin-case-row ${isSelected ? "is-selected" : ""}" data-case-row="${escapeHtml(item.case_id || "")}">
-            <label class="admin-case-select" aria-label="Select ${escapeHtml(item.name || "case")} for bulk repair">
-              <input type="checkbox" data-case-select="${escapeHtml(item.case_id || "")}" />
-            </label>
+            ${
+              canRepairSelected
+                ? `<label class="admin-case-select" aria-label="Select ${escapeHtml(item.name || "case")} for bulk repair">
+                    <input type="checkbox" data-case-select="${escapeHtml(item.case_id || "")}" />
+                  </label>`
+                : '<span class="admin-case-select" aria-hidden="true"></span>'
+            }
             <div class="admin-case-primary">
               <h3>${escapeHtml(item.name || "Customer Case")}</h3>
               <p>${escapeHtml(item.email || "No email")} · ${escapeHtml(item.role || "customer")}</p>
@@ -674,6 +727,10 @@
   function applyRailSelection() {
     document.querySelectorAll("[data-case-queue]").forEach(function (button) {
       const queue = button.getAttribute("data-case-queue") || "";
+      const allowed = isAllowedQueue(queue);
+      button.hidden = !allowed;
+      button.disabled = !allowed;
+      button.setAttribute("aria-disabled", allowed ? "false" : "true");
       button.classList.toggle("is-active", queue === state.queue);
     });
     const meta = QUEUE_META[state.queue] || QUEUE_META.customer_cases;
@@ -686,8 +743,12 @@
   function applyTabSelection() {
     document.querySelectorAll("[data-admin-case-tab]").forEach(function (button) {
       const tab = button.getAttribute("data-admin-case-tab") || "";
+      const allowed = isAllowedTab(tab);
+      button.hidden = !allowed;
+      button.disabled = !allowed;
       button.classList.toggle("is-active", tab === state.selectedTab);
       button.setAttribute("aria-selected", tab === state.selectedTab ? "true" : "false");
+      button.setAttribute("aria-disabled", allowed ? "false" : "true");
     });
   }
 
@@ -710,13 +771,15 @@
     document.querySelectorAll("[data-admin-case-action]").forEach(function (button) {
       const action = button.getAttribute("data-admin-case-action") || "";
       const tier = ACTION_TIERS[action] || "utility";
+      const allowedByRole = isAllowedCaseAction(action);
       const requirements = ACTION_AVAILABILITY[action] || [];
       const allowedByCase =
         selected && (!Array.isArray(selected.quick_actions) || selected.quick_actions.includes(action));
       const hasRequirements = requirements.every(function (key) {
         return selected && selected[key];
       });
-      const available = Boolean(selected && allowedByCase && hasRequirements);
+      const available = Boolean(selected && allowedByRole && allowedByCase && hasRequirements);
+      button.hidden = !allowedByRole;
       button.disabled = !available;
       button.classList.toggle("is-disabled", !available);
       button.setAttribute("data-action-tier", tier);
@@ -724,6 +787,17 @@
       button.classList.toggle("admin-action-tier--secondary", tier === "secondary");
       button.classList.toggle("admin-action-tier--utility", tier === "utility");
       button.setAttribute("aria-disabled", available ? "false" : "true");
+    });
+  }
+
+  function updateBulkActionAvailability() {
+    document.querySelectorAll("[data-admin-bulk-action]").forEach(function (button) {
+      const action = button.getAttribute("data-admin-bulk-action") || "";
+      const allowed = isAllowedBulkAction(action);
+      button.hidden = !allowed;
+      button.disabled = !allowed;
+      button.classList.toggle("is-disabled", !allowed);
+      button.setAttribute("aria-disabled", allowed ? "false" : "true");
     });
   }
 
@@ -736,6 +810,7 @@
     renderCaseHeader();
     renderCaseContext();
     updateActionAvailability();
+    updateBulkActionAvailability();
     renderWorkspaceTab();
     try {
       const payload = await fetchJson(`/admin/control-center/cases/${encodeURIComponent(caseId)}`);
@@ -744,13 +819,15 @@
       renderCaseHeader();
       renderCaseContext();
       updateActionAvailability();
+      updateBulkActionAvailability();
     } catch (error) {
       setPageStatus(error.message || "Unable to load case workspace.", "error");
     }
   }
 
   async function loadCases() {
-    setPageStatus("Loading customer cases...", "info");
+    const meta = QUEUE_META[state.queue] || QUEUE_META.customer_cases;
+    setPageStatus(`Loading ${meta[0].toLowerCase()}...`, "info");
     try {
       const payload = await fetchJson(
         `/admin/control-center/cases?queue=${encodeURIComponent(state.queue)}&limit=80&search=${encodeURIComponent(getSearchValue())}`,
@@ -776,6 +853,7 @@
       renderCaseContext();
       renderCaseHeader();
       updateActionAvailability();
+      updateBulkActionAvailability();
       if (!state.cases.length) renderWorkspaceTab();
       clearPageStatus();
     } catch (error) {
@@ -801,6 +879,10 @@
   }
 
   async function runBulkAction(action) {
+    if (!isAllowedBulkAction(action)) {
+      setPageStatus("Your role cannot run that bulk action.", "error");
+      return;
+    }
     const endpointMap = {
       "repair-missing-entitlements": "/admin/control-center/bulk/repair-missing-entitlements",
       "assign-missing-lanes": "/admin/control-center/bulk/assign-missing-lanes",
@@ -833,6 +915,10 @@
   }
 
   async function runCaseAction(action) {
+    if (!isAllowedCaseAction(action)) {
+      setPageStatus("Your role cannot run that case action.", "error");
+      return;
+    }
     if (!state.selectedCaseId) {
       setPageStatus("Select a case first.", "error");
       return;
@@ -862,7 +948,9 @@
 
       const queueButton = target.closest("[data-case-queue]");
       if (queueButton) {
-        state.queue = queueButton.getAttribute("data-case-queue") || "overview";
+        const queue = queueButton.getAttribute("data-case-queue") || "overview";
+        if (!isAllowedQueue(queue)) return;
+        state.queue = queue;
         applyRailSelection();
         loadCases();
         return;
@@ -892,6 +980,7 @@
 
       const bulkActionButton = target.closest("[data-admin-bulk-action]");
       if (bulkActionButton) {
+        if (bulkActionButton.disabled || bulkActionButton.classList.contains("is-disabled")) return;
         const action = bulkActionButton.getAttribute("data-admin-bulk-action");
         if (action) runBulkAction(action);
         return;
@@ -899,7 +988,9 @@
 
       const tabButton = target.closest("[data-admin-case-tab]");
       if (tabButton) {
-        state.selectedTab = tabButton.getAttribute("data-admin-case-tab") || "identity";
+        const tab = tabButton.getAttribute("data-admin-case-tab") || "identity";
+        if (!isAllowedTab(tab)) return;
+        state.selectedTab = tab;
         applyTabSelection();
         renderWorkspaceTab();
       }
@@ -945,7 +1036,8 @@
       titleNode.textContent = "Customer Operations Workspace";
     }
     if (statusNode) {
-      statusNode.textContent = `Search-first case operations are active for role: ${state.roleKey || "admin"}.`;
+      const queueCount = Array.isArray(state.allowedQueues) ? state.allowedQueues.length : 0;
+      statusNode.textContent = `Search-first case operations are active for role: ${state.roleKey || "admin"} across ${queueCount} permitted queue${queueCount === 1 ? "" : "s"}.`;
     }
   }
 
@@ -959,12 +1051,14 @@
       return;
     }
 
+    await loadAccessProfile();
     updateRoleSummary();
     bindEvents();
     applyRailSelection();
     applyTabSelection();
     renderCaseHeader();
     updateActionAvailability();
+    updateBulkActionAvailability();
     await Promise.allSettled([loadOverview(), loadCases()]);
   }
 

--- a/admin-family-manager.js
+++ b/admin-family-manager.js
@@ -7,18 +7,14 @@
     return;
   }
 
-  const INTERNAL_ROLE_KEYS = new Set([
+  const FAMILY_MANAGER_ROLE_KEYS = new Set([
     "admin",
     "super_admin",
     "root_admin",
     "platform_admin",
     "operations_admin",
-    "finance_admin",
-    "marketing_admin",
     "executive_technology",
     "operations",
-    "finance",
-    "marketing",
   ]);
 
   let familyBuilds = [];
@@ -149,10 +145,6 @@
   }
 
   function ensureAdminAccess(me) {
-    if (app && typeof app.isInternalRole === "function" && app.isInternalRole(me)) {
-      return;
-    }
-
     const values = [
       normalizeValue(me && me.role),
       normalizeValue(me && me.access_tier),
@@ -160,7 +152,7 @@
     ];
 
     const hasAccess = values.some(function (value) {
-      return INTERNAL_ROLE_KEYS.has(value);
+      return FAMILY_MANAGER_ROLE_KEYS.has(value);
     });
 
     if (!hasAccess) {

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -7,18 +7,14 @@
     return;
   }
 
-  const INTERNAL_ROLE_KEYS = new Set([
+  const INTAKE_REVIEW_ROLE_KEYS = new Set([
     "admin",
     "super_admin",
     "root_admin",
     "platform_admin",
     "operations_admin",
-    "finance_admin",
-    "marketing_admin",
     "executive_technology",
     "operations",
-    "finance",
-    "marketing",
   ]);
 
   const LINK_KEY_ENABLED_PACKAGES = new Set([
@@ -233,10 +229,6 @@
   }
 
   function ensureAdminAccess(me) {
-    if (app && typeof app.isInternalRole === "function" && app.isInternalRole(me)) {
-      return;
-    }
-
     const values = [
       normalizeValue(me && me.role),
       normalizeValue(me && me.access_tier),
@@ -244,7 +236,7 @@
     ];
 
     const hasAccess = values.some(function (value) {
-      return INTERNAL_ROLE_KEYS.has(value);
+      return INTAKE_REVIEW_ROLE_KEYS.has(value);
     });
 
     if (!hasAccess) {

--- a/backend/app/routes/admin_control_center.py
+++ b/backend/app/routes/admin_control_center.py
@@ -6,10 +6,13 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
-from app.dependencies.auth import require_permission
+from app.dependencies.auth import require_any_permission, require_permission
 from app.services.audit_log_service import write_audit_log
 from app.services.admin_control_service import (
     MAX_BULK_ACTION_LIMIT,
+    admin_control_access_profile,
+    admin_control_action_allowed,
+    admin_control_bulk_action_allowed,
     admin_console_overview,
     assign_lane,
     assign_missing_lanes,
@@ -101,10 +104,26 @@ class RepairSelectedPayload(BaseModel):
     order_ids: list[str] = Field(default_factory=list)
 
 
+def _assert_bulk_action_allowed(current_user: dict[str, Any], action: str) -> None:
+    if admin_control_bulk_action_allowed(current_user, action):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Admin control bulk action '{action}' is not permitted for this role.",
+    )
+
+
+@router.get("/access-profile")
+def get_admin_control_access_profile(
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    return admin_control_access_profile(current_user)
+
+
 @router.get("/overview")
 def get_admin_control_overview(
     limit: int = Query(default=20, ge=1, le=100),
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
     del current_user
     try:
@@ -118,7 +137,7 @@ async def get_customer_cases(
     search: str = Query(default=""),
     queue: str = Query(default="customer_cases"),
     limit: int = Query(default=50, ge=1, le=200),
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
     del current_user
     return await asyncio.to_thread(list_customer_cases, search=search, queue=queue, limit=limit)
@@ -127,7 +146,7 @@ async def get_customer_cases(
 @router.get("/cases/{case_id}")
 async def get_customer_case_workspace(
     case_id: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
     del current_user
     try:
@@ -140,8 +159,13 @@ async def get_customer_case_workspace(
 async def run_customer_case_action(
     case_id: str,
     action: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    if not admin_control_action_allowed(current_user, action):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Admin control action '{action}' is not permitted for this role.",
+        )
     try:
         return await asyncio.to_thread(
             execute_case_action,
@@ -156,7 +180,7 @@ async def run_customer_case_action(
 @router.get("/projects/{project_id}/workspace")
 def get_project_workspace_snapshot(
     project_id: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
     del current_user
     try:
@@ -169,7 +193,7 @@ def get_project_workspace_snapshot(
 def sync_project_package(
     project_id: str,
     payload: SyncPackagePayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.write")),
 ):
     del current_user
     try:
@@ -181,7 +205,7 @@ def sync_project_package(
 @router.post("/projects/{project_id}/assign-lane")
 def assign_project_lane(
     project_id: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.write")),
 ):
     del current_user
     try:
@@ -194,7 +218,7 @@ def assign_project_lane(
 def link_project_to_order(
     order_id: str,
     payload: LinkOrderPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.billing")),
 ):
     del current_user
     try:
@@ -210,7 +234,7 @@ def link_project_to_order(
 def generate_project_entitlement(
     project_id: str,
     payload: GenerateEntitlementPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.billing")),
 ):
     del current_user
     try:
@@ -227,7 +251,7 @@ def generate_project_entitlement(
 def get_project_readiness(
     project_id: str,
     order_id: str = Query(default=""),
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
     del current_user
     try:
@@ -240,7 +264,7 @@ def get_project_readiness(
 def queue_project_for_mint_review(
     project_id: str,
     payload: EnableMintReviewPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.mint")),
 ):
     del current_user
     try:
@@ -253,7 +277,7 @@ def queue_project_for_mint_review(
 def repair_project_record(
     project_id: str,
     payload: RepairRecordPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.write")),
 ):
     del current_user
     try:
@@ -265,7 +289,7 @@ def repair_project_record(
 @router.post("/projects/{project_id}/repair-mint-status")
 def repair_project_mint_state(
     project_id: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.mint")),
 ):
     del current_user
     try:
@@ -277,7 +301,7 @@ def repair_project_mint_state(
 @router.post("/projects/{project_id}/resync-mint-receipt")
 def resync_project_mint_receipt(
     project_id: str,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.mint")),
 ):
     del current_user
     try:
@@ -289,8 +313,9 @@ def resync_project_mint_receipt(
 @router.post("/bulk/repair-missing-entitlements")
 def bulk_repair_entitlements(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "repair-missing-entitlements")
     result = repair_missing_entitlements(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="repair_missing_entitlements", result_payload=result)
     return result
@@ -299,8 +324,9 @@ def bulk_repair_entitlements(
 @router.post("/bulk/assign-missing-lanes")
 def bulk_assign_lanes(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "assign-missing-lanes")
     result = assign_missing_lanes(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="assign_missing_lanes", result_payload=result)
     return result
@@ -309,8 +335,9 @@ def bulk_assign_lanes(
 @router.post("/bulk/link-unlinked-paid-orders")
 def bulk_link_paid_orders(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "link-unlinked-paid-orders")
     result = link_unlinked_paid_orders(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="link_unlinked_paid_orders", result_payload=result)
     return result
@@ -319,8 +346,9 @@ def bulk_link_paid_orders(
 @router.post("/bulk/normalize-broken-package-records")
 def bulk_normalize_package_records(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "normalize-broken-package-records")
     result = normalize_broken_package_records(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="normalize_broken_package_records", result_payload=result)
     return result
@@ -329,8 +357,9 @@ def bulk_normalize_package_records(
 @router.post("/bulk/refresh-mint-readiness")
 def bulk_refresh_mint_readiness(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "refresh-mint-readiness")
     result = refresh_mint_readiness(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="refresh_mint_readiness", result_payload=result)
     return result
@@ -339,8 +368,9 @@ def bulk_refresh_mint_readiness(
 @router.post("/bulk/repair-selected-records")
 def bulk_repair_selected_records(
     payload: RepairSelectedPayload,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_any_permission(["admin.control.write", "admin.control.billing"])),
 ):
+    _assert_bulk_action_allowed(current_user, "repair-selected-records")
     result = repair_selected_records(project_ids=payload.project_ids, order_ids=payload.order_ids)
     _audit_bulk_action(current_user=current_user, action="repair_selected_records", result_payload=result)
     return result
@@ -349,8 +379,9 @@ def bulk_repair_selected_records(
 @router.post("/bulk/repair-all-safe-records")
 def bulk_repair_all_safe_records(
     payload: BulkRepairPayload | None = None,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
 ):
+    _assert_bulk_action_allowed(current_user, "repair-all-safe-records")
     result = repair_all_safe_records(limit=(payload.limit if payload else BULK_ACTION_DEFAULT_LIMIT))
     _audit_bulk_action(current_user=current_user, action="repair_all_safe_records", result_payload=result)
     return result

--- a/backend/app/routes/admin_intake_submissions.py
+++ b/backend/app/routes/admin_intake_submissions.py
@@ -58,7 +58,7 @@ def _admin_user_id(current_admin: dict[str, Any]) -> str:
 def list_admin_intake_submissions(
     status_filter: Optional[str] = Query(default=None, alias="status"),
     limit: int = Query(default=50, ge=1, le=200),
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.review")),
 ):
     return list_all(limit=limit, status=status_filter)
 
@@ -66,7 +66,7 @@ def list_admin_intake_submissions(
 @router.get("/{submission_id}", response_model=IntakeSubmissionResponse)
 def get_admin_intake_submission(
     submission_id: str,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.review")),
 ):
     submission = get_by_id(submission_id)
     if not submission:
@@ -81,7 +81,7 @@ def get_admin_intake_submission(
 def set_admin_intake_submission_status(
     submission_id: str,
     payload: IntakeSubmissionStatusUpdate,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     try:
         return update_status(
@@ -103,7 +103,7 @@ def set_admin_intake_submission_status(
 def mark_admin_intake_in_review(
     submission_id: str,
     payload: IntakeAdminNotesPayload,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     try:
         return update_status(
@@ -125,7 +125,7 @@ def mark_admin_intake_in_review(
 def approve_admin_intake_submission(
     submission_id: str,
     payload: IntakeAdminNotesPayload,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     try:
         return update_status(
@@ -147,7 +147,7 @@ def approve_admin_intake_submission(
 def reject_admin_intake_submission(
     submission_id: str,
     payload: IntakeAdminNotesPayload,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     try:
         return update_status(
@@ -169,7 +169,7 @@ def reject_admin_intake_submission(
 def provision_admin_intake_build(
     submission_id: str,
     payload: IntakeProvisionBuildPayload,
-    current_admin: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_admin: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     try:
         return provision_build_from_submission(

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -170,7 +170,7 @@ def password_change_route(
 def admin_issue_password_reset_route(
     user_id: str,
     response: Response,
-    current_user: dict = Depends(require_permission("admin.access")),
+    current_user: dict = Depends(require_permission("admin.users.write")),
 ):
     try:
         result = admin_issue_password_reset(

--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -40,7 +40,7 @@ def list_all_orders_admin(
     limit: int = Query(default=100, ge=1, le=500),
     status_filter: str = Query(default="", alias="status"),
     search: str = Query(default=""),
-    current_user: dict = Depends(require_permission("admin.access")),
+    current_user: dict = Depends(require_permission("admin.orders.read")),
 ):
     del current_user
     return {
@@ -55,7 +55,7 @@ def list_all_orders_admin(
 @router.post("/admin/repair-paid-package-access")
 def repair_paid_package_access_admin(
     limit: int = Query(default=500, ge=1, le=1000),
-    current_user: dict = Depends(require_permission("admin.access")),
+    current_user: dict = Depends(require_permission("admin.orders.repair")),
 ):
     del current_user
     return repair_paid_package_order_access(limit=limit)

--- a/backend/app/routes/project_entitlements.py
+++ b/backend/app/routes/project_entitlements.py
@@ -48,7 +48,7 @@ def _is_admin(user: dict[str, Any]) -> bool:
 @router.post("/apply")
 def apply_project_entitlement(
     payload: ApplyProjectEntitlementPayload,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.entitlements.write")),
 ):
     try:
         return upsert_project_entitlement(
@@ -105,7 +105,7 @@ def list_project_entitlements_admin(
     limit: int = 100,
     active_only: bool = False,
     search: str = "",
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.entitlements.read")),
 ):
     del current_user
     return {

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -27,7 +27,7 @@ def _current_user_id(user: dict[str, Any]) -> str:
 
 
 @router.get("/", response_model=list[UserResponse])
-def get_users(current_user: dict[str, Any] = Depends(require_permission("admin.access"))):
+def get_users(current_user: dict[str, Any] = Depends(require_permission("admin.users.read"))):
     users = list_users()
     return [build_user_response(user) for user in users]
 
@@ -35,7 +35,7 @@ def get_users(current_user: dict[str, Any] = Depends(require_permission("admin.a
 @router.post("/", response_model=UserResponse)
 def create_user_route(
     payload: UserCreate,
-    current_user: dict[str, Any] = Depends(require_permission("admin.access")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.users.write")),
 ):
     user = create_user(payload)
     return build_user_response(user)

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -2014,6 +2014,8 @@ def _user_supports_search(user: dict[str, Any], search: str) -> bool:
 
 def _serialize_user_case(user: dict[str, Any]) -> dict[str, Any]:
     user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
+    if not user_id:
+        return {}
     role = _user_role_value(user)
     is_internal = _is_internal_user_document(user)
     status_value = _normalize(user.get("status")) or "active"
@@ -2049,6 +2051,176 @@ def _serialize_user_case(user: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _list_user_account_cases(
+    *,
+    db: Any,
+    search: str,
+    safe_limit: int,
+) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    cursor = db["users"].find({}).sort("updated_at", -1).limit(max(300, safe_limit * 10))
+    for user in cursor:
+        if not _user_supports_search(user, search):
+            continue
+        serialized = _serialize_user_case(user)
+        if serialized:
+            cases.append(serialized)
+        if len(cases) >= safe_limit:
+            break
+    return cases
+
+
+def _user_id_candidates(user: dict[str, Any]) -> list[Any]:
+    user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
+    candidates: list[Any] = []
+    if user_id:
+        candidates.append(user_id)
+    oid = _to_object_id(user_id)
+    if oid is not None:
+        candidates.append(oid)
+    return candidates
+
+
+def _related_projects_for_user(user: dict[str, Any]) -> list[dict[str, Any]]:
+    db = _db()
+    filters: list[dict[str, Any]] = []
+    user_id_values = _user_id_candidates(user)
+    email = _normalize_email(user.get("email"))
+    if user_id_values:
+        filters.append({"owner_user_id": {"$in": user_id_values}})
+    if email:
+        filters.append({"owner_email": email})
+    if not filters:
+        return []
+    cursor = db["projects"].find({"$or": filters}).sort("updated_at", -1).limit(20)
+    return [_serialize_project(project) for project in cursor]
+
+
+def _related_orders_for_user(user: dict[str, Any]) -> list[dict[str, Any]]:
+    db = _db()
+    filters: list[dict[str, Any]] = []
+    user_id_values = _user_id_candidates(user)
+    email = _normalize_email(user.get("email"))
+    if user_id_values:
+        filters.append({"user_id": {"$in": user_id_values}})
+    if email:
+        filters.append({"email": email})
+    if not filters:
+        return []
+    cursor = db["orders"].find({"$or": filters}).sort("created_at", -1).limit(20)
+    return [item for item in (_serialize_order(order) for order in cursor) if item]
+
+
+def _serialize_entitlement_item(entitlement: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _normalize_object_id(entitlement.get("_id")) or None,
+        "project_id": _normalize_object_id(entitlement.get("project_id")) or None,
+        "user_id": _normalize_object_id(entitlement.get("user_id")) or None,
+        "package_code": _normalize(entitlement.get("package_code")) or None,
+        "package_name": _normalize(entitlement.get("package_name")) or None,
+        "package_lane": _normalize(entitlement.get("package_lane")) or None,
+        "maintenance_plan": _normalize(entitlement.get("maintenance_plan")) or None,
+        "maintenance_status": _normalize(entitlement.get("maintenance_status")) or None,
+        "status": _normalize(entitlement.get("status")) or None,
+        "resolved_entitlements": entitlement.get("resolved_entitlements") or {},
+        "created_at": _serialize_datetime(entitlement.get("created_at")),
+        "updated_at": _serialize_datetime(entitlement.get("updated_at")),
+    }
+
+
+def _related_entitlements_for_user(
+    user: dict[str, Any],
+    project_ids: list[str],
+) -> list[dict[str, Any]]:
+    db = _db()
+    filters: list[dict[str, Any]] = []
+    user_id_values = _user_id_candidates(user)
+    if user_id_values:
+        filters.append({"user_id": {"$in": user_id_values}})
+
+    project_id_values: list[Any] = []
+    for project_id in project_ids:
+        normalized_project_id = _normalize_object_id(project_id)
+        if normalized_project_id:
+            project_id_values.append(normalized_project_id)
+        oid = _to_object_id(normalized_project_id)
+        if oid is not None:
+            project_id_values.append(oid)
+    if project_id_values:
+        filters.append({"project_id": {"$in": project_id_values}})
+    if not filters:
+        return []
+    cursor = db["project_entitlements"].find({"$or": filters}).sort("updated_at", -1).limit(20)
+    return [_serialize_entitlement_item(entitlement) for entitlement in cursor]
+
+
+def _user_uploads_snapshot(user: dict[str, Any], project_ids: list[str]) -> dict[str, Any]:
+    db = _db()
+    filters: list[dict[str, Any]] = []
+    email = _normalize_email(user.get("email"))
+    if email:
+        filters.append({"uploaded_by": email})
+    project_id_values = [_normalize_object_id(project_id) for project_id in project_ids if _normalize_object_id(project_id)]
+    if project_id_values:
+        filters.append({"project_id": {"$in": project_id_values}})
+    if not filters:
+        return {"count": 0, "items": []}
+
+    items: list[dict[str, Any]] = []
+    for item in db["uploaded_files"].find({"$or": filters}).sort("created_at", -1).limit(20):
+        items.append(
+            {
+                "id": _normalize_object_id(item.get("_id")) or None,
+                "project_id": _normalize_object_id(item.get("project_id")) or None,
+                "family_id": _normalize_object_id(item.get("family_id")) or None,
+                "member_id": _normalize_object_id(item.get("member_id")) or None,
+                "filename": _normalize(item.get("original_filename") or item.get("filename")) or None,
+                "category": _normalize(item.get("category")) or None,
+                "uploaded_by": _normalize(item.get("uploaded_by")) or None,
+                "status": _normalize(item.get("status")) or None,
+                "created_at": _serialize_datetime(item.get("created_at")),
+            }
+        )
+    return {"count": len(items), "items": items}
+
+
+def _user_audit_timeline(user: dict[str, Any]) -> list[dict[str, Any]]:
+    db = _db()
+    user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
+    email = _normalize_email(user.get("email"))
+    conditions: list[dict[str, Any]] = []
+    if user_id:
+        conditions.extend(
+            [
+                {"actor_user_id": user_id},
+                {"target_id": user_id},
+                {"context.user_id": user_id},
+                {"details.user_id": user_id},
+            ]
+        )
+    if email:
+        conditions.append({"actor_email": email})
+    if not conditions:
+        return []
+
+    timeline: list[dict[str, Any]] = []
+    for item in db["audit_logs"].find({"$or": conditions}).sort("timestamp", -1).limit(40):
+        timeline.append(
+            {
+                "id": _normalize_object_id(item.get("_id")) or None,
+                "action": _normalize(item.get("action") or item.get("event")) or "event",
+                "target_type": _normalize(item.get("target_type") or item.get("entity_type")) or "user",
+                "target_id": _normalize_object_id(item.get("target_id") or item.get("entity_id")) or None,
+                "actor_email": _normalize_email(item.get("actor_email")) or None,
+                "actor_name": _normalize(item.get("actor_name")) or None,
+                "result": _normalize(item.get("result")) or "success",
+                "timestamp": _serialize_datetime(item.get("timestamp") or item.get("created_at")),
+                "details": item.get("details") or {},
+            }
+        )
+    return timeline
+
+
 def _find_case_user(*, email: str = "", user_id: str = "") -> dict[str, Any] | None:
     db = _db()
     normalized_user_id = _normalize(user_id)
@@ -2066,6 +2238,10 @@ def _find_case_user(*, email: str = "", user_id: str = "") -> dict[str, Any] | N
         "role": 1,
         "access_tier": 1,
         "department_role": 1,
+        "status": 1,
+        "created_at": 1,
+        "updated_at": 1,
+        "last_login_at": 1,
     }
 
     if user_oid is not None:
@@ -2203,9 +2379,191 @@ def _mint_record_snapshot(project_id: str) -> dict[str, Any]:
     }
 
 
+def _build_user_workspace_payload(user: dict[str, Any]) -> dict[str, Any]:
+    user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
+    if not user_id:
+        raise ValueError("User account not found.")
+
+    role = _user_role_value(user)
+    is_internal = _is_internal_user_document(user)
+    related_projects = _related_projects_for_user(user)
+    related_orders = _related_orders_for_user(user)
+    project_ids = [
+        _normalize_object_id(project.get("id"))
+        for project in related_projects
+        if _normalize_object_id(project.get("id"))
+    ]
+    related_entitlements = _related_entitlements_for_user(user, project_ids)
+    uploads = _user_uploads_snapshot(user, project_ids)
+    audit = _user_audit_timeline(user)
+    primary_project = related_projects[0] if related_projects else {}
+    primary_order = related_orders[0] if related_orders else {}
+    primary_entitlement = related_entitlements[0] if related_entitlements else {}
+
+    package_code = (
+        _normalize(primary_entitlement.get("package_code"))
+        or _normalize(primary_order.get("package_code"))
+        or _normalize(primary_project.get("package_code"))
+        or "account"
+    )
+    package_name = (
+        _normalize(primary_entitlement.get("package_name"))
+        or _normalize(primary_order.get("package_name"))
+        or _normalize(primary_project.get("package_name"))
+        or "Account"
+    )
+    package_lane = (
+        _normalize(primary_entitlement.get("package_lane"))
+        or _normalize(primary_project.get("project_lane"))
+        or _normalize(primary_project.get("lane"))
+        or ("admin" if is_internal else "customer")
+    )
+    upload_categories = sorted(
+        {
+            _normalize(item.get("category"))
+            for item in uploads.get("items", [])
+            if _normalize(item.get("category"))
+        }
+    )
+    alerts: list[str] = []
+    if is_internal:
+        alerts.append("internal_admin_identity")
+    if not related_projects and not is_internal:
+        alerts.append("customer_without_project")
+    operator_guidance = _operator_guidance_items(alerts=alerts)
+    display_name = _user_display_name(user)
+    status_value = _normalize(user.get("status")) or "active"
+
+    return {
+        "case_id": f"user:{user_id}",
+        "project": primary_project or None,
+        "order": primary_order or None,
+        "package": {
+            "package_code": package_code,
+            "package_slug": package_code,
+            "package_name": package_name,
+            "lane": package_lane,
+            "project_lane": package_lane,
+            "source": "user_account",
+            "normalization_status": "not_applicable",
+            "warnings": [],
+        },
+        "entitlement": primary_entitlement or None,
+        "readiness": {
+            "mint_review_ready": False,
+            "mint_eligible": False,
+            "mint_already_completed": False,
+            "blocking_reasons": ["user_account_case"],
+        },
+        "uploads": uploads,
+        "audit_timeline": audit,
+        "alerts": alerts,
+        "operator_guidance": operator_guidance,
+        "warnings": [],
+        "tabs": {
+            "identity": {
+                "user_id": user_id,
+                "full_name": display_name,
+                "first_name": _normalize(user.get("first_name")) or None,
+                "last_name": _normalize(user.get("last_name")) or None,
+                "email": _normalize_email(user.get("email")) or None,
+                "birthday": _serialize_datetime(
+                    user.get("birthday") or user.get("birth_date") or user.get("date_of_birth") or user.get("dob")
+                ),
+                "role": role,
+                "status": status_value,
+                "admin_user_relationship": "internal_admin_identity" if is_internal else "customer_record",
+                "created_at": _serialize_datetime(user.get("created_at")),
+                "updated_at": _serialize_datetime(user.get("updated_at")),
+                "last_login_at": _serialize_datetime(user.get("last_login_at")),
+            },
+            "package_lane": {
+                "package_slug": package_code,
+                "package_name": package_name,
+                "package_code": package_code,
+                "lane": package_lane,
+                "project_lane": package_lane,
+                "source": "user_account",
+                "related_project_count": len(related_projects),
+                "related_order_count": len(related_orders),
+                "entitlement_count": len(related_entitlements),
+                "warnings": [],
+                "package_normalization_status": "not_applicable",
+            },
+            "orders_billing": {
+                "package_slug": package_code,
+                "package_name": package_name,
+                "package_code": package_code,
+                "lane": package_lane,
+                "order_status": primary_order.get("status"),
+                "paid": bool(primary_order and primary_order.get("status") in PAID_ORDER_STATUSES),
+                "project_link_status": "linked" if primary_order.get("project_id") else "not_linked",
+                "maintenance_state": primary_entitlement.get("maintenance_status"),
+                "primary_order": primary_order,
+                "related_orders": related_orders,
+            },
+            "project": {
+                "project_name": primary_project.get("name"),
+                "project_id": primary_project.get("id"),
+                "package_slug": package_code,
+                "package_name": package_name,
+                "package_code": package_code,
+                "lane": package_lane,
+                "project_lane": package_lane,
+                "build_status": primary_project.get("status"),
+                "phase": primary_project.get("phase"),
+                "source": primary_project.get("source"),
+                "related_projects": related_projects,
+                "uploads_summary": {
+                    "count": uploads.get("count", 0),
+                    "categories": upload_categories,
+                },
+            },
+            "entitlements": {
+                "entitlement_status": "exists" if related_entitlements else "missing",
+                "package_code": primary_entitlement.get("package_code") or package_code,
+                "package_lane": primary_entitlement.get("package_lane") or package_lane,
+                "maintenance_plan": primary_entitlement.get("maintenance_plan"),
+                "maintenance_status": primary_entitlement.get("maintenance_status"),
+                "resolved_entitlements": primary_entitlement.get("resolved_entitlements") or {},
+                "items": related_entitlements,
+            },
+            "uploads_verification": {
+                "uploaded_files": uploads.get("count", 0),
+                "file_categories": upload_categories,
+                "review_status": "pending" if uploads.get("count", 0) <= 0 else "files_present",
+                "verification_readiness": "ready" if uploads.get("count", 0) > 0 else "waiting_for_uploads",
+                "items": uploads.get("items", []),
+            },
+            "mint_readiness": {
+                "eligibility": "not_applicable",
+                "runtime": "not_applicable",
+                "current_state": "user_account_case",
+                "decision": "User account cases do not mint directly.",
+                "next_admin_action": "Review linked projects or orders",
+                "blocking_reasons": ["user_account_case"],
+                "guidance": operator_guidance,
+                "historical_attempts": [],
+                "historical_attempt_count": 0,
+            },
+            "audit_timeline": audit,
+        },
+    }
+
+
 def list_customer_cases(*, search: str = "", limit: int = 50, queue: str = "customer_cases") -> dict[str, Any]:
     db = _db()
     safe_limit = max(1, min(limit, 200))
+    normalized_queue = _normalize(queue).lower()
+    if normalized_queue == "users":
+        return {
+            "items": _list_user_account_cases(
+                db=db,
+                search=search,
+                safe_limit=safe_limit,
+            )
+        }
+
     user_emails, user_ids, family_ids, mint_project_ids = _search_seed_sets(search)
 
     cases: list[dict[str, Any]] = []
@@ -2578,6 +2936,13 @@ def customer_case_workspace(case_id: str) -> dict[str, Any]:
     if not normalized_case_id:
         raise ValueError("Case id is required.")
 
+    if normalized_case_id.startswith("user:"):
+        user_id = normalized_case_id.split(":", 1)[1]
+        user = _find_case_user(user_id=user_id)
+        if user is None:
+            raise ValueError("User account case not found.")
+        return _build_user_workspace_payload(user)
+
     if normalized_case_id.startswith("order:"):
         order_id = normalized_case_id.split(":", 1)[1]
         order = _order_by_id(order_id)
@@ -2748,6 +3113,8 @@ def execute_case_action(
         project = _project_by_id(_normalize(order.get("project_id"))) or _find_matching_approved_project_for_order(order)
         if project is not None:
             project_id = _normalize(project.get("_id"))
+    elif normalized_case_id.startswith("user:"):
+        project_id = ""
 
     if normalized_action in {"refresh_case_data"}:
         payload = customer_case_workspace(normalized_case_id)
@@ -2760,6 +3127,9 @@ def execute_case_action(
             details={"refreshed": True},
         )
         return payload
+
+    if normalized_case_id.startswith("user:"):
+        raise ValueError("User account cases only support refresh_case_data.")
 
     if not project_id:
         raise ValueError("Action requires a linked project.")

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -82,19 +82,36 @@ def _send_email(
     }
 
     try:
+        logger.debug(
+            "Sending Postmark email: recipient=%s subject=%r",
+            normalized_to_email,
+            subject,
+        )
         response = requests.post(
             POSTMARK_EMAIL_ENDPOINT,
             json=payload,
             headers=headers,
             timeout=POSTMARK_TIMEOUT_SECONDS,
         )
+        logger.debug(
+            "Postmark email response: recipient=%s subject=%r status_code=%s "
+            "response_body=%s",
+            normalized_to_email,
+            subject,
+            response.status_code,
+            response.text,
+        )
         response.raise_for_status()
     except RequestException as exc:
         response = getattr(exc, "response", None)
-        response_body = getattr(response, "text", "")
+        status_code = getattr(response, "status_code", "request_error")
+        response_body = getattr(response, "text", str(exc))
         logger.exception(
-            "Failed to send Postmark email to %s. Response: %s",
+            "Failed to send Postmark email: recipient=%s subject=%r "
+            "status_code=%s response_body=%s",
             normalized_to_email,
+            subject,
+            status_code,
             response_body,
         )
 

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -7,7 +7,6 @@ from fastapi import HTTPException, status
 
 from app.core.package_catalog import get_package, normalize_package_code
 from app.database import get_database
-from app.dependencies.auth import has_internal_admin_access
 from app.services.entitlement_service import resolve_project_entitlements
 from app.services.project_membership_service import get_project_access_snapshot
 
@@ -16,6 +15,15 @@ PAID_PACKAGE_STATUSES = {
     "complete",
     "completed",
     "succeeded",
+}
+WORKSPACE_ADMIN_ROLE_KEYS = {
+    "admin",
+    "super_admin",
+    "root_admin",
+    "platform_admin",
+    "operations_admin",
+    "executive_technology",
+    "operations",
 }
 
 
@@ -37,6 +45,15 @@ def _current_user_email(user: dict[str, Any]) -> str:
 
 def _current_user_name(user: dict[str, Any]) -> str:
     return _normalize_value(user.get("full_name") or user.get("name"))
+
+
+def _has_workspace_admin_access(user: dict[str, Any]) -> bool:
+    role_values = {
+        _normalize_value(user.get("role")).lower(),
+        _normalize_value(user.get("access_tier")).lower(),
+        _normalize_value(user.get("department_role")).lower(),
+    }
+    return any(value in WORKSPACE_ADMIN_ROLE_KEYS for value in role_values if value)
 
 
 def _to_object_id(value: str) -> ObjectId | None:
@@ -263,7 +280,7 @@ def _project_is_visible_to_user(
     family: dict[str, Any] | None,
     current_user: dict[str, Any],
 ) -> bool:
-    if has_internal_admin_access(current_user):
+    if _has_workspace_admin_access(current_user):
         return True
 
     current_user_id = _current_user_id(current_user)
@@ -393,7 +410,7 @@ def resolve_workspace_context(
         "resolved_entitlements": entitlement_map.get("resolved_entitlements") or {},
         "entitlement": entitlement_map.get("entitlement"),
         "paid_order": entitlement_map.get("paid_order"),
-        "is_admin": has_internal_admin_access(current_user),
+        "is_admin": _has_workspace_admin_access(current_user),
     }
 
 
@@ -438,7 +455,7 @@ def list_accessible_families_for_user(
     capabilities: Iterable[str] = (),
 ) -> list[dict[str, Any]]:
     db = _require_database()
-    if has_internal_admin_access(current_user):
+    if _has_workspace_admin_access(current_user):
         return list(db["families"].find().sort("created_at", -1))
 
     normalized_capabilities = [

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -1,0 +1,271 @@
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from app.dependencies import auth as auth_dependencies
+from app.services import admin_control_service
+
+
+class FakeCursor(list):
+    def sort(self, field_name, direction):
+        return FakeCursor(
+            sorted(
+                self,
+                key=lambda item: str(item.get(field_name) or ""),
+                reverse=direction < 0,
+            )
+        )
+
+    def limit(self, limit):
+        return FakeCursor(self[:limit])
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    def find_one(self, query=None, projection=None, *args, **kwargs):
+        del projection, args, kwargs
+        query = query or {}
+        for document in self.documents:
+            if self._matches(document, query):
+                return document
+        return None
+
+    def find(self, query=None, projection=None, *args, **kwargs):
+        del projection, args, kwargs
+        query = query or {}
+        return FakeCursor(
+            [document for document in self.documents if self._matches(document, query)]
+        )
+
+    def count_documents(self, query=None):
+        query = query or {}
+        return len([document for document in self.documents if self._matches(document, query)])
+
+    def _get_nested(self, document, key):
+        current = document
+        for part in key.split("."):
+            if not isinstance(current, dict):
+                return None
+            current = current.get(part)
+        return current
+
+    def _matches(self, document, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(document, option) for option in expected):
+                    return False
+                continue
+
+            actual = self._get_nested(document, key)
+            if isinstance(expected, dict):
+                if "$in" in expected:
+                    values = expected["$in"]
+                    if isinstance(actual, list):
+                        if not any(item in values for item in actual):
+                            return False
+                    elif actual not in values:
+                        return False
+                else:
+                    return False
+            elif actual != expected:
+                return False
+
+        return True
+
+
+class FakeDatabase:
+    def __init__(self, collections=None):
+        self.collections = {
+            name: FakeCollection(documents)
+            for name, documents in (collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        if name not in self.collections:
+            self.collections[name] = FakeCollection()
+        return self.collections[name]
+
+
+class AdminPermissionContextTests(unittest.TestCase):
+    def test_finance_role_no_longer_gets_wildcard_permissions(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "user_role_assignments": [],
+                "role_permissions": [],
+                "projects": [],
+                "workflow_events": [],
+            }
+        )
+
+        with (
+            patch.object(
+                auth_dependencies,
+                "_load_user_by_id",
+                return_value={
+                    "_id": user_id,
+                    "email": "finance@example.com",
+                    "role": "finance",
+                },
+            ),
+            patch.object(auth_dependencies, "_db", return_value=db),
+            patch.object(auth_dependencies, "list_user_project_entitlements", return_value=[]),
+        ):
+            context = auth_dependencies.resolve_access_context(str(user_id))
+
+        permissions = set(context["permissions"])
+        self.assertNotIn("*", permissions)
+        self.assertIn("admin.control.billing", permissions)
+        self.assertIn("admin.orders.read", permissions)
+        self.assertNotIn("admin.control.mint", permissions)
+        self.assertNotIn("uploads.admin.review", permissions)
+
+
+class AdminControlAccessProfileTests(unittest.TestCase):
+    def test_finance_profile_can_handle_billing_but_not_mint_or_upload_review(self):
+        current_user = {
+            "role": "finance",
+            "_access_context": {
+                "role_codes": ["finance"],
+                "permissions": [
+                    "admin.access",
+                    "admin.audit.read",
+                    "admin.control.view",
+                    "admin.control.billing",
+                    "admin.entitlements.read",
+                    "admin.entitlements.write",
+                    "admin.orders.read",
+                    "admin.orders.repair",
+                ],
+            },
+        }
+
+        profile = admin_control_service.admin_control_access_profile(current_user)
+
+        self.assertIn("orders", profile["allowed_queues"])
+        self.assertIn("entitlements", profile["allowed_queues"])
+        self.assertNotIn("mint_queue", profile["allowed_queues"])
+        self.assertNotIn("upload_review", profile["allowed_queues"])
+        self.assertTrue(admin_control_service.admin_control_action_allowed(current_user, "generate_entitlement"))
+        self.assertFalse(admin_control_service.admin_control_action_allowed(current_user, "queue_for_mint_review"))
+        self.assertTrue(admin_control_service.admin_control_bulk_action_allowed(current_user, "repair-missing-entitlements"))
+        self.assertFalse(admin_control_service.admin_control_bulk_action_allowed(current_user, "refresh-mint-readiness"))
+
+    def test_marketing_profile_is_read_only_with_user_visibility(self):
+        current_user = {
+            "role": "marketing",
+            "_access_context": {
+                "role_codes": ["marketing"],
+                "permissions": [
+                    "admin.access",
+                    "admin.audit.read",
+                    "admin.control.view",
+                    "admin.orders.read",
+                    "admin.users.read",
+                ],
+            },
+        }
+
+        profile = admin_control_service.admin_control_access_profile(current_user)
+
+        self.assertIn("users", profile["allowed_queues"])
+        self.assertIn("customer_cases", profile["allowed_queues"])
+        self.assertIn("run_readiness_check", profile["allowed_actions"])
+        self.assertNotIn("sync_package", profile["allowed_actions"])
+        self.assertNotIn("generate_entitlement", profile["allowed_actions"])
+        self.assertEqual(profile["allowed_bulk_actions"], [])
+
+    def test_wildcard_profile_gets_all_console_controls(self):
+        current_user = {
+            "role": "root_admin",
+            "_access_context": {
+                "role_codes": ["root_admin"],
+                "permissions": ["*"],
+            },
+        }
+
+        profile = admin_control_service.admin_control_access_profile(current_user)
+
+        self.assertIn("users", profile["allowed_queues"])
+        self.assertIn("mint_queue", profile["allowed_queues"])
+        self.assertIn("uploads_verification", profile["allowed_tabs"])
+        self.assertIn("queue_for_mint_review", profile["allowed_actions"])
+        self.assertIn("repair-all-safe-records", profile["allowed_bulk_actions"])
+
+
+class AdminUserQueueTests(unittest.TestCase):
+    def test_users_queue_lists_customer_and_admin_accounts(self):
+        customer_id = ObjectId()
+        admin_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": customer_id,
+                        "email": "customer@example.com",
+                        "full_name": "Customer Person",
+                        "role": "user",
+                        "status": "active",
+                    },
+                    {
+                        "_id": admin_id,
+                        "email": "ops@example.com",
+                        "full_name": "Ops Admin",
+                        "role": "operations",
+                        "status": "active",
+                    },
+                ],
+                "projects": [],
+                "orders": [],
+                "project_entitlements": [],
+                "uploaded_files": [],
+                "audit_logs": [],
+            }
+        )
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            payload = admin_control_service.list_customer_cases(queue="users", limit=10)
+
+        case_ids = {item["case_id"] for item in payload["items"]}
+        self.assertEqual(len(payload["items"]), 2)
+        self.assertIn(f"user:{customer_id}", case_ids)
+        self.assertIn(f"user:{admin_id}", case_ids)
+        self.assertIn("customer", {item["lane"] for item in payload["items"]})
+        self.assertIn("admin", {item["lane"] for item in payload["items"]})
+
+    def test_user_case_workspace_loads_legacy_account_without_project(self):
+        customer_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": customer_id,
+                        "email": "customer@example.com",
+                        "full_name": "Customer Person",
+                        "role": "user",
+                        "status": "active",
+                    }
+                ],
+                "projects": [],
+                "orders": [],
+                "project_entitlements": [],
+                "uploaded_files": [],
+                "audit_logs": [],
+            }
+        )
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            workspace = admin_control_service.customer_case_workspace(f"user:{customer_id}")
+
+        self.assertEqual(workspace["case_id"], f"user:{customer_id}")
+        self.assertEqual(workspace["tabs"]["identity"]["email"], "customer@example.com")
+        self.assertEqual(workspace["tabs"]["identity"]["admin_user_relationship"], "customer_record")
+        self.assertEqual(workspace["tabs"]["project"]["related_projects"], [])
+        self.assertEqual(workspace["tabs"]["entitlements"]["entitlement_status"], "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Added backend-driven admin control access profile for queues, tabs, case actions, and bulk actions
- Replaced broad admin.access guards with role-specific permissions for control center, users, orders, entitlements, intake, and admin password reset routes
- Fixed Users queue so customer and admin account records appear in the admin console
- Added user account workspace support with stable tabs for identity, projects, orders, entitlements, uploads, and audit history
- Updated frontend admin buttons to hide or disable actions the current role cannot run
- Restricted finance and marketing roles from direct access to intake review and family manager tools
- Tightened workspace admin bypass so package access remains controlled by purchases and entitlements
- Added admin console tests for role separation, access profiles, and user queue behavior