### PR TITLE
Fix admin control center account isolation

### DIFF
--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -231,6 +231,93 @@
     });
   }
 
+  function getWorkspaceContext(selected) {
+    const workspace = state.workspace && state.workspace.case_id === state.selectedCaseId ? state.workspace : null;
+    const tabs = (workspace && workspace.tabs) || {};
+    const identity = tabs.identity || {};
+    const packageTab = tabs.package_lane || {};
+    const projectTab = tabs.project || {};
+    const mintTab = tabs.mint_readiness || {};
+    const project = (workspace && workspace.project) || {};
+    const packageInfo = (workspace && workspace.package) || {};
+    const readiness = (workspace && workspace.readiness) || {};
+    const selectedFallback = selected || {};
+    const blocking = Array.isArray(mintTab.blocking_reasons)
+      ? mintTab.blocking_reasons
+      : Array.isArray(readiness.blocking_reasons)
+        ? readiness.blocking_reasons
+        : Array.isArray(selectedFallback.mint_blocking_reasons)
+          ? selectedFallback.mint_blocking_reasons
+          : [];
+
+    return {
+      workspace,
+      caseId: (workspace && workspace.case_id) || selectedFallback.case_id || "",
+      name:
+        identity.full_name ||
+        project.name ||
+        project.project_name ||
+        selectedFallback.name ||
+        selectedFallback.project ||
+        "Customer Case",
+      email: identity.email || selectedFallback.email || "",
+      projectName:
+        projectTab.project_name ||
+        project.name ||
+        project.project_name ||
+        "",
+      packageName:
+        packageTab.package_name ||
+        packageInfo.package_name ||
+        selectedFallback.package_name ||
+        selectedFallback.package ||
+        "Unknown Package",
+      packageCode:
+        packageTab.package_code ||
+        packageInfo.package_code ||
+        selectedFallback.package_code ||
+        "",
+      lane:
+        packageTab.project_lane ||
+        packageTab.lane ||
+        projectTab.project_lane ||
+        projectTab.lane ||
+        selectedFallback.lane ||
+        "",
+      status:
+        projectTab.build_status ||
+        project.status ||
+        selectedFallback.status ||
+        "unknown",
+      alerts: workspace ? workspace.alerts || [] : selectedFallback.alerts || [],
+      guidance: getGuidanceItems(workspace ? workspace.operator_guidance : selectedFallback.operator_guidance),
+      blocking,
+    };
+  }
+
+  function getActionScope(selected) {
+    const workspace = state.workspace && state.workspace.case_id === state.selectedCaseId ? state.workspace : null;
+    const selectedFallback = selected || {};
+    if (!workspace) {
+      return {
+        project_id: selectedFallback.project_id || "",
+        order_id: selectedFallback.order_id || "",
+      };
+    }
+
+    const tabs = workspace.tabs || {};
+    const projectTab = tabs.project || {};
+    const ordersTab = tabs.orders_billing || {};
+    const primaryOrder = ordersTab.primary_order || {};
+    const project = workspace.project || {};
+    const order = workspace.order || {};
+
+    return {
+      project_id: projectTab.project_id || project.id || project.project_id || "",
+      order_id: order.id || primaryOrder.id || "",
+    };
+  }
+
   function renderScalar(value) {
     if (value == null || value === "") return "—";
     if (typeof value === "boolean") return value ? "yes" : "no";
@@ -703,22 +790,31 @@
       return;
     }
 
