### PR TITLE
Backend upload visibility: Verification Uploads page:

### DIFF
--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -308,10 +308,23 @@ def _require_upload_access(
         current_user_id = _current_user_id(current_user)
         uploaded_by_user_id = _normalize_value(upload_record.get("uploaded_by_user_id"))
         owns_record = bool(current_user_id and uploaded_by_user_id and current_user_id == uploaded_by_user_id)
-        if (
-            bool(upload_record.get("internal_only"))
-            or (not bool(upload_record.get("customer_visible")) and not owns_record)
-        ):
+        if bool(upload_record.get("internal_only")) and not owns_record:
+            try:
+                create_audit_log(
+                    "private_file_access_denied",
+                    current_user_id or None,
+                    "upload",
+                    upload_id,
+                    {"reason": "visibility_policy"},
+                )
+            except Exception:
+                pass
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This file is not visible to customers.",
+            )
+
+        if not bool(upload_record.get("customer_visible")) and not owns_record:
             try:
                 create_audit_log(
                     "private_file_access_denied",
@@ -749,12 +762,28 @@ def _enforce_workspace_storage_limit(
     )
 
 
-def _apply_customer_visibility_filter(query: dict[str, Any], *, is_admin: bool) -> None:
+def _apply_customer_visibility_filter(
+    query: dict[str, Any],
+    *,
+    is_admin: bool,
+    current_user: dict[str, Any],
+) -> None:
     if is_admin:
         return
-    query["internal_only"] = {"$ne": True}
-    query["customer_visible"] = True
-    query["privacy_classification"] = {"$nin": ["admin_only"]}
+
+    current_user_id = _current_user_id(current_user)
+    query["$or"] = [
+        {
+            "uploaded_by_user_id": current_user_id,
+            "privacy_classification": {"$ne": "admin_only"},
+        },
+        {
+            "customer_visible": True,
+            "internal_only": {"$ne": True},
+            "privacy_classification": {"$nin": ["owner_only", "admin_only"]},
+        },
+        {"privacy_classification": "public"},
+    ]
 
 
 @router.get("/admin/review")
@@ -980,7 +1009,11 @@ def list_member_uploads(
         "family_id": _normalize_value((family or {}).get("_id")),
         "project_id": _normalize_value((project or {}).get("_id")),
     }
-    _apply_customer_visibility_filter(query, is_admin=bool(context.get("is_admin")))
+    _apply_customer_visibility_filter(
+        query,
+        is_admin=bool(context.get("is_admin")),
+        current_user=current_user,
+    )
     if normalized_category:
         query["category"] = normalized_category
 
@@ -1019,7 +1052,11 @@ def list_family_uploads(
         "family_id": _normalize_value((family or {}).get("_id")),
         "project_id": _normalize_value((project or {}).get("_id")),
     }
-    _apply_customer_visibility_filter(query, is_admin=bool(context.get("is_admin")))
+    _apply_customer_visibility_filter(
+        query,
+        is_admin=bool(context.get("is_admin")),
+        current_user=current_user,
+    )
     if normalized_category:
         query["category"] = normalized_category
 

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -261,7 +261,7 @@ async def store_verification_evidence_upload(
         "family_id": family_id,
         "member_id": member_id,
         "category": "verification_evidence",
-        "internal_only": True,
+        "internal_only": False,
         "customer_visible": False,
         "vault_scope": "personal",
         "visibility_scope": "private",

--- a/backend/tests/test_upload_visibility.py
+++ b/backend/tests/test_upload_visibility.py
@@ -1,0 +1,260 @@
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from app.routes import uploads as upload_routes
+
+
+class FakeCursor(list):
+    def sort(self, field_name, direction):
+        self.sort_key = field_name
+        reverse = direction < 0
+        return FakeCursor(
+            sorted(self, key=lambda item: str(item.get(field_name) or ""), reverse=reverse)
+        )
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    def find_one(self, query=None):
+        query = query or {}
+        for item in self.documents:
+            if self._matches(item, query):
+                return item
+        return None
+
+    def find(self, query=None):
+        query = query or {}
+        return FakeCursor([item for item in self.documents if self._matches(item, query)])
+
+    def _matches(self, item, query):
+        for key, expected in (query or {}).items():
+            if key == "$or":
+                if not any(self._matches(item, option) for option in expected):
+                    return False
+                continue
+
+            value = item.get(key)
+            if isinstance(expected, dict):
+                if "$in" in expected:
+                    if value not in expected["$in"]:
+                        return False
+                elif "$ne" in expected:
+                    if value == expected["$ne"]:
+                        return False
+                elif "$nin" in expected:
+                    if value in expected["$nin"]:
+                        return False
+                else:
+                    return False
+            elif value != expected:
+                return False
+        return True
+
+
+class FakeDatabase:
+    def __init__(self, collections=None):
+        self.collections = {
+            name: FakeCollection(documents)
+            for name, documents in (collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        if name not in self.collections:
+            self.collections[name] = FakeCollection()
+        return self.collections[name]
+
+
+def workspace_context():
+    return {
+        "member": {"_id": "member-1"},
+        "family": {"_id": "family-1"},
+        "project": {"_id": "project-1"},
+        "is_admin": False,
+        "resolved_entitlements": {
+            "can_upload_verification_docs": True,
+            "can_upload_portraits": True,
+        },
+    }
+
+
+class UploadVisibilityTests(unittest.TestCase):
+    def test_member_uploads_include_owner_private_verification_records(self):
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "member_id": "member-1",
+                        "category": "verification_evidence",
+                        "original_filename": "marquis-id.pdf",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": False,
+                        "privacy_classification": "owner_only",
+                        "created_at": "2026-04-13T20:00:00Z",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "member_id": "member-1",
+                        "category": "verification_evidence",
+                        "original_filename": "other-private.pdf",
+                        "uploaded_by_user_id": "other-user",
+                        "customer_visible": False,
+                        "internal_only": False,
+                        "privacy_classification": "owner_only",
+                        "created_at": "2026-04-13T20:01:00Z",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "member_id": "member-1",
+                        "category": "verification_evidence",
+                        "original_filename": "admin-redacted.pdf",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": True,
+                        "privacy_classification": "admin_only",
+                        "created_at": "2026-04-13T20:02:00Z",
+                    },
+                ]
+            }
+        )
+
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(upload_routes, "require_workspace_capability", return_value=workspace_context()),
+        ):
+            payload = upload_routes.list_member_uploads(
+                "member-1",
+                category="verification_evidence",
+                current_user={"id": "owner-1", "email": "marquis@example.com"},
+            )
+
+        filenames = {item["original_filename"] for item in payload["uploads"]}
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(filenames, {"marquis-id.pdf"})
+
+    def test_family_uploads_include_owner_private_records_without_member_filter(self):
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "member_id": "member-1",
+                        "category": "verification_evidence",
+                        "original_filename": "marquis-record.pdf",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": False,
+                        "privacy_classification": "owner_only",
+                        "created_at": "2026-04-13T20:00:00Z",
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": "project-2",
+                        "family_id": "family-2",
+                        "member_id": "member-2",
+                        "category": "verification_evidence",
+                        "original_filename": "larry-record.pdf",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": False,
+                        "privacy_classification": "owner_only",
+                        "created_at": "2026-04-13T20:01:00Z",
+                    },
+                ]
+            }
+        )
+
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(upload_routes, "require_workspace_capability", return_value=workspace_context()),
+        ):
+            payload = upload_routes.list_family_uploads(
+                "family-1",
+                category="verification_evidence",
+                current_user={"id": "owner-1", "email": "marquis@example.com"},
+            )
+
+        filenames = {item["original_filename"] for item in payload["uploads"]}
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(filenames, {"marquis-record.pdf"})
+
+    def test_owner_can_download_legacy_internal_verification_upload(self):
+        upload_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": upload_id,
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": True,
+                        "privacy_classification": "owner_only",
+                    }
+                ]
+            }
+        )
+
+        with patch.object(
+            upload_routes,
+            "require_workspace_capability",
+            return_value={"project": {"_id": "project-1"}, "is_admin": False},
+        ):
+            upload_record, _context = upload_routes._require_upload_access(
+                str(upload_id),
+                db,
+                {"id": "owner-1", "email": "marquis@example.com"},
+                detail="test",
+            )
+
+        self.assertEqual(str(upload_record["_id"]), str(upload_id))
+
+    def test_non_owner_cannot_download_internal_verification_upload(self):
+        upload_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": upload_id,
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "uploaded_by_user_id": "owner-1",
+                        "customer_visible": False,
+                        "internal_only": True,
+                        "privacy_classification": "owner_only",
+                    }
+                ]
+            }
+        )
+
+        with patch.object(
+            upload_routes,
+            "require_workspace_capability",
+            return_value={"project": {"_id": "project-1"}, "is_admin": False},
+        ):
+            with self.assertRaises(HTTPException):
+                upload_routes._require_upload_access(
+                    str(upload_id),
+                    db,
+                    {"id": "other-user", "email": "other@example.com"},
+                    detail="test",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -270,9 +270,9 @@
 
               <div class="form-grid two-col">
                 <label>
-                  Member
+                  Member Filter
                   <select data-verification-list-member>
-                    <option value="">Select member</option>
+                    <option value="">All members in this workspace</option>
                   </select>
                 </label>
 
@@ -307,7 +307,7 @@
                 data-verification-uploads-empty
                 style="display: none; margin-top: 1rem"
               >
-                No uploaded records found for this member.
+                No verification records found for this workspace.
               </div>
             </div>
 
@@ -569,6 +569,6 @@
       });
     </script>
 
