### PR TITLE
Add org-native Command Structure Network backend domain, routes, and tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,9 +60,11 @@ from app.routes.orders import (
     initialize_order_indexes,
     router as orders_router,
 )
+from app.routes.organizations import router as organizations_router
 from app.services.project_entitlement_service import ensure_project_entitlement_indexes
 from app.services.admin_access_bootstrap_service import bootstrap_admin_access_controls
 from app.services.admin_control_service import ensure_finance_event_indexes
+from app.services.organization_service import ensure_organization_indexes
 from app.routes.package_catalog import router as package_catalog_router
 from app.routes.presence import router as presence_router
 from app.routes.projects import router as projects_router
@@ -128,6 +130,7 @@ async def lifespan(app: FastAPI):
     initialize_mint_job_indexes()
     ensure_stripe_event_indexes()
     ensure_finance_event_indexes()
+    ensure_organization_indexes()
     try:
         bootstrap_admin_access_controls()
     except Exception as exc:
@@ -201,6 +204,7 @@ app.include_router(db_bootstrap_router)
 app.include_router(admin_maintenance_router)
 app.include_router(graph_integrity_router)
 app.include_router(orders_router)
+app.include_router(organizations_router)
 app.include_router(package_catalog_router)
 app.include_router(uploads_router)
 app.include_router(workspace_access_router)

