### PR TITLE
Fix Household Access fetch failures with shared API request path

### DIFF
--- a/ENTITLEMENT_CONFORMANCE_MATRIX.md
+++ b/ENTITLEMENT_CONFORMANCE_MATRIX.md
@@ -1,0 +1,61 @@
+# Entitlement Conformance Matrix (Phase 1)
+
+Source of truth implementation: `backend/app/core/entitlement_conformance_matrix.py`.
+
+This matrix defines package conformance for all lanes and packages.
+
+## Global workspace behavior
+
+- Default workspace member roles: `billing_owner`, `co_owner`, `family_manager`, `contributor`, `viewer`, `minor_viewer`, `linked_relative`, `legacy_executor`.
+- Visibility/access precedence:
+  1. `project_members` membership records
+  2. owner fallback (`owner_user_id` / `owner_email`)
+  3. internal admin override
+  4. family visibility fallback only when owner markers are absent
+- Access boundary: project-scoped access only; no cross-project visibility without explicit membership/owner/admin path.
+
+## Global lifecycle behavior
+
+- Upgrades: only package `upgrade_targets` are valid.
+- Downgrades: blocked in current purchase flow.
+- Maintenance: tracked separately; does not revoke package capability flags.
+- Inactive entitlement status: membership/owner checks still govern workspace visibility paths.
+
+## Portrait lane
+
+| Package | Uploads | Storage (GB) | Members | Households | Org Nodes | Zoom Layers | Family Tree | Org Chart | Verification Docs | Family Intake | Org Intake | Certificate | Narration | Link Keys |
+|---|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---|---|
+| legacy_snapshot | 3 | 0.25 | 1 | 0 | 0 | 0 | No | No | Yes | No | No | No | No | No |
+| legacy_portrait_intro | 5 | 0.5 | 1 | 0 | 0 | 0 | No | No | Yes | No | No | No | No | No |
+| digital_legacy_portrait | 10 | 1 | 1 | 0 | 0 | 0 | No | No | Yes | No | No | No | No | Yes |
+
+## Household lane
+
+| Package | Uploads | Storage (GB) | Members | Households | Org Nodes | Zoom Layers | Family Tree | Org Chart | Verification Docs | Family Intake | Org Intake | Certificate | Narration | Link Keys |
+|---|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---|---|
+| household_foundation | 20 | 3 | 6 | 1 | 0 | 2 | Yes | No | Yes | Yes | No | Yes | No | Yes |
+| heirloom_legacy_tree | 50 | 10 | 15 | 1 | 0 | 4 | Yes | No | Yes | Yes | No | Yes | Yes | Yes |
+| legacy_plus | 100 | 25 | 30 | 1 | 0 | 5 | Yes | No | Yes | Yes | No | Yes | Yes | Yes |
+
+## Network lane
+
+| Package | Uploads | Storage (GB) | Members | Households | Org Nodes | Zoom Layers | Family Tree | Org Chart | Verification Docs | Family Intake | Org Intake | Certificate | Narration | Link Keys |
+|---|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---|---|
+| family_estate_concierge | 250 | 50 | 999 | 3 | 0 | 999 | Yes | No | Yes | Yes | No | Yes | Yes | Yes |
+
+## Organization lane
+
+| Package | Uploads | Storage (GB) | Members | Households | Org Nodes | Zoom Layers | Family Tree | Org Chart | Verification Docs | Family Intake | Org Intake | Certificate | Narration | Link Keys |
+|---|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---|---|
+| command_structure_network | 25 | 5 | 0 | 0 | 15 | 2 | No | Yes | Yes | No | Yes | No | No | No |
+
+## Package lifecycle map (upgrade targets)
+
+- `legacy_snapshot` -> `legacy_portrait_intro`, `digital_legacy_portrait`, `household_foundation`, `heirloom_legacy_tree`, `legacy_plus`, `family_estate_concierge`
+- `legacy_portrait_intro` -> `digital_legacy_portrait`, `household_foundation`, `heirloom_legacy_tree`, `legacy_plus`, `family_estate_concierge`
+- `digital_legacy_portrait` -> `household_foundation`, `heirloom_legacy_tree`, `legacy_plus`, `family_estate_concierge`
+- `household_foundation` -> `heirloom_legacy_tree`, `legacy_plus`, `family_estate_concierge`
+- `heirloom_legacy_tree` -> `legacy_plus`, `family_estate_concierge`
+- `legacy_plus` -> `family_estate_concierge`
+- `family_estate_concierge` -> _(none)_
+- `command_structure_network` -> `family_estate_concierge`

