### PR TITLE
mobile: align API/auth scaffold with backend routes and fix request h…

### DIFF
--- a/mobile/app/(app)/dashboard.tsx
+++ b/mobile/app/(app)/dashboard.tsx
@@ -8,7 +8,8 @@ export default function DashboardScreen() {
       title="Dashboard"
       description="Package-lane dashboard starter for customer progress visibility."
       todoItems={[
-        'TODO: Load package lane cards from FastAPI.',
+        'TODO: Load access context from /users/me/access-context.',
+        'TODO: Load workspace memberships from /workspace-access/my-memberships.',
         'TODO: Show milestone and activity status.',
         'TODO: Add deep links to project, uploads, and certificates.'
       ]}

--- a/mobile/app/(app)/family.tsx
+++ b/mobile/app/(app)/family.tsx
@@ -10,7 +10,7 @@ export default function FamilyScreen() {
       todoItems={[
         'TODO: Fetch family records from FastAPI.',
         'TODO: Add member list and profile drill-down.',
-        'TODO: Apply workspace role visibility constraints.'
+        'TODO: Enforce workspace role visibility (billing_owner/co_owner/family_manager).'
       ]}
     />
   );

--- a/mobile/app/(app)/uploads.tsx
+++ b/mobile/app/(app)/uploads.tsx
@@ -8,7 +8,7 @@ export default function UploadsScreen() {
       title="Uploads"
       description="Customer upload center for project documents and media."
       todoItems={[
-        'TODO: Integrate upload API with FastAPI.',
+        'TODO: Integrate upload API with FastAPI using multipart FormData payloads.',
         'TODO: Show upload queue/progress states.',
         'TODO: Link files to project/member records.'
       ]}

--- a/mobile/src/config/api.ts
+++ b/mobile/src/config/api.ts
@@ -3,6 +3,12 @@ import Constants from 'expo-constants';
 const envBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
 const extraBaseUrl = Constants.expoConfig?.extra?.apiBaseUrl;
 const defaultBaseUrl = 'https://api.tomboflight.com';
+const WORKSPACE_ACCESS_CANONICAL_PREFIX = '/workspace-access';
+const WORKSPACE_ACCESS_PREFIX_ALIASES = [
+  '/workspace-access',
+  '/workspace_access',
+  '/household-access'
+] as const;
 
 function resolveApiBaseUrl(): string {
   const candidate = String(envBaseUrl || extraBaseUrl || defaultBaseUrl)
@@ -34,3 +40,44 @@ export const API_CONFIG = {
   baseUrl: resolveApiBaseUrl(),
   timeoutMs: 15000
 } as const;
+
+/**
+ * Shared backend route map for the mobile app.
+ * Keep these aligned with FastAPI route declarations and web app usage.
+ */
+export const API_ENDPOINTS = {
+  auth: {
+    signIn: '/auth/login',
+    signUp: '/auth/signup',
+    logout: '/auth/logout',
+    csrfToken: '/auth/csrf-token',
+    passwordResetRequest: '/auth/password-reset/request',
+    passwordResetConfirm: '/auth/password-reset/confirm'
+  },
+  users: {
+    accessContext: '/users/me/access-context',
+    profile: '/users/me/profile'
+  },
+  workspaceAccess: {
+    myMemberships: '/workspace-access/my-memberships'
+  }
+} as const;
+
+/**
+ * Produces canonical + legacy workspace access paths for backward compatibility.
+ * TODO: Remove legacy aliases when backend/web have fully standardized on canonical routes.
+ */
+export function workspaceAccessPathAliases(path: string): string[] {
+  const normalized = `/${path.replace(/^\/+/, '')}`;
+  const canonical = normalized
+    .replace(/^\/workspace_access\//, `${WORKSPACE_ACCESS_CANONICAL_PREFIX}/`)
+    .replace(/^\/household-access\//, `${WORKSPACE_ACCESS_CANONICAL_PREFIX}/`);
+
+  if (!canonical.startsWith(`${WORKSPACE_ACCESS_CANONICAL_PREFIX}/`)) {
+    return [normalized];
+  }
+
+  return WORKSPACE_ACCESS_PREFIX_ALIASES.map((prefix) =>
+    canonical.replace(WORKSPACE_ACCESS_CANONICAL_PREFIX, prefix)
+  );
+}

--- a/mobile/src/services/api/access.ts
+++ b/mobile/src/services/api/access.ts
@@ -1,0 +1,57 @@
+import { API_ENDPOINTS, workspaceAccessPathAliases } from '../../config';
+import { ApiError, apiRequest } from './client';
+
+export type AccessContextPayload = Record<string, unknown>;
+
+export type WorkspaceMembership = {
+  id?: string;
+  project_id?: string;
+  member_role?: string;
+  relationship_scope?: string;
+  [key: string]: unknown;
+};
+
+export type WorkspaceMembershipsResponse = {
+  items: WorkspaceMembership[];
+};
+
+/**
+ * Loads the authenticated user's access context.
+ * Mirrors website usage of /users/me/access-context.
+ */
+export async function fetchAccessContext(token?: string): Promise<AccessContextPayload> {
+  return apiRequest<AccessContextPayload>(API_ENDPOINTS.users.accessContext, {
+    method: 'GET',
+    token
+  });
+}
+
+/**
+ * Loads workspace memberships using canonical and legacy aliases.
+ * Mirrors website fallback behavior for route compatibility.
+ */
+export async function fetchMyMemberships(token?: string): Promise<WorkspaceMembershipsResponse> {
+  const candidates = workspaceAccessPathAliases(API_ENDPOINTS.workspaceAccess.myMemberships);
+  let lastNotFoundError: ApiError | null = null;
+
+  for (const candidatePath of candidates) {
+    try {
+      return await apiRequest<WorkspaceMembershipsResponse>(candidatePath, {
+        method: 'GET',
+        token
+      });
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        lastNotFoundError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (lastNotFoundError) {
+    throw lastNotFoundError;
+  }
+
+  throw new Error('Workspace membership endpoints are unavailable.');
+}

--- a/mobile/src/services/api/client.ts
+++ b/mobile/src/services/api/client.ts
@@ -5,7 +5,20 @@ export type ApiRequestOptions = {
   token?: string;
   body?: unknown;
   headers?: Record<string, string>;
+  credentials?: RequestCredentials;
 };
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail?: unknown;
+
+  constructor(status: number, message: string, detail?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
 
 /**
  * Minimal API client starter.
@@ -21,10 +34,7 @@ export async function apiRequest<TResponse>(
   const headers: Record<string, string> = {
     ...options.headers
   };
-
-  if (options.body !== undefined) {
-    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-  }
+  const body = prepareBody(options.body, headers);
 
   if (options.token) {
     headers.Authorization = `Bearer ${options.token}`;
@@ -34,19 +44,29 @@ export async function apiRequest<TResponse>(
     const response = await fetch(url, {
       method: options.method ?? 'GET',
       headers,
+      credentials: options.credentials ?? 'include',
       signal: controller.signal,
-      body: options.body !== undefined ? JSON.stringify(options.body) : undefined
+      body
     });
 
     if (!response.ok) {
-      throw new Error(`API request failed (${response.status}).`);
+      throw await toApiError(response);
     }
 
-    if (response.status === 204) {
+    if (response.status === 204 || response.status === 205 || response.headers.get('content-length') === '0') {
       return undefined as TResponse;
     }
 
-    return (await response.json()) as TResponse;
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.toLowerCase().includes('application/json')) {
+      return (await response.json()) as TResponse;
+    }
+
+    if (contentType.toLowerCase().startsWith('text/')) {
+      return (await response.text()) as TResponse;
+    }
+
+    return undefined as TResponse;
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
       throw new Error('API request timed out.');
@@ -61,4 +81,64 @@ function buildUrl(path: string): string {
   const base = API_CONFIG.baseUrl.replace(/\/+$/, '');
   const normalizedPath = path.replace(/^\/+/, '');
   return `${base}/${normalizedPath}`;
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === lowerName);
+}
+
+function prepareBody(body: unknown, headers: Record<string, string>): BodyInit | undefined {
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  if (
+    typeof body === 'string' ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body)
+  ) {
+    return body as BodyInit;
+  }
+
+  if (!hasHeader(headers, 'Content-Type')) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return JSON.stringify(body);
+}
+
+async function toApiError(response: Response): Promise<ApiError> {
+  const contentType = (response.headers.get('content-type') || '').toLowerCase();
+  let detail: unknown;
+  let message = `API request failed (${response.status}).`;
+
+  try {
+    if (contentType.includes('application/json')) {
+      const payload = (await response.json()) as {
+        detail?: unknown;
+        message?: unknown;
+      };
+      detail = payload.detail ?? payload.message ?? payload;
+
+      if (typeof payload.detail === 'string' && payload.detail.trim()) {
+        message = payload.detail;
+      } else if (typeof payload.message === 'string' && payload.message.trim()) {
+        message = payload.message;
+      }
+    } else {
+      const rawText = (await response.text()).trim();
+      if (rawText) {
+        detail = rawText;
+        message = rawText;
+      }
+    }
+  } catch {
+    // Keep fallback message when response body cannot be parsed.
+  }
+
+  return new ApiError(response.status, message, detail);
 }

--- a/mobile/src/services/api/index.ts
+++ b/mobile/src/services/api/index.ts
@@ -1,1 +1,2 @@
 export * from './client';
+export * from './access';

--- a/mobile/src/services/auth/auth.service.ts
+++ b/mobile/src/services/auth/auth.service.ts
@@ -1,3 +1,6 @@
+import { API_ENDPOINTS } from '../../config';
+import { apiRequest } from '../api';
+
 export type SignInInput = {
   email: string;
   password: string;
@@ -7,19 +10,81 @@ export type SignUpInput = {
   fullName: string;
   email: string;
   password: string;
+  termsAccepted: boolean;
+  privacyAccepted: boolean;
+  eligibilityAttested: boolean;
+  policyVersion?: string;
+};
+
+export type AuthTokenResponse = {
+  access_token: string;
+  token_type: string;
+  csrf_token?: string;
+  mfa_required?: boolean;
+  mfa_enrollment_required?: boolean;
+  mfa_challenge_token?: string | null;
+  backup_codes?: string[];
+};
+
+export type UserSignupResponse = {
+  id: string;
+  email: string;
+  full_name: string;
+  role: string;
+  status: string;
+};
+
+export type PasswordResetResponse = {
+  success: boolean;
+  message: string;
+  expires_at?: string | null;
+  reset_token?: string | null;
+  reset_url?: string | null;
+  delivery_mode?: string | null;
 };
 
 /**
- * TODO: Connect these functions to existing FastAPI auth endpoints.
+ * Uses FastAPI /auth/login.
+ * TODO: Persist token/cookie session through secure mobile storage/session manager.
  */
-export async function signIn(_input: SignInInput) {
-  throw new Error('TODO: Implement sign-in integration.');
+export async function signIn(input: SignInInput): Promise<AuthTokenResponse> {
+  return apiRequest<AuthTokenResponse>(API_ENDPOINTS.auth.signIn, {
+    method: 'POST',
+    body: {
+      email: input.email.trim().toLowerCase(),
+      password: input.password
+    }
+  });
 }
 
-export async function signUp(_input: SignUpInput) {
-  throw new Error('TODO: Implement sign-up integration.');
+/**
+ * Uses FastAPI /auth/signup.
+ * TODO: Build sign-up UI fields for policy acceptance and policy version display.
+ */
+export async function signUp(input: SignUpInput): Promise<UserSignupResponse> {
+  return apiRequest<UserSignupResponse>(API_ENDPOINTS.auth.signUp, {
+    method: 'POST',
+    body: {
+      full_name: input.fullName.trim(),
+      email: input.email.trim().toLowerCase(),
+      password: input.password,
+      terms_accepted: input.termsAccepted,
+      privacy_accepted: input.privacyAccepted,
+      eligibility_attested: input.eligibilityAttested,
+      policy_version: input.policyVersion
+    }
+  });
 }
 
-export async function requestPasswordReset(_email: string) {
-  throw new Error('TODO: Implement password reset integration.');
+/**
+ * Uses FastAPI /auth/password-reset/request.
+ * TODO: Implement token-confirm reset flow via /auth/password-reset/confirm.
+ */
+export async function requestPasswordReset(email: string): Promise<PasswordResetResponse> {
+  return apiRequest<PasswordResetResponse>(API_ENDPOINTS.auth.passwordResetRequest, {
+    method: 'POST',
+    body: {
+      email: email.trim().toLowerCase()
+    }
+  });
 }


### PR DESCRIPTION
…andling

Added shared mobile endpoint config for FastAPI routes (/auth/*, /users/me/access-context, /workspace-access/my-memberships) Added workspace-access alias fallback support (/workspace-access, /workspace_access, /household-access) Fixed API client to correctly handle FormData and non-JSON responses Added typed access service helpers for access-context and memberships Replaced auth TODO throw stubs with real API calls for sign-in, sign-up, and password reset request Updated screen TODO text to match backend role and endpoint conventions If you want, I can also give you a shorter 1-line version for quick commits.