### PR TITLE
Expand organization templates: elected-office metadata and structural-node alias

### DIFF
--- a/backend/app/core/organization_template_catalog.py
+++ b/backend/app/core/organization_template_catalog.py
@@ -339,9 +339,11 @@ ORGANIZATION_TEMPLATE_CATALOG: dict[str, dict[str, Any]] = {
         "display_label": "Elected Office",
         "suggested_profile_fields": [
             "office_name",
+            "office_level",
             "chamber",
             "district",
             "jurisdiction",
+            "jurisdiction_level",
             "state",
             "county",
             "municipality",
@@ -370,6 +372,11 @@ ORGANIZATION_TEMPLATE_CATALOG: dict[str, dict[str, Any]] = {
             "Mayor",
             "Council Member",
             "Commissioner",
+            "School Board Member",
+            "Sheriff",
+            "Attorney General",
+            "Clerk",
+            "Auditor",
             "Chief of Staff",
             "Deputy Chief of Staff",
             "Legislative Director",
@@ -415,6 +422,28 @@ ORGANIZATION_TEMPLATE_CATALOG: dict[str, dict[str, Any]] = {
             "staff_directory",
             "office_memo",
             "public_biography",
+        ],
+        "supported_jurisdiction_levels": [
+            "federal",
+            "state",
+            "county",
+            "city",
+            "local",
+        ],
+        "supported_office_examples": [
+            "U.S. Senate office",
+            "U.S. House of Representatives office",
+            "State Senate office",
+            "State House / Assembly office",
+            "Governor's office",
+            "Mayor's office",
+            "City Council office",
+            "County Commissioner office",
+            "School Board office",
+            "Sheriff's office",
+            "Attorney General office",
+            "Clerk / Treasurer / Auditor office",
+            "Political campaign organization",
         ],
     },
     "legislative_body": {
@@ -1229,10 +1258,21 @@ def get_organization_template(organization_type: Any) -> dict[str, Any] | None:
         return None
     template = deepcopy(ORGANIZATION_TEMPLATE_CATALOG[normalized])
     template["organization_type"] = normalized
+    template["suggested_structural_nodes"] = deepcopy(template.get("suggested_nodes") or [])
     template["customization"] = {
         **deepcopy(_DEFAULT_CUSTOMIZATION),
         **deepcopy(template.get("customization") or {}),
     }
+    if template["organization_type"] == "custom":
+        custom_caps = template.get("custom_template_capabilities") or {}
+        if (
+            "allow_custom_transition_events" in custom_caps
+            and "allow_custom_transition_event_types" not in custom_caps
+        ):
+            custom_caps["allow_custom_transition_event_types"] = bool(
+                custom_caps.get("allow_custom_transition_events")
+            )
+        template["custom_template_capabilities"] = custom_caps
     return template
 
 

--- a/backend/tests/test_organization_template_catalog.py
+++ b/backend/tests/test_organization_template_catalog.py
@@ -19,6 +19,10 @@ class OrganizationTemplateCatalogTests(unittest.TestCase):
         catalog = get_organization_template_catalog()
         templates = catalog.get("templates") or {}
         self.assertEqual(set(templates.keys()), set(ORGANIZATION_TYPE_OPTIONS))
+        self.assertEqual(
+            list((templates.get("military_unit") or {}).get("suggested_structural_nodes") or []),
+            list((templates.get("military_unit") or {}).get("suggested_nodes") or []),
+        )
 
     def test_templates_are_helper_only_and_customizable(self):
         catalog = get_organization_template_catalog()
@@ -40,9 +44,19 @@ class OrganizationTemplateCatalogTests(unittest.TestCase):
     def test_elected_office_template_includes_requested_samples(self):
         templates = get_organization_template_catalog().get("templates") or {}
         elected = templates.get("elected_office") or {}
+        self.assertIn("office_level", list(elected.get("suggested_profile_fields") or []))
         self.assertIn("district", list(elected.get("suggested_profile_fields") or []))
         self.assertIn("Main Office", list(elected.get("suggested_nodes") or []))
         self.assertIn("Senator", list(elected.get("suggested_role_seats") or []))
+        self.assertIn("Sheriff", list(elected.get("suggested_role_seats") or []))
+        self.assertIn(
+            "county",
+            list(elected.get("supported_jurisdiction_levels") or []),
+        )
+        self.assertIn(
+            "U.S. Senate office",
+            list(elected.get("supported_office_examples") or []),
+        )
         self.assertIn(
             "committee_assignment_changed",
             list(elected.get("suggested_transition_event_types") or []),
@@ -74,6 +88,7 @@ class OrganizationTemplateCatalogTests(unittest.TestCase):
         self.assertTrue(bool(capabilities.get("allow_custom_nodes")))
         self.assertTrue(bool(capabilities.get("allow_custom_role_seats")))
         self.assertTrue(bool(capabilities.get("allow_custom_transition_events")))
+        self.assertTrue(bool(capabilities.get("allow_custom_transition_event_types")))
         self.assertTrue(bool(capabilities.get("allow_custom_support_record_labels")))
         self.assertTrue(bool(capabilities.get("allow_custom_statuses")))
         self.assertTrue(bool(capabilities.get("allow_custom_hierarchy_labels")))


### PR DESCRIPTION
### Motivation

- Make the organization templates more universally useful and template-driven by adding richer metadata for political/elected offices and a structural-nodes alias for client compatibility.

### Description

- Added `office_level` and `jurisdiction_level` to the `elected_office` template's `suggested_profile_fields` and expanded `suggested_role_seats` with additional public-office examples such as `School Board Member`, `Sheriff`, `Attorney General`, `Clerk`, and `Auditor` in `backend/app/core/organization_template_catalog.py`.
- Added `supported_jurisdiction_levels` and `supported_office_examples` helper lists to the `elected_office` template to document federal/state/county/city/local coverage and common office examples.
- Exposed a `suggested_structural_nodes` alias (a deep copy of `suggested_nodes`) on every template payload to support clients expecting a structural-node naming convention.
- Normalized custom-template capabilities for the `custom` template by ensuring `allow_custom_transition_event_types` is present when `allow_custom_transition_events` exists.
- Updated unit tests in `backend/tests/test_organization_template_catalog.py` to assert the new alias, new `elected_office` fields/helpers, and the normalized custom capability key.

### Testing

- Ran the catalog unit tests with `python -m pytest backend/tests/test_organization_template_catalog.py -q` and the suite passed with `7 passed`.
- The updated tests validate the `suggested_structural_nodes` alias, presence of `office_level` and sample role seats in `elected_office`, and the `custom` template capability compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eac87684832d94a3af62ac99aede)