--- a/backend/app/routes/organizations.py
+++ b/backend/app/routes/organizations.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies.auth import (
+    get_current_user,
+    require_permission,
+    require_package_capability,
+)
+from app.schemas.organization import (
+    AssignmentCreate,
+    EndAssignmentPayload,
+    LinkedOrganizationCreate,
+    OrganizationNodeCreate,
+    OrganizationPersonCreate,
+    OrganizationProfileUpsert,
+    ReplaceRoleSeatPayload,
+    RoleSeatCreate,
+    SupportRecordCreate,
+    TransitionEventCreate,
+)
+from app.services.audit_log_service import write_audit_log
+from app.services.organization_service import (
+    create_assignment,
+    create_linked_organization,
+    create_organization_node,
+    create_person,
+    create_role_seat,
+    create_support_record,
+    create_transition,
+    end_assignment,
+    list_assignments,
+    list_links,
+    list_organization_nodes,
+    list_organization_profiles,
+    list_people,
+    list_role_seats,
+    list_support_records,
+    list_transitions,
+    replace_role_seat_assignment,
+    upsert_organization_profile,
+)
+
+router = APIRouter(prefix="/organizations", tags=["Organizations"])
+
+
+def _actor_user_id(user: dict[str, Any]) -> str:
+    return str(user.get("id") or user.get("_id") or user.get("user_id") or "").strip()
+
+
+def _audit(current_user: dict[str, Any], action: str, target_type: str, target_id: str, *, details: dict[str, Any]) -> None:
+    write_audit_log(
+        actor_user_id=_actor_user_id(current_user),
+        actor_email=str(current_user.get("email") or "").strip().lower() or None,
+        actor_name=str(current_user.get("full_name") or current_user.get("name") or "").strip() or None,
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        details=details,
+    )
+
+
+def _require_org_lane(current_user: dict[str, Any]) -> None:
+    require_package_capability(
+        current_user,
+        "can_open_org_intake",
+        detail="Command Structure Network entitlement is required for organization routes.",
+    )
+
+
+@router.get("/profile")
+def get_organization_profile(
+    organization_id: str | None = None,
+    current_user: dict[str, Any] = Depends(require_permission("projects.read")),
+):
+    _require_org_lane(current_user)
+    return {"items": list_organization_profiles(organization_id)}
+
+
+@router.post("/profile")
+def post_organization_profile(
+    payload: OrganizationProfileUpsert,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    item = upsert_organization_profile(payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    _audit(current_user, "organization.profile.upsert", "organization", payload.organization_id, details={"project_id": payload.project_id})
+    return item
+
+
+@router.get("/{org_id}/nodes")
+def get_nodes(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_organization_nodes(org_id)}
+
+
+@router.post("/{org_id}/nodes")
+def post_nodes(
+    org_id: str,
+    payload: OrganizationNodeCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_organization_node(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.node.create", "organization_node", str(item.get("node_key")), details={"organization_id": org_id})
+    return item
+
+
+@router.get("/{org_id}/role-seats")
+def get_role_seats(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_role_seats(org_id)}
+
+
+@router.post("/{org_id}/role-seats")
+def post_role_seats(
+    org_id: str,
+    payload: RoleSeatCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_role_seat(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.role_seat.create", "role_seat", str(item.get("role_key")), details={"organization_id": org_id})
+    return item
+
+
+@router.get("/{org_id}/people")
+def get_people(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_people(org_id)}
+
+
+@router.post("/{org_id}/people")
+def post_people(
+    org_id: str,
+    payload: OrganizationPersonCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_person(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.person.create", "organization_person", payload.person_id, details={"organization_id": org_id})
+    return item
+
+
+@router.get("/{org_id}/assignments")
+def get_assignments(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_assignments(org_id)}
+
+
+@router.post("/{org_id}/assignments")
+def post_assignments(
+    org_id: str,
+    payload: AssignmentCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_assignment(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.assignment.create", "assignment", payload.assignment_id, details={"organization_id": org_id, "sensitive": True})
+    return item
+
+
+@router.post("/{org_id}/assignments/{assignment_id}/end")
+def end_assignment_route(
+    org_id: str,
+    assignment_id: str,
+    payload: EndAssignmentPayload,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = end_assignment(
+            org_id,
+            assignment_id,
+            end_date=payload.end_date,
+            status=payload.status,
+            notes=payload.notes,
+            actor_user_id=_actor_user_id(current_user),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.assignment.end", "assignment", assignment_id, details={"organization_id": org_id, "sensitive": True})
+    return item
+
+
+@router.post("/{org_id}/role-seats/{role_seat_id}/replace")
+def replace_role_seat(
+    org_id: str,
+    role_seat_id: str,
+    payload: ReplaceRoleSeatPayload,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = replace_role_seat_assignment(
+            org_id,
+            role_seat_id,
+            payload.model_dump(),
+            actor_user_id=_actor_user_id(current_user),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.role_seat.replace", "role_seat", role_seat_id, details={"organization_id": org_id, "sensitive": True})
+    return item
+
+
+@router.get("/{org_id}/transitions")
+def get_transitions(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_transitions(org_id)}
+
+
+@router.post("/{org_id}/transitions")
+def post_transitions(
+    org_id: str,
+    payload: TransitionEventCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_transition(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.transition.create", "transition", payload.transition_id, details={"organization_id": org_id, "sensitive": True})
+    return item
+
+
+@router.get("/{org_id}/support-records")
+def get_support_records(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_support_records(org_id)}
+
+
+@router.post("/{org_id}/support-records")
+def post_support_records(
+    org_id: str,
+    payload: SupportRecordCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_support_record(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if payload.sensitive:
+        _audit(current_user, "organization.support_record.sensitive_access", "support_record", payload.support_record_id, details={"organization_id": org_id, "privacy_level": payload.privacy_level})
+    _audit(current_user, "organization.support_record.create", "support_record", payload.support_record_id, details={"organization_id": org_id, "privacy_level": payload.privacy_level})
+    return item
+
+
+@router.get("/{org_id}/links")
+def get_links(org_id: str, current_user: dict[str, Any] = Depends(require_permission("projects.read"))):
+    _require_org_lane(current_user)
+    return {"items": list_links(org_id)}
+
+
+@router.post("/{org_id}/links")
+def post_links(
+    org_id: str,
+    payload: LinkedOrganizationCreate,
+    current_user: dict[str, Any] = Depends(require_permission("uploads.write")),
+):
+    _require_org_lane(current_user)
+    try:
+        item = create_linked_organization(org_id, payload.model_dump(), actor_user_id=_actor_user_id(current_user))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    _audit(current_user, "organization.link.create", "organization_link", f"{org_id}:{payload.linked_organization_id}:{payload.link_type}", details={"organization_id": org_id})
+    return item

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class OrganizationProfileUpsert(BaseModel):
+    organization_id: str = Field(min_length=1)
+    project_id: str = Field(min_length=1)
+    organization_name: str = Field(min_length=1)
+    organization_type: str = Field(min_length=1)
+    organization_subtype: str | None = None
+    legal_name: str | None = None
+    short_name: str | None = None
+    jurisdiction: str | None = None
+    nation_state_region: str | None = None
+    charter_number_or_unit_number: str | None = None
+    parent_organization: str | None = None
+    founding_date_or_charter_date: date | None = None
+    status: str = "active"
+    description: str | None = None
+    mission: str | None = None
+    logo_upload_id: str | None = None
+    visibility: str = "private"
+
+
+class OrganizationNodeCreate(BaseModel):
+    node_key: str = Field(min_length=1)
+    node_name: str = Field(min_length=1)
+    node_type: str = Field(min_length=1)
+    description: str | None = None
+    visibility: str = "private"
+
+
+class RoleSeatCreate(BaseModel):
+    node_id: str = Field(min_length=1)
+    role_key: str = Field(min_length=1)
+    role_name: str = Field(min_length=1)
+    seat_status: str = "active"
+    description: str | None = None
+
+
+class OrganizationPersonCreate(BaseModel):
+    person_id: str = Field(min_length=1)
+    full_name: str = Field(min_length=1)
+    display_name: str | None = None
+    rank_title_honorific: str | None = None
+    organization_specific_title: str | None = None
+    status: str = "active"
+    biography: str | None = None
+    portrait_upload_id: str | None = None
+    visibility: str = "private"
+
+
+class AssignmentCreate(BaseModel):
+    assignment_id: str = Field(min_length=1)
+    node_id: str = Field(min_length=1)
+    role_seat_id: str = Field(min_length=1)
+    person_id: str = Field(min_length=1)
+    title_at_time: str | None = None
+    rank_at_time: str | None = None
+    start_date: date
+    end_date: date | None = None
+    status: str = "active"
+    appointment_source: str | None = None
+    evidence_record_ids: list[str] = Field(default_factory=list)
+    notes: str | None = None
+    verified_status: str = "unverified"
+    acting_or_interim: bool = False
+
+
+class EndAssignmentPayload(BaseModel):
+    end_date: date
+    status: str = "ended"
+    notes: str | None = None
+
+
+class ReplaceRoleSeatPayload(BaseModel):
+    assignment_id: str = Field(min_length=1)
+    person_id: str = Field(min_length=1)
+    title_at_time: str | None = None
+    rank_at_time: str | None = None
+    start_date: date
+    appointment_source: str | None = None
+    notes: str | None = None
+    evidence_record_ids: list[str] = Field(default_factory=list)
+    verified_status: str = "unverified"
+    acting_or_interim: bool = False
+
+
+class TransitionEventCreate(BaseModel):
+    transition_id: str = Field(min_length=1)
+    assignment_id: str | None = None
+    role_seat_id: str | None = None
+    person_id: str | None = None
+    event_type: str = Field(min_length=1)
+    event_date: date
+    notes: str | None = None
+    evidence_record_ids: list[str] = Field(default_factory=list)
+
+
+class SupportRecordCreate(BaseModel):
+    support_record_id: str = Field(min_length=1)
+    target_type: Literal["organization", "node", "role_seat", "person", "assignment", "transition"]
+    target_id: str = Field(min_length=1)
+    upload_id: str = Field(min_length=1)
+    title: str | None = None
+    notes: str | None = None
+    privacy_level: Literal["private", "restricted", "confidential"] = "private"
+    sensitive: bool = False
+
+
+class LinkedOrganizationCreate(BaseModel):
+    linked_organization_id: str = Field(min_length=1)
+    link_type: str = Field(min_length=1)
+    notes: str | None = None

--- a/backend/app/services/organization_service.py
+++ b/backend/app/services/organization_service.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pymongo import ASCENDING
+from pymongo.collection import Collection
+from pymongo.errors import DuplicateKeyError
+
+from app.core.package_catalog import COMMAND_STRUCTURE_ORG_NODE_LIMIT
+from app.database import get_database
+
+TRANSITION_EVENT_TYPES = {
+    "assumed_office",
+    "assumed_command",
+    "installed",
+    "elected",
+    "appointed",
+    "promoted",
+    "transferred",
+    "retired",
+    "resigned",
+    "removed",
+    "deceased",
+    "emeritus_designation",
+    "term_ended",
+    "office_renamed",
+    "unit_redesignated",
+    "department_reorganized",
+    "jurisdiction_changed",
+    "district_changed",
+    "charter_updated",
+    "custom",
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _collection(name: str) -> Collection[dict[str, Any]]:
+    db = get_database()
+    return db[name]
+
+
+def ensure_organization_indexes() -> None:
+    _collection("organization_profiles").create_index(
+        [("organization_id", ASCENDING)],
+        unique=True,
+        name="organization_profile_id_uniq",
+    )
+    _collection("organization_nodes").create_index(
+        [("organization_id", ASCENDING), ("node_key", ASCENDING)],
+        unique=True,
+        name="organization_node_natural_key_uniq",
+    )
+    _collection("organization_role_seats").create_index(
+        [("organization_id", ASCENDING), ("node_id", ASCENDING), ("role_key", ASCENDING)],
+        unique=True,
+        name="organization_role_seat_natural_key_uniq",
+    )
+    _collection("organization_people").create_index(
+        [("organization_id", ASCENDING), ("person_id", ASCENDING)],
+        unique=True,
+        name="organization_person_natural_key_uniq",
+    )
+    _collection("organization_assignments").create_index(
+        [("organization_id", ASCENDING), ("assignment_id", ASCENDING)],
+        unique=True,
+        name="organization_assignment_id_uniq",
+    )
+    _collection("organization_support_records").create_index(
+        [("organization_id", ASCENDING), ("support_record_id", ASCENDING)],
+        unique=True,
+        name="organization_support_record_id_uniq",
+    )
+    _collection("organization_links").create_index(
+        [
+            ("organization_id", ASCENDING),
+            ("linked_organization_id", ASCENDING),
+            ("link_type", ASCENDING),
+        ],
+        unique=True,
+        name="organization_link_natural_key_uniq",
+    )
+
+
+def upsert_organization_profile(payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_profiles")
+    doc = dict(payload)
+    now = _utcnow()
+    doc["updated_at"] = now
+    doc["updated_by"] = actor_user_id
+    existing = collection.find_one({"organization_id": doc["organization_id"]})
+    if existing:
+        doc["created_at"] = existing.get("created_at")
+        doc["created_by"] = existing.get("created_by")
+        collection.update_one({"_id": existing["_id"]}, {"$set": doc})
+    else:
+        doc["created_at"] = now
+        doc["created_by"] = actor_user_id
+        collection.insert_one(doc)
+    return collection.find_one({"organization_id": doc["organization_id"]}) or {}
+
+
+def list_organization_profiles(organization_id: str | None = None) -> list[dict[str, Any]]:
+    query = {"organization_id": organization_id} if organization_id else {}
+    return list(_collection("organization_profiles").find(query))
+
+
+def create_organization_node(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_nodes")
+    count = collection.count_documents({"organization_id": organization_id})
+    if count >= COMMAND_STRUCTURE_ORG_NODE_LIMIT:
+        raise ValueError(f"Organization node cap ({COMMAND_STRUCTURE_ORG_NODE_LIMIT}) reached.")
+
+    doc = {
+        "organization_id": organization_id,
+        **payload,
+        "created_at": _utcnow(),
+        "created_by": actor_user_id,
+    }
+    try:
+        collection.insert_one(doc)
+    except DuplicateKeyError as exc:
+        raise ValueError("Duplicate organization node for organization_id + node_key.") from exc
+    return collection.find_one({"organization_id": organization_id, "node_key": payload["node_key"]}) or {}
+
+
+def list_organization_nodes(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_nodes").find({"organization_id": organization_id}))
+
+
+def create_role_seat(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_role_seats")
+    doc = {
+        "organization_id": organization_id,
+        **payload,
+        "created_at": _utcnow(),
+        "created_by": actor_user_id,
+    }
+    try:
+        collection.insert_one(doc)
+    except DuplicateKeyError as exc:
+        raise ValueError("Duplicate role seat for organization_id + node_id + role_key.") from exc
+    return collection.find_one(
+        {
+            "organization_id": organization_id,
+            "node_id": payload["node_id"],
+            "role_key": payload["role_key"],
+        }
+    ) or {}
+
+
+def list_role_seats(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_role_seats").find({"organization_id": organization_id}))
+
+
+def create_person(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_people")
+    doc = {"organization_id": organization_id, **payload, "created_at": _utcnow(), "created_by": actor_user_id}
+    try:
+        collection.insert_one(doc)
+    except DuplicateKeyError as exc:
+        raise ValueError("Duplicate person for organization_id + person_id.") from exc
+    return collection.find_one({"organization_id": organization_id, "person_id": payload["person_id"]}) or {}
+
+
+def list_people(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_people").find({"organization_id": organization_id}))
+
+
+def _find_current_assignment_for_role(organization_id: str, role_seat_id: str) -> dict[str, Any] | None:
+    return _collection("organization_assignments").find_one(
+        {
+            "organization_id": organization_id,
+            "role_seat_id": role_seat_id,
+            "status": {"$in": ["active", "current", "interim", "acting"]},
+            "end_date": None,
+        }
+    )
+
+
+def create_assignment(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    assignments = _collection("organization_assignments")
+    current = _find_current_assignment_for_role(organization_id, payload["role_seat_id"])
+    if current and not payload.get("acting_or_interim"):
+        raise ValueError("Duplicate current assignment is blocked unless acting/interim is selected.")
+
+    doc = {
+        "organization_id": organization_id,
+        **payload,
+        "created_at": _utcnow(),
+        "created_by": actor_user_id,
+        "updated_by": actor_user_id,
+    }
+    try:
+        assignments.insert_one(doc)
+    except DuplicateKeyError as exc:
+        raise ValueError("Duplicate assignment_id for organization.") from exc
+    return assignments.find_one({"organization_id": organization_id, "assignment_id": payload["assignment_id"]}) or {}
+
+
+def end_assignment(
+    organization_id: str,
+    assignment_id: str,
+    *,
+    end_date: Any,
+    status: str,
+    notes: str | None,
+    actor_user_id: str,
+) -> dict[str, Any]:
+    assignments = _collection("organization_assignments")
+    existing = assignments.find_one({"organization_id": organization_id, "assignment_id": assignment_id})
+    if not existing:
+        raise ValueError("Assignment not found.")
+    assignments.update_one(
+        {"_id": existing["_id"]},
+        {
+            "$set": {
+                "end_date": end_date,
+                "status": status,
+                "notes": notes or existing.get("notes"),
+                "updated_by": actor_user_id,
+                "updated_at": _utcnow(),
+            }
+        },
+    )
+    return assignments.find_one({"_id": existing["_id"]}) or {}
+
+
+def replace_role_seat_assignment(
+    organization_id: str,
+    role_seat_id: str,
+    payload: dict[str, Any],
+    *,
+    actor_user_id: str,
+) -> dict[str, Any]:
+    current = _find_current_assignment_for_role(organization_id, role_seat_id)
+    if current:
+        _collection("organization_assignments").update_one(
+            {"_id": current["_id"]},
+            {
+                "$set": {
+                    "status": "ended",
+                    "end_date": payload["start_date"],
+                    "updated_by": actor_user_id,
+                    "updated_at": _utcnow(),
+                }
+            },
+        )
+
+    created = create_assignment(
+        organization_id,
+        {
+            **payload,
+            "role_seat_id": role_seat_id,
+            "status": "active",
+            "end_date": None,
+        },
+        actor_user_id=actor_user_id,
+    )
+    return {"replaced_assignment": current, "new_assignment": created}
+
+
+def list_assignments(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_assignments").find({"organization_id": organization_id}))
+
+
+def create_transition(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    if payload.get("event_type") not in TRANSITION_EVENT_TYPES:
+        raise ValueError("Unsupported transition event_type.")
+
+    collection = _collection("organization_transitions")
+    doc = {"organization_id": organization_id, **payload, "created_at": _utcnow(), "created_by": actor_user_id}
+    collection.insert_one(doc)
+    return collection.find_one({"organization_id": organization_id, "transition_id": payload["transition_id"]}) or {}
+
+
+def list_transitions(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_transitions").find({"organization_id": organization_id}))
+
+
+def create_support_record(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_support_records")
+    if collection.count_documents({"organization_id": organization_id}) >= 25:
+        raise ValueError("Support upload cap (25) reached for organization.")
+    doc = {"organization_id": organization_id, **payload, "created_at": _utcnow(), "created_by": actor_user_id}
+    collection.insert_one(doc)
+    return collection.find_one({"organization_id": organization_id, "support_record_id": payload["support_record_id"]}) or {}
+
+
+def list_support_records(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_support_records").find({"organization_id": organization_id}))
+
+
+def create_linked_organization(organization_id: str, payload: dict[str, Any], *, actor_user_id: str) -> dict[str, Any]:
+    collection = _collection("organization_links")
+    doc = {"organization_id": organization_id, **payload, "created_at": _utcnow(), "created_by": actor_user_id}
+    try:
+        collection.insert_one(doc)
+    except DuplicateKeyError as exc:
+        raise ValueError("Duplicate organization link for organization_id + linked_organization_id + link_type.") from exc
+    return collection.find_one(
+        {
+            "organization_id": organization_id,
+            "linked_organization_id": payload["linked_organization_id"],
+            "link_type": payload["link_type"],
+        }
+    ) or {}
+
+
+def list_links(organization_id: str) -> list[dict[str, Any]]:
+    return list(_collection("organization_links").find({"organization_id": organization_id}))

--- a/backend/tests/test_organization_command_structure_network.py
+++ b/backend/tests/test_organization_command_structure_network.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from app.routes import organizations
+from app.services import organization_service
+
+
+@dataclass
+class _InsertResult:
+    inserted_id: str
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict] = []
+        self.unique_indexes: list[tuple[str, ...]] = []
+
+    def create_index(self, fields, unique=False, name=None):
+        if unique:
+            self.unique_indexes.append(tuple(field for field, _ in fields))
+
+    def _matches(self, doc: dict, query: dict) -> bool:
+        for key, value in query.items():
+            if isinstance(value, dict) and "$in" in value:
+                if doc.get(key) not in value["$in"]:
+                    return False
+            elif isinstance(value, dict) and "$in" not in value:
+                if key == "status" and isinstance(value.get("$in"), list):
+                    if doc.get("status") not in value["$in"]:
+                        return False
+                else:
+                    return False
+            else:
+                if doc.get(key) != value:
+                    return False
+        return True
+
+    def count_documents(self, query: dict) -> int:
+        return len([d for d in self.docs if self._matches(d, query)])
+
+    def find_one(self, query: dict):
+        for doc in self.docs:
+            if self._matches(doc, query):
+                return doc
+        return None
+
+    def find(self, query: dict):
+        return [d for d in self.docs if self._matches(d, query)]
+
+    def insert_one(self, doc: dict):
+        for keys in self.unique_indexes:
+            for existing in self.docs:
+                if all(existing.get(k) == doc.get(k) for k in keys):
+                    raise DuplicateKeyError("duplicate")
+        materialized = dict(doc)
+        materialized.setdefault("_id", f"id-{len(self.docs)+1}")
+        self.docs.append(materialized)
+        return _InsertResult(inserted_id=materialized["_id"])
+
+    def update_one(self, query: dict, update: dict):
+        target = self.find_one(query)
+        if target is None:
+            return
+        if "$set" in update:
+            target.update(update["$set"])
+
+
+class FakeDB(dict):
+    def __getitem__(self, key):
+        if key not in self:
+            self[key] = FakeCollection()
+        return dict.__getitem__(self, key)
+
+
+def _setup_fake_db():
+    db = FakeDB()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        organization_service.ensure_organization_indexes()
+    return db
+
+
+def test_family_or_household_lane_cannot_access_org_routes():
+    with patch("app.routes.organizations.require_package_capability", side_effect=Exception("blocked")):
+        with pytest.raises(Exception):
+            organizations._require_org_lane({"id": "u1"})
+
+
+def test_command_structure_network_can_access_org_routes():
+    with patch("app.routes.organizations.require_package_capability", return_value={"id": "u1"}):
+        organizations._require_org_lane({"id": "u1"})
+
+
+def test_duplicate_node_and_role_seat_are_blocked():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        organization_service.create_organization_node("org1", {"node_key": "bde", "node_name": "Brigade", "node_type": "brigade"}, actor_user_id="u1")
+        with pytest.raises(ValueError):
+            organization_service.create_organization_node("org1", {"node_key": "bde", "node_name": "Brigade 2", "node_type": "brigade"}, actor_user_id="u1")
+
+        organization_service.create_role_seat("org1", {"node_id": "n1", "role_key": "commander", "role_name": "Commander"}, actor_user_id="u1")
+        with pytest.raises(ValueError):
+            organization_service.create_role_seat("org1", {"node_id": "n1", "role_key": "commander", "role_name": "Commander"}, actor_user_id="u1")
+
+
+def test_replacing_leader_creates_new_assignment_and_preserves_old_assignment():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        organization_service.create_assignment("org1", {
+            "assignment_id": "a1",
+            "node_id": "n1",
+            "role_seat_id": "r1",
+            "person_id": "p1",
+            "start_date": "2020-01-01",
+            "end_date": None,
+            "status": "active",
+            "acting_or_interim": False,
+        }, actor_user_id="u1")
+        result = organization_service.replace_role_seat_assignment("org1", "r1", {
+            "assignment_id": "a2",
+            "node_id": "n1",
+            "person_id": "p2",
+            "title_at_time": "Commander",
+            "rank_at_time": "COL",
+            "start_date": "2021-01-01",
+            "acting_or_interim": False,
+        }, actor_user_id="u2")
+
+        assert result["new_assignment"]["assignment_id"] == "a2"
+        old = db["organization_assignments"].find_one({"assignment_id": "a1"})
+        assert old["status"] == "ended"
+        assert old["person_id"] == "p1"
+
+
+def test_ending_term_preserves_person_record():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        organization_service.create_person("org1", {"person_id": "p1", "full_name": "Alex"}, actor_user_id="u1")
+        organization_service.create_assignment("org1", {
+            "assignment_id": "a1", "node_id": "n1", "role_seat_id": "r1", "person_id": "p1", "start_date": "2020-01-01", "end_date": None, "status": "active", "acting_or_interim": False,
+        }, actor_user_id="u1")
+        organization_service.end_assignment("org1", "a1", end_date="2022-01-01", status="ended", notes=None, actor_user_id="u1")
+        assert db["organization_people"].find_one({"person_id": "p1"}) is not None
+
+
+def test_duplicate_current_assignment_blocked_except_acting_or_interim():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        organization_service.create_assignment("org1", {
+            "assignment_id": "a1", "node_id": "n1", "role_seat_id": "r1", "person_id": "p1", "start_date": "2020-01-01", "end_date": None, "status": "active", "acting_or_interim": False,
+        }, actor_user_id="u1")
+        with pytest.raises(ValueError):
+            organization_service.create_assignment("org1", {
+                "assignment_id": "a2", "node_id": "n1", "role_seat_id": "r1", "person_id": "p2", "start_date": "2021-01-01", "end_date": None, "status": "active", "acting_or_interim": False,
+            }, actor_user_id="u1")
+        created = organization_service.create_assignment("org1", {
+            "assignment_id": "a3", "node_id": "n1", "role_seat_id": "r1", "person_id": "p3", "start_date": "2021-01-01", "end_date": None, "status": "interim", "acting_or_interim": True,
+        }, actor_user_id="u1")
+        assert created["assignment_id"] == "a3"
+
+
+def test_support_record_attachment_link_and_caps_enforced_without_family_side_effects():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        support = organization_service.create_support_record("org1", {
+            "support_record_id": "s1", "target_type": "assignment", "target_id": "a1", "upload_id": "u1", "privacy_level": "confidential",
+        }, actor_user_id="u1")
+        assert support["target_type"] == "assignment"
+
+        link = organization_service.create_linked_organization("org1", {
+            "linked_organization_id": "org2", "link_type": "subordinate_command"
+        }, actor_user_id="u1")
+        assert link["link_type"] == "subordinate_command"
+        assert db["family_links"].count_documents({}) == 0
+
+        for idx in range(2, 26):
+            organization_service.create_support_record("org1", {
+                "support_record_id": f"s{idx}", "target_type": "organization", "target_id": "org1", "upload_id": f"u{idx}", "privacy_level": "private",
+            }, actor_user_id="u1")
+        with pytest.raises(ValueError):
+            organization_service.create_support_record("org1", {
+                "support_record_id": "s26", "target_type": "organization", "target_id": "org1", "upload_id": "u26", "privacy_level": "private",
+            }, actor_user_id="u1")
+
+
+def test_node_cap_and_sensitive_audit_log_written():
+    db = _setup_fake_db()
+    with patch("app.services.organization_service.get_database", return_value=db):
+        for idx in range(1, 16):
+            organization_service.create_organization_node("org1", {"node_key": f"n{idx}", "node_name": f"N{idx}", "node_type": "custom"}, actor_user_id="u1")
+        with pytest.raises(ValueError):
+            organization_service.create_organization_node("org1", {"node_key": "overflow", "node_name": "Overflow", "node_type": "custom"}, actor_user_id="u1")
+
+    payload = organizations.SupportRecordCreate(
+        support_record_id="s1",
+        target_type="assignment",
+        target_id="a1",
+        upload_id="u1",
+        privacy_level="confidential",
+        sensitive=True,
+    )
+    with patch("app.routes.organizations.require_package_capability", return_value={"id": "u1"}), patch(
+        "app.routes.organizations.create_support_record",
+        return_value={"support_record_id": "s1"},
+    ), patch("app.routes.organizations.write_audit_log") as audit_mock:
+        organizations.post_support_records(
+            "org1",
+            payload,
+            current_user={"id": "u1", "email": "u1@example.com"},
+        )
+        assert audit_mock.call_count >= 2

--- a/backend/tests/test_startup_initialization.py
+++ b/backend/tests/test_startup_initialization.py
@@ -21,6 +21,7 @@ class StartupInitializationTests(unittest.TestCase):
             patch.object(main_module, "initialize_mint_job_indexes") as mint_job_init_mock,
             patch.object(main_module, "ensure_stripe_event_indexes") as stripe_init_mock,
             patch.object(main_module, "ensure_finance_event_indexes") as finance_init_mock,
+            patch.object(main_module, "ensure_organization_indexes") as organization_init_mock,
             patch.object(main_module, "bootstrap_admin_access_controls") as admin_access_bootstrap_mock,
             patch.object(main_module, "close_mongo_connection") as close_mock,
         ):
@@ -35,6 +36,7 @@ class StartupInitializationTests(unittest.TestCase):
         mint_job_init_mock.assert_called_once()
         stripe_init_mock.assert_called_once()
         finance_init_mock.assert_called_once()
+        organization_init_mock.assert_called_once()
         admin_access_bootstrap_mock.assert_called_once()
         close_mock.assert_called_once()
 


### PR DESCRIPTION
### Motivation
- Provide an org-native domain model and API surface to support Command Structure Network workflows without using family/household models or family-side side effects.
- Capture stable role seats and assignment/tenure history so leadership transitions are auditable and preserved.
- Enforce Command Structure Network limits and privacy/audit rules (node cap, upload cap, sensitive audits) required by the product spec.

### Description
- Added schemas, services and routes for organization-native domain: `app/schemas/organization.py`, `app/services/organization_service.py`, and `app/routes/organizations.py` which implement profiles, nodes, role seats, people, assignments, transitions, support records, and linked organizations. 
- Implemented natural-key uniqueness and indexes for duplicate prevention: `organization_id`; `organization_id + node_key`; `organization_id + node_id + role_key`; `organization_id + person_id`; `organization_id + assignment_id`; `organization_id + support_record_id`; and `organization_id + linked_organization_id + link_type`.
- Enforced Command Structure Network business rules including node cap (15), support upload cap (25), assignment continuity (replace ends prior record and creates new record), prevention of duplicate current assignment unless `acting_or_interim=True`, allowed acting/interim assignments, and validated transition event types.
- Added entitlement and permission gating (`can_open_org_intake` entitlement plus `projects.read`/`uploads.write` permissions) and audit logging for sensitive changes, and wired organization index initialization into app startup lifecycle (`ensure_organization_indexes` in `app/main.py`).

### Testing
- Added `backend/tests/test_organization_command_structure_network.py` covering entitlement gating, duplicate prevention, node/assignment caps, replace/end assignment behavior, support/link behavior, and audit call assertions, and updated `tests/test_startup_initialization.py` to include the new initializer check. 
- Ran unit tests: `cd backend && python -m pytest -q tests`, and the full suite passed: `192 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f7670fd8832db26a12dd5f3f514e)