### PR TITLE
Add fallback to legacy /families/{familyId}/graph for Family Tree view

### DIFF
--- a/tree-view.js
+++ b/tree-view.js
@@ -490,12 +490,17 @@
     const canBuildPrivateTree = Boolean(resolved.can_build_family_tree);
     const linkedEndpoint = `/tree/${familyId}/linked?mode=private`;
     const privateEndpoint = `/tree/${familyId}/private`;
+    const legacyGraphEndpoint = `/families/${encodeURIComponent(familyId)}/graph`;
     const attempts = canTraverseLinked
       ? [
           { label: "linked", endpoint: linkedEndpoint },
           ...(canBuildPrivateTree ? [{ label: "private", endpoint: privateEndpoint }] : []),
+          { label: "legacy", endpoint: legacyGraphEndpoint },
         ]
-      : [{ label: "private", endpoint: privateEndpoint }];
+      : [
+          { label: "private", endpoint: privateEndpoint },
+          { label: "legacy", endpoint: legacyGraphEndpoint },
+        ];
     const projectId = getProjectIdFromContext(context);
 
     console.info("[TreeView] Loading tree", {
@@ -524,9 +529,13 @@
       selectedSource = attempt.label;
 
       if (isFallbackAttempt) {
+        const fallbackMessage =
+          attempt.label === "legacy"
+            ? "Tree renderer service unavailable. Trying family graph fallback..."
+            : "Linked tree unavailable. Trying private family tree...";
         showStatus(
           statusNode,
-          "Linked tree unavailable. Trying private family tree...",
+          fallbackMessage,
           "info",
         );
       }
@@ -602,6 +611,8 @@
         statusNode,
         selectedSource === "linked"
           ? "Linked family graph loaded successfully."
+          : selectedSource === "legacy"
+          ? "Visual family tree loaded from fallback graph service."
           : "Visual family tree loaded successfully. Use the zoom controls for larger families.",
         "success",
       );


### PR DESCRIPTION
### Motivation
- The Family Tree page failed when the visual tree service (`/tree/...`) was unreachable even though a legacy graph endpoint `/families/{familyId}/graph` is available in the codebase, so add a fallback to preserve functionality in those environments.

### Description
- Added `legacyGraphEndpoint = "/families/${encodeURIComponent(familyId)}/graph"` and included it in the `attempts` list inside `loadAndRenderTree` so the tree loader retries the legacy graph when linked/private endpoints fail in `tree-view.js`.
- Added fallback-specific status messaging while retrying and a distinct success message when the legacy graph is used, so users see what retry path is being attempted.

### Testing
- Ran `node --check tree-view.js`, which completed without errors.
- Confirmed the updated `tree-view.js` contains the fallback logic and the new status/success messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df67433af0832d82b9817be59bb47d)