### PR TITLE
backend

### DIFF
--- a/backend/app/services/household_access_service.py
+++ b/backend/app/services/household_access_service.py
@@ -709,8 +709,6 @@ def delete_household_invite(*, invite_id: str, actor_user: dict[str, Any]) -> bo
     if actor_role not in {"billing_owner", "co_owner", "family_manager"}:
         raise PermissionError("You do not have permission to delete invites.")
     invite_status = _normalize(invite.get("status") or "pending").lower()
-    if invite_status == "pending":
-        raise ValueError("Pending invites must be revoked before deletion.")
 
     delete_result = _invites().delete_one({"_id": oid})
     if int(getattr(delete_result, "deleted_count", 0)) <= 0:

--- a/backend/tests/test_household_invites_and_orders.py
+++ b/backend/tests/test_household_invites_and_orders.py
@@ -282,24 +282,30 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
         self.assertEqual(fake_invites.deleted_query, {"_id": "invite-delete-1"})
         audit_log_mock.assert_called_once()
 
-    def test_delete_household_invite_rejects_pending_records(self):
+    def test_delete_household_invite_allows_pending_records(self):
         invite_document = {
             "_id": "invite-delete-pending",
             "project_id": "project-delete-2",
             "status": "pending",
         }
 
+        class FakeDeleteResult:
+            def __init__(self, deleted_count):
+                self.deleted_count = deleted_count
+
         class FakeInvitesCollection:
             def __init__(self, invite):
                 self.invite = dict(invite)
+                self.deleted_query = None
 
             def find_one(self, query):
                 if query.get("_id") == self.invite.get("_id"):
                     return dict(self.invite)
                 return None
 
-            def delete_one(self, _query):
-                raise AssertionError("delete_one should not be called for pending invites")
+            def delete_one(self, query):
+                self.deleted_query = dict(query)
+                return FakeDeleteResult(1)
 
         fake_invites = FakeInvitesCollection(invite_document)
         with (
@@ -311,13 +317,15 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
                 return_value={"_id": "project-delete-2", "owner_user_id": "owner-1", "owner_email": "owner@example.com"},
             ),
             patch.object(household_access_service, "_resolve_actor_role", return_value="billing_owner"),
+            patch.object(household_access_service, "create_audit_log") as audit_log_mock,
         ):
-            with self.assertRaises(ValueError) as error:
-                household_access_service.delete_household_invite(
-                    invite_id="invite-delete-pending",
-                    actor_user={"id": "owner-1", "email": "owner@example.com"},
-                )
-        self.assertIn("revoked before deletion", str(error.exception))
+            deleted = household_access_service.delete_household_invite(
+                invite_id="invite-delete-pending",
+                actor_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+        self.assertTrue(deleted)
+        self.assertEqual(fake_invites.deleted_query, {"_id": "invite-delete-pending"})
+        audit_log_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/household-access.html
+++ b/household-access.html
@@ -156,6 +156,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260416-4"></script>
     <script src="auth.js?v=20260416-1"></script>
-    <script src="household-access.js?v=20260419-1"></script>
+    <script src="household-access.js?v=20260419-2"></script>
   </body>
 </html>

--- a/household-access.js
+++ b/household-access.js
@@ -1017,7 +1017,7 @@
       const inviteLink = inviteAcceptUrl(invite);
       const canResend = canManageInvites && (isPending(invite) || isExpired(invite));
       const canRevoke = canManageInvites && (isPending(invite) || isExpired(invite));
-      const canDelete = canManageInvites && inviteStatusValue !== "pending";
+      const canDelete = canManageInvites;
       const canCopyLink = canManageInvites && isPending(invite) && Boolean(inviteLink);
       let deliveryText = "Delivery: unknown";
       if (emailDeliveryStatus === "sent") {
@@ -1101,6 +1101,66 @@
             await refreshData();
             setText(inviteStatus, "Invite removed from history.", "success");
           } catch (error) {
+            const statusCode = Number(error?.status || 0);
+            const detail = readableMessage(
+              error?.detail || error?.message || error?.data || error?.responseBody,
+              "",
+            ).toLowerCase();
+            const legacyPendingDeleteGuard =
+              statusCode === 400 && detail.includes("revoked before deletion");
+            if (legacyPendingDeleteGuard) {
+              try {
+                await revokeInvite(invite.id);
+                await deleteInvite(invite.id);
+                await refreshData();
+                setText(inviteStatus, "Invite removed from history.", "success");
+                return;
+              } catch (secondError) {
+                const secondStatusCode = Number(secondError?.status || 0);
+                if (secondStatusCode === 404) {
+                  await refreshData();
+                  setText(
+                    inviteStatus,
+                    "Invite was revoked. Permanent delete is not available on this server yet.",
+                    "warning",
+                  );
+                  return;
+                }
+                setText(
+                  inviteStatus,
+                  secondError.message || "Failed to delete invite after revoking.",
+                  "error",
+                );
+                return;
+              }
+            }
+            if (statusCode === 404) {
+              if (isPending(invite)) {
+                try {
+                  await revokeInvite(invite.id);
+                  await refreshData();
+                  setText(
+                    inviteStatus,
+                    "Invite was revoked. Permanent delete is not available on this server yet.",
+                    "warning",
+                  );
+                  return;
+                } catch (revokeError) {
+                  setText(
+                    inviteStatus,
+                    revokeError.message || "Delete is unavailable and revoke also failed.",
+                    "error",
+                  );
+                  return;
+                }
+              }
+              setText(
+                inviteStatus,
+                "Delete is unavailable on this server version. Please deploy the latest backend.",
+                "warning",
+              );
+              return;
+            }
             setText(inviteStatus, error.message || "Failed to delete invite.", "error");
           }
         });


### PR DESCRIPTION
This pull request updates the household invite deletion workflow to allow deleting invites in the "pending" state, aligning backend, frontend, and tests. It also improves frontend compatibility with older backend versions by adding fallback logic for pending invite deletion. The most important changes are:

**Backend logic updates:**

* Removed the restriction that prevented deletion of "pending" household invites in `delete_household_invite`, allowing them to be deleted directly.
* Updated tests to verify that pending invites can now be deleted, including proper audit logging. [[1]](diffhunk://#diff-2846063a690a8a72932c6410c4d08cf9e7bff2d407b0a6c59c1908f3f2693a07L285-R308) [[2]](diffhunk://#diff-2846063a690a8a72932c6410c4d08cf9e7bff2d407b0a6c59c1908f3f2693a07R320-R328)

**Frontend logic and compatibility:**

* Updated `household-access.js` so the "Delete" action is always available for invites, regardless of status.
* Added fallback logic in `household-access.js` to handle older backend versions that still require pending invites to be revoked before deletion, ensuring a smooth user experience across deployments.

**Supporting changes:**

* Bumped the version of `household-access.js` in `household-access.html` to ensure clients receive the updated script.