-    const blocking = Array.isArray(selected.mint_blocking_reasons) ? selected.mint_blocking_reasons : [];
-    const guidance = getGuidanceItems((state.workspace && state.workspace.operator_guidance) || selected.operator_guidance);
+    if (!state.workspace || state.workspace.case_id !== state.selectedCaseId) {
+      node.innerHTML = `
+        <div class="admin-context-card">
+          <h3>Opening case workspace</h3>
+          <p class="card-copy">Loading the case-scoped operations context.</p>
+        </div>
+      `;
+      return;
+    }
+
+    const context = getWorkspaceContext(selected);
     node.innerHTML = `
       <div class="admin-context-card">
-        <h3>${escapeHtml(selected.name || "Selected Case")}</h3>
-        <p class="card-copy"><strong>Case:</strong> <span class="admin-id-ref">${escapeHtml(shortId(selected.case_id))}</span></p>
-        <p class="card-copy"><strong>Package:</strong> ${escapeHtml(selected.package_name || selected.package || "—")} ${selected.package_code ? `<span class="admin-id-ref">${escapeHtml(selected.package_code)}</span>` : ""}</p>
-        <p class="card-copy"><strong>Lane:</strong> ${laneChip(selected.lane)}</p>
-        <div class="admin-context-chip-row">${renderStatusStack(selected.alerts || [], "none")}</div>
+        <h3>${escapeHtml(context.name || "Selected Case")}</h3>
+        <p class="card-copy"><strong>Case:</strong> <span class="admin-id-ref">${escapeHtml(shortId(context.caseId))}</span></p>
+        <p class="card-copy"><strong>Package:</strong> ${escapeHtml(context.packageName || "—")} ${context.packageCode ? `<span class="admin-id-ref">${escapeHtml(context.packageCode)}</span>` : ""}</p>
+        <p class="card-copy"><strong>Lane:</strong> ${laneChip(context.lane)}</p>
+        <div class="admin-context-chip-row">${renderStatusStack(context.alerts || [], "none")}</div>
         <div class="admin-context-guidance">
           <span>Operator Guidance</span>
-          ${renderGuidanceList(guidance, "No active repair guidance", "This case is not reporting a repair blocker in the selected queue.")}
+          ${renderGuidanceList(context.guidance, "No active repair guidance", "This case is not reporting a repair blocker in the selected queue.")}
         </div>
         <div class="admin-blocking-reasons">
           <span>Mint Blocking Reasons</span>
-          <div>${renderStatusStack(blocking, "none")}</div>
+          <div>${renderStatusStack(context.blocking, "none")}</div>
         </div>
       </div>
     `;
@@ -762,12 +858,19 @@
       meta.textContent = "Open a customer or project to isolate the record.";
       return;
     }
