### PR TITLE
blockchain_mint_service.py test_security_hardening.py test_linking_tr…

### DIFF
--- a/backend/app/services/blockchain_mint_service.py
+++ b/backend/app/services/blockchain_mint_service.py
@@ -63,7 +63,7 @@ def _require_mint_runtime() -> None:
         )
 
 
-def _web3_client():
+def _web3_client() -> Any:
     Web3, _Account = _lazy_web3()
     client = Web3(Web3.HTTPProvider(_normalize(settings.nft_rpc_url)))
     if not client.is_connected():

--- a/backend/tests/test_linking_tree_vault.py
+++ b/backend/tests/test_linking_tree_vault.py
@@ -155,6 +155,8 @@ class LinkRequestApprovalTests(unittest.TestCase):
                 is_admin=False,
             )
 
+        self.assertIsNotNone(updated)
+        assert updated is not None
         self.assertEqual(updated["status"], "approved")
         links = db["household_links"].documents
         self.assertEqual(len(links), 1)

--- a/backend/tests/test_package_mapping.py
+++ b/backend/tests/test_package_mapping.py
@@ -32,7 +32,7 @@ class PackageMappingTests(unittest.TestCase):
         self.assertIn("digital-legacy-portrait", payload["package_map"]["packages"])
 
     def test_admin_repairs_routes_registered(self):
-        paths = {route.path for route in admin_control_router.routes}
+        paths = {str(getattr(route, "path", "")) for route in admin_control_router.routes}
         self.assertIn("/admin/control-center/repairs/missing-entitlements", paths)
         self.assertIn("/admin/control-center/repairs/missing-lanes", paths)
         self.assertIn("/admin/control-center/repairs/unlinked-paid-orders", paths)
@@ -40,4 +40,3 @@ class PackageMappingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -135,6 +135,8 @@ class AuthMfaTests(unittest.TestCase):
         )
         with patch.object(auth_service, "_get_database_or_none", return_value=db):
             result = auth_service.authenticate_user("admin@example.com", "StrongPass!123")
+        self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["status"], "authenticated")
         self.assertTrue(result.get("access_token"))
 
@@ -157,6 +159,8 @@ class AuthMfaTests(unittest.TestCase):
         )
         with patch.object(auth_service, "_get_database_or_none", return_value=db):
             result = auth_service.authenticate_user("admin@example.com", "StrongPass!123")
+        self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["status"], "mfa_required")
         self.assertTrue(result.get("mfa_challenge_token"))
 


### PR DESCRIPTION
…ee_vault.py test_package_mapping.py

Marked the dynamic Web3 client as Any so Pyright/Pylance stops throwing false overload/type errors around client.eth.contract, receipts, and transaction hash calls. Added explicit assert result is not None checks before reading auth test results. Added an explicit non-None assertion before reading the link approval result. Replaced direct route.path access with safe getattr(route, "path", "") because FastAPI routes are typed as generic BaseRoute.