### PR TITLE
Fix invite auto-accept logic and improve invite management UI

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -317,7 +317,13 @@ class Settings(BaseSettings):
     # Email / Postmark
     postmark_server_token: str = Field(
         default="",
-        validation_alias=AliasChoices("POSTMARK_SERVER_TOKEN", "POSTMARK_API_TOKEN"),
+        validation_alias=AliasChoices(
+            "POSTMARK_SERVER_TOKEN",
+            "POSTMARK_API_TOKEN",
+            "POSTMARK_TOKEN",
+            "POSTMARK_API_KEY",
+            "POSTMARK_SERVER_KEY",
+        ),
     )
     postmark_from_email: str = Field(
         default="admin@tomboflight.com",

--- a/backend/tests/test_config_email_aliases.py
+++ b/backend/tests/test_config_email_aliases.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from app.config import Settings
+
+
+class ConfigEmailAliasTests(unittest.TestCase):
+    def test_postmark_token_aliases_are_accepted(self):
+        with patch.dict(
+            os.environ,
+            {
+                "POSTMARK_TOKEN": "alias-token-value",
+            },
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+        self.assertEqual(settings.postmark_server_token, "alias-token-value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request expands support for environment variable aliases for the Postmark server token in the configuration, and adds a test to ensure the new aliases are recognized. The main focus is to make the configuration more flexible and robust for different deployment environments.

**Configuration improvements:**

* Added additional accepted environment variable aliases (`POSTMARK_TOKEN`, `POSTMARK_API_KEY`, `POSTMARK_SERVER_KEY`) for the `postmark_server_token` field in the `Settings` class, making it easier to configure Postmark credentials using different commonly-used variable names.

**Testing improvements:**

* Added a new unit test (`test_postmark_token_aliases_are_accepted`) in `test_config_email_aliases.py` to verify that the new environment variable aliases for the Postmark token are correctly recognized by the configuration.… was incorrectly gated behind !currentProjectId, so when an invite URL had project_id (as yours does), accept never auto-ran and your wife stayed “Not authorized.” Missing feature: revoked/old invites had no delete endpoint or UI action, so history kept growing. Visibility gap: failed email delivery could happen but was not clearly shown per invite, making it look like invites were sent when they weren’t.