### PR TITLE
Fix invite auto-accept and improve invite management features

### DIFF
--- a/backend/app/routes/workspace_access.py
+++ b/backend/app/routes/workspace_access.py
@@ -17,6 +17,7 @@ from app.schemas.household_access import (
 from app.services.household_access_service import (
     accept_household_invite,
     create_household_invite,
+    delete_household_invite,
     list_my_memberships,
     list_project_invites,
     list_project_members,
@@ -355,6 +356,25 @@ def resend_invite(invite_id: str, current_user: dict[str, Any] = Depends(get_cur
 @legacy_router.post("/household-access/invites/{invite_id}/resend", include_in_schema=False)
 def resend_invite_legacy(invite_id: str, current_user: dict[str, Any] = Depends(get_current_user)):
     return resend_invite(invite_id=invite_id, current_user=current_user)
+
+
+@router.delete("/invites/{invite_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_invite(invite_id: str, current_user: dict[str, Any] = Depends(get_current_user)):
+    try:
+        deleted = delete_household_invite(invite_id=invite_id, actor_user=current_user)
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite not found.")
+    return None
+
+
+@legacy_router.delete("/workspace_access/invites/{invite_id}", include_in_schema=False)
+@legacy_router.delete("/household-access/invites/{invite_id}", include_in_schema=False)
+def delete_invite_legacy(invite_id: str, current_user: dict[str, Any] = Depends(get_current_user)):
+    return delete_invite(invite_id=invite_id, current_user=current_user)
 
 
 @router.post("/project/{project_id}/members/{membership_id}/role")

--- a/backend/app/schemas/household_access.py
+++ b/backend/app/schemas/household_access.py
@@ -107,6 +107,8 @@ def build_invite_response(data: dict[str, Any]) -> dict[str, Any]:
         "email": _normalize_value(data.get("email")).lower(),
         "invite_key": _normalize_value(data.get("invite_key")) or None,
         "status": _normalize_value(data.get("status") or "pending"),
+        "email_delivery_status": _normalize_value(data.get("email_delivery_status")) or None,
+        "email_delivery_error": _normalize_value(data.get("email_delivery_error")) or None,
         "member_role": normalize_project_member_role(data.get("member_role"), default="viewer"),
         "relationship_scope": _normalize_value(data.get("relationship_scope") or "household_member"),
         "privacy_scope": _normalize_privacy_scope_value(data.get("privacy_scope") or "household_private"),

--- a/backend/app/services/household_access_service.py
+++ b/backend/app/services/household_access_service.py
@@ -694,6 +694,42 @@ def resend_household_invite(
     return invite
 
 
+def delete_household_invite(*, invite_id: str, actor_user: dict[str, Any]) -> bool:
+    oid = _to_oid(invite_id)
+    if oid is None:
+        return False
+    invite = _invites().find_one({"_id": oid})
+    if invite is None:
+        return False
+    invite = _expire_invite_if_needed(invite)
+    project = _find_project(_normalize(invite.get("project_id")))
+    if project is None:
+        return False
+    actor_role = _resolve_actor_role(project, actor_user)
+    if actor_role not in {"billing_owner", "co_owner", "family_manager"}:
+        raise PermissionError("You do not have permission to delete invites.")
+    invite_status = _normalize(invite.get("status") or "pending").lower()
+    if invite_status == "pending":
+        raise ValueError("Pending invites must be revoked before deletion.")
+
+    delete_result = _invites().delete_one({"_id": oid})
+    if int(getattr(delete_result, "deleted_count", 0)) <= 0:
+        return False
+
+    actor_user_id = _normalize(actor_user.get("id") or actor_user.get("_id") or actor_user.get("user_id"))
+    create_audit_log(
+        "household_invite_deleted",
+        actor_user_id or None,
+        "household_invite",
+        str(oid),
+        {
+            "project_id": _normalize(invite.get("project_id")),
+            "invite_status": invite_status,
+        },
+    )
+    return True
+
+
 def update_member_role(
     *,
     project_id: str,

--- a/backend/tests/test_household_access_schema.py
+++ b/backend/tests/test_household_access_schema.py
@@ -34,6 +34,21 @@ class HouseholdAccessSchemaTests(unittest.TestCase):
         self.assertEqual(payload["max_uses"], 1)
         self.assertEqual(payload["use_count"], 0)
 
+    def test_build_invite_response_includes_email_delivery_fields(self):
+        payload = build_invite_response(
+            {
+                "_id": "invite-email-delivery",
+                "project_id": "project-3",
+                "email": "delivery@example.com",
+                "status": "pending",
+                "member_role": "viewer",
+                "email_delivery_status": "failed",
+                "email_delivery_error": "postmark_token_missing",
+            }
+        )
+        self.assertEqual(payload["email_delivery_status"], "failed")
+        self.assertEqual(payload["email_delivery_error"], "postmark_token_missing")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_household_invites_and_orders.py
+++ b/backend/tests/test_household_invites_and_orders.py
@@ -236,6 +236,89 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
         self.assertEqual(user_update.get("active_project_id"), "project-accept-1")
         self.assertEqual(user_update.get("active_project_selected_at"), now_iso)
 
+    def test_delete_household_invite_removes_non_pending_history_record(self):
+        invite_document = {
+            "_id": "invite-delete-1",
+            "project_id": "project-delete-1",
+            "status": "revoked",
+        }
+
+        class FakeDeleteResult:
+            def __init__(self, deleted_count):
+                self.deleted_count = deleted_count
+
+        class FakeInvitesCollection:
+            def __init__(self, invite):
+                self.invite = dict(invite)
+                self.deleted_query = None
+
+            def find_one(self, query):
+                if query.get("_id") == self.invite.get("_id"):
+                    return dict(self.invite)
+                return None
+
+            def delete_one(self, query):
+                self.deleted_query = dict(query)
+                return FakeDeleteResult(1)
+
+        fake_invites = FakeInvitesCollection(invite_document)
+        with (
+            patch.object(household_access_service, "_to_oid", return_value="invite-delete-1"),
+            patch.object(household_access_service, "_invites", return_value=fake_invites),
+            patch.object(
+                household_access_service,
+                "_find_project",
+                return_value={"_id": "project-delete-1", "owner_user_id": "owner-1", "owner_email": "owner@example.com"},
+            ),
+            patch.object(household_access_service, "_resolve_actor_role", return_value="billing_owner"),
+            patch.object(household_access_service, "create_audit_log") as audit_log_mock,
+        ):
+            deleted = household_access_service.delete_household_invite(
+                invite_id="invite-delete-1",
+                actor_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+
+        self.assertTrue(deleted)
+        self.assertEqual(fake_invites.deleted_query, {"_id": "invite-delete-1"})
+        audit_log_mock.assert_called_once()
+
+    def test_delete_household_invite_rejects_pending_records(self):
+        invite_document = {
+            "_id": "invite-delete-pending",
+            "project_id": "project-delete-2",
+            "status": "pending",
+        }
+
+        class FakeInvitesCollection:
+            def __init__(self, invite):
+                self.invite = dict(invite)
+
+            def find_one(self, query):
+                if query.get("_id") == self.invite.get("_id"):
+                    return dict(self.invite)
+                return None
+
+            def delete_one(self, _query):
+                raise AssertionError("delete_one should not be called for pending invites")
+
+        fake_invites = FakeInvitesCollection(invite_document)
+        with (
+            patch.object(household_access_service, "_to_oid", return_value="invite-delete-pending"),
+            patch.object(household_access_service, "_invites", return_value=fake_invites),
+            patch.object(
+                household_access_service,
+                "_find_project",
+                return_value={"_id": "project-delete-2", "owner_user_id": "owner-1", "owner_email": "owner@example.com"},
+            ),
+            patch.object(household_access_service, "_resolve_actor_role", return_value="billing_owner"),
+        ):
+            with self.assertRaises(ValueError) as error:
+                household_access_service.delete_household_invite(
+                    invite_id="invite-delete-pending",
+                    actor_user={"id": "owner-1", "email": "owner@example.com"},
+                )
+        self.assertIn("revoked before deletion", str(error.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_workspace_access_route_aliases.py
+++ b/backend/tests/test_workspace_access_route_aliases.py
@@ -26,7 +26,7 @@ class WorkspaceAccessRouteAliasTests(unittest.TestCase):
                     continue
                 if decorator.func.value.id != "legacy_router":
                     continue
-                if decorator.func.attr not in {"get", "post"}:
+                if decorator.func.attr not in {"get", "post", "delete"}:
                     continue
                 if not decorator.args:
                     continue
@@ -43,6 +43,8 @@ class WorkspaceAccessRouteAliasTests(unittest.TestCase):
             '/household-access/invites/{invite_id}/revoke',
             '/workspace_access/invites/{invite_id}/resend',
             '/household-access/invites/{invite_id}/resend',
+            '/workspace_access/invites/{invite_id}',
+            '/household-access/invites/{invite_id}',
             '/workspace_access/project/{project_id}/members/{membership_id}/role',
             '/household-access/project/{project_id}/members/{membership_id}/role',
             '/workspace_access/project/{project_id}/members/{membership_id}/revoke',

--- a/household-access.html
+++ b/household-access.html
@@ -156,6 +156,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260416-4"></script>
     <script src="auth.js?v=20260416-1"></script>
-    <script src="household-access.js?v=20260418-3"></script>
+    <script src="household-access.js?v=20260419-1"></script>
   </body>
 </html>

--- a/household-access.js
+++ b/household-access.js
@@ -485,6 +485,39 @@
     }
   }
 
+  function inviteAcceptUrl(invite) {
+    const inviteKey = normalizeValue(invite?.invite_key);
+    if (!inviteKey) return "";
+    const projectId = normalizeValue(invite?.project_id || currentProjectId);
+    const params = new URLSearchParams();
+    params.set("invite_key", inviteKey);
+    if (projectId) params.set("project_id", projectId);
+    return `${window.location.origin}/household-access.html?${params.toString()}`;
+  }
+
+  async function copyTextToClipboard(value) {
+    const normalized = normalizeValue(value);
+    if (!normalized) return false;
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(normalized);
+      return true;
+    }
+    const node = document.createElement("textarea");
+    node.value = normalized;
+    node.setAttribute("readonly", "readonly");
+    node.style.position = "absolute";
+    node.style.left = "-9999px";
+    document.body.appendChild(node);
+    node.select();
+    let copied = false;
+    try {
+      copied = document.execCommand("copy");
+    } finally {
+      document.body.removeChild(node);
+    }
+    return copied;
+  }
+
   function normalizeInviteStatus(value) {
     const normalized = normalizeLower(value);
     if (normalized === "accepted") return "Accepted";
@@ -779,6 +812,20 @@
     return String(params.get("project_id") || "").trim();
   }
 
+  function clearInviteContextFromUrl(projectId = "") {
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("invite_key");
+      const normalizedProjectId = normalizeValue(projectId || currentProjectId || projectIdFromQuery());
+      if (normalizedProjectId) {
+        url.searchParams.set("project_id", normalizedProjectId);
+      }
+      window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+    } catch (_error) {
+      // Non-fatal URL cleanup.
+    }
+  }
+
   function signinRedirectUrlWithInviteContext() {
     const inviteKey = inviteKeyFromQuery();
     const projectId = projectIdFromQuery();
@@ -851,16 +898,23 @@
   }
 
   async function resendInvite(inviteId) {
-    await sendWorkspaceAccessRequest(
+    return await sendWorkspaceAccessRequest(
       workspaceAccessPathAliases(`/workspace-access/invites/${encodeURIComponent(inviteId)}/resend`),
       { method: "POST" },
     );
   }
 
   async function revokeInvite(inviteId) {
-    await sendWorkspaceAccessRequest(
+    return await sendWorkspaceAccessRequest(
       workspaceAccessPathAliases(`/workspace-access/invites/${encodeURIComponent(inviteId)}/revoke`),
       { method: "POST" },
+    );
+  }
+
+  async function deleteInvite(inviteId) {
+    await sendWorkspaceAccessRequest(
+      workspaceAccessPathAliases(`/workspace-access/invites/${encodeURIComponent(inviteId)}`),
+      { method: "DELETE" },
     );
   }
 
@@ -957,31 +1011,59 @@
     items.forEach((invite) => {
       const card = document.createElement("article");
       card.className = "form-panel";
+      const inviteStatusValue = normalizeLower(invite?.status || "pending");
+      const emailDeliveryStatus = normalizeLower(invite?.email_delivery_status);
+      const emailDeliveryError = normalizeValue(invite?.email_delivery_error);
+      const inviteLink = inviteAcceptUrl(invite);
       const canResend = canManageInvites && (isPending(invite) || isExpired(invite));
       const canRevoke = canManageInvites && (isPending(invite) || isExpired(invite));
+      const canDelete = canManageInvites && inviteStatusValue !== "pending";
+      const canCopyLink = canManageInvites && isPending(invite) && Boolean(inviteLink);
+      let deliveryText = "Delivery: unknown";
+      if (emailDeliveryStatus === "sent") {
+        deliveryText = "Delivery: sent";
+      } else if (emailDeliveryStatus === "failed") {
+        deliveryText = `Delivery: failed${emailDeliveryError ? ` (${emailDeliveryError})` : ""}`;
+      }
       card.innerHTML = `
         <strong>${invite.email || "Invite"}</strong>
         <p class="card-copy">Role: ${roleLabel(invite.member_role || "viewer")}</p>
         <p class="card-copy">Relationship: ${relationshipLabel(invite.relationship_scope || "household_member")}</p>
         <p class="card-copy">Privacy: ${privacyLabel(invite.privacy_scope || "household_private")}</p>
         <p class="card-copy">Status: ${normalizeInviteStatus(invite.status || "pending")}</p>
+        <p class="card-copy">${deliveryText}</p>
         <p class="card-copy">Created: ${formatDateTime(invite.created_at)}</p>
         <p class="card-copy">Accepted: ${formatDateTime(invite.accepted_at)}</p>
         <p class="card-copy">Expires: ${formatDateTime(invite.expires_at)}</p>
         <div class="inline-actions" style="margin-top:0.75rem;">
           <button class="btn btn-secondary" type="button" data-invite-resend ${canResend ? "" : "disabled"}>Resend Invite</button>
           <button class="btn btn-secondary" type="button" data-invite-revoke ${canRevoke ? "" : "disabled"}>Revoke Invite</button>
+          <button class="btn btn-secondary" type="button" data-invite-copy-link ${canCopyLink ? "" : "disabled"}>Copy Invite Link</button>
+          <button class="btn btn-secondary" type="button" data-invite-delete ${canDelete ? "" : "disabled"}>Delete</button>
         </div>
       `;
 
       const resendButton = card.querySelector("[data-invite-resend]");
       const revokeButton = card.querySelector("[data-invite-revoke]");
+      const copyLinkButton = card.querySelector("[data-invite-copy-link]");
+      const deleteButton = card.querySelector("[data-invite-delete]");
       if (resendButton && canResend) {
         resendButton.addEventListener("click", async function () {
           try {
-            await resendInvite(invite.id);
+            const resentInvite = await resendInvite(invite.id);
             await refreshData();
-            setText(inviteStatus, "Invite resent.", "success");
+            const resendFailed =
+              normalizeLower(resentInvite?.email_delivery_status) === "failed";
+            const resendError = normalizeValue(resentInvite?.email_delivery_error);
+            if (resendFailed) {
+              setText(
+                inviteStatus,
+                `Invite resent, but email delivery failed${resendError ? ` (${resendError})` : ""}. Copy the invite link and share it directly.`,
+                "warning",
+              );
+            } else {
+              setText(inviteStatus, "Invite resent.", "success");
+            }
           } catch (error) {
             setText(inviteStatus, error.message || "Failed to resend invite.", "error");
           }
@@ -995,6 +1077,31 @@
             setText(inviteStatus, "Invite revoked.", "success");
           } catch (error) {
             setText(inviteStatus, error.message || "Failed to revoke invite.", "error");
+          }
+        });
+      }
+      if (copyLinkButton && canCopyLink) {
+        copyLinkButton.addEventListener("click", async function () {
+          try {
+            const copied = await copyTextToClipboard(inviteLink);
+            if (!copied) {
+              setText(inviteStatus, "Unable to copy invite link automatically.", "error");
+              return;
+            }
+            setText(inviteStatus, "Invite link copied. Share it directly with the recipient.", "success");
+          } catch (error) {
+            setText(inviteStatus, error.message || "Failed to copy invite link.", "error");
+          }
+        });
+      }
+      if (deleteButton && canDelete) {
+        deleteButton.addEventListener("click", async function () {
+          try {
+            await deleteInvite(invite.id);
+            await refreshData();
+            setText(inviteStatus, "Invite removed from history.", "success");
+          } catch (error) {
+            setText(inviteStatus, error.message || "Failed to delete invite.", "error");
           }
         });
       }
@@ -1125,6 +1232,8 @@
     try {
       const membership = await acceptInviteByKey(inviteKey);
       hydrateProjectContextFromMembership(membership);
+      clearInviteContextFromUrl(projectIdFromMembership(membership));
+      clear(acceptLinkStatus);
       setText(acceptStatus, "Invite accepted. Workspace access granted.", "success");
       if (currentProjectId) {
         await refreshData();
@@ -1232,6 +1341,8 @@
       if (acceptForm && inviteKey) {
         const keyInput = acceptForm.querySelector('input[name="invite_key"]');
         if (keyInput) keyInput.value = inviteKey;
+        const detailsNode = acceptForm.closest("details");
+        if (detailsNode) detailsNode.open = true;
       }
 
       bindQuickInviteButtons();
@@ -1240,16 +1351,25 @@
       if (inviteForm) inviteForm.addEventListener("submit", handleInviteSubmit);
       if (acceptForm) acceptForm.addEventListener("submit", handleAcceptSubmit);
 
-      if (!currentProjectId && inviteKey && acceptForm) {
+      if (inviteKey && acceptForm) {
         try {
           const membership = await acceptInviteByKey(inviteKey);
           hydrateProjectContextFromMembership(membership);
+          clearInviteContextFromUrl(projectIdFromMembership(membership));
+          clear(acceptLinkStatus);
+          setText(acceptStatus, "Invite accepted. Workspace access granted.", "success");
         } catch (error) {
           const statusCode = Number(error?.status);
+          const detail = readableMessage(error?.detail || error?.message, "invite auto-accept failed");
           console.warn("[HouseholdAccess] Auto-accept invite skipped.", {
-            detail: readableMessage(error?.detail || error?.message, "invite auto-accept failed"),
+            detail,
             status: Number.isFinite(statusCode) && statusCode > 0 ? statusCode : null,
           });
+          setText(
+            acceptStatus,
+            detail || "We couldn't auto-accept this invite. Use the Accept Invite action below.",
+            "warning",
+          );
           // Keep the page interactive so invite acceptance can still be attempted manually.
         }
       }


### PR DESCRIPTION
This pull request introduces the ability to permanently delete non-pending household invites, improves invite management in both backend and frontend, and enhances visibility into invite email delivery status. It also adds new UI actions for copying invite links and deleting invites, and ensures legacy API route compatibility. Comprehensive tests are included for new functionality.

**Backend: Invite Deletion & Email Delivery Status**

* Added `delete_household_invite` to allow authorized users to permanently delete non-pending invites, with proper permission checks and audit logging. Attempting to delete a pending invite now raises an error; such invites must be revoked first. [[1]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R697-R732) [[2]](diffhunk://#diff-ad7862de11aaa18044d335cb109cdbcfdfef1eefc05da1d916aed859d7c1ce09R361-R379)
* Added new API endpoints (`DELETE /invites/{invite_id}`) for deleting invites, with legacy route aliases for backward compatibility. [[1]](diffhunk://#diff-ad7862de11aaa18044d335cb109cdbcfdfef1eefc05da1d916aed859d7c1ce09R361-R379) [[2]](diffhunk://#diff-d7e3a7ff122be3bfbc1c2d6732d3a9ba9e4de5bb008e7e6dd1a9c344f6799223L29-R29) [[3]](diffhunk://#diff-d7e3a7ff122be3bfbc1c2d6732d3a9ba9e4de5bb008e7e6dd1a9c344f6799223R46-R47)
* Invite response schema now includes `email_delivery_status` and `email_delivery_error` fields for better tracking of invite email delivery.

**Frontend: Invite Management Enhancements**

* Added UI actions for deleting non-pending invites and copying invite links directly to the clipboard; improved display of invite email delivery status and error messages. [[1]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR1014-R1066) [[2]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR1083-R1107)
* Enhanced invite acceptance flow: after accepting an invite, the invite context is cleared from the URL, and clearer feedback is provided to the user. [[1]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR1235-R1236) [[2]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR1344-R1345) [[3]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fL1243-R1372)
* Added utility functions for generating invite acceptance URLs, copying to clipboard, and cleaning up URL parameters. [[1]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR488-R520) [[2]](diffhunk://#diff-1a9b1b9307836dbb363b5dd422696de85fa95f572f773ebeebc1b2f4a270690fR815-R828)

**Testing Improvements**

* Added backend tests for deleting non-pending invites, ensuring pending invites cannot be deleted, and verifying audit logging.
* Updated route alias tests to include new delete endpoints. [[1]](diffhunk://#diff-d7e3a7ff122be3bfbc1c2d6732d3a9ba9e4de5bb008e7e6dd1a9c344f6799223L29-R29) [[2]](diffhunk://#diff-d7e3a7ff122be3bfbc1c2d6732d3a9ba9e4de5bb008e7e6dd1a9c344f6799223R46-R47)
* Added schema tests for new email delivery fields in invite responses.

**Miscellaneous**

* Updated static asset versioning for `household-access.js` in the HTML template.Root cause found and fixed in code.

The main bug: invite auto-accept was incorrectly gated behind !currentProjectId, so when an invite URL had project_id (as yours does), accept never auto-ran and your wife stayed “Not authorized.”
Missing feature: revoked/old invites had no delete endpoint or UI action, so history kept growing.
Visibility gap: failed email delivery could happen but was not clearly shown per invite, making it look like invites were sent when they weren’t.