### PR TITLE
Fix red errors after adding mobile environment

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -563,12 +563,18 @@ def _db():
 
 
 def _extract_project_id_from_request(request: Request) -> str | None:
+    def _safe_get(value: Any, key: str) -> Any:
+        getter = getattr(value, "get", None)
+        if callable(getter):
+            return getter(key)
+        return None
+
     path_params = getattr(request, "path_params", None)
     query_params = getattr(request, "query_params", None)
 
     candidates = [
-        path_params.get("project_id") if hasattr(path_params, "get") else None,
-        query_params.get("project_id") if hasattr(query_params, "get") else None,
+        _safe_get(path_params, "project_id"),
+        _safe_get(query_params, "project_id"),
     ]
     for candidate in candidates:
         normalized = _normalize_value(candidate)

--- a/backend/app/routes/project_entitlements.py
+++ b/backend/app/routes/project_entitlements.py
@@ -79,7 +79,7 @@ def apply_project_entitlement(
             user_id=payload.user_id,
             package_code=payload.package_code,
             active_addons=payload.active_addons,
-            maintenance_plan=payload.maintenance_plan,
+            maintenance_plan=payload.maintenance_plan or "none",
             delivered_at=payload.delivered_at,
             status=payload.status,
         )

--- a/backend/tests/test_organization_command_structure_network.py
+++ b/backend/tests/test_organization_command_structure_network.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -48,7 +49,11 @@ class FakeCollection:
         docs = self.docs
         if sort:
             key, direction = sort[0]
-            docs = sorted(docs, key=lambda item: item.get(key), reverse=direction < 0)
+            docs = sorted(
+                docs,
+                key=lambda item: cast(Any, item.get(key)),
+                reverse=direction < 0,
+            )
         for doc in docs:
             if self._matches(doc, query):
                 return doc

--- a/backend/tests/test_phase3_organization_viewer_anchor.py
+++ b/backend/tests/test_phase3_organization_viewer_anchor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any, cast
 from unittest.mock import patch
 
 from bson import ObjectId
@@ -17,7 +18,9 @@ class _InsertResult:
 class _Cursor(list):
     def sort(self, key, direction):
         reverse = int(direction) < 0
-        return _Cursor(sorted(self, key=lambda doc: doc.get(key), reverse=reverse))
+        return _Cursor(
+            sorted(self, key=lambda doc: cast(Any, doc.get(key)), reverse=reverse)
+        )
 
 
 class _Collection:
@@ -30,7 +33,7 @@ class _Collection:
         if sort and matches:
             key, direction = sort[0]
             reverse = int(direction) < 0
-            matches.sort(key=lambda doc: doc.get(key), reverse=reverse)
+            matches.sort(key=lambda doc: cast(Any, doc.get(key)), reverse=reverse)
         return dict(matches[0]) if matches else None
 
     def find(self, query=None):


### PR DESCRIPTION
This pull request introduces several improvements to type safety and default handling in both application and test code. The main changes involve safer dictionary access patterns, explicit handling of missing values, and improved type annotations to help static analysis and prevent runtime errors.

**Type safety and dictionary access improvements:**

* Introduced the `_safe_get` helper function in `_extract_project_id_from_request` to safely access dictionary-like objects, replacing direct calls to `.get` and preventing potential attribute errors (`auth.py`).
* Updated sorting logic in test mocks (`_Cursor.sort` and `find_one` methods) to use `cast(Any, ...)` when accessing dictionary values, improving compatibility with static type checkers and preventing type inference issues (`test_phase3_organization_viewer_anchor.py`, `test_organization_command_structure_network.py`). [[1]](diffhunk://#diff-f81ae4fff4a0ae602a26f2612d58ce8d0bd48d8f6777741361f8c47ca6835ee8L20-R23) [[2]](diffhunk://#diff-f81ae4fff4a0ae602a26f2612d58ce8d0bd48d8f6777741361f8c47ca6835ee8L33-R36) [[3]](diffhunk://#diff-3b21dc6272d7e16284377c2642142ad6a7a6dd4bd975e00bb38e379a048eec8aL51-R56)

**Default value handling:**

* Modified the `maintenance_plan` assignment in `apply_project_entitlement` to default to `"none"` if not provided, ensuring a consistent value and preventing possible errors from `None` values (`project_entitlements.py`).

**Type annotation enhancements in tests:**

* Added imports for `Any` and `cast` from `typing` to test files to support the above changes and enhance type hinting (`test_phase3_organization_viewer_anchor.py`, `test_organization_command_structure_network.py`). [[1]](diffhunk://#diff-f81ae4fff4a0ae602a26f2612d58ce8d0bd48d8f6777741361f8c47ca6835ee8R5) [[2]](diffhunk://#diff-3b21dc6272d7e16284377c2642142ad6a7a6dd4bd975e00bb38e379a048eec8aR5)