### PR TITLE
MFA enrollment is optional, not mandatory.

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -8,7 +8,7 @@
       name="description"
       content="Reset or change your Tomb of Light password through the protected account security layer."
     />
-    <link rel="stylesheet" href="styles.css?v=20260331-2" />
+    <link rel="stylesheet" href="styles.css?v=20260413-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="page-wrap">
@@ -221,6 +221,150 @@
                 aria-live="polite"
               ></div>
             </div>
+
+            <div class="form-panel" data-mfa-settings-panel>
+              <span class="eyebrow">Authenticator MFA</span>
+              <p class="card-copy" data-mfa-settings-intro>
+                Sign in to choose whether your account requires an
+                authenticator code at login.
+              </p>
+
+              <div
+                class="helper"
+                data-mfa-settings-status
+                style="display: none; margin-top: 1rem"
+                aria-live="polite"
+              ></div>
+
+              <div data-mfa-disabled-controls hidden>
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    data-mfa-start-enrollment
+                  >
+                    Set Up Authenticator
+                  </button>
+                </div>
+              </div>
+
+              <div class="portal-mfa-panel" data-mfa-setup-panel hidden>
+                <div class="portal-mfa-top">
+                  <h3>Set up your authenticator.</h3>
+                  <p>
+                    Add Tomb of Light to your authenticator app, then enter the
+                    first code it creates.
+                  </p>
+                </div>
+
+                <div class="portal-mfa-secret-card">
+                  <span>Manual setup key</span>
+                  <code data-mfa-enrollment-secret></code>
+                </div>
+
+                <label class="portal-mfa-url-field">
+                  Authenticator setup URL
+                  <textarea
+                    data-mfa-otpauth-url
+                    rows="3"
+                    readonly
+                  ></textarea>
+                </label>
+
+                <form class="form-grid portal-mfa-form" data-mfa-enrollment-form novalidate>
+                  <label>
+                    First Authenticator Code
+                    <input
+                      type="text"
+                      name="code"
+                      placeholder="123456"
+                      inputmode="numeric"
+                      autocomplete="one-time-code"
+                      pattern="[0-9]{6,12}"
+                      maxlength="12"
+                      required
+                    />
+                  </label>
+
+                  <div class="inline-actions" style="margin-top: 1rem">
+                    <button class="btn btn-primary" type="submit">
+                      Activate MFA
+                    </button>
+                    <button class="btn btn-secondary" type="button" data-mfa-cancel-setup>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              </div>
+
+              <div
+                class="portal-mfa-backup"
+                data-mfa-backup-codes-panel
+                hidden
+                style="margin-top: 1rem"
+              >
+                <div class="portal-mfa-top">
+                  <h3>Save these recovery codes now.</h3>
+                  <p>
+                    Each code can unlock this account once if your
+                    authenticator is unavailable. Tomb of Light will not show
+                    them again.
+                  </p>
+                </div>
+
+                <ol class="portal-mfa-code-list" data-mfa-backup-codes></ol>
+              </div>
+
+              <div data-mfa-enabled-controls hidden>
+                <p class="card-copy" style="margin-top: 1rem">
+                  MFA is active for this account. You will be asked for an
+                  authenticator code when signing in.
+                </p>
+
+                <form class="form-grid" data-mfa-disable-form novalidate>
+                  <label>
+                    Current Password
+                    <input
+                      type="password"
+                      name="current_password"
+                      placeholder="Enter your current password"
+                      autocomplete="current-password"
+                      required
+                    />
+                  </label>
+
+                  <label>
+                    Authenticator Code
+                    <input
+                      type="text"
+                      name="code"
+                      placeholder="123456"
+                      inputmode="numeric"
+                      autocomplete="one-time-code"
+                      pattern="[0-9]{6,12}"
+                      maxlength="12"
+                    />
+                  </label>
+
+                  <label>
+                    Recovery Code
+                    <input
+                      type="text"
+                      name="recovery_code"
+                      placeholder="Enter recovery code"
+                      autocomplete="one-time-code"
+                      maxlength="64"
+                    />
+                  </label>
+
+                  <div class="inline-actions" style="margin-top: 1rem">
+                    <button class="btn btn-secondary" type="submit">
+                      Disable MFA
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
           </div>
         </section>
       </main>
