### PR TITLE
Resolve dashboard workspace for invited collaborators by using membership fallback

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1112,6 +1112,13 @@
     return toArray(payload);
   }
 
+  async function fetchWorkspaceMemberships() {
+    const payload = await app.apiRequest("/workspace-access/my-memberships", {
+      method: "GET",
+    });
+    return toArray(payload);
+  }
+
   async function fetchProjectEntitlementByProjectId(projectId) {
     const normalizedProjectId = String(projectId || "").trim();
     if (!normalizedProjectId) return null;
@@ -1382,7 +1389,7 @@
   async function getDashboardContext(user, orders, options) {
     let entitlements = [];
     let projects = [];
-    const hints = mergeWorkspaceSelectionHints(
+    let hints = mergeWorkspaceSelectionHints(
       options,
       getWorkspaceHintsFromUser(user),
     );
@@ -1402,6 +1409,25 @@
     } catch (error) {
       entitlements = [];
       projects = [];
+    }
+
+    if (!hints.projectId) {
+      try {
+        const memberships = await fetchWorkspaceMemberships();
+        const activeMemberships = sortByMostRecent(
+          (Array.isArray(memberships) ? memberships : []).filter(function (item) {
+            return normalizeValue(item?.status || "active") === "active";
+          }),
+        );
+        const membershipProjectId = String(
+          activeMemberships[0]?.project_id || activeMemberships[0]?.projectId || "",
+        ).trim();
+        if (membershipProjectId) {
+          hints = mergeWorkspaceSelectionHints(hints, { projectId: membershipProjectId });
+        }
+      } catch (error) {
+        // Ignore membership lookup failures so dashboard context can still load.
+      }
     }
 
     if (hints.projectId) {


### PR DESCRIPTION
### Motivation
- Invited collaborators (spouse/co-owner) could sign in but see an empty dashboard because no project hint was available for non-billing users so the dashboard context could not resolve an active workspace. 

### Description
- Added a helper `fetchWorkspaceMemberships()` in `auth.js` to load `/workspace-access/my-memberships` and normalize the response. 
- Updated `getDashboardContext(...)` in `auth.js` to merge a project hint from the first active membership when no project hint is present and then backfill project entitlement data for that hinted project. 
- The change lets invited accounts resolve a valid workspace candidate from memberships and surface the appropriate dashboard content without requiring owner/order data. 

### Testing
- Ran `node --check auth.js` which succeeded. 
- Attempted `pytest -q backend/tests/test_regression_workspace_and_ui.py backend/tests/test_household_invites_and_orders.py backend/tests/test_workspace_access_roles.py` without `PYTHONPATH` which failed during collection due to module import resolution, so a follow-up run used `PYTHONPATH=backend`. 
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_workspace_access_roles.py` which failed during test collection due to the environment Python version not supporting `datetime.UTC` used by backend modules (import error), so backend unit tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e358f48270832dad201131ce4ad5a8)