### PR TITLE
Fix nullish coalescing syntax in signin flow

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -464,8 +464,7 @@
       ),
       lineage_experience_support: Boolean(
         profile?.lineage_experience_support ??
-          lane === "household" ||
-          lane === "network",
+          (lane === "household" || lane === "network"),
       ),
       organization_command_scope: Boolean(
         profile?.organization_command_scope ?? lane === "organization",


### PR DESCRIPTION
This pull request makes a small change to the `auth.js` file, updating the logic for setting the `lineage_experience_support` property to clarify the grouping of conditions. The functional behavior remains the same.