@@ -251,7 +395,7 @@
 
     <script src="config.js?v=20260331-2"></script>
     <script src="app.js?v=20260410-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
-    <script src="account-security.js?v=20260412-1"></script>
+    <script src="auth.js?v=20260413-3"></script>
+    <script src="account-security.js?v=20260413-1"></script>
   </body>
 </html>

--- a/account-security.js
+++ b/account-security.js
@@ -22,6 +22,7 @@
     mode: query("mode").toLowerCase(),
     token: query("token"),
   };
+  let signedInUser = null;
 
   function hasResetTokenFromEmailLink() {
     return resetState.mode === "reset" && resetState.token.length >= 16;
@@ -105,6 +106,7 @@
     const introNode = document.querySelector("[data-password-change-intro]");
     try {
       const me = await app.fetchCurrentUser();
+      signedInUser = me;
       if (introNode) {
         introNode.textContent =
           "You are signed in. Use this form to change your Tomb of Light password directly inside the protected workspace.";
@@ -115,7 +117,303 @@
         introNode.textContent =
           "Sign in first if you want to change your password from inside the protected workspace. Password reset links still work here without a live session.";
       }
+      signedInUser = null;
       return null;
+    }
+  }
+
+  function normalizeMfaEntry(value) {
+    return String(value || "")
+      .trim()
+      .replace(/\s+/g, "");
+  }
+
+  function setHidden(element, hidden) {
+    if (element) {
+      element.hidden = Boolean(hidden);
+    }
+  }
+
+  function setButtonBusy(button, busy, busyLabel, defaultLabel) {
+    if (!button) return;
+    button.disabled = Boolean(busy);
+    button.textContent = busy ? busyLabel : defaultLabel;
+  }
+
+  function renderMfaState(user) {
+    const introNode = document.querySelector("[data-mfa-settings-intro]");
+    const statusNode = document.querySelector("[data-mfa-settings-status]");
+    const disabledControls = document.querySelector("[data-mfa-disabled-controls]");
+    const enabledControls = document.querySelector("[data-mfa-enabled-controls]");
+    const setupPanel = document.querySelector("[data-mfa-setup-panel]");
+    const backupPanel = document.querySelector("[data-mfa-backup-codes-panel]");
+
+    setHidden(setupPanel, true);
+    setHidden(backupPanel, true);
+
+    if (!user) {
+      if (introNode) {
+        introNode.textContent =
+          "Sign in to choose whether your account requires an authenticator code at login.";
+      }
+      setHidden(disabledControls, true);
+      setHidden(enabledControls, true);
+      app.setStatus(
+        statusNode,
+        "Sign in before changing authenticator settings.",
+        "info",
+      );
+      return;
+    }
+
+    app.clearStatus(statusNode);
+
+    if (user.mfa_enabled) {
+      if (introNode) {
+        introNode.textContent =
+          "Authenticator verification is currently enabled for this account.";
+      }
+      setHidden(disabledControls, true);
+      setHidden(enabledControls, false);
+      return;
+    }
+
+    if (introNode) {
+      introNode.textContent =
+        "Authenticator verification is optional. You can enable it here whenever you want an extra sign-in step.";
+    }
+    setHidden(disabledControls, false);
+    setHidden(enabledControls, true);
+  }
+
+  async function refreshMfaUserState() {
+    try {
+      signedInUser = await app.fetchCurrentUser();
+    } catch (_error) {
+      signedInUser = null;
+    }
+    renderMfaState(signedInUser);
+    return signedInUser;
+  }
+
+  function showBackupCodes(codes) {
+    const backupPanel = document.querySelector("[data-mfa-backup-codes-panel]");
+    const backupList = document.querySelector("[data-mfa-backup-codes]");
+    if (backupList) {
+      backupList.innerHTML = "";
+      const backupCodes = Array.isArray(codes) ? codes : [];
+      if (!backupCodes.length) {
+        const item = document.createElement("li");
+        item.textContent = "No recovery codes were returned for this session.";
+        backupList.appendChild(item);
+      }
+      backupCodes.forEach(function (code) {
+        const item = document.createElement("li");
+        item.textContent = code;
+        backupList.appendChild(item);
+      });
+    }
+    setHidden(backupPanel, false);
+  }
+
+  function setupMfaControls() {
+    const startButton = document.querySelector("[data-mfa-start-enrollment]");
+    const cancelButton = document.querySelector("[data-mfa-cancel-setup]");
+    const setupPanel = document.querySelector("[data-mfa-setup-panel]");
+    const disabledControls = document.querySelector("[data-mfa-disabled-controls]");
+    const enrollmentForm = document.querySelector("[data-mfa-enrollment-form]");
+    const disableForm = document.querySelector("[data-mfa-disable-form]");
+    const statusNode = document.querySelector("[data-mfa-settings-status]");
+    const secretNode = document.querySelector("[data-mfa-enrollment-secret]");
+    const otpauthNode = document.querySelector("[data-mfa-otpauth-url]");
+    let setupToken = "";
+
+    if (startButton) {
+      const defaultLabel = startButton.textContent.trim() || "Set Up Authenticator";
+      startButton.addEventListener("click", async function () {
+        app.clearStatus(statusNode);
+        setButtonBusy(startButton, true, "Preparing...", defaultLabel);
+
+        try {
+          const payload = await app.apiRequest("/auth/mfa/enroll/begin-session", {
+            method: "POST",
+            body: JSON.stringify({}),
+          });
+          setupToken = String(payload?.setup_token || "").trim();
+          if (!setupToken) {
+            throw new Error("Authenticator setup could not be started.");
+          }
+
+          if (secretNode) {
+            secretNode.textContent = String(payload?.secret || "").trim();
+          }
+          if (otpauthNode) {
+            otpauthNode.value = String(payload?.otpauth_url || "").trim();
+          }
+
+          setHidden(disabledControls, true);
+          setHidden(setupPanel, false);
+          app.setStatus(
+            statusNode,
+            "Add this key to your authenticator app, then enter the first code it creates.",
+            "info",
+          );
+        } catch (error) {
+          app.setStatus(
+            statusNode,
+            getErrorMessage(error) || "Unable to start authenticator setup.",
+            "error",
+          );
+        } finally {
+          setButtonBusy(startButton, false, "Preparing...", defaultLabel);
+        }
+      });
+    }
+
+    if (cancelButton) {
+      cancelButton.addEventListener("click", function () {
+        setupToken = "";
+        if (enrollmentForm && typeof enrollmentForm.reset === "function") {
+          enrollmentForm.reset();
+        }
+        if (secretNode) {
+          secretNode.textContent = "";
+        }
+        if (otpauthNode) {
+          otpauthNode.value = "";
+        }
+        setHidden(setupPanel, true);
+        setHidden(disabledControls, false);
+        app.clearStatus(statusNode);
+      });
+    }
+
+    if (enrollmentForm) {
+      const submitButton = enrollmentForm.querySelector('button[type="submit"]');
+      const defaultLabel =
+        (submitButton && submitButton.textContent.trim()) || "Activate MFA";
+
+      enrollmentForm.addEventListener("submit", async function (event) {
+        event.preventDefault();
+        app.clearStatus(statusNode);
+
+        if (
+          typeof enrollmentForm.reportValidity === "function" &&
+          !enrollmentForm.reportValidity()
+        ) {
+          return;
+        }
+
+        const formData = new FormData(enrollmentForm);
+        const code = normalizeMfaEntry(formData.get("code"));
+        if (!setupToken) {
+          app.setStatus(
+            statusNode,
+            "Authenticator setup has expired. Start setup again.",
+            "error",
+          );
+          return;
+        }
+        if (!code) {
+          app.setStatus(statusNode, "Enter the authenticator code.", "error");
+          return;
+        }
+
+        setButtonBusy(submitButton, true, "Activating...", defaultLabel);
+
+        try {
+          const payload = await app.apiRequest("/auth/mfa/enroll/verify", {
+            method: "POST",
+            body: JSON.stringify({ setup_token: setupToken, code }),
+          });
+          const token = String(payload?.access_token || "").trim();
+          if (token) {
+            app.saveToken(token);
+          }
+          setupToken = "";
+          if (typeof enrollmentForm.reset === "function") {
+            enrollmentForm.reset();
+          }
+          await refreshMfaUserState();
+          showBackupCodes(payload?.backup_codes);
+          app.setStatus(
+            statusNode,
+            "Authenticator MFA is active. Save your recovery codes now.",
+            "success",
+          );
+        } catch (error) {
+          app.setStatus(
+            statusNode,
+            getErrorMessage(error) || "Unable to activate authenticator MFA.",
+            "error",
+          );
+        } finally {
+          setButtonBusy(submitButton, false, "Activating...", defaultLabel);
+        }
+      });
+    }
+
+    if (disableForm) {
+      const submitButton = disableForm.querySelector('button[type="submit"]');
+      const defaultLabel =
+        (submitButton && submitButton.textContent.trim()) || "Disable MFA";
+
+      disableForm.addEventListener("submit", async function (event) {
+        event.preventDefault();
+        app.clearStatus(statusNode);
+
+        const formData = new FormData(disableForm);
+        const currentPassword = String(formData.get("current_password") || "");
+        const code = normalizeMfaEntry(formData.get("code"));
+        const recoveryCode = normalizeMfaEntry(formData.get("recovery_code"));
+
+        if (!currentPassword) {
+          app.setStatus(statusNode, "Current password is required.", "error");
+          return;
+        }
+        if (!code && !recoveryCode) {
+          app.setStatus(
+            statusNode,
+            "Enter an authenticator code or recovery code.",
+            "error",
+          );
+          return;
+        }
+        if (code && recoveryCode) {
+          app.setStatus(
+            statusNode,
+            "Use either an authenticator code or a recovery code.",
+            "error",
+          );
+          return;
+        }
+
+        setButtonBusy(submitButton, true, "Disabling...", defaultLabel);
+
+        try {
+          await app.apiRequest("/auth/mfa/disable", {
+            method: "POST",
+            body: JSON.stringify({
+              current_password: currentPassword,
+              code: code || null,
+              recovery_code: recoveryCode || null,
+            }),
+          });
+          if (typeof disableForm.reset === "function") {
+            disableForm.reset();
+          }
+          await refreshMfaUserState();
+          app.setStatus(statusNode, "Authenticator MFA is disabled.", "success");
+        } catch (error) {
+          app.setStatus(
+            statusNode,
+            getErrorMessage(error) || "Unable to disable authenticator MFA.",
+            "error",
+          );
+        } finally {
+          setButtonBusy(submitButton, false, "Disabling...", defaultLabel);
+        }
+      });
     }
   }
 
