### PR TITLE
Fix co-owner workspace resolution and shared access flow

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -4,7 +4,7 @@
   const app = window.TOLApp || window.TOLAuth;
   const POST_LOGIN_REDIRECT = "dashboard.html";
   const SIGNUP_POLICY_VERSION = "2026-03-26";
-  const DASHBOARD_CONTEXT_STORAGE_KEY = "tol_dashboard_context_v1";
+  const DASHBOARD_CONTEXT_STORAGE_KEY = "tol_dashboard_context_v2";
   let hasLogoutBinding = false;
   const HOUSEHOLD_LINK_PACKAGE_CODES = new Set([
     "legacy_plus",
@@ -480,6 +480,59 @@
 
   function hasWorkspaceSelectionHints(hints) {
     return Boolean(hints?.projectId || hints?.familyId);
+  }
+
+  function getWorkspaceHintsFromUser(user) {
+    return {
+      projectId: String(
+        user?.active_project_id || user?.activeProjectId || "",
+      ).trim(),
+      familyId: String(
+        user?.active_family_id || user?.activeFamilyId || "",
+      ).trim(),
+    };
+  }
+
+  function mergeWorkspaceSelectionHints(primary, fallback) {
+    const primaryHints =
+      primary && typeof primary === "object"
+        ? {
+            projectId: String(
+              primary.projectId ||
+                primary.project_id ||
+                primary.active_project_id ||
+                "",
+            ).trim(),
+            familyId: String(
+              primary.familyId ||
+                primary.family_id ||
+                primary.active_family_id ||
+                "",
+            ).trim(),
+          }
+        : { projectId: "", familyId: "" };
+    const fallbackHints =
+      fallback && typeof fallback === "object"
+        ? {
+            projectId: String(
+              fallback.projectId ||
+                fallback.project_id ||
+                fallback.active_project_id ||
+                "",
+            ).trim(),
+            familyId: String(
+              fallback.familyId ||
+                fallback.family_id ||
+                fallback.active_family_id ||
+                "",
+            ).trim(),
+          }
+        : { projectId: "", familyId: "" };
+
+    return {
+      projectId: primaryHints.projectId || fallbackHints.projectId,
+      familyId: primaryHints.familyId || fallbackHints.familyId,
+    };
   }
 
   function candidateMatchesWorkspaceHints(candidate, hints) {
@@ -1059,6 +1112,31 @@
     return toArray(payload);
   }
 
+  async function fetchProjectEntitlementByProjectId(projectId) {
+    const normalizedProjectId = String(projectId || "").trim();
+    if (!normalizedProjectId) return null;
+
+    try {
+      return await app.apiRequest(
+        `/project-entitlements/project/${encodeURIComponent(normalizedProjectId)}`,
+        {
+          method: "GET",
+        },
+      );
+    } catch (error) {
+      const message = getErrorMessage(error).toLowerCase();
+      if (
+        message.includes("project entitlement not found") ||
+        message.includes("not authorized") ||
+        message.includes("404") ||
+        message.includes("403")
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
   async function fetchProjects() {
     const payload = await app.apiRequest("/projects/", {
       method: "GET",
@@ -1177,10 +1255,6 @@
       getPackageCodeFromRecord(record);
 
     if (!packageCode || packageCode === "unknown") {
-      return null;
-    }
-
-    if (source === "project" && !activeEntitlement && !paidOrder) {
       return null;
     }
 
@@ -1308,13 +1382,10 @@
   async function getDashboardContext(user, orders, options) {
     let entitlements = [];
     let projects = [];
-    const hints =
-      options && typeof options === "object"
-        ? {
-            projectId: String(options.projectId || "").trim(),
-            familyId: String(options.familyId || "").trim(),
-          }
-        : { projectId: "", familyId: "" };
+    const hints = mergeWorkspaceSelectionHints(
+      options,
+      getWorkspaceHintsFromUser(user),
+    );
 
     try {
       const results = await Promise.all([
@@ -1331,6 +1402,24 @@
     } catch (error) {
       entitlements = [];
       projects = [];
+    }
+
+    if (hints.projectId) {
+      const alreadyIncludesHintedProject = entitlements.some(function (item) {
+        return getProjectIdFromRecord(item) === hints.projectId;
+      });
+      if (!alreadyIncludesHintedProject) {
+        try {
+          const hintedEntitlement = await fetchProjectEntitlementByProjectId(
+            hints.projectId,
+          );
+          if (hintedEntitlement && hasKnownPackage(hintedEntitlement)) {
+            entitlements = [hintedEntitlement].concat(entitlements);
+          }
+        } catch (error) {
+          // Ignore supplemental entitlement lookup so dashboard context can still load.
+        }
+      }
     }
 
     let currentWorkspace = resolveCurrentWorkspace(
@@ -1430,7 +1519,10 @@
   }
 
   async function getDashboardContextForCurrentPage(user, orders) {
-    const hints = getWorkspaceSelectionHints();
+    const hints = mergeWorkspaceSelectionHints(
+      getWorkspaceSelectionHints(),
+      getWorkspaceHintsFromUser(user),
+    );
     const cached = readCachedDashboardContext(user, hints);
 
     if (cached) {
@@ -2497,6 +2589,7 @@
     redirectAfterLogin,
     fetchOrders,
     fetchProjectEntitlements,
+    fetchProjectEntitlementByProjectId,
     fetchProjects,
     getDashboardContext,
     getDashboardContextForCurrentPage,

--- a/backend/app/core/role_catalog.py
+++ b/backend/app/core/role_catalog.py
@@ -35,6 +35,7 @@ SUPER_ADMIN_ROLE_CODES: frozenset[str] = frozenset(
 PROJECT_MEMBER_ROLE_ALIASES: dict[str, str] = {
     "billing_owner": "billing_owner",
     "owner": "billing_owner",
+    "buyer": "billing_owner",
     "co_owner": "co_owner",
     "spouse": "co_owner",
     "partner": "co_owner",

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -226,15 +226,25 @@ def _is_paid_package_order(order: dict[str, Any] | None) -> bool:
     }
 
 
-def _list_active_entitlements_for_user(user_id: str) -> list[dict[str, Any]]:
-    if not user_id:
+def _list_active_entitlements_for_user(
+    user_id: str,
+    *,
+    user_email: str = "",
+) -> list[dict[str, Any]]:
+    if not user_id and not user_email:
         return []
 
     try:
-        return list_user_project_entitlements(user_id, active_only=True)
+        return list_user_project_entitlements(
+            user_id,
+            email=user_email,
+            active_only=True,
+        )
     except TypeError:
         try:
-            entitlements = list_user_project_entitlements(user_id)
+            entitlements = list_user_project_entitlements(
+                user_id,
+            )
         except Exception:
             return []
 
@@ -254,9 +264,13 @@ def get_user_package_capabilities(user: dict[str, Any]) -> set[str]:
         return capabilities
 
     user_id = _current_user_id(user)
+    user_email = _current_user_email(user)
 
-    if user_id:
-        entitlements = _list_active_entitlements_for_user(user_id)
+    if user_id or user_email:
+        entitlements = _list_active_entitlements_for_user(
+            user_id,
+            user_email=user_email,
+        )
         for entitlement in entitlements:
             _collect_capabilities_from_mapping(
                 capabilities,
@@ -798,7 +812,12 @@ def _resolve_workflow_state(project_id: str | None) -> dict[str, Any]:
     }
 
 
-def resolve_access_context(user_id: str, project_id: str | None = None) -> dict[str, Any]:
+def resolve_access_context(
+    user_id: str,
+    project_id: str | None = None,
+    *,
+    user_email: str = "",
+) -> dict[str, Any]:
     user = _load_user_by_id(user_id)
     if user is None:
         raise HTTPException(
@@ -810,7 +829,11 @@ def resolve_access_context(user_id: str, project_id: str | None = None) -> dict[
     capabilities = _collect_capabilities_for_roles(role_codes)
     permissions = _collect_permissions_for_roles(role_codes, capabilities)
 
-    entitlements = list_user_project_entitlements(user_id, active_only=True)
+    entitlements = list_user_project_entitlements(
+        user_id,
+        email=user_email or _current_user_email(user),
+        active_only=True,
+    )
     if project_id:
         entitlements = [
             entitlement
@@ -843,10 +866,18 @@ def _get_or_resolve_access_context(
             return cached_context
 
     user_id = _current_user_id(current_user)
-    context = resolve_access_context(
-        user_id,
-        project_id=normalized_project_id,
-    )
+    user_email = _current_user_email(current_user)
+    if user_email:
+        context = resolve_access_context(
+            user_id,
+            project_id=normalized_project_id,
+            user_email=user_email,
+        )
+    else:
+        context = resolve_access_context(
+            user_id,
+            project_id=normalized_project_id,
+        )
     current_user["_access_context"] = context
     return context
 
@@ -1043,7 +1074,17 @@ def transition_project(
     if not actor_user_id:
         raise HTTPException(status_code=400, detail="Actor user id is required.")
 
-    access_context = resolve_access_context(actor_user_id, project_id=project_id)
+    if actor_email:
+        access_context = resolve_access_context(
+            actor_user_id,
+            project_id=project_id,
+            user_email=actor_email,
+        )
+    else:
+        access_context = resolve_access_context(
+            actor_user_id,
+            project_id=project_id,
+        )
     permission_pool = set(access_context.get("permissions") or [])
     required_permissions = {
         "project.workflow.transition",

--- a/backend/app/routes/asset_delivery.py
+++ b/backend/app/routes/asset_delivery.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Any
 from datetime import timezone
 
+from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
+from app.database import get_database
 from app.dependencies.auth import get_current_user
 from app.services.mint_record_service import build_mint_status
 from app.services.order_service import get_orders_for_user
@@ -51,33 +53,75 @@ def _project_for_request(
     return project
 
 
+PAID_PACKAGE_ORDER_STATUSES = {
+    "paid",
+    "complete",
+    "completed",
+    "succeeded",
+    "active",
+    "fulfilled",
+    "confirmed",
+}
+
+
+def _project_id_candidates(project_id: str) -> list[Any]:
+    normalized_project_id = _normalize(project_id)
+    if not normalized_project_id:
+        return []
+    candidates: list[Any] = [normalized_project_id]
+    if ObjectId.is_valid(normalized_project_id):
+        candidates.append(ObjectId(normalized_project_id))
+    return candidates
+
+
+def _is_paid_package_order(order: dict[str, Any] | None) -> bool:
+    if not isinstance(order, dict):
+        return False
+    item_type = _normalize(order.get("item_type") or "package").lower()
+    status_value = _normalize(order.get("status")).lower()
+    return item_type == "package" and status_value in PAID_PACKAGE_ORDER_STATUSES
+
+
 def _resolve_order_for_project(
     current_user: dict[str, Any], project_id: str
 ) -> dict[str, Any] | None:
     """Return the most recent paid order associated with this project, or None."""
+    project_id_values = _project_id_candidates(project_id)
+    db = get_database()
+    if db is not None and project_id_values:
+        cursor = db["orders"].find(
+            {"project_id": {"$in": project_id_values}}
+        ).sort("created_at", -1)
+        for order_doc in cursor:
+            if not _is_paid_package_order(order_doc):
+                continue
+            serialized = dict(order_doc)
+            serialized.setdefault("id", str(order_doc.get("_id") or ""))
+            serialized.setdefault(
+                "project_id",
+                _normalize(order_doc.get("project_id")),
+            )
+            return serialized
+
+    # Fallback for legacy paid orders that were not linked to a project id.
     try:
         orders = get_orders_for_user(current_user)
     except Exception:
         return None
 
-    if not orders:
-        return None
-
-    # Prefer an order whose project_id field directly matches.
+    normalized_project_id = _normalize(project_id)
     for order in orders:
-        order_project = _normalize(order.get("project_id"))
-        if order_project and order_project == _normalize(project_id):
+        if not _is_paid_package_order(order):
+            continue
+        order_project_id = _normalize(order.get("project_id"))
+        if order_project_id and order_project_id == normalized_project_id:
             return order
 
-    # Fall back to the most recent paid package order for this user.
-    paid_statuses = {"paid", "active", "fulfilled", "confirmed"}
     for order in orders:
-        if _normalize(order.get("item_type")) == "package" and _normalize(
-            order.get("status")
-        ).lower() in paid_statuses:
+        if _is_paid_package_order(order):
             return order
 
-    return orders[0] if orders else None
+    return None
 
 
 @router.get("/projects/{project_id}/digital-collectible")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -35,6 +35,7 @@ from app.services.auth_service import (
     verify_mfa_enrollment,
     verify_mfa_login_challenge,
 )
+from app.services.access_context_service import build_access_context
 from app.services.rate_limit_service import (
     clear_failures,
     enforce_lockout,
@@ -374,7 +375,14 @@ def mfa_disable(
 @router.get("/me", response_model=UserResponse)
 def me(response: Response, current_user: dict = Depends(get_current_user)):
     _apply_no_store(response)
-    return build_user_response(current_user)
+    payload = build_user_response(current_user)
+    try:
+        context = build_access_context(current_user)
+    except Exception:
+        context = {}
+    payload["active_project_id"] = context.get("active_project_id")
+    payload["active_family_id"] = context.get("active_family_id")
+    return payload
 
 
 def _current_user_id(user: dict) -> str:

--- a/backend/app/routes/families.py
+++ b/backend/app/routes/families.py
@@ -13,6 +13,7 @@ from app.schemas.family import FamilyCreate, FamilyResponse, build_family_respon
 from app.services.workspace_access_service import (
     list_accessible_families_for_user,
     require_workspace_capability,
+    require_workspace_member_role,
 )
 
 router = APIRouter(prefix="/families", tags=["Families"])
@@ -175,6 +176,11 @@ def create_family_route(
             project_id=project_id,
             capabilities=("can_build_family_tree", "can_open_family_intake"),
             detail="Your active package does not include family build access.",
+        )
+        require_workspace_member_role(
+            context,
+            allowed_roles=("billing_owner", "co_owner", "family_manager"),
+            detail="Your role cannot create a new family workspace root.",
         )
         project = context["project"]
 

--- a/backend/app/routes/family_members.py
+++ b/backend/app/routes/family_members.py
@@ -15,6 +15,7 @@ from app.services.matching import generate_match_candidates_for_member
 from app.services.workspace_access_service import (
     list_accessible_families_for_user,
     require_workspace_capability,
+    require_workspace_member_role,
 )
 
 router = APIRouter(prefix="/family-members", tags=["family_members"])
@@ -238,6 +239,11 @@ def create_family_member(
         capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include family member editing.",
     )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
+        detail="Your role is read-only for family member edits.",
+    )
 
     user_id = _current_user_id(current_user)
 
@@ -290,6 +296,11 @@ def update_family_member(
         capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include family member editing.",
     )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
+        detail="Your role is read-only for family member edits.",
+    )
     existing = context["member"]
 
     if "family_id" in payload:
@@ -341,6 +352,11 @@ def delete_family_member(
         member_id=member_id,
         capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include family member editing.",
+    )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager"),
+        detail="Your role cannot remove family members.",
     )
     existing = context["member"]
 

--- a/backend/app/routes/project_entitlements.py
+++ b/backend/app/routes/project_entitlements.py
@@ -113,8 +113,13 @@ def list_my_project_entitlements(
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
     current_user_id = _current_user_id(current_user)
+    current_user_email = str(current_user.get("email") or "").strip().lower()
     return {
-        "items": list_user_project_entitlements(current_user_id, active_only=True),
+        "items": list_user_project_entitlements(
+            current_user_id,
+            email=current_user_email,
+            active_only=True,
+        ),
     }
 
 

--- a/backend/app/routes/relationships.py
+++ b/backend/app/routes/relationships.py
@@ -10,7 +10,10 @@ from app.dependencies.auth import (
 )
 from app.schemas.relationship import RelationshipCreate, RelationshipResponse
 from app.services.relationship_guardrails import RelationshipGuardrailService
-from app.services.workspace_access_service import require_workspace_capability
+from app.services.workspace_access_service import (
+    require_workspace_capability,
+    require_workspace_member_role,
+)
 
 router = APIRouter(prefix="/relationships", tags=["Relationships"])
 
@@ -175,6 +178,11 @@ async def create_relationship(
         capabilities=("can_build_family_tree", "can_open_family_intake"),
         detail="Your active package does not include relationship editing.",
     )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
+        detail="Your role is read-only for relationship edits.",
+    )
     resolved_family_id = str(context["family"].get("_id"))
 
     created_by = (
@@ -317,7 +325,12 @@ async def delete_relationship(
 ):
     db = request.app.state.db
 
-    relationship, _family = _require_relationship_access(relationship_id, db, current_user)
+    relationship, context = _require_relationship_access(relationship_id, db, current_user)
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager"),
+        detail="Your role cannot remove relationships.",
+    )
 
     db["relationships"].delete_one({"_id": ObjectId(relationship_id)})
 

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -47,6 +47,7 @@ from app.services.tree_service import list_linked_family_ids
 from app.services.workspace_access_service import (
     count_workspace_uploads,
     require_workspace_capability,
+    require_workspace_member_role,
     resolve_workspace_context,
 )
 
@@ -432,7 +433,17 @@ def _require_upload_management_access(
 
     current_user_id = _current_user_id(current_user)
     uploaded_by_user_id = _normalize_value(upload_record.get("uploaded_by_user_id"))
+    member_role = _normalize_value(context.get("member_role"))
+    if current_user_id == uploaded_by_user_id:
+        return upload_record, context
+
+    if member_role in {"billing_owner", "co_owner", "family_manager"}:
+        return upload_record, context
+
     project_owner_user_id = _normalize_value((context.get("project") or {}).get("owner_user_id"))
+    if current_user_id == project_owner_user_id:
+        return upload_record, context
+
     if current_user_id not in {uploaded_by_user_id, project_owner_user_id}:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -901,6 +912,11 @@ async def upload_member_photo(
         capabilities=("can_upload_portraits",),
         detail="Your active package does not include upload access.",
     )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
+        detail="Your role is read-only for uploads.",
+    )
 
     db = get_database()
     if db is None:
@@ -964,6 +980,11 @@ async def upload_verification_evidence(
         member_id=member_id,
         capabilities=("can_upload_verification_docs",),
         detail="Your active package does not include upload access.",
+    )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
+        detail="Your role is read-only for uploads.",
     )
 
     db = get_database()
@@ -1409,11 +1430,10 @@ def delete_upload(
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    upload_record, _context = _require_upload_access(
+    upload_record, _context = _require_upload_management_access(
         upload_id,
         db,
         current_user,
-        detail="Your active package does not include upload access.",
     )
 
     relative_path = _normalize_value(upload_record.get("relative_path"))

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -101,6 +101,8 @@ class UserResponse(BaseModel):
     mfa_enabled: bool = False
     mfa_enrolled_at: Optional[str] = None
     created_at: str
+    active_project_id: Optional[str] = None
+    active_family_id: Optional[str] = None
 
     policy_version: Optional[str] = None
     terms_accepted_at: Optional[str] = None

--- a/backend/app/services/access_context_service.py
+++ b/backend/app/services/access_context_service.py
@@ -12,6 +12,7 @@ from app.services.experience_catalog_service import (
     get_lane_chambers,
 )
 from app.services.project_entitlement_service import list_user_project_entitlements
+from app.services.project_membership_service import list_accessible_project_ids
 from app.services.workspace_access_service import resolve_workspace_context
 
 
@@ -62,9 +63,35 @@ def resolve_default_project_id(current_user: dict[str, Any]) -> str | None:
     user_id = _current_user_id(current_user)
     user_email = _current_user_email(current_user)
 
+    # Project memberships are the source of truth for invited customers
+    # (co-owner, family manager, contributor, viewer, linked relative).
+    # Use them first so invited users retain durable workspace context.
+    if user_id or user_email:
+        try:
+            accessible_ids = list_accessible_project_ids(
+                user_id=user_id,
+                email=user_email,
+                active_only=True,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Unable to load project memberships for user %s: %s",
+                user_id or user_email,
+                exc,
+            )
+            accessible_ids = []
+        for project_id in accessible_ids:
+            normalized = _normalize(project_id)
+            if normalized:
+                return normalized
+
     if user_id:
         try:
-            entitlements = list_user_project_entitlements(user_id, active_only=True)
+            entitlements = list_user_project_entitlements(
+                user_id,
+                email=user_email,
+                active_only=True,
+            )
         except RuntimeError as exc:
             logger.warning("Unable to load project entitlements for user %s: %s", user_id, exc)
             entitlements = []
@@ -107,7 +134,19 @@ def build_access_context(
     workspace_context: dict[str, Any] = {}
 
     if resolved_project_id:
-        workspace_context = resolve_workspace_context(current_user, project_id=resolved_project_id)
+        try:
+            workspace_context = resolve_workspace_context(
+                current_user,
+                project_id=resolved_project_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Unable to resolve workspace context for user %s project %s: %s",
+                _current_user_id(current_user) or _current_user_email(current_user),
+                resolved_project_id,
+                exc,
+            )
+            workspace_context = {}
 
     project = workspace_context.get("project") or {}
     family = workspace_context.get("family") or {}
@@ -134,7 +173,7 @@ def build_access_context(
         "role": _current_user_role(current_user),
         "status": _current_user_status(current_user),
         "package_lane": package_lane,
-        "active_project_id": _normalize(project.get("_id")) or None,
+        "active_project_id": _normalize(project.get("_id")) or resolved_project_id or None,
         "active_family_id": _normalize(family.get("_id")) or None,
         "active_entitlements": active_entitlements,
         "project_permissions": active_entitlements,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -199,6 +199,8 @@ def build_user_response(user: dict) -> dict:
         "mfa_enabled": bool(user.get("mfa_enabled")),
         "mfa_enrolled_at": user.get("mfa_enrolled_at"),
         "created_at": user["created_at"],
+        "active_project_id": user.get("active_project_id"),
+        "active_family_id": user.get("active_family_id"),
         "policy_version": user.get("policy_version"),
         "terms_accepted_at": user.get("terms_accepted_at"),
         "privacy_accepted_at": user.get("privacy_accepted_at"),

--- a/backend/app/services/household_access_service.py
+++ b/backend/app/services/household_access_service.py
@@ -541,6 +541,21 @@ def accept_household_invite(*, invite_key: str, user: dict[str, Any]) -> dict[st
         upsert=True,
     )
 
+    if user_id:
+        user_lookup: dict[str, Any] = {"$or": [{"id": user_id}, {"user_id": user_id}]}
+        user_oid = _to_oid(user_id)
+        if user_oid is not None:
+            user_lookup["$or"] = [{"_id": user_oid}, *user_lookup["$or"]]
+        _db()["users"].update_one(
+            user_lookup,
+            {
+                "$set": {
+                    "active_project_id": project_id,
+                    "active_project_selected_at": now,
+                }
+            },
+        )
+
     use_count = int(invite.get("use_count") or 0) + 1
     max_uses = max(1, int(invite.get("max_uses") or 1))
     invite_status = "accepted" if use_count >= max_uses else "pending"
@@ -752,5 +767,12 @@ def revoke_membership(*, project_id: str, membership_id: str, actor_user: dict[s
 def list_my_memberships(user: dict[str, Any]) -> list[dict[str, Any]]:
     user_id = _normalize(user.get("id") or user.get("_id") or user.get("user_id"))
     email = _normalize_email(user.get("email"))
-    query = {"$or": [{"user_id": user_id}, {"email": email}]}
+    filters: list[dict[str, Any]] = []
+    if user_id:
+        filters.append({"user_id": user_id})
+    if email:
+        filters.append({"email": email})
+    if not filters:
+        return []
+    query = {"$or": filters}
     return list(_members().find(query).sort("updated_at", -1))

--- a/backend/app/services/project_entitlement_service.py
+++ b/backend/app/services/project_entitlement_service.py
@@ -237,10 +237,11 @@ def get_project_entitlement(project_id: str) -> dict[str, Any] | None:
 def list_user_project_entitlements(
     user_id: str,
     *,
+    email: str = "",
     active_only: bool = True,
 ) -> list[dict[str, Any]]:
     collection = _collection()
-    project_ids = list_accessible_project_ids(user_id=user_id)
+    project_ids = list_accessible_project_ids(user_id=user_id, email=email)
 
     or_filters: list[dict[str, Any]] = []
     user_id_values = _user_id_candidates(user_id)

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 from fastapi import HTTPException, status
 
 from app.core.package_catalog import get_package, normalize_package_code
+from app.core.role_catalog import normalize_project_member_role
 from app.database import get_database
 from app.services.entitlement_service import resolve_project_entitlements
 from app.services.project_membership_service import get_project_access_snapshot
@@ -460,6 +461,32 @@ def require_workspace_capability(
             detail=detail,
         )
 
+    return context
+
+
+def require_workspace_member_role(
+    context: dict[str, Any],
+    *,
+    allowed_roles: Iterable[str],
+    detail: str,
+) -> dict[str, Any]:
+    if context.get("is_admin"):
+        return context
+
+    normalized_role = normalize_project_member_role(
+        context.get("member_role"),
+        default="viewer",
+    )
+    allowed = {
+        normalize_project_member_role(role, default="viewer")
+        for role in allowed_roles
+        if _normalize_value(role)
+    }
+    if normalized_role not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=detail,
+        )
     return context
 
 

--- a/backend/tests/test_asset_delivery.py
+++ b/backend/tests/test_asset_delivery.py
@@ -1,7 +1,29 @@
 import unittest
+from bson import ObjectId
 from unittest.mock import patch
 
 from app.routes import asset_delivery
+
+
+class _FakeOrderCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _FakeOrdersCollection:
+    def __init__(self, docs):
+        self._docs = list(docs)
+        self.last_query = None
+
+    def find(self, query):
+        self.last_query = query
+        return _FakeOrderCursor(self._docs)
 
 
 class AssetDeliveryRouteTests(unittest.TestCase):
@@ -35,6 +57,60 @@ class AssetDeliveryRouteTests(unittest.TestCase):
 
         self.assertEqual(payload["wallet"], "0xabc123")
         self.assertEqual(payload["customer_wallet"], "0xabc123")
+
+    def test_resolve_order_for_project_prefers_project_orders_for_shared_workspace(self):
+        project_id = "507f1f77bcf86cd799439011"
+        paid_order_id = ObjectId("507f1f77bcf86cd799439099")
+        fake_orders = _FakeOrdersCollection(
+            [
+                {
+                    "_id": ObjectId("507f1f77bcf86cd799439055"),
+                    "project_id": ObjectId(project_id),
+                    "item_type": "package",
+                    "status": "pending",
+                },
+                {
+                    "_id": paid_order_id,
+                    "project_id": ObjectId(project_id),
+                    "item_type": "package",
+                    "status": "paid",
+                },
+            ]
+        )
+
+        with (
+            patch.object(asset_delivery, "get_database", return_value={"orders": fake_orders}),
+            patch.object(asset_delivery, "get_orders_for_user", return_value=[]),
+        ):
+            order = asset_delivery._resolve_order_for_project(
+                current_user={"id": "invitee-1", "email": "invitee@example.com"},
+                project_id=project_id,
+            )
+
+        self.assertIsNotNone(order)
+        self.assertEqual(order.get("status"), "paid")
+        self.assertEqual(order.get("id"), str(paid_order_id))
+        self.assertIn("project_id", order)
+
+    def test_resolve_order_for_project_falls_back_to_user_orders_when_project_link_missing(self):
+        with (
+            patch.object(asset_delivery, "get_database", return_value={"orders": _FakeOrdersCollection([])}),
+            patch.object(
+                asset_delivery,
+                "get_orders_for_user",
+                return_value=[
+                    {"id": "order-1", "item_type": "package", "status": "paid"},
+                    {"id": "order-2", "item_type": "addon", "status": "paid"},
+                ],
+            ),
+        ):
+            order = asset_delivery._resolve_order_for_project(
+                current_user={"id": "owner-1", "email": "owner@example.com"},
+                project_id="project-without-order-link",
+            )
+
+        self.assertIsNotNone(order)
+        self.assertEqual(order.get("id"), "order-1")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_household_access_model.py
+++ b/backend/tests/test_household_access_model.py
@@ -12,6 +12,7 @@ from app.services.privacy_access_service import (
 class HouseholdAccessModelTests(unittest.TestCase):
     def test_customer_membership_role_aliases_are_normalized(self):
         self.assertEqual(normalize_project_member_role("owner"), "billing_owner")
+        self.assertEqual(normalize_project_member_role("buyer"), "billing_owner")
         self.assertEqual(normalize_project_member_role("spouse"), "co_owner")
         self.assertEqual(normalize_project_member_role("manager"), "family_manager")
         self.assertEqual(normalize_project_member_role("editor"), "contributor")

--- a/backend/tests/test_household_invites_and_orders.py
+++ b/backend/tests/test_household_invites_and_orders.py
@@ -139,6 +139,102 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
         ):
             self.assertEqual(household_access_service._resolve_member_seat_cap("project-legacy"), 30)
 
+    def test_accept_household_invite_sets_user_active_project_context(self):
+        now_iso = "2026-04-16T12:00:00+00:00"
+        invite_document = {
+            "_id": "invite-accept-1",
+            "invite_key": "hhinv_accept_key",
+            "status": "pending",
+            "project_id": "project-accept-1",
+            "email": "invitee@example.com",
+            "member_role": "co_owner",
+            "relationship_scope": "spouse",
+            "privacy_scope": "household_private",
+            "use_count": 0,
+            "max_uses": 1,
+        }
+
+        class FakeInvitesCollection:
+            def __init__(self, invite):
+                self.invite = dict(invite)
+
+            def find_one(self, query):
+                if query.get("invite_key") == self.invite.get("invite_key"):
+                    return dict(self.invite)
+                if query.get("_id") == self.invite.get("_id"):
+                    return dict(self.invite)
+                return None
+
+            def update_one(self, query, update):
+                if query.get("_id") != self.invite.get("_id"):
+                    return
+                updates = update.get("$set") or {}
+                self.invite.update(updates)
+
+        class FakeMembersCollection:
+            def __init__(self):
+                self.member = {}
+
+            def update_one(self, _query, update, upsert=False):
+                updates = update.get("$set") or {}
+                self.member.update(updates)
+                self.member.setdefault("_id", "membership-accept-1")
+                if upsert and "$setOnInsert" in update:
+                    for key, value in (update.get("$setOnInsert") or {}).items():
+                        self.member.setdefault(key, value)
+
+            def find_one(self, _query):
+                return dict(self.member)
+
+        class FakeUsersCollection:
+            def __init__(self):
+                self.updates = []
+
+            def update_one(self, query, update):
+                self.updates.append(
+                    {
+                        "query": dict(query),
+                        "update": dict(update),
+                    }
+                )
+
+        fake_invites = FakeInvitesCollection(invite_document)
+        fake_members = FakeMembersCollection()
+        fake_users = FakeUsersCollection()
+        fake_db = {"users": fake_users}
+
+        with (
+            patch.object(household_access_service, "_invites", return_value=fake_invites),
+            patch.object(household_access_service, "_members", return_value=fake_members),
+            patch.object(household_access_service, "_db", return_value=fake_db),
+            patch.object(
+                household_access_service,
+                "_now",
+                return_value=SimpleNamespace(isoformat=lambda: now_iso),
+            ),
+            patch.object(
+                household_access_service,
+                "_active_member_count",
+                return_value=0,
+            ),
+            patch.object(
+                household_access_service,
+                "_resolve_member_seat_cap",
+                return_value=10,
+            ),
+            patch.object(household_access_service, "create_audit_log"),
+        ):
+            membership = household_access_service.accept_household_invite(
+                invite_key="hhinv_accept_key",
+                user={"id": "user-accept-1", "email": "invitee@example.com"},
+            )
+
+        self.assertEqual(membership.get("project_id"), "project-accept-1")
+        self.assertEqual(len(fake_users.updates), 1)
+        user_update = fake_users.updates[0]["update"]["$set"]
+        self.assertEqual(user_update.get("active_project_id"), "project-accept-1")
+        self.assertEqual(user_update.get("active_project_selected_at"), now_iso)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_project_entitlement_access.py
+++ b/backend/tests/test_project_entitlement_access.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import patch
+
+from app.routes import project_entitlements
+from app.services import project_entitlement_service
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _FakeEntitlementCollection:
+    def __init__(self, docs):
+        self._docs = list(docs)
+        self.last_query = None
+
+    def find(self, query):
+        self.last_query = query
+        return _FakeCursor(self._docs)
+
+
+class ProjectEntitlementAccessTests(unittest.TestCase):
+    def test_service_uses_email_memberships_when_listing_user_entitlements(self):
+        fake_collection = _FakeEntitlementCollection(
+            [
+                {
+                    "_id": "entitlement-1",
+                    "project_id": "project-123",
+                    "user_id": "owner-1",
+                    "package_code": "legacy_plus",
+                    "package_name": "Legacy Plus",
+                    "package_lane": "household",
+                    "status": "active",
+                    "active_addons": [],
+                    "created_at": "2026-04-16T00:00:00Z",
+                    "updated_at": "2026-04-16T00:00:00Z",
+                }
+            ]
+        )
+
+        with (
+            patch.object(
+                project_entitlement_service,
+                "_collection",
+                return_value=fake_collection,
+            ),
+            patch.object(
+                project_entitlement_service,
+                "list_accessible_project_ids",
+                return_value=["project-123"],
+            ) as project_ids_mock,
+        ):
+            items = project_entitlement_service.list_user_project_entitlements(
+                "invitee-1",
+                email="invitee@example.com",
+                active_only=True,
+            )
+
+        project_ids_mock.assert_called_once_with(
+            user_id="invitee-1",
+            email="invitee@example.com",
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].get("project_id"), "project-123")
+        self.assertEqual(items[0].get("package_code"), "legacy_plus")
+
+    def test_route_passes_current_user_email_to_entitlement_service(self):
+        with patch.object(
+            project_entitlements,
+            "list_user_project_entitlements",
+            return_value=[],
+        ) as service_mock:
+            payload = project_entitlements.list_my_project_entitlements(
+                current_user={"id": "invitee-1", "email": "Invitee@Example.com"},
+            )
+
+        service_mock.assert_called_once_with(
+            "invitee-1",
+            email="invitee@example.com",
+            active_only=True,
+        )
+        self.assertEqual(payload, {"items": []})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_workspace_access_roles.py
+++ b/backend/tests/test_workspace_access_roles.py
@@ -1,0 +1,214 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from app.routes import family_members as family_member_routes
+from app.routes import relationships as relationship_routes
+from app.routes import uploads as upload_routes
+from app.schemas.relationship import RelationshipCreate
+from app.services import access_context_service
+from app.services.auth_service import build_user_response
+from app.services.workspace_access_service import require_workspace_member_role
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    def find_one(self, query=None):
+        query = query or {}
+        for document in self.documents:
+            if self._matches(document, query):
+                return document
+        return None
+
+    def _matches(self, document, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(document, option) for option in expected):
+                    return False
+                continue
+            if document.get(key) != expected:
+                return False
+        return True
+
+
+class FakeDatabase:
+    def __init__(self, collections=None):
+        self._collections = {
+            name: FakeCollection(documents)
+            for name, documents in (collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        return self._collections.setdefault(name, FakeCollection())
+
+
+class WorkspaceAccessRoleTests(unittest.TestCase):
+    def test_resolve_default_project_uses_project_membership_for_invited_users(self):
+        with (
+            patch.object(
+                access_context_service,
+                "list_accessible_project_ids",
+                return_value=["project-membership-1"],
+            ) as membership_mock,
+            patch.object(
+                access_context_service,
+                "list_user_project_entitlements",
+                return_value=[],
+            ) as entitlements_mock,
+        ):
+            project_id = access_context_service.resolve_default_project_id(
+                {"id": "user-1", "email": "invitee@example.com"}
+            )
+
+        self.assertEqual(project_id, "project-membership-1")
+        membership_mock.assert_called_once()
+        entitlements_mock.assert_not_called()
+
+    def test_auth_user_response_keeps_active_workspace_identifiers(self):
+        payload = build_user_response(
+            {
+                "_id": "user-1",
+                "email": "invitee@example.com",
+                "full_name": "Invitee User",
+                "role": "user",
+                "status": "active",
+                "created_at": "2026-04-10T00:00:00Z",
+                "active_project_id": "project-123",
+                "active_family_id": "family-456",
+            }
+        )
+        self.assertEqual(payload["active_project_id"], "project-123")
+        self.assertEqual(payload["active_family_id"], "family-456")
+
+    def test_workspace_member_role_guard_blocks_viewer_write(self):
+        with self.assertRaises(HTTPException) as error:
+            require_workspace_member_role(
+                {"is_admin": False, "member_role": "viewer"},
+                allowed_roles=("billing_owner", "co_owner", "family_manager"),
+                detail="Denied",
+            )
+        self.assertEqual(error.exception.status_code, 403)
+
+    def test_family_member_create_blocks_read_only_role(self):
+        payload = {"family_id": "507f1f77bcf86cd799439011", "first_name": "Test"}
+        context = {
+            "family": {"_id": "507f1f77bcf86cd799439011"},
+            "member_role": "viewer",
+            "is_admin": False,
+        }
+        with (
+            patch.object(
+                family_member_routes,
+                "get_database",
+                return_value=FakeDatabase(),
+            ),
+            patch.object(
+                family_member_routes,
+                "require_workspace_capability",
+                return_value=context,
+            ),
+        ):
+            with self.assertRaises(HTTPException) as error:
+                family_member_routes.create_family_member(
+                    payload=payload,
+                    current_user={"id": "user-1", "email": "viewer@example.com"},
+                )
+        self.assertEqual(error.exception.status_code, 403)
+
+    def test_relationship_create_blocks_read_only_role(self):
+        payload = RelationshipCreate(
+            family_id="507f1f77bcf86cd799439011",
+            source_member_id="member-a",
+            target_member_id="member-b",
+            relationship_type="spouse",
+            notes="",
+            created_by="",
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(db=FakeDatabase()))
+        )
+        context = {
+            "family": {"_id": "507f1f77bcf86cd799439011"},
+            "member_role": "viewer",
+            "is_admin": False,
+        }
+        with patch.object(
+            relationship_routes,
+            "require_workspace_capability",
+            return_value=context,
+        ):
+            with self.assertRaises(HTTPException) as error:
+                asyncio.run(
+                    relationship_routes.create_relationship(
+                        payload=payload,
+                        request=request,
+                        current_user={"id": "user-1", "email": "viewer@example.com"},
+                    )
+                )
+        self.assertEqual(error.exception.status_code, 403)
+
+    def test_upload_management_allows_co_owner_even_if_not_uploader(self):
+        upload_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": upload_id,
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "uploaded_by_user_id": "uploader-1",
+                    }
+                ]
+            }
+        )
+        context = {
+            "is_admin": False,
+            "member_role": "co_owner",
+            "project": {"_id": "project-1", "owner_user_id": "owner-1"},
+        }
+        with patch.object(upload_routes, "resolve_workspace_context", return_value=context):
+            upload_record, resolved = upload_routes._require_upload_management_access(
+                str(upload_id),
+                db,
+                {"id": "co-owner-1", "email": "coowner@example.com"},
+            )
+        self.assertEqual(str(upload_record["_id"]), str(upload_id))
+        self.assertEqual(resolved.get("member_role"), "co_owner")
+
+    def test_upload_management_blocks_viewer_when_not_uploader(self):
+        upload_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "uploaded_files": [
+                    {
+                        "_id": upload_id,
+                        "project_id": "project-1",
+                        "family_id": "family-1",
+                        "uploaded_by_user_id": "uploader-1",
+                    }
+                ]
+            }
+        )
+        context = {
+            "is_admin": False,
+            "member_role": "viewer",
+            "project": {"_id": "project-1", "owner_user_id": "owner-1"},
+        }
+        with patch.object(upload_routes, "resolve_workspace_context", return_value=context):
+            with self.assertRaises(HTTPException) as error:
+                upload_routes._require_upload_management_access(
+                    str(upload_id),
+                    db,
+                    {"id": "viewer-1", "email": "viewer@example.com"},
+                )
+        self.assertEqual(error.exception.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -29,6 +29,12 @@
     "archived",
   ]);
 
+  const HOUSEHOLD_MANAGEMENT_ROLES = new Set([
+    "billing_owner",
+    "co_owner",
+    "family_manager",
+  ]);
+
   let legacyAnchorState = null;
 
   function normalizeValue(value) {
@@ -117,6 +123,79 @@
   function text(node, value) {
     if (!node) return;
     node.textContent = value;
+  }
+
+  function setPanelVisible(selector, visible) {
+    document.querySelectorAll(selector).forEach(function (node) {
+      node.style.display = visible ? "" : "none";
+    });
+  }
+
+  function applyDashboardHierarchy(context, history) {
+    const lane = normalizeValue(context?.packageLane || context?.resolvedEntitlements?.package_lane);
+    const isHouseholdLane = lane === "household";
+    const historyCount = Array.isArray(history) ? history.length : 0;
+    const memberRole = normalizeMemberRole(
+      context?.household_access?.member_role,
+    );
+    const isInvitedCollaborator = Boolean(
+      memberRole && memberRole !== "billing_owner",
+    );
+
+    // Reduce visual overload for household customers by hiding explanatory
+    // duplicate cards and surfacing only operational panels.
+    setPanelVisible(".portal-workspace-panel", !isHouseholdLane);
+    setPanelVisible(".portal-build-panel", !isHouseholdLane);
+    setPanelVisible(".portal-status-panel", !isHouseholdLane);
+    setPanelVisible(".portal-orders-panel", !isInvitedCollaborator);
+    setPanelVisible("[data-dashboard-purchase-actions]", !isInvitedCollaborator);
+
+    // Intake history is only useful when there is more than one record.
+    setPanelVisible(".portal-history-panel", historyCount > 1);
+  }
+
+  function normalizeMemberRole(value) {
+    return normalizeValue(value);
+  }
+
+  function canManageHouseholdAccess(memberRole) {
+    return HOUSEHOLD_MANAGEMENT_ROLES.has(normalizeMemberRole(memberRole));
+  }
+
+  async function resolveDashboardMemberRole(context) {
+    const projectId = getContextProjectId(context);
+    if (!projectId) return "";
+
+    try {
+      const payload = await app.apiRequest("/workspace-access/my-memberships", {
+        method: "GET",
+      });
+      const items = Array.isArray(payload?.items) ? payload.items : [];
+      const user =
+        context?.user ||
+        window.TOLResolvedUser ||
+        (typeof app.getSavedUser === "function" ? app.getSavedUser() : null) ||
+        {};
+      const userId = String(user?.id || user?._id || user?.user_id || "").trim();
+      const userEmail = normalizeValue(user?.email);
+
+      const match = items.find(function (item) {
+        const membershipProjectId = String(item?.project_id || "").trim();
+        if (!membershipProjectId || membershipProjectId !== projectId) return false;
+        const status = normalizeValue(item?.status || "active");
+        if (status && status !== "active") return false;
+        const membershipUserId = String(item?.user_id || "").trim();
+        const membershipEmail = normalizeValue(item?.email);
+        return (
+          (userId && membershipUserId && userId === membershipUserId) ||
+          (userEmail && membershipEmail && userEmail === membershipEmail)
+        );
+      });
+
+      return normalizeMemberRole(match?.member_role);
+    } catch (_error) {
+      return "";
+    }
   }
 
   function getContextFamilyId(context) {
@@ -1256,6 +1335,11 @@
       config,
       latestSubmission,
     );
+    const explicitHouseholdManageFlag = context?.household_access?.can_manage;
+    const showHouseholdInviteActions =
+      typeof explicitHouseholdManageFlag === "boolean"
+        ? explicitHouseholdManageFlag
+        : true;
 
     applyNavVisibility("tree-view.html", config.navTree && hasWorkspaceFamily);
     applyNavVisibility(
@@ -1300,7 +1384,7 @@
       "[data-dashboard-digital-collectible-action], a[href^=\"digital-collectible.html\"]",
       {
         href: withFamilyId("digital-collectible.html", context),
-        show: true,
+        show: Boolean(context?.hasPackageAccess),
       },
     );
 
@@ -1332,12 +1416,16 @@
     );
 
     applyAction(
-      "[data-dashboard-household-invite-co-owner], [data-dashboard-household-invite-family], [data-dashboard-household-view-members], [data-dashboard-household-pending-invites]",
+      "[data-dashboard-household-invite-co-owner], [data-dashboard-household-invite-family], [data-dashboard-household-pending-invites]",
       {
         href: withFamilyId("household-access.html", context),
-        show: true,
+        show: showHouseholdInviteActions,
       },
     );
+    applyAction("[data-dashboard-household-view-members]", {
+      href: withFamilyId("household-access.html", context),
+      show: true,
+    });
 
     applyAction(
       "[data-dashboard-hero-tree-action], [data-dashboard-package-tree-action], [data-dashboard-workspace-tree-action], a[href=\"tree-view.html\"][data-paid-action]",
@@ -1364,35 +1452,44 @@
 
     const upgradeAction = document.querySelector("[data-upgrade-action]");
     if (upgradeAction) {
-      const re = context.resolvedEntitlements || {};
-      const upgradeTargets = Array.isArray(re.upgrade_targets)
-        ? re.upgrade_targets
-        : [];
-      const allowedAddons = Array.isArray(re.allowed_addons)
-        ? re.allowed_addons
-        : [];
-      const resolveDisplayName =
-        window.TOLAuthPages &&
-        typeof window.TOLAuthPages.resolvePackageDisplayName === "function"
-          ? window.TOLAuthPages.resolvePackageDisplayName
-          : function (code) {
-              return code || "Package";
-            };
-
-      if (upgradeTargets.length > 0) {
-        const firstName = resolveDisplayName(upgradeTargets[0]);
-        upgradeAction.textContent =
-          upgradeTargets.length === 1
-            ? "Upgrade to " + firstName
-            : "Upgrade to " + firstName + " or higher";
-        upgradeAction.setAttribute("href", "index.html#pricing");
-        upgradeAction.style.display = "";
-      } else if (allowedAddons.length > 0) {
-        upgradeAction.textContent = "View Available Add-Ons";
-        upgradeAction.setAttribute("href", "index.html#pricing");
-        upgradeAction.style.display = "";
-      } else {
+      const memberRole = normalizeMemberRole(
+        context?.household_access?.member_role,
+      );
+      const canManageBilling =
+        !memberRole || memberRole === "billing_owner";
+      if (!canManageBilling) {
         upgradeAction.style.display = "none";
+      } else {
+        const re = context.resolvedEntitlements || {};
+        const upgradeTargets = Array.isArray(re.upgrade_targets)
+          ? re.upgrade_targets
+          : [];
+        const allowedAddons = Array.isArray(re.allowed_addons)
+          ? re.allowed_addons
+          : [];
+        const resolveDisplayName =
+          window.TOLAuthPages &&
+          typeof window.TOLAuthPages.resolvePackageDisplayName === "function"
+            ? window.TOLAuthPages.resolvePackageDisplayName
+            : function (code) {
+                return code || "Package";
+              };
+
+        if (upgradeTargets.length > 0) {
+          const firstName = resolveDisplayName(upgradeTargets[0]);
+          upgradeAction.textContent =
+            upgradeTargets.length === 1
+              ? "Upgrade to " + firstName
+              : "Upgrade to " + firstName + " or higher";
+          upgradeAction.setAttribute("href", "index.html#pricing");
+          upgradeAction.style.display = "";
+        } else if (allowedAddons.length > 0) {
+          upgradeAction.textContent = "View Available Add-Ons";
+          upgradeAction.setAttribute("href", "index.html#pricing");
+          upgradeAction.style.display = "";
+        } else {
+          upgradeAction.style.display = "none";
+        }
       }
     }
 
@@ -1549,9 +1646,18 @@
       return;
     }
 
-    const config = getEntitlementConfig(context);
-    updateLaneUi(context, config, null);
-    applyPortalTheme(context, config);
+    const memberRole = await resolveDashboardMemberRole(context);
+    const contextWithMembership = Object.assign({}, context, {
+      household_access: {
+        member_role: memberRole || null,
+        can_manage: canManageHouseholdAccess(memberRole),
+      },
+    });
+
+    const config = getEntitlementConfig(contextWithMembership);
+    updateLaneUi(contextWithMembership, config, null);
+    applyPortalTheme(contextWithMembership, config);
+    applyDashboardHierarchy(contextWithMembership, []);
 
     const intakeCardStatus = document.querySelector(
       "[data-intake-card-status]",
@@ -1578,7 +1684,7 @@
     try {
       const latest = await getLatestSubmission();
       const history = await getSubmissionHistory();
-      const contextWithLatest = Object.assign({}, context, {
+      const contextWithLatest = Object.assign({}, contextWithMembership, {
         latestSubmission: latest || null,
       });
       await updateLegacyAnchorPanel(contextWithLatest);
@@ -1589,8 +1695,9 @@
       );
 
       updateLaneUi(contextWithLatest, config, latest);
+      applyDashboardHierarchy(contextWithLatest, history);
 
-      text(currentPackage, context.packageName || "Active Package");
+      text(currentPackage, contextWithMembership.packageName || "Active Package");
 
       if (!latest) {
         text(intakeCardStatus, config.presenceTitle);
@@ -1615,13 +1722,13 @@
         );
 
         if (openAction) {
-          updatePrimaryIntakeAction(context, "", openAction);
+          updatePrimaryIntakeAction(contextWithMembership, "", openAction);
         }
       } else {
         const status = normalizeStatus(
           latest.status || latest.submission_status,
         );
-        const laneMessages = getLaneAwareIntakeMessages(context, status);
+        const laneMessages = getLaneAwareIntakeMessages(contextWithMembership, status);
 
         text(intakeCardStatus, laneMessages.cardCopy);
         text(statusBadge, humanizeStatus(status));
@@ -1633,7 +1740,7 @@
         text(workspaceCopy, laneMessages.workspaceCopy);
 
         if (openAction) {
-          updatePrimaryIntakeAction(context, status, openAction);
+          updatePrimaryIntakeAction(contextWithMembership, status, openAction);
         }
       }
 
@@ -1648,9 +1755,10 @@
       }
 
       if (dashboardStatus) {
-        dashboardStatus.textContent = `Your package is active: ${context.packageName || "Active Package"}.`;
+        dashboardStatus.textContent = `Your package is active: ${contextWithMembership.packageName || "Active Package"}.`;
       }
     } catch (error) {
+      applyDashboardHierarchy(contextWithMembership, []);
       setLegacyAnchorUnavailable(
         "Legacy Anchor status is temporarily unavailable.",
         "Please refresh shortly. Tomb of Light could not finish loading the customer workspace state.",

--- a/dashboard.html
+++ b/dashboard.html
@@ -392,7 +392,11 @@
                 </a>
               </div>
 
-              <div class="inline-actions" style="margin-top: 1rem">
+              <div
+                class="inline-actions"
+                style="margin-top: 1rem"
+                data-dashboard-purchase-actions
+              >
                 <a
                   class="btn btn-secondary"
                   href="index.html#pricing"

--- a/digital-collectible.js
+++ b/digital-collectible.js
@@ -404,10 +404,14 @@
       "Digital collectible delivery service is temporarily unavailable. Please try again shortly.";
     let badge = "Service Error";
 
-    if (status === 401 || status === 403) {
+    if (status === 401) {
       message =
         "Authentication is required to view this digital collectible. Please sign in again.";
       badge = "Auth Required";
+    } else if (status === 403) {
+      message =
+        "This account does not have access to the selected workspace delivery record.";
+      badge = "Access Required";
     } else if (status === 404) {
       message =
         "No digital collectible delivery record exists for this workspace yet.";
@@ -851,15 +855,33 @@
         }
       }
 
-      if (!context || !context.hasPackageAccess) {
-        renderNoAccess(
-          "Package access is required to view your digital collectible. " +
-            "Please complete your purchase to continue.",
-        );
+      const hints = getWorkspaceHints();
+      const userActiveProjectId = String(
+        me.active_project_id || me.activeProjectId || "",
+      ).trim();
+      const resolvedProjectId =
+        resolveProjectId(context, hints) || userActiveProjectId;
+
+      if (!resolvedProjectId) {
+        if (!context || !context.hasPackageAccess) {
+          renderNoAccess(
+            "Package access is required to view your digital collectible. " +
+              "Please complete your purchase to continue.",
+          );
+          return;
+        }
+        renderNoAccess("No active project found for this account.");
         return;
       }
 
-      await loadDeliveryPage(context);
+      const deliveryContext = Object.assign({}, context || {}, {
+        projectId: resolvedProjectId,
+        activeProject: Object.assign({}, context?.activeProject || {}, {
+          project_id: resolvedProjectId,
+        }),
+      });
+
+      await loadDeliveryPage(deliveryContext);
     };
 
     // Auth.js may have already resolved the user before this script ran.

--- a/household-access.js
+++ b/household-access.js
@@ -75,8 +75,29 @@
     },
   };
 
+  const ROLE_PRIORITY = {
+    billing_owner: 100,
+    co_owner: 80,
+    family_manager: 60,
+    contributor: 40,
+    viewer: 20,
+    minor_viewer: 10,
+    linked_relative: 10,
+    legacy_executor: 5,
+  };
+
+  const ROLE_ASSIGNMENTS = {
+    billing_owner: new Set(ROLE_OPTIONS),
+    co_owner: new Set(["family_manager", "contributor", "viewer", "minor_viewer", "linked_relative"]),
+    family_manager: new Set(["contributor", "viewer", "minor_viewer"]),
+  };
+
+  const ROLE_CAN_MANAGE_ACCESS = new Set(["billing_owner", "co_owner", "family_manager"]);
+
   let currentProjectId = "";
   let currentUser = null;
+  let currentMemberRole = "viewer";
+  let hasResolvedMemberRole = false;
 
   function inviteApiFallbackBaseUrls() {
     const configuredFallbacks = Array.isArray(window.TOL_CONFIG?.INVITE_API_BASE_URL_FALLBACKS)
@@ -527,6 +548,41 @@
       });
   }
 
+  function normalizeValue(value) {
+    return String(value || "").trim();
+  }
+
+  function normalizeLower(value) {
+    return normalizeValue(value).toLowerCase();
+  }
+
+  function normalizeRole(value) {
+    const normalized = normalizeLower(value);
+    return ROLE_OPTIONS.includes(normalized) ? normalized : "viewer";
+  }
+
+  function roleRank(role) {
+    return Number(ROLE_PRIORITY[normalizeRole(role)] || 0);
+  }
+
+  function roleCanAssign(actorRole, targetRole) {
+    const actor = normalizeRole(actorRole);
+    const target = normalizeRole(targetRole);
+    return Boolean(ROLE_ASSIGNMENTS[actor] && ROLE_ASSIGNMENTS[actor].has(target));
+  }
+
+  function roleCanManageAccess(role) {
+    return ROLE_CAN_MANAGE_ACCESS.has(normalizeRole(role));
+  }
+
+  function currentUserIdentity() {
+    if (!currentUser) return { userId: "", email: "" };
+    return {
+      userId: normalizeValue(currentUser?.id || currentUser?._id || currentUser?.user_id),
+      email: normalizeLower(currentUser?.email),
+    };
+  }
+
   function roleNode() {
     return inviteForm ? inviteForm.querySelector('select[name="member_role"]') : null;
   }
@@ -589,8 +645,151 @@
 
     const context = window.TOLDashboardContext || null;
     const activeProject = context?.activeProject || null;
-    if (activeProject && activeProject.id) return String(activeProject.id).trim();
+    if (activeProject && (activeProject.id || activeProject._id || activeProject.project_id)) {
+      return String(activeProject.id || activeProject._id || activeProject.project_id).trim();
+    }
     return String(user?.active_project_id || "").trim();
+  }
+
+  async function resolveProjectIdFromAccessContext() {
+    try {
+      const payload = await sendLoadRequest(
+        "/users/me/access-context",
+        "load_access_context",
+        "",
+        { fallbackStatusCodes: [404, 500, 502, 503, 504] },
+      );
+      return normalizeValue(payload?.active_project_id);
+    } catch (error) {
+      return "";
+    }
+  }
+
+  async function resolveProjectIdFromMemberships() {
+    try {
+      const payload = await sendLoadRequest(
+        "/workspace-access/my-memberships",
+        "load_my_memberships",
+        "",
+        { fallbackStatusCodes: [404, 500, 502, 503, 504] },
+      );
+      const items = Array.isArray(payload?.items) ? payload.items : [];
+      const active = items.find(function (item) {
+        return normalizeLower(item?.status || "active") === "active" && normalizeValue(item?.project_id);
+      });
+      return normalizeValue(active?.project_id);
+    } catch (error) {
+      return "";
+    }
+  }
+
+  async function resolveProjectId(user) {
+    const direct = projectIdFromContext(user);
+    if (direct) return direct;
+
+    const fromAccessContext = await resolveProjectIdFromAccessContext();
+    if (fromAccessContext) return fromAccessContext;
+
+    const fromMemberships = await resolveProjectIdFromMemberships();
+    if (fromMemberships) return fromMemberships;
+
+    return "";
+  }
+
+  function resolveCurrentMemberRole(items) {
+    const members = Array.isArray(items) ? items : [];
+    const identity = currentUserIdentity();
+    const found = members.find(function (member) {
+      const memberUserId = normalizeValue(member?.user_id);
+      const memberEmail = normalizeLower(member?.email);
+      return (
+        (identity.userId && memberUserId && identity.userId === memberUserId) ||
+        (identity.email && memberEmail && identity.email === memberEmail)
+      );
+    });
+    if (!found) return "";
+    return normalizeRole(found?.member_role || "viewer");
+  }
+
+  async function resolveCurrentMemberRoleFromMemberships(projectId) {
+    const normalizedProjectId = normalizeValue(projectId);
+    if (!normalizedProjectId) return "";
+    try {
+      const payload = await sendLoadRequest(
+        "/workspace-access/my-memberships",
+        "load_my_memberships_role",
+        normalizedProjectId,
+        { fallbackStatusCodes: [404, 500, 502, 503, 504] },
+      );
+      const items = Array.isArray(payload?.items) ? payload.items : [];
+      const identity = currentUserIdentity();
+      const found = items.find(function (item) {
+        const status = normalizeLower(item?.status || "active");
+        const itemProjectId = normalizeValue(item?.project_id);
+        const itemUserId = normalizeValue(item?.user_id);
+        const itemEmail = normalizeLower(item?.email);
+        if (status !== "active") return false;
+        if (!itemProjectId || itemProjectId !== normalizedProjectId) return false;
+        return (
+          (identity.userId && itemUserId && identity.userId === itemUserId) ||
+          (identity.email && itemEmail && identity.email === itemEmail)
+        );
+      });
+      if (!found) return "";
+      return normalizeRole(found?.member_role || "viewer");
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function applyInviteFormRoleAccess() {
+    if (!inviteForm) return;
+    const canManage = hasResolvedMemberRole && roleCanManageAccess(currentMemberRole);
+    const roleSelect = roleNode();
+    const relationshipSelect = relationshipNode();
+    const privacySelect = privacyNode();
+    const notesInput = noteNode();
+    const emailInput = inviteForm.querySelector('input[name="email"]');
+    const submitButtons = inviteForm.querySelectorAll('button[type="submit"], button[type="button"]');
+
+    [roleSelect, relationshipSelect, privacySelect, notesInput, emailInput].forEach(function (node) {
+      if (!node) return;
+      node.disabled = !canManage;
+    });
+    submitButtons.forEach(function (button) {
+      button.disabled = !canManage;
+    });
+
+    if (roleSelect) {
+      Array.from(roleSelect.options || []).forEach(function (option) {
+        option.disabled = !canManage || !roleCanAssign(currentMemberRole, option.value);
+      });
+      if (canManage && roleSelect.selectedOptions.length) {
+        const selected = roleSelect.selectedOptions[0];
+        if (selected && selected.disabled) {
+          const firstEnabled = Array.from(roleSelect.options).find(function (option) {
+            return !option.disabled;
+          });
+          if (firstEnabled) roleSelect.value = firstEnabled.value;
+        }
+      }
+    }
+
+    if (!hasResolvedMemberRole) {
+      setText(
+        inviteStatus,
+        "Accept your invite to activate workspace access controls.",
+        "info",
+      );
+    } else if (!canManage) {
+      setText(
+        inviteStatus,
+        "Your role is read-only for invites and member access changes.",
+        "warning",
+      );
+    } else if (inviteStatus && inviteStatus.dataset.state === "warning") {
+      clear(inviteStatus);
+    }
   }
 
   function inviteKeyFromQuery() {
@@ -687,16 +886,22 @@
       return;
     }
     if (membersEmpty) membersEmpty.style.display = "none";
+    const canManage = roleCanManageAccess(currentMemberRole);
+    const actorRank = roleRank(currentMemberRole);
     items.forEach((member) => {
       const card = document.createElement("article");
       card.className = "form-panel";
 
       const emailLabel = member.email || member.user_id || "Unassigned member";
-      const role = String(member.member_role || "viewer").trim();
+      const role = normalizeRole(member.member_role || "viewer");
       const isBillingOwner = role === "billing_owner";
+      const targetRank = roleRank(role);
+      const canTouchTarget = canManage && !isBillingOwner && targetRank < actorRank;
       const options = ROLE_OPTIONS.map(
-        (roleCode) =>
-          `<option value="${roleCode}" ${roleCode === role ? "selected" : ""}>${roleLabel(roleCode)}</option>`,
+        (roleCode) => {
+          const disabled = !canManage || !roleCanAssign(currentMemberRole, roleCode);
+          return `<option value="${roleCode}" ${roleCode === role ? "selected" : ""} ${disabled ? "disabled" : ""}>${roleLabel(roleCode)}</option>`;
+        },
       ).join("");
       card.innerHTML = `
         <strong>${emailLabel}</strong>
@@ -705,18 +910,18 @@
         <p class="card-copy">Privacy: ${privacyLabel(member.privacy_scope || "household_private")}</p>
         <p class="card-copy">Status: ${member.status || "active"}</p>
         <label>Change Role
-          <select ${isBillingOwner ? "disabled" : ""} data-member-role-select>${options}</select>
+          <select ${canTouchTarget ? "" : "disabled"} data-member-role-select>${options}</select>
         </label>
         <div class="inline-actions" style="margin-top:0.75rem;">
-          <button class="btn btn-secondary" type="button" data-member-role-save ${isBillingOwner ? "disabled" : ""}>Change Role</button>
-          <button class="btn btn-secondary" type="button" data-member-remove ${isBillingOwner ? "disabled" : ""}>Remove Member</button>
+          <button class="btn btn-secondary" type="button" data-member-role-save ${canTouchTarget ? "" : "disabled"}>Change Role</button>
+          <button class="btn btn-secondary" type="button" data-member-remove ${canTouchTarget ? "" : "disabled"}>Remove Member</button>
         </div>
       `;
 
       const roleSave = card.querySelector("[data-member-role-save]");
       const roleSelect = card.querySelector("[data-member-role-select]");
       const removeButton = card.querySelector("[data-member-remove]");
-      if (roleSave && roleSelect && !isBillingOwner) {
+      if (roleSave && roleSelect && canTouchTarget) {
         roleSave.addEventListener("click", async function () {
           try {
             await changeMemberRole(member.id, roleSelect.value);
@@ -727,7 +932,7 @@
           }
         });
       }
-      if (removeButton && !isBillingOwner) {
+      if (removeButton && canTouchTarget) {
         removeButton.addEventListener("click", async function () {
           try {
             await removeMember(member.id);
@@ -752,11 +957,12 @@
     }
     if (invitesEmpty) invitesEmpty.style.display = "none";
     renderPendingCount(items);
+    const canManageInvites = roleCanManageAccess(currentMemberRole);
     items.forEach((invite) => {
       const card = document.createElement("article");
       card.className = "form-panel";
-      const canResend = isPending(invite) || isExpired(invite);
-      const canRevoke = isPending(invite) || isExpired(invite);
+      const canResend = canManageInvites && (isPending(invite) || isExpired(invite));
+      const canRevoke = canManageInvites && (isPending(invite) || isExpired(invite));
       card.innerHTML = `
         <strong>${invite.email || "Invite"}</strong>
         <p class="card-copy">Role: ${roleLabel(invite.member_role || "viewer")}</p>
@@ -805,7 +1011,15 @@
       sendLoadRequest(workspaceMembersLoadPaths(currentProjectId), "load_members", currentProjectId),
       sendLoadRequest(workspaceInvitesLoadPaths(currentProjectId), "load_invites", currentProjectId),
     ]);
-    renderMembers(membersPayload?.items || []);
+    const memberItems = membersPayload?.items || [];
+    let resolvedRole = resolveCurrentMemberRole(memberItems);
+    if (!resolvedRole) {
+      resolvedRole = await resolveCurrentMemberRoleFromMemberships(currentProjectId);
+    }
+    currentMemberRole = resolvedRole || "viewer";
+    hasResolvedMemberRole = Boolean(resolvedRole);
+    applyInviteFormRoleAccess();
+    renderMembers(memberItems);
     renderInvites(invitesPayload?.items || []);
   }
 
@@ -818,6 +1032,10 @@
   async function handleInviteSubmit(event) {
     event.preventDefault();
     clear(inviteStatus);
+    if (!roleCanManageAccess(currentMemberRole)) {
+      setText(inviteStatus, "Your role cannot send invites from this workspace.", "error");
+      return;
+    }
     if (!currentProjectId) {
       setText(inviteStatus, "Select a workspace project first.", "error");
       return;
@@ -900,6 +1118,10 @@
         body: JSON.stringify({ invite_key: inviteKey }),
       });
       setText(acceptStatus, "Invite accepted. Workspace access granted.", "success");
+      currentProjectId = currentProjectId || (await resolveProjectId(currentUser));
+      if (statusNode && currentProjectId) {
+        statusNode.textContent = `Managing workspace access for project ${currentProjectId}.`;
+      }
       await refreshData();
     } catch (error) {
       setText(acceptStatus, error.message || "Failed to accept invite.", "error");
@@ -966,19 +1188,22 @@
         app.saveUser(currentUser);
       }
 
-      currentProjectId = projectIdFromContext(currentUser);
-      if (!currentProjectId) {
+      const inviteKey = inviteKeyFromQuery();
+      currentProjectId = await resolveProjectId(currentUser);
+      if (!currentProjectId && !inviteKey) {
         if (statusNode) {
           statusNode.textContent =
             "No active workspace project was detected. Open this page from your dashboard workspace.";
         }
         return;
       }
-      if (statusNode) {
+      if (statusNode && currentProjectId) {
         statusNode.textContent = `Managing workspace access for project ${currentProjectId}.`;
+      } else if (statusNode) {
+        statusNode.textContent =
+          "Invite context detected. Accept the invite key below to activate workspace access.";
       }
 
-      const inviteKey = inviteKeyFromQuery();
       if (acceptForm && inviteKey) {
         const keyInput = acceptForm.querySelector('input[name="invite_key"]');
         if (keyInput) keyInput.value = inviteKey;
@@ -986,6 +1211,7 @@
 
       bindQuickInviteButtons();
       updateAutoInviteDefaults(true);
+      applyInviteFormRoleAccess();
       console.info("[HouseholdAccess] Invite runtime API context.", {
         resolvedApiBaseUrl:
           typeof app.getApiBaseUrl === "function" ? normalizeBaseUrl(app.getApiBaseUrl()) : "",
@@ -998,10 +1224,27 @@
       });
       if (inviteForm) inviteForm.addEventListener("submit", handleInviteSubmit);
       if (acceptForm) acceptForm.addEventListener("submit", handleAcceptSubmit);
-      await refreshData();
+      if (currentProjectId) {
+        try {
+          await refreshData();
+        } catch (error) {
+          const statusCode = Number(error?.status || 0);
+          if (statusCode === 403 && inviteKey) {
+            hasResolvedMemberRole = false;
+            applyInviteFormRoleAccess();
+            setText(
+              acceptStatus,
+              "Accept this invite to activate workspace access for this project.",
+              "info",
+            );
+            return;
+          }
+          throw error;
+        }
+      }
     } catch (error) {
       const statusCode = Number(error?.status || 0);
-      if (statusCode === 401 || statusCode === 403) {
+      if (statusCode === 401 || (statusCode === 403 && !inviteKeyFromQuery())) {
         if (typeof app.clearSession === "function") app.clearSession();
         window.location.href = signinRedirectUrlWithInviteContext();
         return;


### PR DESCRIPTION
Completed a master audit and implemented fixes for shared workspace access, especially invited co-owner accounts.

Main fixes:
- Resolved the issue where accepted co-owners were treated like unpaid standalone accounts after refresh/re-login
- Updated access and entitlement resolution to use project membership, email-linked membership, and active workspace hints
- Persisted active_project_id on invite acceptance for more durable workspace loading
- Fixed digital collectible and delivery access so shared workspace members are not blocked just because they do not directly own the package/order
- Improved dashboard role handling so invited collaborators do not see misleading purchase-required states
- Reduced dashboard clutter and improved role-aware action visibility
- Added regression coverage for co-owner access, invite persistence, entitlement access, and delivery behavior

Result:
Buyer-granted co-owner access now resolves into the shared paid workspace more reliably, instead of collapsing into a no-package / buy-package experience.