--- a/SYSTEM_BASELINE_AUDIT.md
+++ b/SYSTEM_BASELINE_AUDIT.md
@@ -1,0 +1,163 @@
+# Tomb of Light Baseline Audit (Phase 0)
+
+## Scope
+
+This document captures the current **as-built** architecture and behavior for:
+
+1. Package and entitlement system
+2. Account/auth system
+3. Workspace and project scoping
+
+It is intended as a pre-change baseline before deeper remediation and UX upgrades.
+
+## 1) System Architecture Map
+
+### Frontend surface
+
+- Multi-page web application with dedicated customer/admin flows (`dashboard.html`, `billing.html`, intake/upload pages, workspace access pages).
+- Frontend API calls are routed to FastAPI backend endpoints (e.g., `/billing/*`, `/auth/*`, `/projects/*`).
+- Billing frontend resolves user context and package-aware maintenance links using package code keyed payment links.
+
+### Backend service
+
+- FastAPI application (`backend/app/main.py`) composes modular routers for auth, billing, projects, entitlements, uploads, workspace access, family graph, verification, admin consoles, and audit logs.
+- Startup lifecycle initializes MongoDB connection and key operational indexes, including:
+  - orders indexes
+  - project entitlement indexes
+  - mint indexes
+  - stripe event indexes
+- Security headers and CORS are centrally enforced at middleware level.
+
+### Data layer (MongoDB)
+
+Primary collections inferred from services/routes include:
+
+- `users`
+- `orders`
+- `projects`
+- `project_entitlements`
+- `project_members`
+- `families`
+- `family_members`
+- additional domain collections (verification, minting, records, logs)
+
+### Purchase-to-workspace flow (current)
+
+Current orchestrated path:
+
+1. User account exists (or pending checkout user is created).
+2. Paid package order is written (`orders`).
+3. Order reconciliation/provisioning links order to an existing eligible project or creates a new project.
+4. Project package fields are normalized (`package_code`, `package_slug`, `project_lane`).
+5. Project entitlement record is upserted in `project_entitlements` with resolved package capabilities and maintenance status.
+6. Owner membership is ensured in `project_members` to establish workspace access.
+
+## 2) Package & Entitlement Model (Current Behavior)
+
+### Canonical package implementation
+
+The platform currently uses concrete package codes and lanes:
+
+- Portrait lane (self-like scope):
+  - `legacy_snapshot`
+  - `legacy_portrait_intro`
+  - `digital_legacy_portrait`
+- Household lane:
+  - `household_foundation`
+  - `heirloom_legacy_tree`
+  - `legacy_plus`
+- Network lane:
+  - `family_estate_concierge`
+- Organization lane:
+  - `command_structure_network`
+
+Alias and slug translation normalize incoming identifiers to canonical package codes.
+
+### Entitlement resolution
+
+Entitlements are computed from package baseline + active addons:
+
+- Limits: uploads, storage, members, households, org nodes, zoom layers
+- Feature flags: family tree/org chart build capabilities, intake visibility, link key access, certificate capability, narration capability
+- Addon expansions are merged into resolved entitlement map
+
+### Upgrade and maintenance behavior
+
+- Upgrade legality is constrained by package `upgrade_targets`.
+- Maintenance defaults come from package control policy and are materialized into entitlement lifecycle fields:
+  - scheduled start
+  - active period start/end
+  - renew-at
+  - Stripe maintenance subscription metadata
+
+## 3) Account System (Current Behavior)
+
+### Registration/login
+
+- Signup requires legal acceptance fields (terms/privacy/eligibility attestation).
+- Password policy validation occurs during registration.
+- Login supports:
+  - credential validation
+  - IP/principal-aware rate limiting
+  - lockout after threshold failures
+  - MFA-required and MFA-enrollment-required challenge modes
+- Auth token is returned and set in HttpOnly auth cookie.
+- CSRF token is generated and set in separate cookie.
+
+### Session/security posture
+
+- No-store cache headers are applied for auth responses.
+- Security middleware adds HSTS (on secure requests), frame/type hardening, strict referrer policy, and permissions policy.
+
+## 4) Workspace/Project Scoping (Current Behavior)
+
+### Access model
+
+Workspace access is resolved through a layered model:
+
+1. `project_members` membership records (primary)
+2. Owner fallback (`owner_user_id` / `owner_email`)
+3. Internal admin override roles
+4. Family visibility fallback when owner markers are absent
+
+### Default project selection
+
+For authenticated users, active/default project selection prioritizes:
+
+1. Accessible project IDs from membership records
+2. Active project entitlements
+3. Owner project fallback (or latest project for admins)
+
+### Entitlement binding to workspace
+
+Workspace context resolution combines:
+
+- project record
+- active entitlement (if present)
+- paid package order fallback
+
+Resolved entitlement capabilities are then transformed into:
+
+- active permission flags (`can_*`)
+- lane experience mode
+- allowed modules/chambers
+
+## 5) Initial Risk/Gap Notes for Next Audit Phase
+
+These are not code changes yet; they are baseline observations to prioritize in Phase 1 deep audit.
+
+1. **Tier naming abstraction gap**: business-facing tier names (Self/Household/Network/Organization) do not appear as first-class canonical codes; implementation uses product package codes grouped by lane.
+2. **Data representation variance**: several services include defensive handling for string/ObjectId variants, suggesting historical inconsistency in stored identifiers.
+3. **Provisioning reliance on repair jobs**: order/project/entitlement coherence is reinforced by reconciliation helpers, indicating need to validate real-time path completeness and idempotency under load.
+4. **Access-path complexity**: workspace visibility uses multiple fallbacks (membership, owner, shared family data, admin), which is robust but should be formally regression-tested for strict isolation.
+
+## 6) Recommended Next Step
+
+Proceed to a **package entitlement conformance matrix** that enumerates each lane/package against:
+
+- upload/storage/member/node limits
+- feature gates
+- workspace access behavior
+- onboarding/upgrade/downgrade edge states
+
+Then execute automated scenario tests by tier and membership role.

