### PR TITLE
Fixed the Tomb of Light signin flow so MFA-required admin logins no l…

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -53,6 +53,30 @@
     );
   }
 
+  function getMfaChallengeToken(loginData) {
+    return String(
+      loginData?.mfa_challenge_token || loginData?.mfaChallengeToken || "",
+    ).trim();
+  }
+
+  function isTruthyFlag(value) {
+    return value === true || value === 1 || value === "true" || value === "1";
+  }
+
+  function isMfaEnrollmentChallenge(loginData) {
+    return Boolean(
+      isTruthyFlag(loginData?.mfa_required) &&
+        isTruthyFlag(loginData?.mfa_enrollment_required) &&
+        getMfaChallengeToken(loginData),
+    );
+  }
+
+  function isMfaVerificationChallenge(loginData) {
+    return Boolean(
+      isTruthyFlag(loginData?.mfa_required) && getMfaChallengeToken(loginData),
+    );
+  }
+
   function getErrorMessage(error) {
     if (!error) return "Unknown error";
     if (typeof error === "string") return error;
@@ -592,12 +616,7 @@
     return user;
   }
 
-  async function handleLogin(email, password) {
-    const loginData = await app.apiRequest("/auth/login", {
-      method: "POST",
-      body: JSON.stringify({ email, password }),
-    });
-
+  async function completeAuthenticatedLogin(loginData) {
     const token = getAccessTokenFromResponse(loginData);
 
     if (!token) {
@@ -610,7 +629,73 @@
     const me = await fetchCurrentUserWithToken(token);
     app.saveUser(me);
 
-    return { loginData, me };
+    return { status: "authenticated", loginData, me };
+  }
+
+  async function handleLogin(email, password) {
+    const loginData = await app.apiRequest("/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (getAccessTokenFromResponse(loginData)) {
+      return await completeAuthenticatedLogin(loginData);
+    }
+
+    if (isMfaEnrollmentChallenge(loginData)) {
+      clearCachedDashboardContext();
+      app.clearSession();
+      return {
+        status: "mfa_enrollment_required",
+        loginData,
+        mfaChallengeToken: getMfaChallengeToken(loginData),
+      };
+    }
+
+    if (isMfaVerificationChallenge(loginData)) {
+      clearCachedDashboardContext();
+      app.clearSession();
+      return {
+        status: "mfa_required",
+        loginData,
+        mfaChallengeToken: getMfaChallengeToken(loginData),
+      };
+    }
+
+    throw new Error("Login succeeded but no access token was returned.");
+  }
+
+  async function beginMfaEnrollment(mfaChallengeToken) {
+    return await app.apiRequest("/auth/mfa/enroll/begin", {
+      method: "POST",
+      body: JSON.stringify({ mfa_challenge_token: mfaChallengeToken }),
+    });
+  }
+
+  async function verifyMfaEnrollment(setupToken, code) {
+    const loginData = await app.apiRequest("/auth/mfa/enroll/verify", {
+      method: "POST",
+      body: JSON.stringify({ setup_token: setupToken, code }),
+    });
+
+    return await completeAuthenticatedLogin(loginData);
+  }
+
+  async function verifyMfaLogin(mfaChallengeToken, code, recoveryCode) {
+    const payload = { mfa_challenge_token: mfaChallengeToken };
+    if (code) {
+      payload.code = code;
+    }
+    if (recoveryCode) {
+      payload.recovery_code = recoveryCode;
+    }
+
+    const loginData = await app.apiRequest("/auth/mfa/login/verify", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+
+    return await completeAuthenticatedLogin(loginData);
   }
 
   function redirectAfterLogin() {
@@ -1365,7 +1450,12 @@
           "success",
         );
 
-        await handleLogin(email, password);
+        const loginResult = await handleLogin(email, password);
+        if (loginResult.status !== "authenticated") {
+          throw new Error(
+            "Account created. Please sign in to complete secure verification.",
+          );
+        }
         redirectAfterLogin();
       } catch (error) {
         app.setStatus(
@@ -1392,6 +1482,226 @@
       (submitBtn && submitBtn.textContent
         ? submitBtn.textContent.trim()
         : "") || "Enter Portal";
+    const enrollmentPanel = document.querySelector(
+      "[data-mfa-enrollment-panel]",
+    );
+    const enrollmentSetup = document.querySelector(
+      "[data-mfa-enrollment-setup]",
+    );
+    const enrollmentVerifyArea = document.querySelector(
+      "[data-mfa-enrollment-verify-area]",
+    );
+    const enrollmentForm = document.querySelector(
+      "[data-mfa-enrollment-form]",
+    );
+    const enrollmentStatus = document.querySelector(
+      "[data-mfa-enrollment-status]",
+    );
+    const enrollmentSubmitBtn =
+      enrollmentForm && enrollmentForm.querySelector("[data-submit-btn]");
+    const enrollmentSecretNode = document.querySelector(
+      "[data-mfa-enrollment-secret]",
+    );
+    const enrollmentOtpauthNode = document.querySelector(
+      "[data-mfa-otpauth-url]",
+    );
+    const enrollmentOtpauthLink = document.querySelector(
+      "[data-mfa-otpauth-link]",
+    );
+    const backupCodesPanel = document.querySelector(
+      "[data-mfa-backup-codes-panel]",
+    );
+    const backupCodesList = document.querySelector("[data-mfa-backup-codes]");
+    const continueDashboardBtn = document.querySelector(
+      "[data-mfa-continue-dashboard]",
+    );
+    const verificationPanel = document.querySelector(
+      "[data-mfa-verification-panel]",
+    );
+    const verificationForm = document.querySelector(
+      "[data-mfa-verification-form]",
+    );
+    const verificationStatus = document.querySelector(
+      "[data-mfa-verification-status]",
+    );
+    const verificationSubmitBtn =
+      verificationForm && verificationForm.querySelector("[data-submit-btn]");
+    const resetButtons = document.querySelectorAll("[data-mfa-reset]");
+    let activeMfaChallengeToken = "";
+    let activeMfaSetupToken = "";
+
+    function setHidden(element, hidden) {
+      if (element) {
+        element.hidden = Boolean(hidden);
+      }
+    }
+
+    function normalizeMfaEntry(value) {
+      return String(value || "")
+        .trim()
+        .replace(/\s+/g, "");
+    }
+
+    function focusFirstInput(container) {
+      if (!container) return;
+      const input = container.querySelector("input, textarea, button, a");
+      if (input && typeof input.focus === "function") {
+        input.focus();
+      }
+    }
+
+    function setBusy(button, busy, busyLabel, defaultLabel) {
+      if (!button) return;
+      button.disabled = Boolean(busy);
+      button.textContent = busy ? busyLabel : defaultLabel;
+    }
+
+    function setMfaFlowVisible(flowName) {
+      const isEnrollment = flowName === "enrollment";
+      const isVerification = flowName === "verification";
+      form.hidden = isEnrollment || isVerification;
+      setHidden(enrollmentPanel, !isEnrollment);
+      setHidden(verificationPanel, !isVerification);
+      app.clearStatus(statusNode);
+    }
+
+    function resetMfaFlow() {
+      activeMfaChallengeToken = "";
+      activeMfaSetupToken = "";
+      form.hidden = false;
+      if (typeof form.reset === "function") {
+        form.reset();
+      }
+      if (enrollmentForm && typeof enrollmentForm.reset === "function") {
+        enrollmentForm.reset();
+      }
+      if (verificationForm && typeof verificationForm.reset === "function") {
+        verificationForm.reset();
+      }
+      if (enrollmentSecretNode) {
+        enrollmentSecretNode.textContent = "";
+      }
+      if (enrollmentOtpauthNode) {
+        enrollmentOtpauthNode.value = "";
+      }
+      if (enrollmentOtpauthLink) {
+        enrollmentOtpauthLink.removeAttribute("href");
+      }
+      if (backupCodesList) {
+        backupCodesList.innerHTML = "";
+      }
+      setHidden(enrollmentPanel, true);
+      setHidden(verificationPanel, true);
+      setHidden(enrollmentSetup, false);
+      setHidden(enrollmentVerifyArea, true);
+      setHidden(backupCodesPanel, true);
+      app.clearStatus(statusNode);
+      app.clearStatus(enrollmentStatus);
+      app.clearStatus(verificationStatus);
+      setBusy(submitBtn, false, "Signing In...", defaultSubmitLabel);
+      setBusy(
+        enrollmentSubmitBtn,
+        false,
+        "Verifying...",
+        "Activate MFA",
+      );
+      setBusy(
+        verificationSubmitBtn,
+        false,
+        "Verifying...",
+        "Verify and Enter Portal",
+      );
+    }
+
+    async function startMfaEnrollment(mfaChallengeToken) {
+      activeMfaChallengeToken = mfaChallengeToken;
+      activeMfaSetupToken = "";
+      setMfaFlowVisible("enrollment");
+      setHidden(enrollmentSetup, false);
+      setHidden(enrollmentVerifyArea, true);
+      setHidden(backupCodesPanel, true);
+      app.setStatus(
+        enrollmentStatus,
+        "Preparing your authenticator setup...",
+        "info",
+      );
+
+      try {
+        const setupData = await beginMfaEnrollment(activeMfaChallengeToken);
+        activeMfaSetupToken = String(setupData?.setup_token || "").trim();
+        if (!activeMfaSetupToken) {
+          throw new Error("MFA setup could not be started.");
+        }
+
+        const secret = String(setupData?.secret || "").trim();
+        const otpauthUrl = String(setupData?.otpauth_url || "").trim();
+        if (enrollmentSecretNode) {
+          enrollmentSecretNode.textContent = secret || "Unavailable";
+        }
+        if (enrollmentOtpauthNode) {
+          enrollmentOtpauthNode.value = otpauthUrl;
+        }
+        if (enrollmentOtpauthLink && otpauthUrl) {
+          enrollmentOtpauthLink.href = otpauthUrl;
+        }
+
+        setHidden(enrollmentVerifyArea, false);
+        app.setStatus(
+          enrollmentStatus,
+          "Add this key to your authenticator app, then enter the first code it creates.",
+          "info",
+        );
+        focusFirstInput(enrollmentVerifyArea);
+      } catch (error) {
+        app.setStatus(
+          enrollmentStatus,
+          getErrorMessage(error) || "MFA enrollment could not be started.",
+          "error",
+        );
+      }
+    }
+
+    function startMfaVerification(mfaChallengeToken) {
+      activeMfaChallengeToken = mfaChallengeToken;
+      setMfaFlowVisible("verification");
+      app.setStatus(
+        verificationStatus,
+        "Enter an authenticator code or one recovery code to continue.",
+        "info",
+      );
+      focusFirstInput(verificationPanel);
+    }
+
+    function showBackupCodes(backupCodes) {
+      const codes = Array.isArray(backupCodes) ? backupCodes : [];
+      if (backupCodesList) {
+        backupCodesList.innerHTML = "";
+        if (codes.length) {
+          codes.forEach(function (code) {
+            const item = document.createElement("li");
+            item.textContent = code;
+            backupCodesList.appendChild(item);
+          });
+        } else {
+          const item = document.createElement("li");
+          item.textContent =
+            "No backup codes were returned for this session.";
+          backupCodesList.appendChild(item);
+        }
+      }
+
+      setHidden(enrollmentSetup, true);
+      setHidden(enrollmentVerifyArea, true);
+      setHidden(backupCodesPanel, false);
+      app.setStatus(
+        enrollmentStatus,
+        "MFA is active. Keep these recovery codes before opening the dashboard.",
+        "success",
+      );
+      if (continueDashboardBtn && typeof continueDashboardBtn.focus === "function") {
+        continueDashboardBtn.focus();
+      }
+    }
 
     form.addEventListener("submit", async function (event) {
       event.preventDefault();
@@ -1422,9 +1732,24 @@
       }
 
       try {
-        await handleLogin(email, password);
-        app.setStatus(statusNode, "Portal access granted.", "success");
-        redirectAfterLogin();
+        const loginResult = await handleLogin(email, password);
+        if (loginResult.status === "authenticated") {
+          app.setStatus(statusNode, "Portal access granted.", "success");
+          redirectAfterLogin();
+          return;
+        }
+
+        if (loginResult.status === "mfa_enrollment_required") {
+          await startMfaEnrollment(loginResult.mfaChallengeToken);
+          return;
+        }
+
+        if (loginResult.status === "mfa_required") {
+          startMfaVerification(loginResult.mfaChallengeToken);
+          return;
+        }
+
+        throw new Error("Login could not be completed.");
       } catch (error) {
         app.setStatus(
           statusNode,
@@ -1438,6 +1763,135 @@
         }
       }
     });
+
+    if (enrollmentForm) {
+      enrollmentForm.addEventListener("submit", async function (event) {
+        event.preventDefault();
+        app.clearStatus(enrollmentStatus);
+
+        if (
+          typeof enrollmentForm.reportValidity === "function" &&
+          !enrollmentForm.reportValidity()
+        ) {
+          return;
+        }
+
+        const formData = new FormData(enrollmentForm);
+        const code = normalizeMfaEntry(formData.get("code"));
+
+        if (!activeMfaSetupToken) {
+          app.setStatus(
+            enrollmentStatus,
+            "MFA setup has expired. Please sign in again.",
+            "error",
+          );
+          return;
+        }
+
+        if (!code) {
+          app.setStatus(
+            enrollmentStatus,
+            "Enter the code from your authenticator app.",
+            "error",
+          );
+          return;
+        }
+
+        setBusy(enrollmentSubmitBtn, true, "Verifying...", "Activate MFA");
+
+        try {
+          const result = await verifyMfaEnrollment(activeMfaSetupToken, code);
+          showBackupCodes(result.loginData?.backup_codes);
+        } catch (error) {
+          app.setStatus(
+            enrollmentStatus,
+            getErrorMessage(error) || "MFA enrollment could not be verified.",
+            "error",
+          );
+        } finally {
+          setBusy(enrollmentSubmitBtn, false, "Verifying...", "Activate MFA");
+        }
+      });
+    }
+
+    if (verificationForm) {
+      verificationForm.addEventListener("submit", async function (event) {
+        event.preventDefault();
+        app.clearStatus(verificationStatus);
+
+        if (
+          typeof verificationForm.reportValidity === "function" &&
+          !verificationForm.reportValidity()
+        ) {
+          return;
+        }
+
+        const formData = new FormData(verificationForm);
+        const code = normalizeMfaEntry(formData.get("code"));
+        const recoveryCode = normalizeMfaEntry(formData.get("recovery_code"));
+
+        if (!activeMfaChallengeToken) {
+          app.setStatus(
+            verificationStatus,
+            "MFA verification has expired. Please sign in again.",
+            "error",
+          );
+          return;
+        }
+
+        if (!code && !recoveryCode) {
+          app.setStatus(
+            verificationStatus,
+            "Enter an authenticator code or recovery code.",
+            "error",
+          );
+          return;
+        }
+
+        if (code && recoveryCode) {
+          app.setStatus(
+            verificationStatus,
+            "Use either an authenticator code or a recovery code.",
+            "error",
+          );
+          return;
+        }
+
+        setBusy(
+          verificationSubmitBtn,
+          true,
+          "Verifying...",
+          "Verify and Enter Portal",
+        );
+
+        try {
+          await verifyMfaLogin(activeMfaChallengeToken, code, recoveryCode);
+          app.setStatus(verificationStatus, "Portal access granted.", "success");
+          redirectAfterLogin();
+        } catch (error) {
+          app.setStatus(
+            verificationStatus,
+            getErrorMessage(error) || "MFA verification failed.",
+            "error",
+          );
+        } finally {
+          setBusy(
+            verificationSubmitBtn,
+            false,
+            "Verifying...",
+            "Verify and Enter Portal",
+          );
+        }
+      });
+    }
+
+    resetButtons.forEach(function (button) {
+      button.addEventListener("click", resetMfaFlow);
+    });
+
+    if (continueDashboardBtn) {
+      continueDashboardBtn.addEventListener("click", redirectAfterLogin);
+    }
   }
 
   async function setupDashboard() {

--- a/signin.html
+++ b/signin.html
@@ -8,7 +8,7 @@
       name="description"
       content="Enter your private Tomb of Light customer or operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260412-1" />
+    <link rel="stylesheet" href="styles.css?v=20260413-1" />
   </head>
   <body class="portal-login-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -183,6 +183,176 @@
                 </div>
               </form>
 
+              <section
+                class="portal-mfa-panel"
+                data-mfa-enrollment-panel
+                hidden
+                aria-label="Authenticator enrollment"
+              >
+                <div data-mfa-enrollment-setup>
+                  <div class="portal-mfa-top">
+                    <span class="eyebrow">Operations Verification</span>
+                    <h3>Set up your authenticator.</h3>
+                    <p>
+                      Add Tomb of Light to your authenticator app, then enter
+                      the first code it creates for this account.
+                    </p>
+                  </div>
+
+                  <div class="portal-mfa-secret-card">
+                    <span>Manual setup key</span>
+                    <code data-mfa-enrollment-secret></code>
+                  </div>
+
+                  <label class="portal-mfa-url-field">
+                    Authenticator setup URL
+                    <textarea
+                      data-mfa-otpauth-url
+                      rows="3"
+                      readonly
+                    ></textarea>
+                  </label>
+
+                  <div class="inline-actions">
+                    <button class="btn btn-secondary" type="button" data-mfa-reset>
+                      Use Another Account
+                    </button>
+                  </div>
+                </div>
+
+                <div
+                  class="helper"
+                  data-mfa-enrollment-status
+                  aria-live="polite"
+                  style="display: none"
+                ></div>
+
+                <form
+                  class="form-grid portal-mfa-form"
+                  data-mfa-enrollment-form
+                  data-mfa-enrollment-verify-area
+                  hidden
+                  novalidate
+                >
+                  <label>
+                    First Authenticator Code
+                    <input
+                      type="text"
+                      name="code"
+                      placeholder="123456"
+                      inputmode="numeric"
+                      autocomplete="one-time-code"
+                      pattern="[0-9]{6,12}"
+                      maxlength="12"
+                      required
+                    />
+                  </label>
+
+                  <div class="inline-actions">
+                    <button class="btn btn-primary" type="submit" data-submit-btn>
+                      Activate MFA
+                    </button>
+                    <button class="btn btn-secondary" type="button" data-mfa-reset>
+                      Use Another Account
+                    </button>
+                  </div>
+                </form>
+
+                <div
+                  class="portal-mfa-backup"
+                  data-mfa-backup-codes-panel
+                  hidden
+                >
+                  <div class="portal-mfa-top">
+                    <span class="eyebrow">Recovery Access</span>
+                    <h3>Save these recovery codes now.</h3>
+                    <p>
+                      Each code can unlock this operations account once if your
+                      authenticator is unavailable. Tomb of Light will not show
+                      them again.
+                    </p>
+                  </div>
+
+                  <ol class="portal-mfa-code-list" data-mfa-backup-codes></ol>
+
+                  <div class="inline-actions">
+                    <button
+                      class="btn btn-primary"
+                      type="button"
+                      data-mfa-continue-dashboard
+                    >
+                      Continue to Dashboard
+                    </button>
+                  </div>
+                </div>
+              </section>
+
+              <section
+                class="portal-mfa-panel"
+                data-mfa-verification-panel
+                hidden
+                aria-label="Authenticator verification"
+              >
+                <div class="portal-mfa-top">
+                  <span class="eyebrow">Operations Verification</span>
+                  <h3>Verify your secure access.</h3>
+                  <p>
+                    Enter a current authenticator code, or use one recovery code
+                    to open your internal workspace.
+                  </p>
+                </div>
+
+                <form
+                  class="form-grid portal-mfa-form"
+                  data-mfa-verification-form
+                  novalidate
+                >
+                  <label>
+                    Authenticator Code
+                    <input
+                      type="text"
+                      name="code"
+                      placeholder="123456"
+                      inputmode="numeric"
+                      autocomplete="one-time-code"
+                      pattern="[0-9]{6,12}"
+                      maxlength="12"
+                    />
+                  </label>
+
+                  <div class="portal-mfa-choice" aria-hidden="true">
+                    or use a recovery code
+                  </div>
+
+                  <label>
+                    Recovery Code
+                    <input
+                      type="text"
+                      name="recovery_code"
+                      placeholder="Enter recovery code"
+                      autocomplete="one-time-code"
+                      maxlength="64"
+                    />
+                  </label>
+
+                  <div
+                    class="helper"
+                    data-mfa-verification-status
+                    aria-live="polite"
+                    style="display: none"
+                  ></div>
+
+                  <div class="inline-actions">
+                    <button class="btn btn-primary" type="submit" data-submit-btn>
+                      Verify and Enter Portal
+                    </button>
+                    <button class="btn btn-secondary" type="button" data-mfa-reset>
+                      Use Another Account
+                    </button>
+                  </div>
+                </form>
+              </section>
+
               <div class="portal-access-footer">
                 <div class="portal-access-note">
                   <strong>Customer access:</strong> portrait, household,
@@ -269,6 +439,6 @@
 
     <script src="config.js?v=20260328-8"></script>
     <script src="app.js?v=20260410-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="auth.js?v=20260413-1"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1987,6 +1987,118 @@ textarea {
   box-shadow: 0 0 0 4px rgba(120, 217, 255, 0.14);
 }
 
+.portal-access-form[hidden],
+.portal-mfa-panel[hidden],
+.portal-mfa-form[hidden],
+.portal-mfa-backup[hidden],
+[data-mfa-enrollment-setup][hidden] {
+  display: none;
+}
+
+.portal-mfa-panel {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+  border: 1px solid rgba(138, 169, 213, 0.16);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at top right, rgba(120, 217, 255, 0.07), transparent 44%),
+    rgba(255, 255, 255, 0.025);
+}
+
+.portal-mfa-top {
+  display: grid;
+  gap: 10px;
+}
+
+.portal-mfa-top h3 {
+  margin: 0;
+  font-size: 1.55rem;
+  letter-spacing: 0;
+}
+
+.portal-mfa-top p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.portal-mfa-secret-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid rgba(214, 176, 102, 0.24);
+  border-radius: 8px;
+  background: rgba(214, 176, 102, 0.07);
+}
+
+.portal-mfa-secret-card span,
+.portal-mfa-url-field {
+  color: var(--muted-2);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.portal-mfa-secret-card code,
+.portal-mfa-code-list li {
+  color: var(--text);
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.portal-mfa-url-field {
+  display: grid;
+  gap: 8px;
+}
+
+.portal-mfa-url-field textarea {
+  min-height: 92px;
+  background: rgba(4, 11, 22, 0.84);
+  border-color: rgba(138, 169, 213, 0.18);
+  color: var(--text);
+  font-family:
+    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.88rem;
+  letter-spacing: 0;
+}
+
+.portal-mfa-url-field textarea:focus {
+  border-color: var(--portal-accent);
+  box-shadow: 0 0 0 4px rgba(120, 217, 255, 0.14);
+}
+
+.portal-mfa-form,
+.portal-mfa-backup {
+  display: grid;
+  gap: 18px;
+}
+
+.portal-mfa-choice {
+  color: var(--muted-2);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.portal-mfa-code-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.portal-mfa-code-list li {
+  padding: 12px;
+  border: 1px solid rgba(138, 169, 213, 0.16);
+  border-radius: 8px;
+  background: rgba(4, 11, 22, 0.74);
+}
+
 .portal-access-footer {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
…onger fail with “Login succeeded but no access token was returned.” Normal customer login still goes straight to the dashboard, while internal admin accounts now branch into MFA enrollment or MFA verification as required.

The login handler now recognizes three successful /auth/login outcomes:

access_token present: saves the token, fetches /auth/me, saves the user session, and redirects to dashboard.html. mfa_required=true, mfa_enrollment_required=true, and mfa_challenge_token present: starts MFA enrollment by calling /auth/mfa/enroll/begin, shows the authenticator setup secret and URL, verifies the first 6-digit code through /auth/mfa/enroll/verify, saves the returned session, displays backup codes once, then continues to the dashboard. mfa_required=true and mfa_challenge_token present: shows MFA verification UI with authenticator-code and recovery-code options, verifies through /auth/mfa/login/verify, saves the returned session, and redirects to the dashboard. Also added hidden MFA enrollment and verification panels to signin.html, plus matching portal-styled CSS so the new flow fits the existing premium Tomb of Light design. Validation passed for JS syntax, diff whitespace, targeted backend security tests, and a local harness covering normal login, enrollment challenge, and verification challenge branches.