-    <script src="verification-upload.js?v=20260413-1"></script>
+    <script src="verification-upload.js?v=20260413-2"></script>
   </body>
 </html>

--- a/verification-upload.js
+++ b/verification-upload.js
@@ -280,7 +280,7 @@
     setSelectOptions(
       document.querySelector("[data-verification-list-member]"),
       members,
-      "Select member",
+      "All members in this workspace",
     );
   }
 
@@ -467,8 +467,16 @@
 
       populateMemberSelects();
       if (members.length) {
+        const listMember = document.querySelector(
+          "[data-verification-list-member]",
+        );
+        if (listMember) {
+          listMember.value = "";
+        }
+
         pageStatus.textContent = `Family ${familyId} loaded successfully.`;
         setStatus(actionStatus, "Family loaded successfully.", "success");
+        await loadUploads();
       } else {
         pageStatus.textContent = `Family ${familyId} loaded, but no member records were found yet.`;
         setStatus(
@@ -741,10 +749,10 @@
     const memberId = String(memberSelect ? memberSelect.value : "").trim();
     const category = String(categorySelect ? categorySelect.value : "").trim();
 
-    if (!memberId) {
+    if (!memberId && !currentFamilyId) {
       setStatus(
         actionStatus,
-        "Select a member before loading uploads.",
+        "Load a family before loading verification records.",
         "error",
       );
       return;
@@ -753,9 +761,15 @@
     try {
       setStatus(actionStatus, "Loading uploaded records...", "info");
 
-      const query = category ? `?category=${encodeURIComponent(category)}` : "";
+      const effectiveCategory = category || "verification_evidence";
+      const query = effectiveCategory
+        ? `?category=${encodeURIComponent(effectiveCategory)}`
+        : "";
+      const endpoint = memberId
+        ? `/uploads/member/${encodeURIComponent(memberId)}${query}`
+        : `/uploads/family/${encodeURIComponent(currentFamilyId)}${query}`;
       const payload = await app.apiRequest(
-        `/uploads/member/${encodeURIComponent(memberId)}${query}`,
+        endpoint,
         { method: "GET" },
       );
 


### PR DESCRIPTION
Found it, and yes, it was an across-the-board issue.

The backend was storing verification evidence as private owner-only records, but the customer upload listing endpoints were filtering for customer_visible=true, so a customer could upload a document and then not see it afterward. Marquis hit that exact path.

I fixed it in two places:

Backend upload visibility:

backend/app/routes/uploads.py: customers can now list/download their own private verification uploads, while other users’ private files and admin_only files stay hidden. backend/app/services/upload_service.py: new verification evidence uploads are no longer marked internal_only; they remain private/owner-only. Verification Uploads page:

verification-upload.js: the page now loads verification records for the whole workspace by default instead of requiring a member filter first. verification-upload.html: changed the list UI to Member Filter with All members in this workspace, and bumped the JS cache version. Added focused coverage:

backend/tests/test_upload_visibility.py: proves owner-private verification records show up, cross-project records do not leak, legacy internal owner uploads still download for the owner, and non-owners are blocked. Validation passed:

venv/bin/python -m unittest tests.test_upload_visibility venv/bin/python -m unittest discover tests -> 40 tests OK venv/bin/python -m py_compile app/routes/uploads.py app/services/upload_service.py tests/test_upload_visibility.py node --check verification-upload.js
git diff --check
So Marquis should now be able to open Verification Uploads and see his previously uploaded documents without having to guess the right member filter first.