--- a/backend/app/core/entitlement_conformance_matrix.py
+++ b/backend/app/core/entitlement_conformance_matrix.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from app.core.package_catalog import get_package_catalog
+from app.services.experience_catalog_service import derive_allowed_modules
+
+WORKSPACE_DEFAULT_MEMBER_ROLES: list[str] = [
+    "billing_owner",
+    "co_owner",
+    "family_manager",
+    "contributor",
+    "viewer",
+    "minor_viewer",
+    "linked_relative",
+    "legacy_executor",
+]
+
+WORKSPACE_VISIBILITY_RULES: dict[str, str] = {
+    "membership_first": "project_members record grants access before owner fallback checks",
+    "owner_fallback": "owner_user_id/owner_email retains billing-owner access",
+    "admin_override": "internal admin roles can traverse workspace context",
+    "family_fallback": "family visibility fallback applies only when family owner markers are absent",
+}
+
+LIFECYCLE_NOTES: dict[str, str] = {
+    "upgrade": "only upgrade_targets listed by package are accepted in purchase flow",
+    "downgrade": "downgrades are blocked in current purchase flow (no allowed reverse path)",
+    "maintenance": "maintenance status is tracked but does not revoke package capability flags",
+    "inactive_entitlement": "workspace access depends on membership/owner checks even when entitlement state is inactive",
+}
+
+
+def _feature_access_from_package(package: dict[str, Any]) -> dict[str, Any]:
+    entitlements = deepcopy(package)
+    package_lane = str(package.get("package_lane") or "").strip().lower()
+
+    return {
+        "can_build_household": bool(entitlements.get("can_build_household")),
+        "can_build_family_tree": bool(entitlements.get("can_build_family_tree")),
+        "can_build_org_chart": bool(entitlements.get("can_build_org_chart")),
+        "can_link_households": bool(entitlements.get("can_link_households")),
+        "can_link_org_units": bool(entitlements.get("can_link_org_units")),
+        "can_upload_portraits": bool(entitlements.get("can_upload_portraits")),
+        "can_upload_verification_docs": bool(entitlements.get("can_upload_verification_docs")),
+        "can_use_viewer": bool(entitlements.get("can_use_viewer")),
+        "can_use_narration": bool(entitlements.get("can_use_narration")),
+        "can_use_lineage_certificate": bool(entitlements.get("can_use_lineage_certificate")),
+        "can_open_family_intake": bool(entitlements.get("can_open_family_intake")),
+        "can_open_org_intake": bool(entitlements.get("can_open_org_intake")),
+        "can_use_link_keys": bool(entitlements.get("can_use_link_keys")),
+        "can_manage_link_keys": bool(entitlements.get("can_manage_link_keys")),
+        "workspace_modules_enabled": derive_allowed_modules(package_lane, entitlements),
+    }
+
+
+def _hard_limits_from_package(package: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "max_uploads": int(package.get("max_uploads") or 0),
+        "max_storage_gb": float(package.get("max_storage_gb") or 0),
+        "max_members": int(package.get("max_members") or 0),
+        "max_households": int(package.get("max_households") or 0),
+        "max_org_nodes": int(package.get("max_org_nodes") or 0),
+        "max_zoom_layers": int(package.get("max_zoom_layers") or 0),
+    }
+
+
+def _lifecycle_behavior_from_package(package: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "upgrade_targets": list(package.get("upgrade_targets") or []),
+        "downgrade_policy": LIFECYCLE_NOTES["downgrade"],
+        "maintenance_behavior": LIFECYCLE_NOTES["maintenance"],
+        "inactive_entitlement_behavior": LIFECYCLE_NOTES["inactive_entitlement"],
+    }
+
+
+def build_entitlement_conformance_matrix() -> dict[str, Any]:
+    package_catalog = get_package_catalog()
+
+    lanes: dict[str, dict[str, Any]] = {
+        "portrait": {"packages": {}},
+        "household": {"packages": {}},
+        "network": {"packages": {}},
+        "organization": {"packages": {}},
+    }
+
+    for package_code, package in package_catalog.items():
+        package_lane = str(package.get("package_lane") or "").strip().lower()
+        if package_lane not in lanes:
+            continue
+
+        lanes[package_lane]["packages"][package_code] = {
+            "package_code": package_code,
+            "display_name": package.get("display_name"),
+            "hard_limits": _hard_limits_from_package(package),
+            "feature_access": _feature_access_from_package(package),
+            "workspace_behavior": {
+                "default_member_roles": list(WORKSPACE_DEFAULT_MEMBER_ROLES),
+                "visibility_rules": deepcopy(WORKSPACE_VISIBILITY_RULES),
+                "access_boundary": "project-scoped access only; cross-project access requires explicit membership/owner/admin path",
+            },
+            "lifecycle_behavior": _lifecycle_behavior_from_package(package),
+        }
+
+    return {
+        "version": "phase1-v1",
+        "single_source_of_truth": "backend.app.core.entitlement_conformance_matrix",
+        "lifecycle_global_notes": deepcopy(LIFECYCLE_NOTES),
+        "lanes": lanes,
+    }
+
+
+def validate_entitlement_conformance_matrix(matrix: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    package_catalog = get_package_catalog()
+
+    covered_packages: set[str] = set()
+    lanes = matrix.get("lanes") if isinstance(matrix, dict) else {}
+    if not isinstance(lanes, dict):
+        return ["Matrix lanes payload is invalid."]
+
+    for lane_key in ("portrait", "household", "network", "organization"):
+        lane_value = lanes.get(lane_key)
+        if not isinstance(lane_value, dict):
+            errors.append(f"Lane '{lane_key}' is missing or invalid.")
+            continue
+
+        lane_packages = lane_value.get("packages")
+        if not isinstance(lane_packages, dict):
+            errors.append(f"Lane '{lane_key}' packages payload is invalid.")
+            continue
+
+        for package_code, definition in lane_packages.items():
+            covered_packages.add(package_code)
+            source = package_catalog.get(package_code)
+            if source is None:
+                errors.append(f"Matrix includes unknown package '{package_code}'.")
+                continue
+
+            source_lane = str(source.get("package_lane") or "").strip().lower()
+            if source_lane != lane_key:
+                errors.append(
+                    f"Package '{package_code}' lane mismatch: matrix={lane_key} source={source_lane}."
+                )
+
+            hard_limits = (definition or {}).get("hard_limits") if isinstance(definition, dict) else {}
+            if not isinstance(hard_limits, dict):
+                errors.append(f"Package '{package_code}' has invalid hard_limits.")
+                continue
+
+            for limit_key in (
+                "max_uploads",
+                "max_storage_gb",
+                "max_members",
+                "max_households",
+                "max_org_nodes",
+                "max_zoom_layers",
+            ):
+                if limit_key not in hard_limits:
+                    errors.append(f"Package '{package_code}' missing hard limit '{limit_key}'.")
+
+    source_packages = set(package_catalog.keys())
+    missing = sorted(source_packages - covered_packages)
+    extra = sorted(covered_packages - source_packages)
+
+    for package_code in missing:
+        errors.append(f"Matrix missing package '{package_code}'.")
+    for package_code in extra:
+        errors.append(f"Matrix has non-catalog package '{package_code}'.")
+
+    return errors
+
+
+def get_entitlement_conformance_matrix() -> dict[str, Any]:
+    matrix = build_entitlement_conformance_matrix()
+    errors = validate_entitlement_conformance_matrix(matrix)
+    if errors:
+        raise ValueError("Entitlement conformance matrix is invalid: " + "; ".join(errors))
+    return matrix

--- a/backend/app/routes/package_catalog.py
+++ b/backend/app/routes/package_catalog.py
@@ -14,6 +14,7 @@ from app.services.entitlement_service import (
     compute_upgrade_quote,
     resolve_project_entitlements,
 )
+from app.core.entitlement_conformance_matrix import get_entitlement_conformance_matrix
 
 router = APIRouter(prefix="/packages", tags=["Packages"])
 
@@ -27,6 +28,11 @@ def get_package_catalog_route():
         "package_identifier_map": get_package_identifier_map(),
         "control_profiles": list_package_control_profiles(),
     }
