### PR TITLE
Implemented the cleaner production reset UX.

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -51,7 +51,7 @@
               <h1>Password recovery and protected account changes.</h1>
               <p data-account-security-page-status>
                 Tomb of Light can issue secure reset requests, accept one-time
-                reset tokens, and let signed-in users change their password
+                reset links, and let signed-in users change their password
                 directly inside the portal.
               </p>
             </div>
@@ -60,7 +60,11 @@
 
         <section class="page-sections">
           <div class="container form-shell portal-account-grid">
-            <div class="form-panel" id="reset-request">
+            <div
+              class="form-panel"
+              id="reset-request"
+              data-password-reset-request-panel
+            >
               <span class="eyebrow">Reset Request</span>
               <p class="card-copy">
                 Enter the email attached to your Tomb of Light account. If it
@@ -99,11 +103,15 @@
               ></div>
             </div>
 
-            <div class="form-panel" id="reset-confirm">
-              <span class="eyebrow">Use Reset Token</span>
+            <div
+              class="form-panel"
+              id="reset-confirm"
+              data-password-reset-confirm-panel
+              hidden
+            >
+              <span class="eyebrow">Reset Password</span>
               <p class="card-copy">
-                Open the reset link from your email or paste the token below,
-                then set a strong new password.
+                Enter a strong new password to finish securing your account.
               </p>
               <p class="card-copy" style="font-size: 0.875rem; color: var(--color-muted, #888);">
                 Passwords must be at least 12 characters and include at least
@@ -113,23 +121,13 @@
 
               <form class="form-grid" data-password-reset-confirm-form novalidate>
                 <label>
-                  Reset Token
-                  <input
-                    type="text"
-                    name="token"
-                    placeholder="Paste your secure reset token"
-                    autocomplete="off"
-                    required
-                  />
-                </label>
-
-                <label>
                   New Password
                   <input
                     type="password"
                     name="new_password"
                     placeholder="Create a new password"
                     autocomplete="new-password"
+                    minlength="12"
                     required
                   />
                 </label>
@@ -141,13 +139,14 @@
                     name="confirm_new_password"
                     placeholder="Re-enter your new password"
                     autocomplete="new-password"
+                    minlength="12"
                     required
                   />
                 </label>
 
                 <div class="inline-actions" style="margin-top: 1rem">
                   <button class="btn btn-primary" type="submit">
-                    Apply New Password
+                    Reset Password
                   </button>
                 </div>
               </form>
@@ -191,6 +190,7 @@
                     name="new_password"
                     placeholder="Create a new password"
                     autocomplete="new-password"
+                    minlength="12"
                     required
                   />
                 </label>
@@ -202,6 +202,7 @@
                     name="confirm_new_password"
                     placeholder="Re-enter your new password"
                     autocomplete="new-password"
+                    minlength="12"
                     required
                   />
                 </label>
@@ -251,6 +252,6 @@
     <script src="config.js?v=20260331-2"></script>
     <script src="app.js?v=20260410-1"></script>
     <script src="auth.js?v=20260410-2"></script>
-    <script src="account-security.js?v=20260411-1"></script>
+    <script src="account-security.js?v=20260412-1"></script>
   </body>
 </html>

--- a/account-security.js
+++ b/account-security.js
@@ -6,6 +6,9 @@
     return;
   }
 
+  const PASSWORD_POLICY_MESSAGE =
+    "Password must be at least 12 characters and include at least one uppercase letter, one lowercase letter, one number, and one special character.";
+
   function query(name) {
     try {
       const params = new URLSearchParams(window.location.search);
@@ -15,27 +18,86 @@
     }
   }
 
+  const resetState = {
+    mode: query("mode").toLowerCase(),
+    token: query("token"),
+  };
+
+  function hasResetTokenFromEmailLink() {
+    return resetState.mode === "reset" && resetState.token.length >= 16;
+  }
+
   function getErrorMessage(error) {
     return String((error && error.message) || error || "Unknown error");
   }
 