-    heading.textContent = selected.name || selected.project || "Customer Case";
-    meta.innerHTML = `${escapeHtml(selected.email || "No email")} · ${escapeHtml(selected.project || "No project")} · ${laneChip(selected.lane)} · ${statusChip(selected.status || "unknown", chipClassForValue(selected.status))}`;
+    if (!state.workspace || state.workspace.case_id !== state.selectedCaseId) {
+      heading.textContent = "Opening case workspace";
+      meta.textContent = "Loading isolated case details.";
+      return;
+    }
+    const context = getWorkspaceContext(selected);
+    heading.textContent = context.name || "Customer Case";
+    meta.innerHTML = `${escapeHtml(context.email || "No email")} · ${escapeHtml(context.projectName || "No project")} · ${laneChip(context.lane)} · ${statusChip(context.status || "unknown", chipClassForValue(context.status))}`;
   }
 
   function updateActionAvailability() {
     const selected = getSelectedCase();
+    const scope = getActionScope(selected);
     document.querySelectorAll("[data-admin-case-action]").forEach(function (button) {
       const action = button.getAttribute("data-admin-case-action") || "";
       const tier = ACTION_TIERS[action] || "utility";
@@ -777,9 +880,9 @@
         selected && (!Array.isArray(selected.quick_actions) || selected.quick_actions.includes(action));
       const hasRequirements =
         action === "link_order_to_project"
-          ? Boolean(selected && (selected.project_id || selected.order_id))
+          ? Boolean(scope.project_id && scope.order_id)
           : requirements.every(function (key) {
-              return selected && selected[key];
+              return scope[key];
             });
       const available = Boolean(selected && allowedByRole && allowedByCase && hasRequirements);
       button.hidden = !allowedByRole;

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -85,18 +85,6 @@ CASE_ACTION_PERMISSIONS: dict[str, set[str]] = {
     "rebuild_mint_summary": {"admin.control.mint"},
     "resync_mint_receipt": {"admin.control.mint"},
 }
-# Actions that can benefit from an order resolved from the project owner when
-# no order is directly linked to the project yet.
-ACTIONS_REQUIRING_ORDER_FALLBACK: frozenset[str] = frozenset({
-    "sync_package",
-    "normalize_package",
-    "generate_entitlement",
-    "refresh_entitlement",
-    "run_readiness_check",
-    "queue_for_mint_review",
-    "repair_record",
-    "link_order_to_project",
-})
 BULK_ACTION_PERMISSIONS: dict[str, set[str]] = {
     "repair-missing-entitlements": {"admin.control.billing"},
     "assign-missing-lanes": {"admin.control.write"},
@@ -479,15 +467,20 @@ def _order_by_id(order_id: str) -> dict[str, Any] | None:
     return None
 
 
-def _project_id_candidates(project_id: str) -> list[Any]:
-    values: list[Any] = [project_id]
-    oid = _to_object_id(project_id)
+def _document_id_candidates(value: str) -> list[Any]:
+    normalized = _normalize(value)
+    values: list[Any] = [normalized]
+    oid = _to_object_id(normalized)
     if oid is not None:
         values.append(oid)
         oid_text = str(oid)
         values.append(f'ObjectId("{oid_text}")')
         values.append(f"ObjectId('{oid_text}')")
     return values
+
+
+def _project_id_candidates(project_id: str) -> list[Any]:
+    return _document_id_candidates(project_id)
 
 
 def _project_is_approved(project: dict[str, Any]) -> bool:
@@ -522,6 +515,18 @@ def _latest_linked_order(project_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _order_project_id_matches(order: dict[str, Any] | None, project_id: str) -> bool:
+    if not order or not _normalize(project_id):
+        return False
+    project_ids = {
+        _normalize_object_id(value)
+        for value in _project_id_candidates(project_id)
+        if _normalize_object_id(value)
+    }
+    order_project_id = _normalize_object_id(order.get("project_id"))
+    return bool(order_project_id and order_project_id in project_ids)
+
+
 def _latest_user_order_for_project(project: dict[str, Any]) -> dict[str, Any] | None:
     db = _db()
     owner_email = _normalize_email(project.get("owner_email"))
@@ -545,17 +550,27 @@ def _latest_user_order_for_project(project: dict[str, Any]) -> dict[str, Any] | 
     return None
 
 
-def _resolve_project_order_context(project_id: str, preferred_order_id: str = "") -> tuple[dict[str, Any], dict[str, Any] | None]:
+def _resolve_project_order_context(
+    project_id: str,
+    preferred_order_id: str = "",
+    *,
+    allow_owner_order_fallback: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
     project = _project_by_id(project_id)
     if project is None:
         raise ValueError("Project not found.")
 
+    project_id_str = _normalize(project.get("_id") or project.get("id"))
     order: dict[str, Any] | None = None
     if preferred_order_id:
-        order = _order_by_id(preferred_order_id)
+        preferred_order = _order_by_id(preferred_order_id)
+        if preferred_order is not None:
+            if not _order_project_id_matches(preferred_order, project_id_str):
+                raise ValueError("Order does not belong to the selected project.")
+            order = preferred_order
     if order is None:
-        order = _latest_linked_order(_normalize(project.get("_id")))
-    if order is None:
+        order = _latest_linked_order(project_id_str)
+    if order is None and allow_owner_order_fallback:
         order = _latest_user_order_for_project(project)
     return project, order
 
@@ -1298,9 +1313,10 @@ def project_workspace_snapshot(project_id: str) -> dict[str, Any]:
 
     related_orders = []
     db = _db()
-    owner_email = _normalize_email(project.get("owner_email"))
-    if owner_email:
-        cursor = db["orders"].find({"email": owner_email}).sort("created_at", -1).limit(10)
+    if project_id_str:
+        cursor = db["orders"].find(
+            {"project_id": {"$in": _project_id_candidates(project_id_str)}}
+        ).sort("created_at", -1).limit(10)
         related_orders = [_serialize_order(item) for item in cursor if _serialize_order(item)]
 
     return {
@@ -1900,26 +1916,27 @@ def _find_duplicate_identity(email: str) -> bool:
 
 
 def _workspace_audit_timeline(*, project_id: str, order_id: str = "", owner_email: str = "") -> list[dict[str, Any]]:
+    del owner_email
     db = _db()
     conditions: list[dict[str, Any]] = []
     if project_id:
+        project_id_values = _document_id_candidates(project_id)
         conditions.extend(
             [
-                {"target_id": project_id},
-                {"context.project_id": project_id},
-                {"details.project_id": project_id},
+                {"target_id": {"$in": project_id_values}},
+                {"context.project_id": {"$in": project_id_values}},
+                {"details.project_id": {"$in": project_id_values}},
             ]
         )
     if order_id:
+        order_id_values = _document_id_candidates(order_id)
         conditions.extend(
             [
-                {"target_id": order_id},
-                {"context.order_id": order_id},
-                {"details.order_id": order_id},
+                {"target_id": {"$in": order_id_values}},
+                {"context.order_id": {"$in": order_id_values}},
+                {"details.order_id": {"$in": order_id_values}},
             ]
         )
-    if owner_email:
-        conditions.append({"actor_email": _normalize_email(owner_email)})
     if not conditions:
         return []
 
@@ -1942,17 +1959,16 @@ def _workspace_audit_timeline(*, project_id: str, order_id: str = "", owner_emai
 
 
 def _workspace_uploads_snapshot(project_id: str, owner_email: str) -> dict[str, Any]:
+    del owner_email
     db = _db()
-    filters: list[dict[str, Any]] = []
-    if project_id:
-        filters.append({"project_id": {"$in": _project_id_candidates(project_id)}})
-    if owner_email:
-        filters.append({"uploaded_by": _normalize_email(owner_email)})
-    if not filters:
+    if not project_id:
         return {"count": 0, "items": []}
 
     items: list[dict[str, Any]] = []
-    for item in db["uploaded_files"].find({"$or": filters}).sort("created_at", -1).limit(12):
+    cursor = db["uploaded_files"].find(
+        {"project_id": {"$in": _project_id_candidates(project_id)}}
+    ).sort("created_at", -1).limit(12)
+    for item in cursor:
         items.append(
             {
                 "id": _normalize(item.get("_id")),
@@ -2391,6 +2407,37 @@ def _mint_record_snapshot(project_id: str) -> dict[str, Any]:
     }
 
 
+def _workspace_related_orders(
+    *,
+    project_id: str,
+    primary_order: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    db = _db()
+    seen: set[str] = set()
+    related_orders: list[dict[str, Any]] = []
+
+    def append_order(order: dict[str, Any] | None) -> None:
+        serialized = _serialize_order(order)
+        order_id = _normalize((serialized or {}).get("id"))
+        if not serialized or not order_id or order_id in seen:
+            return
+        seen.add(order_id)
+        related_orders.append(serialized)
+
+    if project_id:
+        cursor = db["orders"].find(
+            {"project_id": {"$in": _project_id_candidates(project_id)}}
+        ).sort("created_at", -1).limit(10)
+        for order in cursor:
+            append_order(order)
+        if _order_project_id_matches(primary_order, project_id):
+            append_order(primary_order)
+        return related_orders[:10]
+
+    append_order(primary_order)
+    return related_orders
+
+
 def _build_user_workspace_payload(user: dict[str, Any]) -> dict[str, Any]:
     user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
     if not user_id:
@@ -2596,7 +2643,12 @@ def list_customer_cases(*, search: str = "", limit: int = 50, queue: str = "cust
         order = _latest_linked_order(project_id) or _latest_user_order_for_project(project)
         entitlement = get_project_entitlement(project_id)
         package_fields = _package_fields_from_context(project, order, entitlement)
-        readiness = run_readiness_check(project_id=project_id, order_id=_normalize((order or {}).get("_id")))
+        readiness_order_id = (
+            _normalize((order or {}).get("_id"))
+            if _order_project_id_matches(order, project_id)
+            else ""
+        )
+        readiness = run_readiness_check(project_id=project_id, order_id=readiness_order_id)
         upload_count = count_workspace_uploads(project_id=project_id)
         duplicate_identity = _find_duplicate_identity(_normalize_email(project.get("owner_email")))
         alerts = _case_alerts(
@@ -2635,7 +2687,7 @@ def list_customer_cases(*, search: str = "", limit: int = 50, queue: str = "cust
             {
                 "case_id": project_id,
                 "project_id": project_id,
-                "order_id": _normalize((order or {}).get("_id")) or None,
+                "order_id": readiness_order_id or None,
                 "name": user_name,
                 "email": owner_email or None,
                 "role": _normalize((user or {}).get("role")) or "customer",
@@ -2742,8 +2794,9 @@ def _build_case_workspace_payload(
     project: dict[str, Any] | None,
     order: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    db = _db()
     project_id = _normalize((project or {}).get("_id") or (project or {}).get("id"))
+    if project_id and order is not None and not _order_project_id_matches(order, project_id):
+        order = None
     order_id = _normalize((order or {}).get("_id"))
     owner_email = _normalize_email((project or {}).get("owner_email") or (order or {}).get("email"))
     owner_user_id = _normalize((project or {}).get("owner_user_id") or (order or {}).get("user_id"))
@@ -2762,10 +2815,10 @@ def _build_case_workspace_payload(
     family = _linked_family_snapshot(project)
     mint_record = _mint_record_snapshot(project_id)
 
-    related_orders = []
-    if owner_email:
-        cursor = db["orders"].find({"email": owner_email}).sort("created_at", -1).limit(10)
-        related_orders = [_serialize_order(item) for item in cursor if _serialize_order(item)]
+    related_orders = _workspace_related_orders(
+        project_id=project_id,
+        primary_order=order,
+    )
 
     project_snapshot = _serialize_project(project) if project else None
     order_snapshot = _serialize_order(order)
@@ -2964,7 +3017,7 @@ def customer_case_workspace(case_id: str) -> dict[str, Any]:
         order = _order_by_id(order_id)
         if order is None:
             raise ValueError("Order case not found.")
-        project = _project_by_id(_normalize(order.get("project_id"))) or _find_matching_approved_project_for_order(order)
+        project = _project_by_id(_normalize(order.get("project_id")))
         return _build_case_workspace_payload(
             case_id=normalized_case_id,
             project=project,
@@ -3065,9 +3118,9 @@ def repair_selected_records(*, project_ids: list[str], order_ids: list[str]) -> 
             if order is None:
                 failures.append({"order_id": _normalize(order_id), "error": "Order not found."})
                 continue
-            project = _project_by_id(_normalize(order.get("project_id"))) or _find_matching_approved_project_for_order(order)
+            project = _project_by_id(_normalize(order.get("project_id")))
             if project is None:
-                failures.append({"order_id": _normalize(order_id), "error": "Matching project not found."})
+                failures.append({"order_id": _normalize(order_id), "error": "Linked project not found."})
                 continue
             repaired.append(repair_record(project_id=_normalize(project.get("_id")), order_id=_normalize(order_id)))
         except Exception:
@@ -3126,7 +3179,8 @@ def execute_case_action(
         order = _order_by_id(order_id)
         if order is None:
             raise ValueError("Order not found.")
-        project = _project_by_id(_normalize(order.get("project_id"))) or _find_matching_approved_project_for_order(order)
+        project_id = ""
+        project = _project_by_id(_normalize(order.get("project_id")))
         if project is not None:
             project_id = _normalize(project.get("_id"))
     elif normalized_case_id.startswith("user:"):
@@ -3152,10 +3206,6 @@ def execute_case_action(
 
     if not order_id:
         linked = _latest_linked_order(project_id)
-        if linked is None and normalized_action in ACTIONS_REQUIRING_ORDER_FALLBACK:
-            project_doc = _project_by_id(project_id)
-            if project_doc is not None:
-                linked = _latest_user_order_for_project(project_doc)
         order_id = _normalize((linked or {}).get("_id"))
 
     action_handlers: dict[str, Callable[[], dict[str, Any]]] = {

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -266,6 +266,267 @@ class AdminUserQueueTests(unittest.TestCase):
         self.assertEqual(workspace["tabs"]["project"]["related_projects"], [])
         self.assertEqual(workspace["tabs"]["entitlements"]["entitlement_status"], "missing")
 
+    def test_project_case_workspace_isolates_related_records_to_selected_project(self):
+        larry_user_id = ObjectId()
+        larry_project_id = ObjectId()
+        larry_other_project_id = ObjectId()
+        marquis_project_id = ObjectId()
+        selected_order_id = ObjectId()
+        larry_other_order_id = ObjectId()
+        marquis_order_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": larry_user_id,
+                        "email": "larry@example.com",
+                        "full_name": "Larry Robinson",
+                        "role": "user",
+                        "status": "active",
+                    }
+                ],
+                "projects": [
+                    {
+                        "_id": larry_project_id,
+                        "owner_user_id": str(larry_user_id),
+                        "owner_email": "larry@example.com",
+                        "name": "Larry Selected Project",
+                        "package_code": "legacy_snapshot",
+                        "project_lane": "portrait",
+                        "status": "build_ready",
+                        "phase": "intake_approved",
+                    },
+                    {
+                        "_id": larry_other_project_id,
+                        "owner_user_id": str(larry_user_id),
+                        "owner_email": "larry@example.com",
+                        "name": "Larry Other Project",
+                        "package_code": "legacy_plus",
+                        "project_lane": "household",
+                        "status": "build_ready",
+                        "phase": "intake_approved",
+                    },
+                    {
+                        "_id": marquis_project_id,
+                        "owner_email": "marquis@example.com",
+                        "name": "Marquis Project",
+                        "package_code": "legacy_snapshot",
+                        "project_lane": "portrait",
+                        "status": "build_ready",
+                        "phase": "intake_approved",
+                    },
+                ],
+                "orders": [
+                    {
+                        "_id": selected_order_id,
+                        "email": "larry@example.com",
+                        "project_id": larry_project_id,
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                    },
+                    {
+                        "_id": larry_other_order_id,
+                        "email": "larry@example.com",
+                        "project_id": larry_other_project_id,
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_plus",
+                    },
+                    {
+                        "_id": marquis_order_id,
+                        "email": "marquis@example.com",
+                        "project_id": marquis_project_id,
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                    },
+                ],
+                "project_entitlements": [],
+                "uploaded_files": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": larry_project_id,
+                        "uploaded_by": "larry@example.com",
+                        "filename": "larry-selected.jpg",
+                        "category": "member_photo",
+                        "status": "received",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": larry_other_project_id,
+                        "uploaded_by": "larry@example.com",
+                        "filename": "larry-other.jpg",
+                        "category": "member_photo",
+                        "status": "received",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": marquis_project_id,
+                        "uploaded_by": "marquis@example.com",
+                        "filename": "marquis.jpg",
+                        "category": "member_photo",
+                        "status": "received",
+                    },
+                ],
+                "audit_logs": [
+                    {
+                        "_id": ObjectId(),
+                        "target_id": larry_project_id,
+                        "actor_email": "larry@example.com",
+                        "action": "selected_project_event",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "target_id": str(larry_other_project_id),
+                        "actor_email": "larry@example.com",
+                        "action": "other_larry_project_event",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "target_id": str(marquis_project_id),
+                        "actor_email": "marquis@example.com",
+                        "action": "marquis_project_event",
+                    },
+                ],
+                "families": [],
+                "households": [],
+            }
+        )
+
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=None),
+            patch.object(
+                admin_control_service,
+                "run_readiness_check",
+                return_value={
+                    "mint_review_ready": False,
+                    "mint_eligible": False,
+                    "mint_already_completed": False,
+                    "blocking_reasons": [],
+                },
+            ),
+            patch.object(admin_control_service, "_mint_record_snapshot", return_value={}),
+        ):
+            workspace = admin_control_service.customer_case_workspace(str(larry_project_id))
+
+        related_order_ids = {
+            item["id"] for item in workspace["tabs"]["orders_billing"]["related_orders"]
+        }
+        upload_names = {
+            item["filename"] for item in workspace["tabs"]["uploads_verification"]["items"]
+        }
+        audit_actions = {item["action"] for item in workspace["audit_timeline"]}
+
+        self.assertEqual(workspace["tabs"]["project"]["project_id"], str(larry_project_id))
+        self.assertEqual(related_order_ids, {str(selected_order_id)})
+        self.assertEqual(upload_names, {"larry-selected.jpg"})
+        self.assertEqual(audit_actions, {"selected_project_event"})
+
+    def test_order_case_workspace_does_not_infer_unlinked_project_by_email(self):
+        order_id = ObjectId()
+        same_email_project_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [],
+                "projects": [
+                    {
+                        "_id": same_email_project_id,
+                        "owner_email": "genesis@example.com",
+                        "name": "Genesis Existing Project",
+                        "package_code": "legacy_snapshot",
+                        "project_lane": "portrait",
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "email": "genesis@example.com",
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                    }
+                ],
+                "project_entitlements": [],
+                "uploaded_files": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": same_email_project_id,
+                        "uploaded_by": "genesis@example.com",
+                        "filename": "genesis-project.jpg",
+                    }
+                ],
+                "audit_logs": [],
+                "families": [],
+                "households": [],
+            }
+        )
+
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=None),
+            patch.object(admin_control_service, "_mint_record_snapshot", return_value={}),
+        ):
+            workspace = admin_control_service.customer_case_workspace(f"order:{order_id}")
+
+        related_order_ids = [
+            item["id"] for item in workspace["tabs"]["orders_billing"]["related_orders"]
+        ]
+        self.assertIsNone(workspace["project"])
+        self.assertIsNone(workspace["tabs"]["project"]["project_id"])
+        self.assertEqual(related_order_ids, [str(order_id)])
+        self.assertEqual(workspace["tabs"]["uploads_verification"]["items"], [])
+
+    def test_order_case_actions_do_not_infer_unlinked_project_by_email(self):
+        order_id = ObjectId()
+        same_email_project_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [],
+                "projects": [
+                    {
+                        "_id": same_email_project_id,
+                        "owner_email": "genesis@example.com",
+                        "name": "Genesis Existing Project",
+                        "package_code": "legacy_snapshot",
+                        "project_lane": "portrait",
+                        "status": "build_ready",
+                        "phase": "intake_approved",
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "email": "genesis@example.com",
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                    }
+                ],
+                "project_entitlements": [],
+                "uploaded_files": [],
+                "audit_logs": [],
+                "families": [],
+                "households": [],
+            }
+        )
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            with self.assertRaisesRegex(ValueError, "Action requires a linked project."):
+                admin_control_service.execute_case_action(
+                    case_id=f"order:{order_id}",
+                    action="run_readiness_check",
+                )
+            result = admin_control_service.repair_selected_records(
+                project_ids=[],
+                order_ids=[str(order_id)],
+            )
+
+        self.assertEqual(result["repaired_count"], 0)
+        self.assertEqual(result["failed_count"], 1)
+        self.assertEqual(result["failed"][0]["error"], "Linked project not found.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This update tightens the admin case workspace on both the backend and frontend so customer records are no longer mixed through broad email, user, family, household, or loosely matched order context.

On the backend, the workspace now uses project_id as the primary scope anchor for related orders, uploads, audit timeline, readiness, entitlement, mint context, and workspace payloads. Order cases no longer infer a project by matching email, and project-scoped admin actions now require an explicitly linked project before they can run.

On the frontend, the left rail case list remains unchanged, but the opened case header, context panel, and action availability now rely on the isolated workspace payload instead of broad list-row data. This ensures the selected case view reflects only the records that belong to that exact account/project.

Validation
	•	Added regression tests proving one selected project cannot load another customer’s related orders, uploads, or audit records
	•	Added tests proving unlinked orders do not infer projects by email
	•	Passed full backend test discovery: 36 tests OK
	•	Passed node --check admin-control-center.js
	•	Passed git diff --check