+
+
+@router.get("/conformance-matrix")
+def get_package_conformance_matrix_route():
+    return get_entitlement_conformance_matrix()
 
 
 @router.get("/entitlements/{package_code}")

--- a/backend/tests/test_entitlement_conformance_matrix.py
+++ b/backend/tests/test_entitlement_conformance_matrix.py
@@ -1,0 +1,45 @@
+import unittest
+
+from app.core.entitlement_conformance_matrix import (
+    get_entitlement_conformance_matrix,
+    validate_entitlement_conformance_matrix,
+)
+from app.core.package_catalog import get_package_catalog
+
+
+class EntitlementConformanceMatrixTests(unittest.TestCase):
+    def test_matrix_covers_all_catalog_packages(self):
+        matrix = get_entitlement_conformance_matrix()
+        catalog = get_package_catalog()
+
+        covered = set()
+        for lane in ("portrait", "household", "network", "organization"):
+            lane_packages = matrix["lanes"][lane]["packages"]
+            covered.update(lane_packages.keys())
+
+        self.assertEqual(set(catalog.keys()), covered)
+
+    def test_matrix_has_complete_hard_limits(self):
+        matrix = get_entitlement_conformance_matrix()
+        required_limit_keys = {
+            "max_uploads",
+            "max_storage_gb",
+            "max_members",
+            "max_households",
+            "max_org_nodes",
+            "max_zoom_layers",
+        }
+
+        for lane in matrix["lanes"].values():
+            for package in lane["packages"].values():
+                limits = package["hard_limits"]
+                self.assertEqual(required_limit_keys, set(limits.keys()))
+
+    def test_matrix_self_validation_passes(self):
+        matrix = get_entitlement_conformance_matrix()
+        errors = validate_entitlement_conformance_matrix(matrix)
+        self.assertEqual([], errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/household-access.html
+++ b/household-access.html
@@ -156,6 +156,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260416-4"></script>
     <script src="auth.js?v=20260416-1"></script>
-    <script src="household-access.js?v=20260416-7"></script>
+    <script src="household-access.js?v=20260418-3"></script>
   </body>
 </html>

--- a/household-access.js
+++ b/household-access.js
@@ -1,6 +1,6 @@
 (function () {
   const app = window.TOLApp || window.TOLAuth;
-  if (!app) return;
+  if (!app || typeof app.apiRequest !== "function") return;
 
   const statusNode = document.querySelector("[data-household-status]");
   const inviteForm = document.querySelector("[data-household-invite-form]");
@@ -332,7 +332,6 @@
 
   async function sendLoadRequest(pathOrPaths, action, projectId, options = {}) {
     const paths = loadRequestPaths(pathOrPaths);
-    const apiBaseUrls = resolveInviteApiBaseUrls();
     const authToken = typeof app.getToken === "function" ? String(app.getToken() || "").trim() : "";
     const fallbackStatusCodes = new Set(
       (Array.isArray(options.fallbackStatusCodes) && options.fallbackStatusCodes.length
@@ -345,78 +344,41 @@
     let lastError = null;
 
     for (const path of paths) {
-      for (const apiBaseUrl of apiBaseUrls) {
-        const requestUrl = `${apiBaseUrl}${path}`;
-        logLoadRequest(action, path, "GET", projectId, {
-          requestUrl,
-          resolvedApiBaseUrl: apiBaseUrl,
+      logLoadRequest(action, path, "GET", projectId, { requestUrl: path });
+      try {
+        const headers = { Accept: "application/json" };
+        if (authToken) headers.Authorization = `Bearer ${authToken}`;
+        const responseBody = await app.apiRequest(path, {
+          method: "GET",
+          headers,
         });
-        try {
-          const headers = { Accept: "application/json" };
-          if (authToken) headers.Authorization = `Bearer ${authToken}`;
-          const response = await fetch(requestUrl, {
-            method: "GET",
-            credentials: "include",
-            headers,
-          });
-          const contentType = String(response.headers.get("content-type") || "").toLowerCase();
-          let responseBody = null;
-          if (contentType.includes("application/json")) {
-            responseBody = await response.json();
-          } else {
-            const text = await response.text();
-            responseBody = text ? { detail: text } : null;
-          }
-          const responseMeta = {
-            requestUrl,
-            resolvedApiBaseUrl: apiBaseUrl,
-            status: response.status,
-          };
-          logLoadResponse(action, path, "GET", projectId, responseMeta, responseBody);
-          if (!response.ok) {
-            const detail = readableMessage(
-              responseBody?.detail || responseBody?.message || responseBody?.error || responseBody,
-              response.statusText || `Request failed with status ${response.status}`,
-            );
-            const error = new Error(detail || `Request failed with status ${response.status}`);
-            error.status = response.status;
-            error.statusText = response.statusText;
-            error.detail = detail;
-            error.data = responseBody;
-            error.responseBody = responseBody;
-            error.requestUrl = requestUrl;
-            error.resolvedApiBaseUrl = apiBaseUrl;
-            lastError = error;
-            logLoadFailure(action, path, "GET", projectId, error);
-            if (fallbackStatusCodes.has(response.status)) {
-              continue;
-            }
-            throw error;
-          }
-          return responseBody;
-        } catch (error) {
-          if (fallbackStatusCodes.has(Number(error?.status || 0))) {
-            lastError = error;
-            continue;
-          }
-          if (Number(error?.status || 0) > 0) {
-            throw error;
-          }
-          const networkError = new Error(error?.message || "Network request failed.");
-          networkError.status = 0;
-          networkError.detail = error?.message || "Network request failed.";
-          networkError.requestUrl = requestUrl;
-          networkError.resolvedApiBaseUrl = apiBaseUrl;
-          lastError = networkError;
-          logLoadFailure(action, path, "GET", projectId, networkError);
+        logLoadResponse(
+          action,
+          path,
+          "GET",
+          projectId,
+          {
+            requestUrl: path,
+            resolvedApiBaseUrl: typeof app.getApiBaseUrl === "function" ? app.getApiBaseUrl() : "",
+            status: 200,
+          },
+          responseBody,
+        );
+        return responseBody;
+      } catch (error) {
+        lastError = error;
+        logLoadFailure(action, path, "GET", projectId, error);
+        if (fallbackStatusCodes.has(Number(error?.status || 0))) {
+          continue;
         }
+        throw error;
       }
     }
 
     throw (
       lastError ||
       new Error(
-        `Load endpoint unavailable for paths [${paths.join(", ") || "none"}] across all configured hosts: ${apiBaseUrls.join(", ") || "none"}`,
+        `Load endpoint unavailable for paths [${paths.join(", ") || "none"}].`,
       )
     );
   }
@@ -440,99 +402,19 @@
   }
 
   async function sendInviteRequest(path, payload, action) {
-    const apiBaseUrls = resolveInviteApiBaseUrls();
-    const authToken = typeof app.getToken === "function" ? String(app.getToken() || "").trim() : "";
-    let lastError = null;
-    for (const apiBaseUrl of apiBaseUrls) {
-      const requestUrl = `${apiBaseUrl}${path}`;
-      logInviteRequest(action, path, payload);
-      console.info("[HouseholdAccess] Invite request attempt.", {
-        action,
-        resolvedApiBaseUrl: apiBaseUrl,
-        requestUrl,
-        method: "POST",
-        payload,
-      });
-      try {
-        const headers = {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        };
-        if (authToken) headers.Authorization = `Bearer ${authToken}`;
-        const response = await fetch(requestUrl, {
-          method: "POST",
-          credentials: "include",
-          headers,
-          body: JSON.stringify(payload),
-        });
-        const contentType = String(response.headers.get("content-type") || "").toLowerCase();
-        let responseBody = null;
-        if (contentType.includes("application/json")) {
-          responseBody = await response.json();
-        } else {
-          const text = await response.text();
-          responseBody = text ? { detail: text } : null;
-        }
-        console.info("[HouseholdAccess] Invite request response.", {
-          action,
-          resolvedApiBaseUrl: apiBaseUrl,
-          requestUrl,
-          method: "POST",
-          payload,
-          status: response.status,
-          responseBody,
-        });
-        if (!response.ok) {
-          const detail = readableMessage(
-            responseBody?.detail || responseBody?.message || responseBody?.error || responseBody,
-            response.statusText || `Request failed with status ${response.status}`,
-          );
-          const error = new Error(detail || `Request failed with status ${response.status}`);
-          error.status = response.status;
-          error.statusText = response.statusText;
-          error.detail = detail;
-          error.data = responseBody;
-          error.responseBody = responseBody;
-          error.requestUrl = requestUrl;
-          error.resolvedApiBaseUrl = apiBaseUrl;
-          lastError = error;
-          if (response.status === 404) {
-            // Some live environments run mixed backend versions per host; keep
-            // trying remaining API hosts so invite creation is not blocked.
-            continue;
-          }
-          throw error;
-        }
-        return {
-          responseBody,
-          meta: {
-            requestUrl,
-            resolvedApiBaseUrl: apiBaseUrl,
-            status: response.status,
-          },
-        };
-      } catch (error) {
-        if (Number(error?.status || 0) === 404) {
-          lastError = error;
-          continue;
-        }
-        if (Number(error?.status || 0) > 0) {
-          throw error;
-        }
-        const networkError = new Error(error?.message || "Network request failed.");
-        networkError.status = 0;
-        networkError.detail = error?.message || "Network request failed.";
-        networkError.requestUrl = requestUrl;
-        networkError.resolvedApiBaseUrl = apiBaseUrl;
-        lastError = networkError;
-      }
-    }
-    throw (
-      lastError ||
-      new Error(
-        `Invite endpoint unavailable across all configured hosts: ${apiBaseUrls.join(", ") || "none"}`,
-      )
-    );
+    logInviteRequest(action, path, payload);
+    const responseBody = await app.apiRequest(path, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    return {
+      responseBody,
+      meta: {
+        requestUrl: path,
+        resolvedApiBaseUrl: typeof app.getApiBaseUrl === "function" ? app.getApiBaseUrl() : "",
+        status: 201,
+      },
+    };
   }
 
   function setText(node, message, type = "info") {
@@ -908,7 +790,10 @@
       error?.detail || error?.message || error?.data || error?.responseBody,
       "",
     ).toLowerCase();
-    if (!statusCode && raw.includes("network")) {
+    if (
+      !statusCode &&
+      (raw.includes("network") || raw.includes("failed to fetch") || raw.includes("load failed"))
+    ) {
       return "We couldn’t reach the workspace access service. Please refresh and try again.";
     }
     if (statusCode === 404) {


### PR DESCRIPTION
### Motivation
- Users were seeing persistent raw "Failed to fetch" failures and partial page initialization on the Household Workspace Access page because the page implemented its own transport loop instead of using the app’s canonical request client. 
- The change forces deterministic API host discovery/retry behavior and prevents partial bootstraps that surface low-level network text to end users.

### Description
- Added a stricter bootstrap guard so the page only runs when the shared client `app.apiRequest` is present and callable. 
- Replaced the page-local raw `fetch` loops in `sendLoadRequest` and `sendInviteRequest` with calls to the shared `app.apiRequest` so members/invites loads and invite creation inherit platform host discovery, retry and credential behavior. 
- Normalized low-level network messages (including `Failed to fetch` and other browser network strings) in `householdLoadFailureMessage` so user-facing errors are actionable rather than leaking raw browser text. 
- Bumped the Household Access script version token in `household-access.html` to force clients/CDNs to pick up the updated `household-access.js` bundle immediately.

### Testing
- Ran `node --check household-access.js` to validate the modified client-side script and it succeeded. 
- Verified the HTML now references the updated bundle with `rg "household-access.js?v=" -n household-access.html` and confirmed the version bump.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3602fb130832db0ed3ff1f8281edb)