-  function focusResetConfirmFromLink() {
-    const mode = query("mode").toLowerCase();
-    const token = query("token");
-    if (mode !== "reset" || !token) {
+  function validatePasswordStrength(password) {
+    const value = String(password || "");
+    if (value.length < 12) {
+      return PASSWORD_POLICY_MESSAGE;
+    }
+    if (!/[A-Z]/.test(value)) {
+      return PASSWORD_POLICY_MESSAGE;
+    }
+    if (!/[a-z]/.test(value)) {
+      return PASSWORD_POLICY_MESSAGE;
+    }
+    if (!/\d/.test(value)) {
+      return PASSWORD_POLICY_MESSAGE;
+    }
+    if (!/[^A-Za-z0-9]/.test(value)) {
+      return PASSWORD_POLICY_MESSAGE;
+    }
+    return "";
+  }
+
+  function setupResetModeUi() {
+    const requestPanel = document.querySelector(
+      "[data-password-reset-request-panel]",
+    );
+    const confirmPanel = document.querySelector(
+      "[data-password-reset-confirm-panel]",
+    );
+    const changePanel = document.querySelector("[data-password-change-panel]");
+    const pageStatus = document.querySelector(
+      "[data-account-security-page-status]",
+    );
+
+    if (hasResetTokenFromEmailLink()) {
+      if (requestPanel) requestPanel.hidden = true;
+      if (confirmPanel) confirmPanel.hidden = false;
+      if (changePanel) changePanel.hidden = true;
+      if (pageStatus) {
+        pageStatus.textContent =
+          "Choose a new password for your Tomb of Light account. The secure link from your email will be verified when you submit.";
+      }
+      return;
+    }
+
+    if (requestPanel) requestPanel.hidden = false;
+    if (confirmPanel) confirmPanel.hidden = true;
+    if (changePanel) changePanel.hidden = false;
+    if (resetState.mode === "reset" && pageStatus) {
+      pageStatus.textContent =
+        "This reset link is incomplete. Request a fresh password reset email to continue.";
+    }
+  }
+
+  function focusResetFormFromLink() {
+    if (!hasResetTokenFromEmailLink()) {
       return;
     }
 
     const panel = document.getElementById("reset-confirm");
-    const tokenField = document.querySelector(
-      '[data-password-reset-confirm-form] input[name="token"]',
+    const passwordField = document.querySelector(
+      '[data-password-reset-confirm-form] input[name="new_password"]',
     );
 
     if (panel && typeof panel.scrollIntoView === "function") {
       panel.scrollIntoView({ block: "start" });
     }
-    if (tokenField && typeof tokenField.focus === "function") {
-      tokenField.focus();
+    if (passwordField && typeof passwordField.focus === "function") {
+      passwordField.focus();
     }
   }
 
@@ -51,7 +113,7 @@
     } catch (_error) {
       if (introNode) {
         introNode.textContent =
-          "Sign in first if you want to change your password from inside the protected workspace. Reset requests and one-time reset tokens still work here without a live session.";
+          "Sign in first if you want to change your password from inside the protected workspace. Password reset links still work here without a live session.";
       }
       return null;
     }
@@ -106,24 +168,34 @@
       "[data-password-reset-confirm-status]",
     );
 
-    const tokenField = form.querySelector('input[name="token"]');
-    if (tokenField) {
-      tokenField.value = query("token");
-    }
-
     form.addEventListener("submit", async function (event) {
       event.preventDefault();
       app.clearStatus(statusNode);
 
       const formData = new FormData(form);
-      const token = String(formData.get("token") || "").trim();
-      const newPassword = String(formData.get("new_password") || "").trim();
+      const token = String(resetState.token || "").trim();
+      const newPassword = String(formData.get("new_password") || "");
       const confirmPassword = String(
         formData.get("confirm_new_password") || "",
-      ).trim();
+      );
 
-      if (!token || !newPassword || !confirmPassword) {
-        app.setStatus(statusNode, "Please complete all reset fields.", "error");
+      if (!token) {
+        app.setStatus(
+          statusNode,
+          "Use the secure password reset link from your email to continue.",
+          "error",
+        );
+        return;
+      }
+
+      if (!newPassword || !confirmPassword) {
+        app.setStatus(statusNode, "Please complete all password fields.", "error");
+        return;
+      }
+
+      const passwordPolicyError = validatePasswordStrength(newPassword);
+      if (passwordPolicyError) {
+        app.setStatus(statusNode, passwordPolicyError, "error");
         return;
       }
 
@@ -166,16 +238,20 @@
       app.clearStatus(statusNode);
 
       const formData = new FormData(form);
-      const currentPassword = String(
-        formData.get("current_password") || "",
-      ).trim();
-      const newPassword = String(formData.get("new_password") || "").trim();
+      const currentPassword = String(formData.get("current_password") || "");
+      const newPassword = String(formData.get("new_password") || "");
       const confirmPassword = String(
         formData.get("confirm_new_password") || "",
-      ).trim();
+      );
 
       if (!currentPassword || !newPassword || !confirmPassword) {
         app.setStatus(statusNode, "Please complete all password fields.", "error");
+        return;
+      }
+
+      const passwordPolicyError = validatePasswordStrength(newPassword);
+      if (passwordPolicyError) {
+        app.setStatus(statusNode, passwordPolicyError, "error");
         return;
       }
 
@@ -206,10 +282,11 @@
   }
 
   document.addEventListener("DOMContentLoaded", async function () {
+    setupResetModeUi();
     await populateSignedInState();
     setupResetRequestForm();
     setupResetConfirmForm();
     setupPasswordChangeForm();
-    focusResetConfirmFromLink();
+    focusResetFormFromLink();
   });
 })();

--- a/signin.html
+++ b/signin.html
@@ -180,9 +180,6 @@
                   <a class="btn btn-secondary" href="account-security.html#reset-request">
                     Forgot Password
                   </a>
-                  <a class="btn btn-secondary" href="account-security.html#reset-confirm">
-                    Use Reset Token
-                  </a>
                 </div>
               </form>
 


### PR DESCRIPTION
The reset-link flow now works like this in account-security.js (line 21): when the page loads with ?mode=reset&token=<TOKEN>, the token is read into JS state and never rendered into a visible input. In reset-link mode, the page hides the reset-request and change-password panels, then shows only the reset form with:

New Password
Confirm New Password
Reset Password