### PR TITLE
 The portrait flow is now a separate, clearer path

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -2214,6 +2214,7 @@
     const page = window.location.pathname.split("/").pop() || "";
 
     const uploadPages = new Set(["verification-upload.html"]);
+    const portraitUploadPages = new Set(["portrait-upload.html"]);
     const linkKeyPages = new Set(["link-keys.html"]);
     const familyIntakePages = new Set([
       "intake-welcome.html",
@@ -2235,6 +2236,7 @@
 
     if (
       !uploadPages.has(page) &&
+      !portraitUploadPages.has(page) &&
       !linkKeyPages.has(page) &&
       !familyIntakePages.has(page) &&
       !familyTreePages.has(page) &&
@@ -2288,6 +2290,11 @@
           resolved.can_upload_verification_docs || resolved.can_upload_portraits
         )
       ) {
+        window.location.href = "dashboard.html?purchase_required=1";
+        return;
+      }
+
+      if (portraitUploadPages.has(page) && !resolved.can_upload_portraits) {
         window.location.href = "dashboard.html?purchase_required=1";
         return;
       }

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -925,8 +925,8 @@
         workspaceCopy: canUseLinkKeys
           ? "Your portrait workspace connects package access, portrait uploads, verification records, guided delivery, and link capabilities in one place."
           : "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
-        primaryActionText: "Upload Portrait & Records",
-        primaryActionHref: "verification-upload.html",
+        primaryActionText: "Upload Portrait",
+        primaryActionHref: "portrait-upload.html",
         secondaryActionText: "Verification Uploads",
         secondaryActionHref: "verification-upload.html",
         showTree: canBuildFamilyTree,
@@ -1157,7 +1157,8 @@
           cardCopy: canUseLinkKeys
             ? "Your portrait package is approved and ready for portrait, verification, and link-enabled work."
             : "Your portrait package is approved and ready for portrait and verification work.",
-          nextStep: "Upload portrait and supporting verification records.",
+          nextStep:
+            "Upload the portrait first, then add verification records only if needed.",
           lockNote:
             "Editing is locked because this portrait package has already been approved and provisioned.",
           workspaceCopy: canUseLinkKeys
@@ -1168,7 +1169,8 @@
 
       return {
         cardCopy: "Your portrait intake information is shown below.",
-        nextStep: "Upload portrait and supporting verification records.",
+        nextStep:
+          "Upload the portrait first, then add verification records only if needed.",
         lockNote: "Intake lock state is based on your current review status.",
         workspaceCopy: canUseLinkKeys
           ? "Your portrait workspace connects package access, portrait uploads, verification records, guided delivery, and link capabilities in one place."
@@ -1262,6 +1264,10 @@
       config.navCertificate && hasWorkspaceFamily,
     );
     applyNavVisibility("intake-review.html", config.navIntake);
+    applyNavVisibility(
+      "portrait-upload.html",
+      config.lane === "portrait" && config.showVerification,
+    );
     applyNavVisibility("verification-upload.html", config.showVerification);
     applyNavVisibility("link-keys.html", config.navLinkKeys);
 
@@ -1278,6 +1284,11 @@
     applyAction('.site-nav a[href^="link-keys.html"]', {
       href: withFamilyId("link-keys.html", context),
       show: config.navLinkKeys,
+    });
+
+    applyAction('.site-nav a[href^="portrait-upload.html"]', {
+      href: withFamilyId("portrait-upload.html", context),
+      show: config.lane === "portrait" && config.showVerification,
     });
 
     applyAction(
@@ -1433,8 +1444,8 @@
     const canOpenOrgIntake = Boolean(resolved.can_open_org_intake);
 
     if (lane === "portrait") {
-      actionNode.textContent = "Upload Portrait & Records";
-      actionNode.setAttribute("href", "verification-upload.html");
+      actionNode.textContent = "Upload Portrait";
+      actionNode.setAttribute("href", "portrait-upload.html");
       return;
     }
 
@@ -1568,7 +1579,7 @@
         text(
           nextStep,
           config.lane === "portrait"
-            ? "Upload portrait and supporting records to begin."
+            ? "Upload the portrait first, then add verification records only if needed."
             : config.lane === "organization"
               ? "Upload organization and supporting records to begin."
               : "Open your intake flow and submit the review step.",

--- a/dashboard.html
+++ b/dashboard.html
@@ -33,6 +33,7 @@
           <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html" aria-current="page">Dashboard</a>
             <a href="intake-review.html" style="display: none">My Intake</a>
+            <a href="portrait-upload.html" style="display: none">Portrait Uploads</a>
             <a href="verification-upload.html" style="display: none">Verification Uploads</a>
             <a href="link-keys.html" style="display: none">Link Keys</a>
             <a href="tree-view.html" style="display: none">Family Tree</a>
@@ -77,7 +78,7 @@
                 <div class="inline-actions portal-core-actions">
                   <a
                     class="btn btn-primary"
-                    href="verification-upload.html"
+                    href="portrait-upload.html"
                     data-dashboard-hero-primary-action
                     data-dashboard-hero-action
                     style="display: none"
@@ -350,7 +351,7 @@
               <div class="inline-actions" style="margin-top: 1.5rem">
                 <a
                   class="btn btn-primary"
-                  href="verification-upload.html"
+                  href="portrait-upload.html"
                   data-dashboard-package-primary-action
                   style="display: none"
                 >
@@ -682,8 +683,8 @@
 
     <script src="config.js?v=20260329-1"></script>
     <script src="app.js?v=20260410-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
-    <script src="dashboard-intake.js?v=20260331-1"></script>
+    <script src="auth.js?v=20260413-4"></script>
+    <script src="dashboard-intake.js?v=20260413-1"></script>
     <script src="dashboard-admin.js?v=20260410-1"></script>
   </body>
 </html>

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portrait Uploads | Tomb of Light</title>
+    <meta
+      name="description"
+      content="Upload portrait images for your Tomb of Light portrait workspace."
+    />
+    <link rel="stylesheet" href="styles.css?v=20260331-1" />
+  </head>
+  <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
+    <div class="site-watermark" aria-hidden="true"></div>
+
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+
+          <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="portrait-upload.html" aria-current="page">
+              Portrait Uploads
+            </a>
+            <a href="verification-upload.html">Verification Uploads</a>
+            <a href="link-keys.html" style="display: none">Link Keys</a>
+            <a href="tree-view.html" style="display: none">Family Tree</a>
+            <a href="lineage-certificate.html" style="display: none">
+              Lineage Certificate
+            </a>
+            <a href="faq.html">Help</a>
+          </nav>
+
+          <div class="header-actions">
+            <button class="btn btn-secondary" type="button" data-logout-btn>
+              Log Out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" data-portrait-upload-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Portrait Workspace</span>
+              <h1>Upload your portrait record.</h1>
+              <p data-portrait-page-status>
+                Loading your portrait workspace...
+              </p>
+
+              <div class="inline-actions" style="margin-top: 1.5rem">
+                <a
+                  class="btn btn-primary"
+                  href="dashboard.html"
+                  data-portrait-dashboard-link
+                >
+                  Return to Dashboard
+                </a>
+                <a
+                  class="btn btn-secondary"
+                  href="verification-upload.html"
+                  data-portrait-verification-link
+                >
+                  Verification Uploads
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Before Uploading</span>
+              <div class="notice">
+                Upload portrait images you have the lawful right to submit and
+                share. Tomb of Light uses these files to support your selected
+                portrait workspace.
+              </div>
+              <div class="helper" style="margin-top: 1rem">
+                Verification records belong on the Verification Uploads page.
+                This page is only for portrait images.
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Step 1 - Load Portrait Record</span>
+
+              <div class="form-grid two-col">
+                <label>
+                  Portrait Record
+                  <select data-portrait-family-select>
+                    <option value="">Loading portrait records...</option>
+                  </select>
+                </label>
+
+                <label>
+                  Load Record
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    data-portrait-load-family
+                    style="margin-top: 0.45rem"
+                  >
+                    Load Portrait Record
+                  </button>
+                </label>
+              </div>
+
+              <div
+                class="helper"
+                data-portrait-action-status
+                aria-live="polite"
+                style="display: none"
+              ></div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Step 2 - Upload Portrait</span>
+
+              <form class="form-grid" data-portrait-upload-form novalidate>
+                <div class="form-grid two-col">
+                  <label>
+                    Portrait Subject
+                    <select name="member_id" data-portrait-member-select required>
+                      <option value="">Select subject</option>
+                    </select>
+                  </label>
+
+                  <label>
+                    Portrait File
+                    <input
+                      type="file"
+                      name="photo_file"
+                      accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
+                      required
+                    />
+                  </label>
+                </div>
+
+                <div class="helper">
+                  Allowed formats: JPG, PNG, and WEBP. Use the image you want
+                  attached to this portrait workspace.
+                </div>
+
+                <div style="display: grid; gap: 0.85rem; margin-top: 0.85rem">
+                  <label
+                    style="display: flex; gap: 0.65rem; align-items: flex-start"
+                  >
+                    <input
+                      type="checkbox"
+                      required
+                      style="margin-top: 0.2rem"
+                    />
+                    <span>
+                      I confirm that I have the lawful right and authority to
+                      upload this image and, where required, permission from the
+                      living individual involved or from the parent or legal
+                      guardian of a minor.
+                    </span>
+                  </label>
+
+                  <label
+                    style="display: flex; gap: 0.65rem; align-items: flex-start"
+                  >
+                    <input
+                      type="checkbox"
+                      required
+                      style="margin-top: 0.2rem"
+                    />
+                    <span>
+                      I understand that Tomb of Light may review uploaded
+                      materials for workflow, support, security, fraud
+                      prevention, compliance, and service fulfillment.
+                    </span>
+                  </label>
+                </div>
+
+                <div class="inline-actions" style="margin-top: 1rem">
+                  <button
+                    class="btn btn-primary"
+                    type="submit"
+                    data-portrait-upload-submit
+                  >
+                    Upload Portrait
+                  </button>
+                  <a
+                    class="btn btn-secondary"
+                    href="dashboard.html"
+                    data-portrait-dashboard-link
+                  >
+                    Return to Dashboard
+                  </a>
+                </div>
+              </form>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Step 3 - Portrait Uploads</span>
+
+              <div class="form-grid two-col">
+                <label>
+                  Portrait Subject
+                  <select data-portrait-list-member>
+                    <option value="">Select subject</option>
+                  </select>
+                </label>
+
+                <label>
+                  Uploaded Portraits
+                  <button
+                    class="btn btn-secondary"
+                    type="button"
+                    data-portrait-load-uploads
+                    style="margin-top: 0.45rem"
+                  >
+                    Load Portrait Uploads
+                  </button>
+                </label>
+              </div>
+
+              <div
+                class="grid-3"
+                data-portrait-uploads-list
+                style="margin-top: 1.25rem"
+              ></div>
+
+              <div
+                class="helper"
+                data-portrait-uploads-empty
+                style="display: none; margin-top: 1rem"
+              >
+                No portrait uploads found for this subject.
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Next Step</span>
+              <p class="card-copy">
+                Return to the dashboard when the portrait is uploaded. Use
+                Verification Uploads only when you need to add records or
+                supporting documents.
+              </p>
+
+              <div class="inline-actions" style="margin-top: 1rem">
+                <a
+                  class="btn btn-primary"
+                  href="dashboard.html"
+                  data-portrait-dashboard-link
+                >
+                  Return to Dashboard
+                </a>
+                <a
+                  class="btn btn-secondary"
+                  href="verification-upload.html"
+                  data-portrait-verification-link
+                >
+                  Verification Uploads
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">
+                  Tomb of Light<span class="brand-symbol">™</span>
+                </div>
+                <p class="footer-copy">
+                  A private, guided, premium digital lineage platform for
+                  protecting memory, lineage, and identity across generations.
+                </p>
+                <div class="cookie-status" data-cookie-status>
+                  Your cookie preference has not been set yet.
+                </div>
+              </div>
+
+              <div class="footer-links">
+                <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms</a>
+                <a href="data-request.html">Data Requests</a>
+                <a href="security.html">Security</a>
+                <a href="faq.html">Help</a>
+              </div>
+            </div>
+
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+              <span>
+                Tomb of Light technology and platform design are proprietary.
+              </span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <div
+      class="cookie-banner"
+      data-cookie-banner
+      role="contentinfo"
+      aria-label="Cookie preferences"
+    >
+      <div class="cookie-inner">
+        <div class="cookie-copy">
+          We use essential site technologies and may use optional analytics
+          tools only where permitted. You can accept or decline optional
+          analytics cookies and review your choices at any time.
+        </div>
+        <div class="cookie-actions">
+          <button class="btn btn-primary" type="button" data-cookie-accept>
+            Accept
+          </button>
+          <button class="btn btn-secondary" type="button" data-cookie-decline>
+            Decline
+          </button>
+          <a class="btn btn-ghost" href="privacy-choices.html">
+            Privacy Choices
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260410-1"></script>
+    <script src="auth.js?v=20260413-4"></script>
+    <script src="portrait-upload.js?v=20260413-1"></script>
+  </body>
+</html>

--- a/portrait-upload.js
+++ b/portrait-upload.js
@@ -4,18 +4,11 @@
   const app = window.TOLApp || window.TOLAuth;
   const authPages = window.TOLAuthPages || {};
   if (!app || typeof app.apiRequest !== "function") {
-    console.error("verification-upload.js requires app.js/auth.js first.");
+    console.error("portrait-upload.js requires app.js/auth.js first.");
     return;
   }
 
   const ALLOWED_PHOTO_TYPES = new Set([
-    "image/jpeg",
-    "image/png",
-    "image/webp",
-  ]);
-
-  const ALLOWED_EVIDENCE_TYPES = new Set([
-    "application/pdf",
     "image/jpeg",
     "image/png",
     "image/webp",
@@ -126,17 +119,56 @@
 
   function updateNav(context, familyIdOverride) {
     [
-      "intake-review.html",
+      "dashboard.html",
       "portrait-upload.html",
       "verification-upload.html",
       "link-keys.html",
       "tree-view.html",
       "lineage-certificate.html",
     ].forEach(function (href) {
-      document.querySelectorAll(`.site-nav a[href^="${href}"]`).forEach(function (node) {
-        node.setAttribute("href", withWorkspaceHref(href, context, familyIdOverride));
-      });
+      document
+        .querySelectorAll(`.site-nav a[href^="${href}"]`)
+        .forEach(function (node) {
+          node.setAttribute("href", withWorkspaceHref(href, context, familyIdOverride));
+        });
     });
+
+    document.querySelectorAll("[data-portrait-dashboard-link]").forEach(function (node) {
+      node.setAttribute("href", withWorkspaceHref("dashboard.html", context, familyIdOverride));
+    });
+
+    document
+      .querySelectorAll("[data-portrait-verification-link]")
+      .forEach(function (node) {
+        node.setAttribute(
+          "href",
+          withWorkspaceHref("verification-upload.html", context, familyIdOverride),
+        );
+      });
+  }
+
+  function setNavVisible(href, isVisible) {
+    document
+      .querySelectorAll(`.site-nav a[href^="${href}"]`)
+      .forEach(function (node) {
+        node.style.display = isVisible ? "" : "none";
+      });
+  }
+
+  function applyEntitlementNav(context) {
+    const resolved = context?.resolvedEntitlements || {};
+    if (!Object.keys(resolved).length) return;
+
+    setNavVisible(
+      "verification-upload.html",
+      Boolean(resolved.can_upload_verification_docs || resolved.can_upload_portraits),
+    );
+    setNavVisible("link-keys.html", Boolean(resolved.can_use_link_keys));
+    setNavVisible("tree-view.html", Boolean(resolved.can_build_family_tree));
+    setNavVisible(
+      "lineage-certificate.html",
+      Boolean(resolved.can_use_lineage_certificate),
+    );
   }
 
   async function getCurrentContext() {
@@ -219,7 +251,7 @@
 
     const joined =
       `${member.first_name || ""} ${member.last_name || ""}`.trim();
-    return joined || "Unknown Member";
+    return joined || "Portrait Subject";
   }
 
   function sortMembers(members) {
@@ -241,7 +273,7 @@
     const currentValue = String(selectNode.value || "").trim();
     const options = sortMembers(members || [])
       .map(function (member) {
-        return `<option value="${escapeHtml(member.id)}">${escapeHtml(getDisplayName(member))} — Gen ${escapeHtml(member.generation ?? "—")}</option>`;
+        return `<option value="${escapeHtml(member.id)}">${escapeHtml(getDisplayName(member))}</option>`;
       })
       .join("");
 
@@ -268,34 +300,27 @@
       : [];
 
     setSelectOptions(
-      document.querySelector("[data-verification-member-select]"),
+      document.querySelector("[data-portrait-member-select]"),
       members,
-      "Select member",
+      "Select subject",
     );
     setSelectOptions(
-      document.querySelector("[data-verification-photo-member]"),
+      document.querySelector("[data-portrait-list-member]"),
       members,
-      "Select member",
-    );
-    setSelectOptions(
-      document.querySelector("[data-verification-list-member]"),
-      members,
-      "Select member",
+      "Select subject",
     );
   }
 
   function renderFamilies(preferredFamilyId) {
-    const selectNode = document.querySelector(
-      "[data-verification-family-select]",
-    );
+    const selectNode = document.querySelector("[data-portrait-family-select]");
     if (!selectNode) return;
 
     if (!families.length) {
       if (preferredFamilyId) {
-        selectNode.innerHTML = `<option value="">Select family</option>`;
+        selectNode.innerHTML = `<option value="">Select portrait record</option>`;
         const option = document.createElement("option");
         option.value = preferredFamilyId;
-        option.textContent = "Current Workspace Family";
+        option.textContent = "Current Portrait Workspace";
         selectNode.appendChild(option);
         selectNode.value = preferredFamilyId;
         currentFamilyId = preferredFamilyId;
@@ -303,13 +328,13 @@
         return;
       }
 
-      selectNode.innerHTML = `<option value="">No family records found</option>`;
+      selectNode.innerHTML = `<option value="">No portrait records found</option>`;
       currentFamilyId = "";
       updateNav(currentContext, "");
       return;
     }
 
-    selectNode.innerHTML = `<option value="">Select family</option>`;
+    selectNode.innerHTML = `<option value="">Select portrait record</option>`;
 
     families.forEach(function (family) {
       const option = document.createElement("option");
@@ -330,7 +355,7 @@
       if (!matched) {
         const option = document.createElement("option");
         option.value = preferredFamilyId;
-        option.textContent = "Current Workspace Family";
+        option.textContent = "Current Portrait Workspace";
         selectNode.appendChild(option);
       }
 
@@ -352,7 +377,7 @@
     if (typeof form.reportValidity === "function" && !form.reportValidity()) {
       setStatus(
         statusNode,
-        "Please complete all required fields and confirmations before continuing.",
+        "Please complete the required fields and confirmations before uploading.",
         "error",
       );
       return false;
@@ -361,27 +386,23 @@
     return true;
   }
 
-  function validateFileType(file, allowedTypes, fallbackExtensions) {
+  function validateFileType(file) {
     if (!file) return false;
 
     const type = String(file.type || "").toLowerCase();
-    if (type && allowedTypes.has(type)) {
+    if (type && ALLOWED_PHOTO_TYPES.has(type)) {
       return true;
     }
 
     const name = String(file.name || "").toLowerCase();
-    return fallbackExtensions.some(function (ext) {
+    return [".jpg", ".jpeg", ".png", ".webp"].some(function (ext) {
       return name.endsWith(ext);
     });
   }
 
   async function loadFamilies(preferredFamilyId) {
-    const pageStatus = document.querySelector(
-      "[data-verification-page-status]",
-    );
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
+    const pageStatus = document.querySelector("[data-portrait-page-status]");
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
 
     try {
       clearStatus(actionStatus);
@@ -394,35 +415,29 @@
       renderFamilies(preferredFamilyId);
 
       pageStatus.textContent = families.length
-        ? `Loaded ${families.length} family record(s).`
+        ? `Loaded ${families.length} portrait record(s).`
         : preferredFamilyId
-          ? "Loaded your current workspace family."
-          : "No family records are available yet.";
+          ? "Loaded your current portrait workspace."
+          : "No portrait records are available yet.";
     } catch (error) {
-      console.error("Failed to load families:", error);
-      pageStatus.textContent = "Unable to load family records.";
+      console.error("Failed to load portrait records:", error);
+      pageStatus.textContent = "Unable to load portrait records.";
       setStatus(
         actionStatus,
-        error.message || "Unable to load family records.",
+        error.message || "Unable to load portrait records.",
         "error",
       );
     }
   }
 
   async function loadFamilyGraph() {
-    const familySelect = document.querySelector(
-      "[data-verification-family-select]",
-    );
-    const pageStatus = document.querySelector(
-      "[data-verification-page-status]",
-    );
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
+    const familySelect = document.querySelector("[data-portrait-family-select]");
+    const pageStatus = document.querySelector("[data-portrait-page-status]");
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
 
     const familyId = String(familySelect ? familySelect.value : "").trim();
     if (!familyId) {
-      setStatus(actionStatus, "Please select a family first.", "error");
+      setStatus(actionStatus, "Please select a portrait record first.", "error");
       return;
     }
 
@@ -453,47 +468,48 @@
             );
             members = Array.isArray(graph.members) ? graph.members : [];
           } catch (retryError) {
-            console.warn(
-              "Verification upload member backfill retry failed:",
-              retryError,
-            );
+            console.warn("Portrait member backfill retry failed:", retryError);
           }
         }
       }
 
-      currentGraph = {
-        members,
-      };
-
+      currentGraph = { members };
       populateMemberSelects();
+
       if (members.length) {
-        pageStatus.textContent = `Family ${familyId} loaded successfully.`;
-        setStatus(actionStatus, "Family loaded successfully.", "success");
+        const firstMember = String(members[0]?.id || "").trim();
+        const listMember = document.querySelector("[data-portrait-list-member]");
+        if (members.length === 1 && listMember && firstMember) {
+          listMember.value = firstMember;
+          await loadUploads();
+        }
+
+        pageStatus.textContent = "Portrait record loaded successfully.";
+        setStatus(actionStatus, "Portrait record loaded successfully.", "success");
       } else {
-        pageStatus.textContent = `Family ${familyId} loaded, but no member records were found yet.`;
+        pageStatus.textContent =
+          "Portrait record loaded, but no subject record was found yet.";
         setStatus(
           actionStatus,
-          "Family loaded, but no member record is available yet for uploads. Please refresh or contact Tomb of Light support if this workspace was just provisioned.",
+          "Portrait record loaded, but no subject is available yet for uploads. Please refresh or contact Tomb of Light support if this workspace was just provisioned.",
           "error",
         );
       }
     } catch (error) {
-      console.error("Failed to load family graph:", error);
+      console.error("Failed to load portrait record:", error);
       setStatus(
         actionStatus,
-        error.message || "Unable to load family graph.",
+        error.message || "Unable to load portrait record.",
         "error",
       );
     }
   }
 
-  async function handlePhotoUploadSubmit(event) {
+  async function handlePortraitUploadSubmit(event) {
     event.preventDefault();
 
     const form = event.currentTarget;
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
 
     if (!validateRequiredForm(form, actionStatus)) {
       return;
@@ -502,7 +518,7 @@
     if (!currentFamilyId) {
       setStatus(
         actionStatus,
-        "Load a family before uploading a member photo.",
+        "Load the portrait record before uploading a portrait.",
         "error",
       );
       return;
@@ -513,21 +529,14 @@
     const file = fileInput && fileInput.files ? fileInput.files[0] : null;
 
     if (!memberId || !file) {
-      setStatus(actionStatus, "Member and photo file are required.", "error");
+      setStatus(actionStatus, "Portrait subject and file are required.", "error");
       return;
     }
 
-    if (
-      !validateFileType(file, ALLOWED_PHOTO_TYPES, [
-        ".jpg",
-        ".jpeg",
-        ".png",
-        ".webp",
-      ])
-    ) {
+    if (!validateFileType(file)) {
       setStatus(
         actionStatus,
-        "Invalid file type. Allowed member photo formats are JPG, PNG, and WEBP.",
+        "Invalid file type. Allowed portrait formats are JPG, PNG, and WEBP.",
         "error",
       );
       return;
@@ -539,7 +548,7 @@
     body.append("file", file);
 
     try {
-      setStatus(actionStatus, "Uploading member photo...", "info");
+      setStatus(actionStatus, "Uploading portrait...", "info");
 
       await app.apiRequest("/uploads/member-photo", {
         method: "POST",
@@ -548,127 +557,30 @@
 
       form.reset();
 
-      const listMember = document.querySelector(
-        "[data-verification-list-member]",
-      );
-      const categoryFilter = document.querySelector(
-        "[data-verification-category-filter]",
-      );
+      const memberSelect = document.querySelector("[data-portrait-member-select]");
+      const listMember = document.querySelector("[data-portrait-list-member]");
+      if (memberSelect) memberSelect.value = memberId;
       if (listMember) listMember.value = memberId;
-      if (categoryFilter) categoryFilter.value = "member_photo";
-
-      setStatus(actionStatus, "Member photo uploaded successfully.", "success");
-      await loadUploads();
-    } catch (error) {
-      console.error("Photo upload failed:", error);
-      setStatus(
-        actionStatus,
-        error.message || "Unable to upload member photo.",
-        "error",
-      );
-    }
-  }
-
-  async function handleUploadSubmit(event) {
-    event.preventDefault();
-
-    const form = event.currentTarget;
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
-
-    if (!validateRequiredForm(form, actionStatus)) {
-      return;
-    }
-
-    if (!currentFamilyId) {
-      setStatus(
-        actionStatus,
-        "Load a family before uploading evidence.",
-        "error",
-      );
-      return;
-    }
-
-    const memberId = String(form.member_id.value || "").trim();
-    const verificationType = String(form.verification_type.value || "").trim();
-    const evidenceKind = String(form.evidence_kind.value || "").trim();
-    const fileInput = form.querySelector('input[name="evidence_file"]');
-    const file = fileInput && fileInput.files ? fileInput.files[0] : null;
-
-    if (!memberId || !verificationType || !evidenceKind || !file) {
-      setStatus(
-        actionStatus,
-        "Member, verification type, evidence kind, and file are required.",
-        "error",
-      );
-      return;
-    }
-
-    if (
-      !validateFileType(file, ALLOWED_EVIDENCE_TYPES, [
-        ".pdf",
-        ".jpg",
-        ".jpeg",
-        ".png",
-        ".webp",
-      ])
-    ) {
-      setStatus(
-        actionStatus,
-        "Invalid file type. Allowed evidence formats are PDF, JPG, PNG, and WEBP.",
-        "error",
-      );
-      return;
-    }
-
-    const body = new FormData();
-    body.append("family_id", currentFamilyId);
-    body.append("member_id", memberId);
-    body.append("verification_type", verificationType);
-    body.append("evidence_kind", evidenceKind);
-    body.append("file", file);
-
-    try {
-      setStatus(actionStatus, "Uploading verification evidence...", "info");
-
-      await app.apiRequest("/uploads/verification-evidence", {
-        method: "POST",
-        body,
-      });
-
-      form.reset();
-
-      const listMember = document.querySelector(
-        "[data-verification-list-member]",
-      );
-      const categoryFilter = document.querySelector(
-        "[data-verification-category-filter]",
-      );
-      if (listMember) listMember.value = memberId;
-      if (categoryFilter) categoryFilter.value = "verification_evidence";
 
       setStatus(
         actionStatus,
-        "Verification evidence uploaded successfully.",
+        "Portrait uploaded successfully. You can return to the dashboard or add another portrait.",
         "success",
       );
       await loadUploads();
     } catch (error) {
-      console.error("Upload failed:", error);
+      console.error("Portrait upload failed:", error);
       setStatus(
         actionStatus,
-        error.message || "Unable to upload verification evidence.",
+        error.message || "Unable to upload portrait.",
         "error",
       );
     }
   }
 
   function renderUploads(uploads) {
-    const listNode = document.querySelector("[data-verification-uploads-list]");
-    const emptyNode = document.querySelector(
-      "[data-verification-uploads-empty]",
-    );
+    const listNode = document.querySelector("[data-portrait-uploads-list]");
+    const emptyNode = document.querySelector("[data-portrait-uploads-empty]");
     if (!listNode) return;
 
     if (!Array.isArray(uploads) || !uploads.length) {
@@ -681,19 +593,19 @@
 
     listNode.innerHTML = uploads
       .map(function (upload, index) {
+        const downloadUrl =
+          (typeof app.getApiBaseUrl === "function"
+            ? app.getApiBaseUrl()
+            : "") +
+          "/uploads/" +
+          encodeURIComponent(upload.id || "") +
+          "/download";
         const preview = String(upload.content_type || "").startsWith("image/")
           ? `<div style="margin: 0 0 1rem;">
                  <img
-                   src="${escapeHtml(
-                     (typeof app.getApiBaseUrl === "function"
-                       ? app.getApiBaseUrl()
-                       : "") +
-                       "/uploads/" +
-                       encodeURIComponent(upload.id || "") +
-                       "/download",
-                   )}"
-                   alt="${escapeHtml(upload.original_filename || "Uploaded image")}"
-                   style="width: 100%; max-height: 220px; object-fit: cover; border-radius: 18px; border: 1px solid rgba(255,255,255,0.08);"
+                   src="${escapeHtml(downloadUrl)}"
+                   alt="${escapeHtml(upload.original_filename || "Uploaded portrait")}"
+                   style="width: 100%; max-height: 260px; object-fit: cover; border-radius: 8px; border: 1px solid rgba(255,255,255,0.08);"
                  />
                </div>`
           : "";
@@ -702,10 +614,8 @@
           <div class="family-record-card">
             <div class="card-number">${index + 1}</div>
             ${preview}
-            <h3>${escapeHtml(upload.original_filename || "Uploaded File")}</h3>
-            <p class="card-copy"><strong>Category:</strong> ${escapeHtml(upload.category || "—")}</p>
-            <p class="card-copy"><strong>Verification Type:</strong> ${escapeHtml(upload.verification_type || "—")}</p>
-            <p class="card-copy"><strong>Evidence Kind:</strong> ${escapeHtml(upload.evidence_kind || "—")}</p>
+            <h3>${escapeHtml(upload.original_filename || "Uploaded Portrait")}</h3>
+            <p class="card-copy"><strong>Category:</strong> ${escapeHtml(upload.category || "member_photo")}</p>
             <p class="card-copy"><strong>Content Type:</strong> ${escapeHtml(upload.content_type || "—")}</p>
             <p class="card-copy"><strong>Size:</strong> ${escapeHtml(upload.size_bytes ?? "—")}</p>
             <p class="card-copy"><strong>Uploaded By:</strong> ${escapeHtml(upload.uploaded_by || "—")}</p>
@@ -728,57 +638,41 @@
   }
 
   async function loadUploads() {
-    const memberSelect = document.querySelector(
-      "[data-verification-list-member]",
-    );
-    const categorySelect = document.querySelector(
-      "[data-verification-category-filter]",
-    );
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
+    const memberSelect = document.querySelector("[data-portrait-list-member]");
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
 
     const memberId = String(memberSelect ? memberSelect.value : "").trim();
-    const category = String(categorySelect ? categorySelect.value : "").trim();
-
     if (!memberId) {
       setStatus(
         actionStatus,
-        "Select a member before loading uploads.",
+        "Select a portrait subject before loading uploads.",
         "error",
       );
       return;
     }
 
     try {
-      setStatus(actionStatus, "Loading uploaded records...", "info");
+      setStatus(actionStatus, "Loading portrait uploads...", "info");
 
-      const query = category ? `?category=${encodeURIComponent(category)}` : "";
       const payload = await app.apiRequest(
-        `/uploads/member/${encodeURIComponent(memberId)}${query}`,
+        `/uploads/member/${encodeURIComponent(memberId)}?category=member_photo`,
         { method: "GET" },
       );
 
       renderUploads(Array.isArray(payload.uploads) ? payload.uploads : []);
-      setStatus(
-        actionStatus,
-        "Uploaded records loaded successfully.",
-        "success",
-      );
+      setStatus(actionStatus, "Portrait uploads loaded successfully.", "success");
     } catch (error) {
-      console.error("Load uploads failed:", error);
+      console.error("Load portrait uploads failed:", error);
       setStatus(
         actionStatus,
-        error.message || "Unable to load uploaded records.",
+        error.message || "Unable to load portrait uploads.",
         "error",
       );
     }
   }
 
   async function downloadUpload(uploadId, originalFilename) {
-    const actionStatus = document.querySelector(
-      "[data-verification-action-status]",
-    );
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
 
     if (!uploadId) {
       setStatus(actionStatus, "Missing upload id.", "error");
@@ -786,7 +680,7 @@
     }
 
     try {
-      setStatus(actionStatus, "Downloading file...", "info");
+      setStatus(actionStatus, "Downloading portrait...", "info");
 
       const token = app.getToken ? app.getToken() : "";
       const apiBaseUrl =
@@ -803,14 +697,14 @@
 
       if (!response.ok) {
         const text = await response.text();
-        throw new Error(text || "Unable to download file.");
+        throw new Error(text || "Unable to download portrait.");
       }
 
       const blob = await response.blob();
       const objectUrl = window.URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = objectUrl;
-      link.download = originalFilename || "download";
+      link.download = originalFilename || "portrait-download";
       document.body.appendChild(link);
       link.click();
       link.remove();
@@ -818,17 +712,17 @@
 
       setStatus(actionStatus, "Download started.", "success");
     } catch (error) {
-      console.error("Download failed:", error);
+      console.error("Portrait download failed:", error);
       setStatus(
         actionStatus,
-        error.message || "Unable to download uploaded file.",
+        error.message || "Unable to download portrait.",
         "error",
       );
     }
   }
 
-  async function setupVerificationUploadPage() {
-    const page = document.querySelector("[data-verification-upload-page]");
+  async function setupPortraitUploadPage() {
+    const page = document.querySelector("[data-portrait-upload-page]");
     if (!page) return;
 
     try {
@@ -847,20 +741,13 @@
 
       const preferredFamilyId = await ensureWorkspaceFamilyId(currentContext);
       updateNav(currentContext, preferredFamilyId);
+      applyEntitlementNav(currentContext);
       await loadFamilies(preferredFamilyId);
 
-      const loadFamilyButton = document.querySelector(
-        "[data-verification-load-family]",
-      );
-      const photoForm = document.querySelector(
-        "[data-verification-photo-form]",
-      );
-      const uploadForm = document.querySelector(
-        "[data-verification-upload-form]",
-      );
-      const loadUploadsButton = document.querySelector(
-        "[data-verification-load-uploads]",
-      );
+      const loadFamilyButton = document.querySelector("[data-portrait-load-family]");
+      const uploadForm = document.querySelector("[data-portrait-upload-form]");
+      const loadUploadsButton = document.querySelector("[data-portrait-load-uploads]");
+      const familySelect = document.querySelector("[data-portrait-family-select]");
 
       if (loadFamilyButton) {
         loadFamilyButton.addEventListener("click", function () {
@@ -868,12 +755,8 @@
         });
       }
 
-      if (photoForm) {
-        photoForm.addEventListener("submit", handlePhotoUploadSubmit);
-      }
-
       if (uploadForm) {
-        uploadForm.addEventListener("submit", handleUploadSubmit);
+        uploadForm.addEventListener("submit", handlePortraitUploadSubmit);
       }
 
       if (loadUploadsButton) {
@@ -883,9 +766,7 @@
       }
 
       document.addEventListener("click", function (event) {
-        const downloadButton = event.target.closest(
-          "[data-download-upload-id]",
-        );
+        const downloadButton = event.target.closest("[data-download-upload-id]");
         if (!downloadButton) return;
 
         downloadUpload(
@@ -894,39 +775,33 @@
         );
       });
 
-      const familySelect = document.querySelector(
-        "[data-verification-family-select]",
-      );
       if (familySelect) {
         familySelect.addEventListener("change", function () {
           updateNav(currentContext, familySelect.value);
         });
       }
+
       if (familySelect && familySelect.value) {
         await loadFamilyGraph();
       }
     } catch (error) {
-      console.error("Verification upload page setup failed:", error);
-      const pageStatus = document.querySelector(
-        "[data-verification-page-status]",
-      );
-      const actionStatus = document.querySelector(
-        "[data-verification-action-status]",
-      );
+      console.error("Portrait upload page setup failed:", error);
+      const pageStatus = document.querySelector("[data-portrait-page-status]");
+      const actionStatus = document.querySelector("[data-portrait-action-status]");
 
       if (pageStatus) {
-        pageStatus.textContent = "Verification workspace could not be loaded.";
+        pageStatus.textContent = "Portrait workspace could not be loaded.";
       }
 
       setStatus(
         actionStatus,
-        error.message || "Unable to load verification workspace.",
+        error.message || "Unable to load portrait workspace.",
         "error",
       );
     }
   }
 
   document.addEventListener("DOMContentLoaded", function () {
-    setupVerificationUploadPage();
+    setupPortraitUploadPage();
   });
 })();

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -6,7 +6,7 @@
     <title>Verification Uploads | Tomb of Light</title>
     <meta
       name="description"
-      content="Upload verification records, portraits, and supporting family documents to Tomb of Light."
+      content="Upload verification records and supporting family documents to Tomb of Light."
     />
     <link rel="stylesheet" href="styles.css?v=20260328-7" />
   </head>
@@ -35,6 +35,9 @@
           <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html">Dashboard</a>
             <a href="intake-review.html" style="display: none">My Intake</a>
+            <a href="portrait-upload.html" style="display: none">
+              Portrait Uploads
+            </a>
             <a href="verification-upload.html" aria-current="page">
               Verification Uploads
             </a>
@@ -119,85 +122,7 @@
             </div>
 
             <div class="form-panel">
-              <span class="eyebrow">Step 2 — Upload Member Photo</span>
-
-              <form class="form-grid" data-verification-photo-form novalidate>
-                <div class="form-grid two-col">
-                  <label>
-                    Family Member
-                    <select
-                      name="member_id"
-                      data-verification-photo-member
-                      required
-                    >
-                      <option value="">Select member</option>
-                    </select>
-                  </label>
-
-                  <label>
-                    Photo File
-                    <input
-                      type="file"
-                      name="photo_file"
-                      accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
-                      required
-                    />
-                  </label>
-                </div>
-
-                <div class="helper">
-                  Upload portrait images for family members. Allowed: JPG, PNG,
-                  and WEBP. Submit only images you have the lawful right to use
-                  and share.
-                </div>
-
-                <div style="display: grid; gap: 0.85rem; margin-top: 0.85rem">
-                  <label
-                    style="display: flex; gap: 0.65rem; align-items: flex-start"
-                  >
-                    <input
-                      type="checkbox"
-                      required
-                      style="margin-top: 0.2rem"
-                    />
-                    <span>
-                      I confirm that I have the lawful right and authority to
-                      upload this image and, where required, permission from the
-                      living individual involved or from the parent or legal
-                      guardian of a minor.
-                    </span>
-                  </label>
-
-                  <label
-                    style="display: flex; gap: 0.65rem; align-items: flex-start"
-                  >
-                    <input
-                      type="checkbox"
-                      required
-                      style="margin-top: 0.2rem"
-                    />
-                    <span>
-                      I understand that Tomb of Light may review uploaded
-                      materials for workflow, support, security, fraud
-                      prevention, compliance, and service fulfillment.
-                    </span>
-                  </label>
-                </div>
-
-                <div class="inline-actions" style="margin-top: 1rem">
-                  <button
-                    class="btn btn-primary"
-                    type="submit"
-                    data-verification-photo-submit
-                  >
-                    Upload Member Photo
-                  </button>
-                </div>
-              </form>
-            </div>
-
-            <div class="form-panel">
-              <span class="eyebrow">Step 3 — Upload Verification Evidence</span>
+              <span class="eyebrow">Step 2 — Upload Verification Evidence</span>
 
               <form class="form-grid" data-verification-upload-form novalidate>
                 <div class="form-grid two-col">
@@ -341,7 +266,7 @@
             </div>
 
             <div class="form-panel">
-              <span class="eyebrow">Step 4 — View Uploaded Records</span>
+              <span class="eyebrow">Step 3 — View Uploaded Records</span>
 
               <div class="form-grid two-col">
                 <label>
@@ -354,9 +279,7 @@
                 <label>
                   Upload Category
                   <select data-verification-category-filter>
-                    <option value="">All upload categories</option>
-                    <option value="member_photo">member_photo</option>
-                    <option value="verification_evidence">
+                    <option value="verification_evidence" selected>
                       verification_evidence
                     </option>
                   </select>
@@ -412,10 +335,10 @@
 
                 <div>
                   <div class="card-number">3</div>
-                  <h3>Portrait Files</h3>
+                  <h3>Supporting Images</h3>
                   <p class="card-copy">
-                    Portraits and member photos used to support visual lineage
-                    presentation and related family record workflows.
+                    Supplemental images used to support the verification record
+                    when a document is not enough on its own.
                   </p>
                 </div>
               </div>
@@ -490,7 +413,7 @@
 
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260410-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="auth.js?v=20260413-4"></script>
 
     <script>
       document.addEventListener("DOMContentLoaded", async function () {
@@ -556,6 +479,11 @@
           const me = await app.apiRequest("/auth/me", { method: "GET" });
           if (auth.isInternalRole && auth.isInternalRole(me)) {
             document
+              .querySelectorAll('.site-nav a[href^="portrait-upload.html"]')
+              .forEach(function (node) {
+                node.style.display = "";
+              });
+            document
               .querySelectorAll('.site-nav a[href^="verification-upload.html"]')
               .forEach(function (node) {
                 node.style.display = "";
@@ -583,12 +511,18 @@
           const canUpload =
             !!resolved.can_upload_verification_docs ||
             !!resolved.can_upload_portraits;
+          const packageLane = String(
+            context?.packageLane || resolved.package_lane || "",
+          ).toLowerCase();
+          const canUploadPortraits =
+            packageLane === "portrait" && !!resolved.can_upload_portraits;
           const canUseLinkKeys = !!resolved.can_use_link_keys;
           const canOpenFamilyIntake = !!resolved.can_open_family_intake;
           const canBuildFamilyTree = !!resolved.can_build_family_tree;
           const canUseCertificate = !!resolved.can_use_lineage_certificate;
 
           updateNavHref("intake-review.html", context);
+          updateNavHref("portrait-upload.html", context);
           updateNavHref("verification-upload.html", context);
           updateNavHref("link-keys.html", context);
           updateNavHref("tree-view.html", context);
@@ -598,6 +532,12 @@
             .querySelectorAll('.site-nav a[href^="intake-review.html"]')
             .forEach(function (node) {
               node.style.display = canOpenFamilyIntake ? "" : "none";
+            });
+
+          document
+            .querySelectorAll('.site-nav a[href^="portrait-upload.html"]')
+            .forEach(function (node) {
+              node.style.display = canUploadPortraits ? "" : "none";
             });
 
           document
@@ -629,6 +569,6 @@
       });
     </script>
 
-    <script src="verification-upload.js?v=20260330-1"></script>
+    <script src="verification-upload.js?v=20260413-1"></script>
   </body>
 </html>


### PR DESCRIPTION
Digital Legacy Portrait dashboard primary action now says Upload Portrait and opens portrait-upload.html. Verification Uploads still opens verification-upload.html, but that page is now focused on verification evidence/documents only. The new portrait page has clear Return to Dashboard buttons at the top, inside the upload area, and at the end of the page. The portrait page keeps workspace context in the URL so the user can move back to the dashboard without losing the selected project/family context.