### PR TITLE
Phase 3: switch Command Structure Network viewer anchors to organization-native entities

### DIFF
--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -48,6 +48,9 @@ def _current_user_email(user: dict[str, Any]) -> str:
 
 
 def _display_name(member: dict[str, Any]) -> str:
+    full_name = _normalize_value(member.get("full_name"))
+    if full_name:
+        return full_name
     joined = f"{_normalize_value(member.get('first_name'))} {_normalize_value(member.get('last_name'))}".strip()
     return joined or _normalize_value(member.get("display_name")) or "Unknown Member"
 
@@ -315,6 +318,7 @@ def _serialize_project_summary(project: dict[str, Any]) -> dict[str, Any]:
         "package_code": _normalize_value(project.get("package_code")),
         "lane": _lane_from_project(project),
         "family_id": _normalize_value(project.get("family_id")) or None,
+        "organization_id": _normalize_value(project.get("organization_id")) or None,
     }
 
 
@@ -327,6 +331,33 @@ def load_project_workspace_anchor(
     db = get_database()
     if db is None:
         return None, None, project
+    lane = _lane_from_project(project)
+
+    if lane == "organization":
+        project_id = _normalize_value(project.get("_id") or project.get("id"))
+        organization_id = _normalize_value(project.get("organization_id")) or project_id
+        profile = db["organization_profiles"].find_one({"organization_id": organization_id})
+        primary_person = db["organization_people"].find_one(
+            {"organization_id": organization_id},
+            sort=[("created_at", 1)],
+        )
+        return (
+            {
+                "organization_id": organization_id,
+                "project_id": project_id,
+                "family_name": _normalize_value(
+                    (profile or {}).get("display_name")
+                    or (profile or {}).get("organization_name")
+                    or project.get("project_name")
+                    or project.get("name")
+                    or "Command Workspace"
+                ),
+                "description": _normalize_value((profile or {}).get("description")),
+                "visibility": _coerce_visibility((profile or {}).get("visibility")),
+            },
+            primary_person,
+            project,
+        )
 
     submission = submission or _find_submission_for_project(project)
     families = db["families"]
@@ -393,6 +424,12 @@ def ensure_project_workspace_anchor(
     lane = _lane_from_project(project)
     if lane not in {"portrait", "household", "network", "organization"}:
         return None, None, project
+
+    if lane == "organization":
+        return load_project_workspace_anchor(
+            project=project,
+            submission=submission,
+        )
 
     submission = submission or _find_submission_for_project(project)
 
@@ -717,7 +754,15 @@ def build_viewer_manifest(
     can_use_narration = bool(resolved_entitlements.get("can_use_narration"))
     family_id_value = _normalize_value((family_doc or {}).get("_id") or project.get("family_id"))
     members: list[dict[str, Any]] = []
-    if family_id_value:
+    if lane == "organization":
+        organization_id = _normalize_value(project.get("organization_id")) or _normalize_value(
+            project.get("_id") or project.get("id")
+        )
+        if organization_id:
+            members = list(
+                db["organization_people"].find({"organization_id": organization_id}),
+            )
+    elif family_id_value:
         members = list(
             db["family_members"].find(
                 {"family_id": {"$in": _family_id_candidates(family_id_value)}},
@@ -738,12 +783,20 @@ def build_viewer_manifest(
         project_id_value = _normalize_value(project.get("_id") or project.get("id"))
         valid_member_views: list[tuple[dict[str, Any], dict[str, Any]]] = []
         for member in ordered_members:
-            upload_record = _resolve_member_photo_upload(
-                db=db,
-                member=member,
-                project_id=project_id_value,
-                family_id=family_id_value,
-            )
+            if lane == "organization":
+                upload_record = None
+                upload_id = _normalize_value(member.get("photo_upload_id"))
+                if upload_id and ObjectId.is_valid(upload_id):
+                    candidate = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
+                    if candidate and _normalize_value(candidate.get("project_id")) == project_id_value:
+                        upload_record = candidate
+            else:
+                upload_record = _resolve_member_photo_upload(
+                    db=db,
+                    member=member,
+                    project_id=project_id_value,
+                    family_id=family_id_value,
+                )
             if upload_record is not None:
                 valid_member_views.append((member, upload_record))
 
@@ -836,8 +889,29 @@ def build_viewer_manifest(
         for state in states[:6]
     ]
 
-    return {
-        "mode": "secure_share" if secure_share_only else "dynamic",
+    mode = "secure_share" if secure_share_only else "dynamic"
+    if lane == "organization":
+        mode = "organization_command"
+
+    controls = {
+        "allow_lineage_navigation": not secure_share_only,
+        "allow_zoom": (not secure_share_only) and max_zoom_layers > 0,
+        "allow_branch_navigation": not secure_share_only,
+        "allow_gaze_navigation": not secure_share_only,
+        "allow_narration_auto_advance": (not secure_share_only) and can_use_narration,
+        "max_zoom_layers": max(0, max_zoom_layers),
+    }
+    if lane == "organization":
+        controls = {
+            "allow_command_navigation": True,
+            "allow_zoom": max_zoom_layers > 0,
+            "allow_role_navigation": True,
+            "allow_narration_auto_advance": False,
+            "max_zoom_layers": max(0, max_zoom_layers),
+        }
+
+    manifest = {
+        "mode": mode,
         "navigation_mode": "sequence",
         "hero_kicker": package_name,
         "hero_title": hero_title,
@@ -852,14 +926,7 @@ def build_viewer_manifest(
         "path_title": path_title,
         "path_items": path_items,
         "nav_labels": nav_labels,
-        "controls": {
-            "allow_lineage_navigation": not secure_share_only,
-            "allow_zoom": (not secure_share_only) and max_zoom_layers > 0,
-            "allow_branch_navigation": not secure_share_only,
-            "allow_gaze_navigation": not secure_share_only,
-            "allow_narration_auto_advance": (not secure_share_only) and can_use_narration,
-            "max_zoom_layers": max(0, max_zoom_layers),
-        },
+        "controls": controls,
         "states": states,
         "initial_state_id": states[0]["id"] if states else "",
         "branch_options_by_state": {},
@@ -868,3 +935,18 @@ def build_viewer_manifest(
         "primary_member_id": primary_member_id or None,
         "has_uploaded_portraits": any(_normalize_value(state.get("image")) for state in states),
     }
+    if lane == "organization":
+        manifest["viewer_modes"] = [
+            {"id": "current_command_view", "available": True},
+            {"id": "historical_date_view", "available": False},
+            {"id": "succession_timeline", "available": False},
+            {"id": "officer_wall", "available": False},
+            {"id": "continuity_map", "available": False},
+            {"id": "linked_organization_view", "available": False},
+        ]
+        manifest["family"] = None
+        manifest["instructions"] = (
+            "Navigate protected organization command portraits. "
+            "Unavailable command views remain locked until configured."
+        )
+    return manifest

--- a/backend/tests/test_phase3_organization_viewer_anchor.py
+++ b/backend/tests/test_phase3_organization_viewer_anchor.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from app.services import intake_pipeline_service, viewer_manifest_service
+
+
+@dataclass
+class _InsertResult:
+    inserted_id: ObjectId
+
+
+class _Cursor(list):
+    def sort(self, key, direction):
+        reverse = int(direction) < 0
+        return _Cursor(sorted(self, key=lambda doc: doc.get(key), reverse=reverse))
+
+
+class _Collection:
+    def __init__(self, docs=None):
+        self.docs = [dict(doc) for doc in (docs or [])]
+
+    def find_one(self, query=None, sort=None):
+        query = query or {}
+        matches = [doc for doc in self.docs if self._matches(doc, query)]
+        if sort and matches:
+            key, direction = sort[0]
+            reverse = int(direction) < 0
+            matches.sort(key=lambda doc: doc.get(key), reverse=reverse)
+        return dict(matches[0]) if matches else None
+
+    def find(self, query=None):
+        query = query or {}
+        return _Cursor([dict(doc) for doc in self.docs if self._matches(doc, query)])
+
+    def insert_one(self, doc):
+        materialized = dict(doc)
+        materialized.setdefault("_id", ObjectId())
+        self.docs.append(materialized)
+        return _InsertResult(inserted_id=materialized["_id"])
+
+    def update_one(self, query, update):
+        target = None
+        for doc in self.docs:
+            if self._matches(doc, query):
+                target = doc
+                break
+        if target is None:
+            return
+        if "$set" in update:
+            target.update(update["$set"])
+        if "$unset" in update:
+            for key in update["$unset"]:
+                target.pop(key, None)
+
+    @staticmethod
+    def _matches(doc, query):
+        for key, value in query.items():
+            if isinstance(value, dict) and "$in" in value:
+                if doc.get(key) not in value["$in"]:
+                    return False
+            else:
+                if doc.get(key) != value:
+                    return False
+        return True
+
+
+class _FakeDB(dict):
+    def __getitem__(self, key):
+        if key not in self:
+            self[key] = _Collection()
+        return dict.__getitem__(self, key)
+
+
+def test_command_structure_network_provisioning_does_not_create_family_or_member_records():
+    submission_id = ObjectId()
+    now = datetime.now(timezone.utc)
+    db = _FakeDB(
+        {
+            "intake_submissions": _Collection(
+                [
+                    {
+                        "_id": submission_id,
+                        "status": "approved",
+                        "email": "commander@example.com",
+                        "package_code": "command_structure_network",
+                        "package_name": "Command Structure Network",
+                        "household": {
+                            "household_name": "Joint Task Force",
+                            "primary_contact_name": "Commander Prime",
+                            "project_scope": "Command graph setup",
+                        },
+                        "family_map": {},
+                        "consent": {},
+                        "review": {},
+                        "created_at": now,
+                        "updated_at": now,
+                    }
+                ]
+            ),
+            "families": _Collection(),
+            "family_members": _Collection(),
+            "households": _Collection(),
+            "projects": _Collection(),
+            "organization_profiles": _Collection(),
+            "organization_people": _Collection(),
+        }
+    )
+
+    with (
+        patch.object(intake_pipeline_service, "get_database", return_value=db),
+        patch.object(viewer_manifest_service, "get_database", return_value=db),
+        patch.object(
+            intake_pipeline_service,
+            "transition_project",
+            side_effect=lambda project_id, _phase, _actor: db["projects"].find_one(
+                {"_id": ObjectId(project_id)}
+            ),
+        ),
+    ):
+        intake_pipeline_service.provision_build_from_submission(
+            submission_id=str(submission_id),
+            provisioned_by="admin@example.com",
+            provisioned_by_user_id="admin-1",
+        )
+
+    assert db["families"].docs == []
+    assert db["family_members"].docs == []
+    project = db["projects"].docs[0]
+    assert project["project_lane"] == "organization"
+    assert project["family_id"] is None
+
+
+def test_command_structure_network_manifest_uses_organization_command_mode_and_org_controls():
+    project = {
+        "_id": "org-project-1",
+        "project_lane": "organization",
+        "project_name": "Joint Task Force",
+        "package_code": "command_structure_network",
+        "package_name": "Command Structure Network",
+        "organization_id": "org-1",
+    }
+    db = _FakeDB(
+        {
+            "organization_profiles": _Collection(
+                [
+                    {
+                        "organization_id": "org-1",
+                        "display_name": "Joint Task Force",
+                        "description": "Operational command view",
+                    }
+                ]
+            ),
+            "organization_people": _Collection(),
+            "uploaded_files": _Collection(),
+        }
+    )
+
+    with (
+        patch.object(viewer_manifest_service, "get_database", return_value=db),
+        patch.object(viewer_manifest_service, "resolve_project_for_viewer", return_value=project),
+        patch.object(viewer_manifest_service, "_find_submission_for_project", return_value=None),
+    ):
+        manifest = viewer_manifest_service.build_viewer_manifest(
+            current_user={"id": "user-1", "email": "owner@example.com"},
+            project_id="org-project-1",
+        )
+
+    assert manifest["mode"] == "organization_command"
+    assert manifest.get("family") is None
+    controls = manifest["controls"]
+    assert "allow_lineage_navigation" not in controls
+    assert "allow_branch_navigation" not in controls
+    assert controls["allow_command_navigation"] is True
+    assert controls["allow_role_navigation"] is True
+
+    mode_map = {item["id"]: bool(item["available"]) for item in manifest.get("viewer_modes", [])}
+    assert mode_map == {
+        "current_command_view": True,
+        "historical_date_view": False,
+        "succession_timeline": False,
+        "officer_wall": False,
+        "continuity_map": False,
+        "linked_organization_view": False,
+    }
+    assert "organization command portraits" in manifest["instructions"].lower()
+
+
+def test_household_manifest_keeps_family_viewer_controls():
+    project = {
+        "_id": "project-household",
+        "project_name": "Household Workspace",
+        "package_code": "household_foundation",
+        "package_name": "Household Foundation",
+    }
+    family = {"_id": "family-household", "family_name": "Household Family"}
+    primary_member = {"_id": "member-household", "generation": 1}
+
+    with (
+        patch.object(
+            viewer_manifest_service,
+            "get_database",
+            return_value=_FakeDB({"family_members": _Collection()}),
+        ),
+        patch.object(viewer_manifest_service, "resolve_project_for_viewer", return_value=project),
+        patch.object(viewer_manifest_service, "_find_submission_for_project", return_value=None),
+        patch.object(
+            viewer_manifest_service,
+            "load_project_workspace_anchor",
+            return_value=(family, primary_member, project),
+        ),
+    ):
+        manifest = viewer_manifest_service.build_viewer_manifest(
+            current_user={"id": "user-1", "email": "owner@example.com"},
+            project_id="project-household",
+        )
+
+    assert manifest["mode"] == "dynamic"
+    controls = manifest["controls"]
+    assert controls["allow_lineage_navigation"] is True
+    assert controls["allow_branch_navigation"] is True
+    assert "viewer_modes" not in manifest


### PR DESCRIPTION
### Motivation
- Prevent organization-lane viewer logic from creating `families` / `family_members` anchor records and ensure viewer mode and language are organization-native for the Command Structure Network package.
- Meet Command Structure Network model requirements: use org-native entities and avoid family/household semantics and controls for organization projects.

### Description
- Updated `backend/app/services/viewer_manifest_service.py` to load organization anchors from `organization_profiles` and `organization_people` when the project lane is `organization`, and to short-circuit anchor provisioning for organization lane so no `families` / `family_members` are created.
- Switched organization viewer manifest `mode` to `organization_command`, replaced family/lineage controls with organization-specific controls (`allow_command_navigation`, `allow_role_navigation`, etc.), and removed family fallback (`family` set to `null`) and family-language copy for org workspaces.
- Added explicit `viewer_modes` for organization manifests with `current_command_view` available and the other organization modes present but marked unavailable.
- Small UX/data improvements: project summary now includes `organization_id` and `_display_name` was extended to prefer `full_name` when present.
- Added test file `backend/tests/test_phase3_organization_viewer_anchor.py` that verifies provisioning does not create family records, organization manifest mode/controls/available-modes, and a household regression guard.

### Testing
- Added and ran `backend/tests/test_phase3_organization_viewer_anchor.py`, all tests passed (3 passed).
- Ran the full backend test suite via `cd backend && python -m pytest -q tests`, resulting in `195 passed`.
- The new tests assert that `provision_build_from_submission` for `command_structure_network` leaves `families` and `family_members` empty and that `build_viewer_manifest` for organization lane returns `mode: "organization_command"`, organization controls, `viewer_modes` with unavailable modes, and `family` set to `null`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f9d8b18c832da19f12f6802c9352)