### PR TITLE
package_catalog.py, mint_record_service.py, and test_email_service.py.

### DIFF
--- a/backend/app/core/package_catalog.py
+++ b/backend/app/core/package_catalog.py
@@ -704,7 +704,7 @@ def get_addon_catalog() -> dict[str, dict[str, Any]]:
     return deepcopy(ADDON_CATALOG)
 
 
-def normalize_package_code(package_code: str) -> str:
+def normalize_package_code(package_code: Any) -> str:
     raw = str(package_code or "").strip().lower()
     return PACKAGE_CODE_ALIASES.get(
         raw,
@@ -752,7 +752,7 @@ def get_package_identifier_map() -> dict[str, Any]:
     }
 
 
-def normalize_addon_code(addon_code: str) -> str:
+def normalize_addon_code(addon_code: Any) -> str:
     raw = str(addon_code or "").strip().lower()
     return ADDON_CODE_ALIASES.get(
         raw,
@@ -760,7 +760,7 @@ def normalize_addon_code(addon_code: str) -> str:
     )
 
 
-def get_package(package_code: str) -> dict[str, Any] | None:
+def get_package(package_code: Any) -> dict[str, Any] | None:
     normalized = normalize_package_code(package_code)
     if not normalized:
         return None

--- a/backend/app/services/mint_record_service.py
+++ b/backend/app/services/mint_record_service.py
@@ -766,6 +766,8 @@ def create_mint_record(
 
     existing_summary = resolve_canonical_mint_status(project_id, include_history=False)
     existing = existing_summary.get("current_record")
+    if not isinstance(existing, dict):
+        existing = None
     explicit_new_version = version_strategy in REQUEUE_VERSION_STRATEGIES
     if (
         version_strategy == "new_version_if_needed"
@@ -776,6 +778,8 @@ def create_mint_record(
     ):
         return existing
     if existing_summary.get("is_minted") and not explicit_new_version:
+        if existing is None:
+            raise ValueError("Canonical mint summary is missing the current mint record.")
         return existing
 
     version_number = _next_version_number(project_id)

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,7 +1,8 @@
 import unittest
+from typing import cast
 from unittest.mock import patch
 
-from requests import HTTPError
+from requests import HTTPError, Response
 
 from app.services import email_service
 
@@ -29,7 +30,10 @@ class FakePostmarkResponse:
 
     def raise_for_status(self):
         if self.status_code >= 400:
-            raise HTTPError(f"{self.status_code} Postmark error", response=self)
+            raise HTTPError(
+                f"{self.status_code} Postmark error",
+                response=cast(Response, self),
+            )
 
 
 class PostmarkEmailLoggingTests(unittest.TestCase):
@@ -59,15 +63,15 @@ class PostmarkEmailLoggingTests(unittest.TestCase):
 
         self.assertEqual(len(captured.records), 1)
         record = captured.records[0]
-        self.assertEqual(record.event, "postmark_email_send_failed")
-        self.assertEqual(record.email_provider, "postmark")
-        self.assertEqual(record.email_type, "password_reset")
-        self.assertEqual(record.recipient_email, "user@example.com")
-        self.assertEqual(record.message_stream, "outbound")
-        self.assertEqual(record.postmark_status_code, 422)
-        self.assertEqual(record.postmark_error_code, 300)
+        self.assertEqual(getattr(record, "event"), "postmark_email_send_failed")
+        self.assertEqual(getattr(record, "email_provider"), "postmark")
+        self.assertEqual(getattr(record, "email_type"), "password_reset")
+        self.assertEqual(getattr(record, "recipient_email"), "user@example.com")
+        self.assertEqual(getattr(record, "message_stream"), "outbound")
+        self.assertEqual(getattr(record, "postmark_status_code"), 422)
+        self.assertEqual(getattr(record, "postmark_error_code"), 300)
         self.assertEqual(
-            record.postmark_error_message,
+            getattr(record, "postmark_error_message"),
             "Your Postmark account is pending approval.",
         )
 
@@ -100,8 +104,8 @@ class PostmarkEmailLoggingTests(unittest.TestCase):
             )
 
         record = captured.records[0]
-        self.assertFalse(record.postmark_response_json)
-        self.assertEqual(record.postmark_response_content_type, "text/html")
+        self.assertFalse(getattr(record, "postmark_response_json"))
+        self.assertEqual(getattr(record, "postmark_response_content_type"), "text/html")
 
         logged_output = "\n".join(captured.output)
         self.assertNotIn("raw body", logged_output)


### PR DESCRIPTION
The intake/package squiggle was a type annotation mismatch, not a runtime bug: normalize_package_code() already handled None, but its signature only said str. I updated the catalog helpers to accept the loose input they already supported in package_catalog.py:707.

The mint_record_service.py warning was the only one with real bug potential. create_mint_record() could theoretically return None if a future/inconsistent canonical summary said “minted” but had no current record. I added a guard so it now either returns a real dict or raises a clear error in mint_record_service.py:767.

The email test red flags were Pylance not understanding dynamic logging extra fields. The tests were already passing, so no behavior bug there; I changed those assertions to getattr(...) so the editor should stop yelling in test_email_service.py:62.