@@ -284,9 +582,11 @@
   document.addEventListener("DOMContentLoaded", async function () {
     setupResetModeUi();
     await populateSignedInState();
+    renderMfaState(signedInUser);
     setupResetRequestForm();
     setupResetConfirmForm();
     setupPasswordChangeForm();
+    setupMfaControls();
     focusResetFormFromLink();
   });
 })();

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -434,12 +434,9 @@ def get_current_user(
             detail="Session has been revoked. Please log in again.",
         )
 
-    if _has_internal_admin_access(normalized_user):
-        if not bool(normalized_user.get("mfa_enabled")):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="MFA enrollment is required for internal admin access.",
-            )
+    if _has_internal_admin_access(normalized_user) and bool(
+        normalized_user.get("mfa_enabled")
+    ):
         if not bool(payload.get("mfa")):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -24,6 +24,7 @@ from app.services.auth_service import (
     admin_issue_password_reset,
     authenticate_user,
     begin_mfa_enrollment,
+    begin_mfa_enrollment_for_user,
     build_user_response,
     change_password,
     disable_mfa_for_user,
@@ -233,6 +234,22 @@ def issue_csrf_token(request: Request, response: Response, current_user: dict = 
 def mfa_enroll_begin(payload: MfaEnrollmentBeginRequest, response: Response):
     try:
         result = begin_mfa_enrollment(payload.mfa_challenge_token)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _apply_no_store(response)
+    return result
+
+
+@router.post("/mfa/enroll/begin-session")
+def mfa_enroll_begin_session(
+    response: Response,
+    current_user: dict = Depends(get_current_user),
+):
+    user = get_user_by_id(_current_user_id(current_user))
+    if not user:
+        raise HTTPException(status_code=404, detail="User account not found.")
+    try:
+        result = begin_mfa_enrollment_for_user(user)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     _apply_no_store(response)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -98,6 +98,8 @@ class UserResponse(BaseModel):
     access_tier: Optional[str] = None
     department_role: Optional[str] = None
     status: str
+    mfa_enabled: bool = False
+    mfa_enrolled_at: Optional[str] = None
     created_at: str
 
     policy_version: Optional[str] = None

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -19,7 +19,6 @@ from app.core.security import (
     hash_password,
     verify_password,
 )
-from app.core.role_catalog import has_internal_admin_role
 from app.database import get_database
 from app.schemas.auth import UserCreate
 from app.services.audit_log_service import create_audit_log
@@ -76,17 +75,6 @@ def _session_version(user: dict) -> int:
         return max(0, int(user.get("session_token_version") or 0))
     except Exception:
         return 0
-
-
-def _is_internal_admin_user(user: dict) -> bool:
-    return has_internal_admin_role(
-        (
-            user.get("role"),
-            user.get("access_tier"),
-            user.get("department_role"),
-            user.get("account_type"),
-        )
-    )
 
 
 def _mfa_encrypt_secret(secret: str, *, user_id: str) -> str:
@@ -208,6 +196,8 @@ def build_user_response(user: dict) -> dict:
         "access_tier": user.get("access_tier"),
         "department_role": user.get("department_role"),
         "status": user.get("status", "active"),
+        "mfa_enabled": bool(user.get("mfa_enabled")),
+        "mfa_enrolled_at": user.get("mfa_enrolled_at"),
         "created_at": user["created_at"],
         "policy_version": user.get("policy_version"),
         "terms_accepted_at": user.get("terms_accepted_at"),
@@ -371,23 +361,7 @@ def authenticate_user(email: str, password: str) -> dict[str, Any] | None:
     if not password_hash or not verify_password(password, password_hash):
         return None
 
-    is_internal_admin = _is_internal_admin_user(user)
     mfa_enabled = bool(user.get("mfa_enabled"))
-    if is_internal_admin and not mfa_enabled:
-        challenge = create_access_token(
-            {
-                "sub": user["email"],
-                "user_id": str(user["_id"]),
-                "purpose": "mfa_enroll",
-                "tv": _session_version(user),
-            },
-            expires_minutes=max(2, int(settings.mfa_challenge_expire_minutes or 10)),
-        )
-        return {
-            "status": "mfa_enrollment_required",
-            "mfa_challenge_token": challenge,
-        }
-
     if mfa_enabled:
         challenge = create_access_token(
             {
@@ -455,16 +429,17 @@ def _consume_recovery_code(user: dict, code: str) -> bool:
     return True
 
 
-def begin_mfa_enrollment(challenge_token: str) -> dict[str, Any]:
-    payload = decode_access_token(_normalize_text(challenge_token))
-    if not payload or _normalize_text(payload.get("purpose")) != "mfa_enroll":
-        raise ValueError("Invalid MFA challenge token.")
-    user = get_user_by_email(_normalize_text(payload.get("sub")).lower())
+def _begin_mfa_enrollment_for_user_document(user: dict) -> dict[str, Any]:
     if not user:
         raise ValueError("User not found.")
-    user_id = str(user.get("_id") or "")
-    if _normalize_text(payload.get("user_id")) != user_id:
-        raise ValueError("Invalid MFA challenge token.")
+    if bool(user.get("mfa_enabled")):
+        raise ValueError("MFA is already enabled for this account.")
+
+    user_id = _current_user_id_from_doc(user)
+    email = _normalize_text(user.get("email")).lower()
+    if not user_id or not email:
+        raise ValueError("User account is incomplete.")
+
     secret = _generate_totp_secret()
     now_iso = _now_iso()
     db = get_database()
@@ -479,7 +454,7 @@ def begin_mfa_enrollment(challenge_token: str) -> dict[str, Any]:
     )
     setup_token = create_access_token(
         {
-            "sub": user["email"],
+            "sub": email,
             "user_id": user_id,
             "purpose": "mfa_enroll_verify",
             "tv": _session_version(user),
@@ -489,8 +464,25 @@ def begin_mfa_enrollment(challenge_token: str) -> dict[str, Any]:
     return {
         "setup_token": setup_token,
         "secret": secret,
-        "otpauth_url": _build_mfa_otpauth_uri(secret, email=user["email"]),
+        "otpauth_url": _build_mfa_otpauth_uri(secret, email=email),
     }
+
+
+def begin_mfa_enrollment(challenge_token: str) -> dict[str, Any]:
+    payload = decode_access_token(_normalize_text(challenge_token))
+    if not payload or _normalize_text(payload.get("purpose")) != "mfa_enroll":
+        raise ValueError("Invalid MFA challenge token.")
+    user = get_user_by_email(_normalize_text(payload.get("sub")).lower())
+    if not user:
+        raise ValueError("User not found.")
+    user_id = str(user.get("_id") or "")
+    if _normalize_text(payload.get("user_id")) != user_id:
+        raise ValueError("Invalid MFA challenge token.")
+    return _begin_mfa_enrollment_for_user_document(user)
+
+
+def begin_mfa_enrollment_for_user(user: dict) -> dict[str, Any]:
+    return _begin_mfa_enrollment_for_user_document(user)
 
 
 def verify_mfa_enrollment(setup_token: str, code: str) -> dict[str, Any]:
@@ -614,10 +606,6 @@ def disable_mfa_for_user(
     recovery_code: str | None,
     actor_user_id: str,
 ) -> None:
-    if _is_internal_admin_user(user):
-        raise ValueError(
-            "Internal admin MFA cannot be self-disabled. Use an authorized admin security reset."
-        )
     password_hash = _normalize_text(user.get("password_hash"))
     if not verify_password(current_password, password_hash):
         raise ValueError("Current password is incorrect.")

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -116,7 +116,7 @@ class RateLimitAndLockoutTests(unittest.TestCase):
 
 
 class AuthMfaTests(unittest.TestCase):
-    def test_internal_admin_requires_mfa_enrollment(self):
+    def test_internal_admin_without_mfa_can_authenticate(self):
         user_id = ObjectId()
         db = FakeDatabase(
             {
@@ -135,7 +135,29 @@ class AuthMfaTests(unittest.TestCase):
         )
         with patch.object(auth_service, "_get_database_or_none", return_value=db):
             result = auth_service.authenticate_user("admin@example.com", "StrongPass!123")
-        self.assertEqual(result["status"], "mfa_enrollment_required")
+        self.assertEqual(result["status"], "authenticated")
+        self.assertTrue(result.get("access_token"))
+
+    def test_mfa_enabled_user_requires_verification(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "admin@example.com",
+                        "status": "active",
+                        "password_hash": auth_service.hash_password("StrongPass!123"),
+                        "role": "admin",
+                        "mfa_enabled": True,
+                        "session_token_version": 0,
+                    }
+                ]
+            }
+        )
+        with patch.object(auth_service, "_get_database_or_none", return_value=db):
+            result = auth_service.authenticate_user("admin@example.com", "StrongPass!123")
+        self.assertEqual(result["status"], "mfa_required")
         self.assertTrue(result.get("mfa_challenge_token"))
 
 


### PR DESCRIPTION
What changed:

Admin accounts without MFA now log in normally with email/password. Accounts that already enabled MFA still get the MFA verification prompt at signin. Internal admin access no longer rejects an admin just because MFA is not enrolled. Account Security now has an Authenticator MFA section where a signed-in user can: Set up authenticator MFA
Verify the first authenticator code
See backup codes once
Disable MFA later with password plus authenticator/recovery code Files changed:

account-security.html
account-security.js
auth.py
auth.py
auth.py
auth_service.py
test_security_hardening.py
Validation passed:

node --check account-security.js
node --check auth.js
git diff --check
venv/bin/python -m unittest tests.test_security_hardening tests.test_account_separation tests.test_admin_console After this is deployed, your admin account should log in directly. Then you can go to Dashboard → Account Security and enable MFA only if you want it.