### PR TITLE
backend

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -323,6 +323,17 @@ class Settings(BaseSettings):
             "POSTMARK_TOKEN",
             "POSTMARK_API_KEY",
             "POSTMARK_SERVER_KEY",
+            "POSTMARK_SERVER_API_TOKEN",
+            "POSTMARK_API_SERVER_TOKEN",
+            "POSTMARK_KEY",
+        ),
+    )
+    postmark_server_token_file: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "POSTMARK_SERVER_TOKEN_FILE",
+            "POSTMARK_API_TOKEN_FILE",
+            "POSTMARK_TOKEN_FILE",
         ),
     )
     postmark_from_email: str = Field(

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -4,6 +4,7 @@ import logging
 from datetime import UTC, datetime
 from email.utils import formataddr
 from html import escape
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote_plus, urlsplit, urlunsplit
 
@@ -19,6 +20,13 @@ POSTMARK_EMAIL_ENDPOINT = "https://api.postmarkapp.com/email"
 POSTMARK_TIMEOUT_SECONDS = 10
 DEFAULT_MESSAGE_STREAM = "outbound"
 MAX_POSTMARK_MESSAGE_LOG_LENGTH = 500
+POSTMARK_TOKEN_FILE_CANDIDATES = (
+    "/etc/secrets/POSTMARK_SERVER_TOKEN",
+    "/etc/secrets/POSTMARK_API_TOKEN",
+    "/etc/secrets/POSTMARK_TOKEN",
+    "/etc/secrets/postmark_server_token",
+    "/etc/secrets/postmark_token",
+)
 
 
 def _normalize_text(value: object) -> str:
@@ -29,8 +37,32 @@ def _normalize_email(value: object) -> str:
     return _normalize_text(value).lower()
 
 
+def _load_secret_file(path: str) -> str:
+    normalized = _normalize_text(path)
+    if not normalized:
+        return ""
+    try:
+        return _normalize_text(Path(normalized).read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+
+
 def _postmark_token() -> str:
-    return _normalize_text(settings.postmark_server_token)
+    direct = _normalize_text(settings.postmark_server_token)
+    if direct:
+        return direct
+
+    configured_file = _normalize_text(getattr(settings, "postmark_server_token_file", ""))
+    from_configured_file = _load_secret_file(configured_file)
+    if from_configured_file:
+        return from_configured_file
+
+    for candidate in POSTMARK_TOKEN_FILE_CANDIDATES:
+        token_from_file = _load_secret_file(candidate)
+        if token_from_file:
+            return token_from_file
+
+    return ""
 
 
 def _postmark_from_email() -> str:

--- a/backend/app/services/household_access_service.py
+++ b/backend/app/services/household_access_service.py
@@ -225,6 +225,69 @@ def _persist_invite_email_delivery(
         return False
 
 
+def _find_latest_reusable_invite(*, project_id: str, email: str) -> dict[str, Any] | None:
+    normalized_project_id = _normalize(project_id)
+    normalized_email = _normalize_email(email)
+    if not normalized_project_id or not normalized_email:
+        return None
+    query = {
+        "project_id": normalized_project_id,
+        "email": normalized_email,
+        "status": {"$in": ["pending", "expired"]},
+    }
+    invite_collection = _invites()
+    try:
+        invite = invite_collection.find_one(query, sort=[("created_at", -1)])
+    except TypeError:
+        invite = invite_collection.find_one(query)
+    if invite is None:
+        return None
+    invite = _expire_invite_if_needed(invite)
+    status_value = _normalize(invite.get("status") or "pending").lower()
+    if status_value not in {"pending", "expired"}:
+        return None
+    return invite
+
+
+def _revoke_superseded_pending_invites(*, project_id: str, email: str, keep_invite_id: Any) -> None:
+    normalized_project_id = _normalize(project_id)
+    normalized_email = _normalize_email(email)
+    if not normalized_project_id or not normalized_email or keep_invite_id in (None, ""):
+        return
+    invite_collection = _invites()
+    if not hasattr(invite_collection, "update_many"):
+        return
+    now_iso = _now().isoformat()
+    try:
+        invite_collection.update_many(
+            {
+                "project_id": normalized_project_id,
+                "email": normalized_email,
+                "status": "pending",
+                "_id": {"$ne": keep_invite_id},
+            },
+            {
+                "$set": {
+                    "status": "revoked",
+                    "revoked_at": now_iso,
+                    "updated_at": now_iso,
+                    "revoked_reason": "superseded_by_latest_invite",
+                }
+            },
+        )
+    except Exception as exc:
+        logger.exception(
+            (
+                "household_access_service.revoke_superseded_pending_invites_failed "
+                "project_id=%s email=%s keep_invite_id=%s error=%s"
+            ),
+            normalized_project_id,
+            normalized_email,
+            _normalize(keep_invite_id),
+            str(exc),
+        )
+
+
 def _resolve_actor_role(project: dict[str, Any], actor_user: dict[str, Any]) -> str:
     snapshot = get_project_access_snapshot(
         project,
@@ -356,6 +419,7 @@ def create_household_invite(
         )
         raise ValueError("Invite email is required.")
 
+    normalized_relationship_scope = _normalize_relationship_scope(relationship_scope or "household_member")
     normalized_privacy_scope = _normalize_privacy_scope(privacy_scope or "household_private")
     if normalized_privacy_scope not in PRIVACY_SCOPES:
         logger.warning(
@@ -402,6 +466,91 @@ def create_household_invite(
         )
         raise ValueError("This email already has active workspace access.")
 
+    reusable_invite = _find_latest_reusable_invite(project_id=project_id, email=normalized_email)
+    if reusable_invite is not None:
+        now = _now()
+        invite_key = f"hhinv_{secrets.token_urlsafe(24)}"
+        updates = {
+            "status": "pending",
+            "invite_key": invite_key,
+            "member_role": normalized_role,
+            "relationship_scope": normalized_relationship_scope,
+            "privacy_scope": normalized_privacy_scope,
+            "issuer_user_id": actor_user_id or None,
+            "target_email": normalized_email,
+            "allowed_role": normalized_role,
+            "max_uses": max(1, int(max_uses or 1)),
+            "use_count": 0,
+            "notes": _normalize(notes),
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "expires_at": (now + timedelta(days=max(1, int(expires_in_days or 7)))).isoformat(),
+            "accepted_at": None,
+            "revoked_at": None,
+            "expired_at": None,
+        }
+        _invites().update_one({"_id": reusable_invite["_id"]}, {"$set": updates})
+        document = _invites().find_one({"_id": reusable_invite["_id"]}) or {
+            **reusable_invite,
+            **updates,
+            "_id": reusable_invite["_id"],
+        }
+        _revoke_superseded_pending_invites(
+            project_id=_normalize(project_id),
+            email=normalized_email,
+            keep_invite_id=document["_id"],
+        )
+        create_audit_log(
+            "household_invite_reused",
+            actor_user_id or None,
+            "household_invite",
+            str(document["_id"]),
+            {
+                "project_id": _normalize(project_id),
+                "invite_email": normalized_email,
+                "member_role": normalized_role,
+            },
+        )
+        email_delivery: dict[str, Any] = {"sent": True}
+        logger.info(
+            (
+                "household_access_service.create_household_invite.reused_existing "
+                "project_id=%s invite_id=%s invite_email=%s"
+            ),
+            _normalize(project_id),
+            _normalize(document["_id"]),
+            normalized_email,
+        )
+        try:
+            email_delivery = send_household_invite_email(
+                to_email=normalized_email,
+                invite_key=invite_key,
+                project_id=_normalize(project_id),
+                member_role=normalized_role,
+                inviter_email=_normalize_email(actor_user.get("email")),
+                is_resend=True,
+            ) or {"sent": False, "error": "unknown_email_delivery_failure"}
+        except Exception as exc:
+            logger.exception(
+                "household_access_service.create_household_invite.reused_email_exception "
+                "project_id=%s invite_id=%s invite_email=%s error=%s",
+                _normalize(project_id),
+                _normalize(document["_id"]),
+                normalized_email,
+                str(exc),
+            )
+            email_delivery = {
+                "sent": False,
+                "error": str(exc) or type(exc).__name__,
+                "exception_type": type(exc).__name__,
+            }
+        _persist_invite_email_delivery(
+            invite_id=document["_id"],
+            invite_document=document,
+            email_delivery=email_delivery,
+        )
+        return document
+
     now = _now()
     invite_key = f"hhinv_{secrets.token_urlsafe(24)}"
     document = {
@@ -411,7 +560,7 @@ def create_household_invite(
         "key_type": "household_invite_key",
         "status": "pending",
         "member_role": normalized_role,
-        "relationship_scope": _normalize_relationship_scope(relationship_scope or "household_member"),
+        "relationship_scope": normalized_relationship_scope,
         "privacy_scope": normalized_privacy_scope,
         "issuer_user_id": actor_user_id or None,
         "target_email": normalized_email,
@@ -445,7 +594,7 @@ def create_household_invite(
         _normalize(result.inserted_id),
         normalized_email,
         normalized_role,
-        _normalize_relationship_scope(relationship_scope or "household_member"),
+        normalized_relationship_scope,
         normalized_privacy_scope,
     )
     create_audit_log(
@@ -458,6 +607,11 @@ def create_household_invite(
             "invite_email": normalized_email,
             "member_role": normalized_role,
         },
+    )
+    _revoke_superseded_pending_invites(
+        project_id=_normalize(project_id),
+        email=normalized_email,
+        keep_invite_id=result.inserted_id,
     )
     email_delivery: dict[str, Any] = {"sent": True}
     logger.info(
@@ -672,6 +826,11 @@ def resend_household_invite(
     invite = _invites().find_one({"_id": invite["_id"]})
     if invite is None:
         return None
+    _revoke_superseded_pending_invites(
+        project_id=_normalize(invite.get("project_id")),
+        email=_normalize_email(invite.get("email")),
+        keep_invite_id=invite.get("_id"),
+    )
     email_delivery: dict[str, Any] = {"sent": True}
     try:
         email_delivery = send_household_invite_email(

--- a/backend/tests/test_config_email_aliases.py
+++ b/backend/tests/test_config_email_aliases.py
@@ -1,11 +1,18 @@
 import os
+import tempfile
 import unittest
+from typing import Any, cast
 from unittest.mock import patch
 
 from app.config import Settings
 
 
 class ConfigEmailAliasTests(unittest.TestCase):
+    def _settings_from_env(self) -> Settings:
+        # Pydantic Settings accepts `_env_file` at runtime; cast to satisfy static typing.
+        settings_type = cast(Any, Settings)
+        return settings_type(_env_file=None)
+
     def test_postmark_token_aliases_are_accepted(self):
         with patch.dict(
             os.environ,
@@ -14,8 +21,36 @@ class ConfigEmailAliasTests(unittest.TestCase):
             },
             clear=True,
         ):
-            settings = Settings(_env_file=None)
+            settings = self._settings_from_env()
         self.assertEqual(settings.postmark_server_token, "alias-token-value")
+
+    def test_postmark_extended_aliases_are_accepted(self):
+        with patch.dict(
+            os.environ,
+            {
+                "POSTMARK_SERVER_API_TOKEN": "extended-alias-token",
+            },
+            clear=True,
+        ):
+            settings = self._settings_from_env()
+        self.assertEqual(settings.postmark_server_token, "extended-alias-token")
+
+    def test_postmark_token_file_alias_is_loaded(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write("file-token-value\n")
+            token_file = handle.name
+        try:
+            with patch.dict(
+                os.environ,
+                {
+                    "POSTMARK_SERVER_TOKEN_FILE": token_file,
+                },
+                clear=True,
+            ):
+                settings = self._settings_from_env()
+            self.assertEqual(settings.postmark_server_token_file, token_file)
+        finally:
+            os.unlink(token_file)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,4 +1,6 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
 
@@ -37,6 +39,16 @@ class FakePostmarkResponse:
 
 
 class PostmarkEmailLoggingTests(unittest.TestCase):
+    def test_postmark_token_uses_configured_secret_file_when_env_token_missing(self):
+        with TemporaryDirectory() as temp_dir:
+            token_path = Path(temp_dir) / "postmark_token"
+            token_path.write_text("secret-file-token\n", encoding="utf-8")
+            with (
+                patch.object(email_service.settings, "postmark_server_token", ""),
+                patch.object(email_service.settings, "postmark_server_token_file", str(token_path)),
+            ):
+                self.assertEqual(email_service._postmark_token(), "secret-file-token")
+
     def test_password_reset_postmark_block_logs_safe_structured_context(self):
         response = FakePostmarkResponse(
             payload={

--- a/backend/tests/test_household_invites_and_orders.py
+++ b/backend/tests/test_household_invites_and_orders.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -13,6 +14,9 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
         class FakeInvitesCollection:
             def __init__(self):
                 self.updated = []
+
+            def find_one(self, *_args, **_kwargs):
+                return None
 
             def insert_one(self, document):
                 inserted_docs.append(dict(document))
@@ -62,6 +66,109 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
         self.assertIn("pending approval", invite["email_delivery_error"])
         self.assertEqual(fake_invites.updated[-1]["email_delivery_status"], "failed")
         send_email_mock.assert_called_once()
+
+    def test_create_household_invite_reuses_existing_pending_invite_for_same_email(self):
+        fixed_now = datetime(2026, 4, 19, 21, 45, tzinfo=UTC)
+        existing_invite = {
+            "_id": "invite-existing",
+            "project_id": "project-1",
+            "email": "wife@example.com",
+            "status": "pending",
+            "member_role": "viewer",
+            "relationship_scope": "household_member",
+            "privacy_scope": "household_private",
+            "invite_key": "hhinv_old_key",
+            "created_at": "2026-04-18T00:00:00+00:00",
+            "updated_at": "2026-04-18T00:00:00+00:00",
+            "expires_at": "2026-04-25T00:00:00+00:00",
+        }
+
+        class FakeInvitesCollection:
+            def __init__(self, invite):
+                self.invite = dict(invite)
+                self.insert_calls = 0
+                self.updated = []
+                self.update_many_calls = []
+
+            def find_one(self, query, sort=None):  # noqa: ARG002
+                project_id = query.get("project_id")
+                email = query.get("email")
+                status_in = (query.get("status") or {}).get("$in")
+                if project_id and email and status_in is not None:
+                    if (
+                        project_id == self.invite.get("project_id")
+                        and email == self.invite.get("email")
+                        and self.invite.get("status") in status_in
+                    ):
+                        return dict(self.invite)
+                    return None
+                if query.get("_id") == self.invite.get("_id"):
+                    return dict(self.invite)
+                return None
+
+            def insert_one(self, _document):
+                self.insert_calls += 1
+                return SimpleNamespace(inserted_id="invite-new")
+
+            def update_one(self, query, update):
+                if query.get("_id") == self.invite.get("_id"):
+                    updates = update.get("$set") or {}
+                    self.invite.update(updates)
+                    self.updated.append(dict(updates))
+
+            def update_many(self, query, update):
+                self.update_many_calls.append(
+                    {
+                        "query": dict(query),
+                        "update": dict(update),
+                    }
+                )
+
+        class FakeMembersCollection:
+            def find_one(self, *_args, **_kwargs):
+                return None
+
+        fake_invites = FakeInvitesCollection(existing_invite)
+        actor = {"_id": "owner-1", "email": "owner@example.com"}
+        with (
+            patch.object(
+                household_access_service,
+                "_find_project",
+                return_value={"_id": "project-1", "owner_user_id": "owner-1", "owner_email": "owner@example.com"},
+            ),
+            patch.object(household_access_service, "_resolve_actor_role", return_value="billing_owner"),
+            patch.object(household_access_service, "_active_member_count", return_value=0),
+            patch.object(household_access_service, "_resolve_member_seat_cap", return_value=6),
+            patch.object(household_access_service, "_members", return_value=FakeMembersCollection()),
+            patch.object(household_access_service, "_invites", return_value=fake_invites),
+            patch.object(household_access_service, "_now", return_value=fixed_now),
+            patch.object(household_access_service, "create_audit_log"),
+            patch.object(
+                household_access_service,
+                "send_household_invite_email",
+                return_value={"sent": False, "error": "postmark_token_missing"},
+            ) as send_email_mock,
+        ):
+            invite = household_access_service.create_household_invite(
+                project_id="project-1",
+                actor_user=actor,
+                email="wife@example.com",
+                member_role="co_owner",
+                relationship_scope="spouse",
+                privacy_scope="household_private",
+            )
+
+        self.assertEqual(fake_invites.insert_calls, 0)
+        self.assertEqual(invite.get("_id"), "invite-existing")
+        self.assertEqual(invite.get("status"), "pending")
+        self.assertEqual(invite.get("member_role"), "co_owner")
+        self.assertEqual(invite.get("relationship_scope"), "spouse")
+        self.assertEqual(invite.get("email_delivery_status"), "failed")
+        self.assertEqual(invite.get("email_delivery_error"), "postmark_token_missing")
+        self.assertTrue(str(invite.get("invite_key") or "").startswith("hhinv_"))
+        self.assertEqual(fake_invites.update_many_calls[0]["query"]["email"], "wife@example.com")
+        send_email_mock.assert_called_once()
+        self.assertTrue(send_email_mock.call_args.kwargs.get("is_resend"))
 
     def test_build_invite_response_includes_expired_timestamp(self):
         payload = build_invite_response(
@@ -419,8 +526,12 @@ class HouseholdInviteAndOrderTests(unittest.TestCase):
                 actor_user={"id": "owner-1", "email": "owner@example.com"},
             )
 
+        if updated is None:
+            self.fail("Expected updated member document after billing owner transfer.")
         self.assertEqual(updated.get("member_role"), "billing_owner")
         owner_membership = fake_members.find_one({"_id": "membership-owner"})
+        if owner_membership is None:
+            self.fail("Expected owner membership document to remain present.")
         self.assertEqual(owner_membership.get("member_role"), "co_owner")
         self.assertEqual(fake_projects.doc.get("owner_user_id"), "co-1")
         self.assertEqual(fake_projects.doc.get("owner_email"), "coowner@example.com")

--- a/household-access.html
+++ b/household-access.html
@@ -156,6 +156,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260416-4"></script>
     <script src="auth.js?v=20260416-1"></script>
-    <script src="household-access.js?v=20260419-4"></script>
+    <script src="household-access.js?v=20260419-5"></script>
   </body>
 </html>

--- a/household-access.js
+++ b/household-access.js
@@ -934,6 +934,7 @@
 
       const emailLabel = member.email || member.user_id || "Unassigned member";
       const fullName = memberDisplayName(member);
+      const membershipId = normalizeValue(member?.id || member?._id || member?.membership_id);
       const role = normalizeRole(member.member_role || "viewer");
       const isBillingOwner = role === "billing_owner";
       const isCoOwnerSpouse =
@@ -945,8 +946,9 @@
           : "";
       const targetRank = roleRank(role);
       const targetStatus = normalizeLower(member.status || "active");
+      const hasActionableId = Boolean(membershipId);
       const canTouchTarget =
-        canManage && targetStatus === "active" && !isBillingOwner && targetRank < actorRank;
+        canManage && hasActionableId && targetStatus === "active" && !isBillingOwner && targetRank < actorRank;
       const options = ROLE_OPTIONS.map(
         (roleCode) => {
           const disabled = !canManage || !roleCanAssign(currentMemberRole, roleCode);
@@ -963,6 +965,8 @@
           <button class="btn btn-secondary" type="button" data-member-remove>Remove Member</button>
         </div>
       `
+        : !hasActionableId
+          ? `<p class="card-copy">Member actions are unavailable because this member record is missing an id on this API host.</p>`
         : isBillingOwner
           ? `<p class="card-copy">Billing Owner is the highest household role. To pass ownership, set another active member's role to Billing Owner.</p>`
           : `<p class="card-copy">You can only change or remove members with lower active roles.</p>`;
@@ -983,22 +987,36 @@
       if (roleSave && roleSelect && canTouchTarget) {
         roleSave.addEventListener("click", async function () {
           try {
-            await changeMemberRole(member.id, roleSelect.value);
+            await changeMemberRole(membershipId, roleSelect.value);
             await refreshData();
             setText(inviteStatus, "Member role updated.", "success");
           } catch (error) {
-            setText(inviteStatus, error.message || "Failed to change role.", "error");
+            setText(
+              inviteStatus,
+              readableMessage(
+                error?.detail || error?.message || error?.data || error?.responseBody,
+                "Failed to change role.",
+              ),
+              "error",
+            );
           }
         });
       }
       if (removeButton && canTouchTarget) {
         removeButton.addEventListener("click", async function () {
           try {
-            await removeMember(member.id);
+            await removeMember(membershipId);
             await refreshData();
             setText(inviteStatus, "Member removed.", "success");
           } catch (error) {
-            setText(inviteStatus, error.message || "Failed to remove member.", "error");
+            setText(
+              inviteStatus,
+              readableMessage(
+                error?.detail || error?.message || error?.data || error?.responseBody,
+                "Failed to remove member.",
+              ),
+              "error",
+            );
           }
         });
       }
@@ -1020,13 +1038,15 @@
     items.forEach((invite) => {
       const card = document.createElement("article");
       card.className = "form-panel";
+      const inviteId = normalizeValue(invite?.id || invite?._id || invite?.invite_id);
       const inviteStatusValue = normalizeLower(invite?.status || "pending");
       const emailDeliveryStatus = normalizeLower(invite?.email_delivery_status);
       const emailDeliveryError = normalizeValue(invite?.email_delivery_error);
       const inviteLink = inviteAcceptUrl(invite);
-      const canResend = canManageInvites && (isPending(invite) || isExpired(invite));
-      const canRevoke = canManageInvites && (isPending(invite) || isExpired(invite));
-      const canDelete = canManageInvites;
+      const hasInviteId = Boolean(inviteId);
+      const canResend = hasInviteId && canManageInvites && (isPending(invite) || isExpired(invite));
+      const canRevoke = hasInviteId && canManageInvites && (isPending(invite) || isExpired(invite));
+      const canDelete = hasInviteId && canManageInvites;
       const canCopyLink = canManageInvites && isPending(invite) && Boolean(inviteLink);
       let deliveryText = "Delivery: unknown";
       if (emailDeliveryStatus === "sent") {
@@ -1034,6 +1054,9 @@
       } else if (emailDeliveryStatus === "failed") {
         deliveryText = `Delivery: failed${emailDeliveryError ? ` (${emailDeliveryError})` : ""}`;
       }
+      const missingInviteIdNote = hasInviteId
+        ? ""
+        : `<p class="card-copy">Invite actions are unavailable because this invite record is missing an id on this API host.</p>`;
       card.innerHTML = `
         <strong>${invite.email || "Invite"}</strong>
         <p class="card-copy">Role: ${roleLabel(invite.member_role || "viewer")}</p>
@@ -1044,6 +1067,7 @@
         <p class="card-copy">Created: ${formatDateTime(invite.created_at)}</p>
         <p class="card-copy">Accepted: ${formatDateTime(invite.accepted_at)}</p>
         <p class="card-copy">Expires: ${formatDateTime(invite.expires_at)}</p>
+        ${missingInviteIdNote}
         <div class="inline-actions" style="margin-top:0.75rem;">
           <button class="btn btn-secondary" type="button" data-invite-resend ${canResend ? "" : "disabled"}>Resend Invite</button>
           <button class="btn btn-secondary" type="button" data-invite-revoke ${canRevoke ? "" : "disabled"}>Revoke Invite</button>
@@ -1059,7 +1083,7 @@
       if (resendButton && canResend) {
         resendButton.addEventListener("click", async function () {
           try {
-            const resentInvite = await resendInvite(invite.id);
+            const resentInvite = await resendInvite(inviteId);
             await refreshData();
             const resendFailed =
               normalizeLower(resentInvite?.email_delivery_status) === "failed";
@@ -1074,18 +1098,32 @@
               setText(inviteStatus, "Invite resent.", "success");
             }
           } catch (error) {
-            setText(inviteStatus, error.message || "Failed to resend invite.", "error");
+            setText(
+              inviteStatus,
+              readableMessage(
+                error?.detail || error?.message || error?.data || error?.responseBody,
+                "Failed to resend invite.",
+              ),
+              "error",
+            );
           }
         });
       }
       if (revokeButton && canRevoke) {
         revokeButton.addEventListener("click", async function () {
           try {
-            await revokeInvite(invite.id);
+            await revokeInvite(inviteId);
             await refreshData();
             setText(inviteStatus, "Invite revoked.", "success");
           } catch (error) {
-            setText(inviteStatus, error.message || "Failed to revoke invite.", "error");
+            setText(
+              inviteStatus,
+              readableMessage(
+                error?.detail || error?.message || error?.data || error?.responseBody,
+                "Failed to revoke invite.",
+              ),
+              "error",
+            );
           }
         });
       }
@@ -1106,7 +1144,7 @@
       if (deleteButton && canDelete) {
         deleteButton.addEventListener("click", async function () {
           try {
-            await deleteInvite(invite.id);
+            await deleteInvite(inviteId);
             await refreshData();
             setText(inviteStatus, "Invite removed from history.", "success");
           } catch (error) {
@@ -1119,8 +1157,8 @@
               statusCode === 400 && detail.includes("revoked before deletion");
             if (legacyPendingDeleteGuard) {
               try {
-                await revokeInvite(invite.id);
-                await deleteInvite(invite.id);
+                await revokeInvite(inviteId);
+                await deleteInvite(inviteId);
                 await refreshData();
                 setText(inviteStatus, "Invite removed from history.", "success");
                 return;
@@ -1146,7 +1184,7 @@
             if (statusCode === 404) {
               if (isPending(invite)) {
                 try {
-                  await revokeInvite(invite.id);
+                  await revokeInvite(inviteId);
                   await refreshData();
                   setText(
                     inviteStatus,
@@ -1170,7 +1208,14 @@
               );
               return;
             }
-            setText(inviteStatus, error.message || "Failed to delete invite.", "error");
+            setText(
+              inviteStatus,
+              readableMessage(
+                error?.detail || error?.message || error?.data || error?.responseBody,
+                "Failed to delete invite.",
+              ),
+              "error",
+            );
           }
         });
       }


### PR DESCRIPTION
This pull request introduces enhancements to email configuration and household invite management. The main improvements are: expanding support for Postmark token configuration (including additional environment variable aliases and secret file loading), and refactoring the household invite logic to efficiently reuse and manage pending invites for the same email address. Comprehensive tests have been added to ensure correct behavior for these new features.

**Email configuration improvements:**

* Added support for additional Postmark token environment variable aliases and introduced `postmark_server_token_file` for loading tokens from secret files, with fallback logic to search common file locations. This increases flexibility and security for deployments. [[1]](diffhunk://#diff-91d704eebe9288029281dfdd5f9656f85cc4c563292c8721107be54754dc359fR326-R336) [[2]](diffhunk://#diff-f4418b67137a221d1a9e8f3170d312edccdda3aa91ac0edb242d9f0032a9fc5cR23-R29) [[3]](diffhunk://#diff-f4418b67137a221d1a9e8f3170d312edccdda3aa91ac0edb242d9f0032a9fc5cR40-R65)
* Expanded and improved tests to verify token loading from environment variables and secret files. [[1]](diffhunk://#diff-57ef211c4185cb69adf626c0492fb93eaee577aa7bb3de7efcaeeddd7f984952L17-R54) [[2]](diffhunk://#diff-57ef211c4185cb69adf626c0492fb93eaee577aa7bb3de7efcaeeddd7f984952R2-R15) [[3]](diffhunk://#diff-2dd026f8e85fff78b27a8fa90d98adacfdb4d434a29bf419679130947b45919dR2-R3) [[4]](diffhunk://#diff-2dd026f8e85fff78b27a8fa90d98adacfdb4d434a29bf419679130947b45919dR42-R51)

**Household invite logic enhancements:**

* Refactored invite creation to check for and reuse the latest pending or expired invite for the same email, updating its details and ensuring only one active invite per email/project. [[1]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R228-R290) [[2]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R469-R553)
* Added logic to revoke any superseded pending invites when a new or reused invite is issued, ensuring data consistency and preventing duplicate active invites. [[1]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R228-R290) [[2]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R611-R615) [[3]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R829-R833)
* Improved and added tests to verify invite reuse, revocation of superseded invites, and correct handling of invite attributes and email delivery status. [[1]](diffhunk://#diff-2846063a690a8a72932c6410c4d08cf9e7bff2d407b0a6c59c1908f3f2693a07R18-R20) [[2]](diffhunk://#diff-2846063a690a8a72932c6410c4d08cf9e7bff2d407b0a6c59c1908f3f2693a07R70-R172)

**Other improvements:**

* Minor refactoring for normalization and test utility methods to improve maintainability and clarity. [[1]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54R422) [[2]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54L414-R563) [[3]](diffhunk://#diff-8deac45dfe7956374e7b7b0c2c7614cf35efdc38123583871a82c39a5fc11c54L448-R597) [[4]](diffhunk://#diff-f4418b67137a221d1a9e8f3170d312edccdda3aa91ac0edb242d9f0032a9fc5cR7) [[5]](diffhunk://#diff-2846063a690a8a72932c6410c4d08cf9e7bff2d407b0a6c59c1908f3f2693a07R529-R534)