### PR TITLE
Add guided intake options, public package vault entitlements, project limits, and CEO super-admin

### DIFF
--- a/backend/app/core/admin_permission_registry.py
+++ b/backend/app/core/admin_permission_registry.py
@@ -55,6 +55,7 @@ ROLE_CAPABILITIES: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit capability grants.
     "admin": set(),
     "super_admin": {"*"},
+    "ceo_super_admin": {"*"},
     "executive_tech_admin": {
         "manage_roles",
         "manage_users_full",
@@ -94,6 +95,7 @@ ROLE_PERMISSION_MAP: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit permission grants.
     "admin": set(),
     "super_admin": {"*"},
+    "ceo_super_admin": {"*"},
     "executive_tech_admin": {
         "admin.access",
         "admin.audit.read",
@@ -148,6 +150,10 @@ ROLE_METADATA: dict[str, dict[str, str]] = {
         "name": "Super Admin",
         "description": "Break-glass emergency full override controls.",
     },
+    "ceo_super_admin": {
+        "name": "CEO Super Admin",
+        "description": "CEO-level full platform controls with required audit logging.",
+    },
     "executive_tech_admin": {
         "name": "Executive Technical Admin",
         "description": "Executive technical operations and admin control center access.",
@@ -167,7 +173,8 @@ ROLE_METADATA: dict[str, dict[str, str]] = {
 }
 
 OFFICER_ROLE_MAPPING: dict[str, list[str]] = {
-    "l.robinson@tomboflight.com": ["SUPERADMIN", "EXECUTIVE_TECH_ADMIN"],
+    "l.robinson@tomboflight.com": ["CEO_SUPER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
+    "l.robinson@tomboflight": ["CEO_SUPER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
     "marquis.l.floyd@tomboflight.com": ["CMO_ADMIN"],
     "jenn.wood@tomboflight.com": ["CFO_ADMIN"],
     "k.goffigan@tomboflight.com": ["COO_ADMIN"],

--- a/backend/app/core/dropdown_registry.py
+++ b/backend/app/core/dropdown_registry.py
@@ -81,6 +81,92 @@ ORGANIZATION_SUBTYPE_OPTIONS: dict[str, list[dict[str, str]]] = {
     ],
 }
 
+
+
+INTAKE_DROPDOWN_REGISTRY: dict[str, list[dict[str, str]]] = {
+    "who_are_you_adding": [
+        {"key": "myself", "label": "Myself"},
+        {"key": "parent", "label": "Parent"},
+        {"key": "child", "label": "Child"},
+        {"key": "spouse_or_partner", "label": "Spouse or Partner"},
+        {"key": "sibling", "label": "Sibling"},
+        {"key": "grandparent", "label": "Grandparent"},
+        {"key": "grandchild", "label": "Grandchild"},
+        {"key": "other_relative", "label": "Other Relative"},
+        {"key": "household_member", "label": "Household Member"},
+        {"key": "linked_household_member", "label": "Linked Household Member"},
+        {"key": "organization_member", "label": "Organization Member"},
+    ],
+    "exact_relationship_type": [
+        {"key": "biological_parent", "label": "Biological Parent"},
+        {"key": "adoptive_parent", "label": "Adoptive Parent"},
+        {"key": "step_parent", "label": "Step Parent"},
+        {"key": "guardian", "label": "Guardian"},
+        {"key": "spouse", "label": "Spouse"},
+        {"key": "former_spouse", "label": "Former Spouse"},
+        {"key": "sibling", "label": "Sibling"},
+        {"key": "household_member", "label": "Household Member"},
+        {"key": "linked_household", "label": "Linked Household"},
+    ],
+    "where_should_this_belong": [
+        {"key": "auto", "label": "Let Tomb of Light place this automatically"},
+        {"key": "main_household_line", "label": "Main Household Line"},
+        {"key": "linked_household_branch", "label": "Linked Household Branch"},
+        {"key": "organization_structure", "label": "Organization Structure"},
+    ],
+    "what_are_you_uploading": [
+        {"key": "portrait_photo", "label": "Portrait Photo"},
+        {"key": "group_photo", "label": "Group Photo"},
+        {"key": "document", "label": "Document"},
+        {"key": "certificate", "label": "Certificate"},
+        {"key": "private_voice_message", "label": "Private Voice Message"},
+        {"key": "private_video_message", "label": "Private Video Message"},
+        {"key": "narration_audio", "label": "Narration Audio"},
+        {"key": "memorial_media", "label": "Memorial Media"},
+        {"key": "verification_evidence", "label": "Verification Evidence"},
+    ],
+    "who_does_this_item_belong_to": [
+        {"key": "project", "label": "Project"},
+        {"key": "household", "label": "Household"},
+        {"key": "specific_person", "label": "Specific Person"},
+        {"key": "relationship_record", "label": "Relationship Record"},
+        {"key": "organization_unit", "label": "Organization Unit"},
+    ],
+    "privacy_scope": [
+        {"key": "only_me", "label": "Only Me"},
+        {"key": "me_and_co_owner", "label": "Me and Co-Owner"},
+        {"key": "household_private", "label": "Household Private"},
+        {"key": "branch_shared", "label": "Branch Shared"},
+        {"key": "linked_household_shared", "label": "Linked Household Shared"},
+        {"key": "public_memorial", "label": "Public Memorial"},
+        {"key": "minor_protected", "label": "Minor Protected"},
+    ],
+    "release_mode": [
+        {"key": "immediate", "label": "Immediate"},
+        {"key": "scheduled", "label": "Scheduled"},
+        {"key": "manual", "label": "Manual"},
+    ],
+    "verification_choice": [
+        {"key": "no_verification_needed", "label": "No Verification Needed"},
+        {"key": "attach_supporting_evidence", "label": "Attach Supporting Evidence"},
+        {
+            "key": "this_is_evidence_for_existing_person_or_relationship",
+            "label": "Evidence for Existing Person or Relationship",
+        },
+    ],
+}
+
+
+PRIVACY_SCOPE_CANONICAL_MAP: dict[str, str] = {
+    "only_me": "private_to_owner",
+    "me_and_co_owner": "private_to_owner_and_co_owner",
+    "household_private": "household_private",
+    "branch_shared": "branch_shared",
+    "linked_household_shared": "linked_family_shared",
+    "public_memorial": "public_memorial",
+    "minor_protected": "minor_protected",
+}
+
 SHARED_DROPDOWN_REGISTRY: dict[str, list[dict[str, str]]] = {
     "organization_type": [
         {"key": key, "label": ORGANIZATION_TYPE_LABELS[key]} for key in ORGANIZATION_TYPE_OPTIONS
@@ -161,3 +247,11 @@ def assert_no_duplicate_dropdown_keys() -> None:
                     f"Dropdown group '{group_key}' contains duplicate key '{option_key}'."
                 )
             seen.add(option_key)
+
+
+def get_intake_dropdowns() -> dict[str, list[dict[str, str]]]:
+    return deepcopy(INTAKE_DROPDOWN_REGISTRY)
+
+
+def get_privacy_scope_canonical_map() -> dict[str, str]:
+    return deepcopy(PRIVACY_SCOPE_CANONICAL_MAP)

--- a/backend/app/core/package_catalog.py
+++ b/backend/app/core/package_catalog.py
@@ -74,6 +74,106 @@ ADDON_CODE_ALIASES: dict[str, str] = {
 PROJECT_LANES = frozenset({"portrait", "household", "network", "organization"})
 COMMAND_STRUCTURE_ORG_NODE_LIMIT = 15
 
+ALLOWED_VISIBILITY_SCOPES = [
+    "private_to_owner",
+    "private_to_owner_and_co_owner",
+    "household_private",
+    "branch_shared",
+    "linked_family_shared",
+    "public_memorial",
+    "minor_protected",
+]
+
+BASE_ALLOWED_ASSET_TYPES = [
+    "portrait_photo",
+    "group_photo",
+    "document",
+    "certificate",
+    "verification_evidence",
+]
+
+EXTENDED_ALLOWED_ASSET_TYPES = BASE_ALLOWED_ASSET_TYPES + [
+    "private_voice_message",
+    "private_video_message",
+    "narration_audio",
+    "memorial_media",
+]
+
+VAULT_ENTITLEMENT_BY_PACKAGE: dict[str, dict[str, Any]] = {
+    "legacy_snapshot": {
+        "can_use_personal_vault": True,
+        "can_use_household_vault": False,
+        "can_use_future_message_vault": False,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": False,
+        "allowed_asset_types": BASE_ALLOWED_ASSET_TYPES,
+    },
+    "legacy_portrait_intro": {
+        "can_use_personal_vault": True,
+        "can_use_household_vault": False,
+        "can_use_future_message_vault": False,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": False,
+        "allowed_asset_types": BASE_ALLOWED_ASSET_TYPES,
+    },
+    "digital_legacy_portrait": {
+        "can_use_personal_vault": True,
+        "can_use_household_vault": False,
+        "can_use_future_message_vault": False,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": True,
+        "allowed_asset_types": EXTENDED_ALLOWED_ASSET_TYPES,
+    },
+    "household_foundation": {
+        "can_use_personal_vault": False,
+        "can_use_household_vault": True,
+        "can_use_future_message_vault": False,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": True,
+        "allowed_asset_types": EXTENDED_ALLOWED_ASSET_TYPES,
+    },
+    "heirloom_legacy_tree": {
+        "can_use_personal_vault": False,
+        "can_use_household_vault": True,
+        "can_use_future_message_vault": True,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": True,
+        "allowed_asset_types": EXTENDED_ALLOWED_ASSET_TYPES,
+    },
+    "legacy_plus": {
+        "can_use_personal_vault": False,
+        "can_use_household_vault": True,
+        "can_use_future_message_vault": True,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": True,
+        "allowed_asset_types": EXTENDED_ALLOWED_ASSET_TYPES,
+    },
+    "family_estate_concierge": {
+        "can_use_personal_vault": False,
+        "can_use_household_vault": True,
+        "can_use_future_message_vault": True,
+        "can_use_linked_household_vault": True,
+        "can_use_organization_records_vault": False,
+        "can_use_scheduled_reveal": True,
+        "allowed_asset_types": EXTENDED_ALLOWED_ASSET_TYPES,
+    },
+    "command_structure_network": {
+        "can_use_personal_vault": False,
+        "can_use_household_vault": False,
+        "can_use_future_message_vault": False,
+        "can_use_linked_household_vault": False,
+        "can_use_organization_records_vault": True,
+        "can_use_scheduled_reveal": False,
+        "allowed_asset_types": ["document", "certificate", "verification_evidence", "private_voice_message"],
+    },
+}
+
 PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
     "legacy_snapshot": {
         "package_code": "legacy_snapshot",
@@ -719,7 +819,8 @@ ADDON_CATALOG: dict[str, dict[str, Any]] = {
 def _copy_package(value: dict[str, Any]) -> dict[str, Any]:
     package = deepcopy(value)
     package["package_lane"] = normalize_package_type(package.get("package_lane"))
-    return package
+    package_code = str(package.get("package_code") or "").strip()
+    return _with_vault_entitlements(package_code, package)
 
 
 def get_package_catalog() -> dict[str, dict[str, Any]]:
@@ -850,3 +951,40 @@ def get_addon(addon_code: str) -> dict[str, Any] | None:
         return None
     value = ADDON_CATALOG.get(normalized)
     return deepcopy(value) if value else None
+
+
+def _with_vault_entitlements(package_code: str, package: dict[str, Any]) -> dict[str, Any]:
+    entitlements = deepcopy(VAULT_ENTITLEMENT_BY_PACKAGE.get(package_code) or {})
+    package.update(entitlements)
+    package["allowed_visibility_scopes"] = deepcopy(ALLOWED_VISIBILITY_SCOPES)
+    return package
+
+
+def get_public_package_catalog() -> list[dict[str, Any]]:
+    packages: list[dict[str, Any]] = []
+    for package_code, raw in PACKAGE_CATALOG.items():
+        package = _with_vault_entitlements(package_code, _copy_package(raw))
+        control_profile = get_package_control_profile(package_code) or {}
+        mint_policy = dict(control_profile.get("mint_policy") or {})
+        package["maintenance_meaning"] = {
+            "covers": [
+                "storage continuity",
+                "protected access",
+                "retrieval",
+                "role-based workspace continuity",
+                "package-compatible platform updates",
+                "delivery continuity",
+                "normal support for the delivered project",
+            ],
+            "does_not_cover": [
+                "a new build",
+                "new branch creation",
+                "genealogy research",
+                "major redesign",
+                "add-ons not purchased",
+            ],
+        }
+        package["verification_meaning"] = "Verification is a private evidence and review path used to support trusted lineage records."
+        package["minting_available"] = bool(mint_policy.get("product_includes_onchain_anchor"))
+        packages.append(package)
+    return packages

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from app.routes.identity_anchor import router as identity_anchor_router
 from app.routes.experience import router as experience_router
 from app.routes.identity_links import router as identity_links_router
 from app.routes.intake import router as intake_router
+from app.routes.intake_options import router as intake_options_router
 from app.routes.intake_submissions import router as intake_submissions_router
 from app.routes.issued_certificates import router as issued_certificates_router
 from app.routes.lineage_certificate import router as lineage_certificate_router
@@ -66,6 +67,7 @@ from app.services.admin_access_bootstrap_service import bootstrap_admin_access_c
 from app.services.admin_control_service import ensure_finance_event_indexes
 from app.services.organization_service import ensure_organization_indexes
 from app.routes.package_catalog import router as package_catalog_router
+from app.routes.package_catalog_public import router as package_catalog_public_router
 from app.routes.presence import router as presence_router
 from app.routes.projects import router as projects_router
 from app.routes.project_entitlements import router as project_entitlements_router
@@ -196,6 +198,7 @@ app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(billing_router)
 app.include_router(intake_router)
+app.include_router(intake_options_router)
 app.include_router(intake_submissions_router)
 app.include_router(admin_intake_submissions_router)
 app.include_router(admin_control_center_router)
@@ -219,6 +222,7 @@ app.include_router(graph_integrity_router)
 app.include_router(orders_router)
 app.include_router(organizations_router)
 app.include_router(package_catalog_router)
+app.include_router(package_catalog_public_router)
 app.include_router(uploads_router)
 app.include_router(workspace_access_router)
 app.include_router(workspace_access_legacy_router)

--- a/backend/app/routes/intake_options.py
+++ b/backend/app/routes/intake_options.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.dropdown_registry import (
+    get_intake_dropdowns,
+    get_privacy_scope_canonical_map,
+)
+
+router = APIRouter(tags=["Intake Options"])
+
+
+@router.get("/intake/options")
+def get_intake_options_route():
+    return {
+        "dropdowns": get_intake_dropdowns(),
+        "privacy_scope_mapping": get_privacy_scope_canonical_map(),
+        "defaults": {
+            "where_should_this_belong": "auto",
+            "privacy_scope": "household_private",
+            "release_mode": "immediate",
+        },
+    }

--- a/backend/app/routes/package_catalog.py
+++ b/backend/app/routes/package_catalog.py
@@ -6,6 +6,7 @@ from app.core.package_catalog import (
     get_addon_catalog,
     get_package_identifier_map,
     get_package_catalog,
+    get_public_package_catalog,
     list_package_control_profiles,
 )
 from app.core.organization_template_catalog import get_organization_template_catalog
@@ -90,3 +91,8 @@ def check_addon_compatibility_route(package_code: str, addon_code: str):
         "addon_code": addon_code,
         "allowed": allowed,
     }
+
+
+@router.get("/public")
+def get_public_package_catalog_route():
+    return {"packages": get_public_package_catalog()}

--- a/backend/app/routes/package_catalog_public.py
+++ b/backend/app/routes/package_catalog_public.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.package_catalog import get_public_package_catalog
+
+router = APIRouter(tags=["Package Catalog"])
+
+
+@router.get("/package-catalog/public")
+def get_public_package_catalog_route():
+    return {"packages": get_public_package_catalog()}

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from app.database import get_database
+
 from app.dependencies.auth import (
     get_current_user,
     has_internal_admin_access,
@@ -11,6 +13,7 @@ from app.schemas.experience import ExperienceLaneResponse
 from app.schemas.project import ProjectCreate, ProjectResponse, build_project_response
 from app.services.access_context_service import describe_project_experience_lane
 from app.services.project_service import create_project, list_projects
+from app.services.project_entitlement_service import get_project_entitlement
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
 
@@ -69,3 +72,43 @@ def get_project_experience_lane(
         return describe_project_experience_lane(current_user, project_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/{project_id}/limits")
+def get_project_limits(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    current_user_id = _current_user_id(current_user)
+    current_user_email = _current_user_email(current_user)
+
+    projects = list_projects(
+        owner_user_id=current_user_id,
+        owner_email=current_user_email,
+        is_admin=has_internal_admin_access(current_user),
+    )
+    if not any(str(project.get("id") or project.get("_id") or "") == project_id for project in projects):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found.")
+
+    entitlement = get_project_entitlement(project_id)
+    resolved = dict((entitlement or {}).get("resolved_entitlements") or {})
+
+    db = get_database()
+    uploads = list(db["uploaded_files"].find({"project_id": project_id, "quarantined": {"$ne": True}}))
+    usage_upload_count = len(uploads)
+    usage_storage_bytes = int(sum(int(item.get("size_bytes") or 0) for item in uploads))
+
+    return {
+        "project_id": project_id,
+        "limits": {
+            "max_uploads": resolved.get("max_uploads"),
+            "max_storage_gb": resolved.get("max_storage_gb"),
+            "max_members": resolved.get("max_members"),
+            "max_households": resolved.get("max_households"),
+            "max_org_nodes": resolved.get("max_org_nodes"),
+        },
+        "usage": {
+            "uploads": usage_upload_count,
+            "storage_bytes": usage_storage_bytes,
+        },
+    }

--- a/backend/tests/test_admin_access_bootstrap.py
+++ b/backend/tests/test_admin_access_bootstrap.py
@@ -100,7 +100,11 @@ class AdminAccessBootstrapTests(unittest.TestCase):
         mapping = normalized_officer_role_mapping()
         self.assertEqual(
             mapping["l.robinson@tomboflight.com"],
-            ["executive_tech_admin", "super_admin"],
+            ["ceo_super_admin", "executive_tech_admin"],
+        )
+        self.assertEqual(
+            mapping["l.robinson@tomboflight"],
+            ["ceo_super_admin", "executive_tech_admin"],
         )
         self.assertEqual(mapping["jenn.wood@tomboflight.com"], ["finance_admin"])
         self.assertEqual(mapping["marquis.l.floyd@tomboflight.com"], ["marketing_admin"])
@@ -132,7 +136,7 @@ class AdminAccessBootstrapTests(unittest.TestCase):
             for doc in user_role_assignments
             if doc["user_id"] == "u-larry" and doc.get("status") == "active"
         )
-        self.assertEqual(larry_roles, ["executive_tech_admin", "super_admin"])
+        self.assertEqual(larry_roles, ["ceo_super_admin", "executive_tech_admin"])
 
         jenn_roles = [
             doc["role_code"]

--- a/backend/tests/test_intake_options_and_public_catalog.py
+++ b/backend/tests/test_intake_options_and_public_catalog.py
@@ -1,0 +1,39 @@
+import unittest
+
+from app.core.package_catalog import get_package, get_public_package_catalog
+from app.core.dropdown_registry import get_intake_dropdowns, get_privacy_scope_canonical_map
+from app.routes.intake_options import get_intake_options_route
+
+
+class IntakeOptionsTests(unittest.TestCase):
+    def test_intake_options_include_guided_dropdowns_and_defaults(self):
+        payload = get_intake_options_route()
+        dropdowns = payload["dropdowns"]
+        self.assertIn("who_are_you_adding", dropdowns)
+        self.assertIn("exact_relationship_type", dropdowns)
+        self.assertIn("privacy_scope", dropdowns)
+        self.assertEqual(payload["defaults"]["where_should_this_belong"], "auto")
+        self.assertEqual(payload["defaults"]["release_mode"], "immediate")
+
+    def test_privacy_scope_mapping_targets_existing_canonical_values(self):
+        mapping = get_privacy_scope_canonical_map()
+        self.assertEqual(mapping["only_me"], "private_to_owner")
+        self.assertEqual(mapping["linked_household_shared"], "linked_family_shared")
+
+
+class PublicCatalogEntitlementTests(unittest.TestCase):
+    def test_public_catalog_exposes_new_vault_entitlements(self):
+        packages = {item["package_code"]: item for item in get_public_package_catalog()}
+        self.assertTrue(packages["digital_legacy_portrait"]["can_use_scheduled_reveal"])
+        self.assertTrue(packages["family_estate_concierge"]["can_use_linked_household_vault"])
+        self.assertTrue(packages["command_structure_network"]["can_use_organization_records_vault"])
+
+    def test_package_copy_includes_allowed_visibility_scopes(self):
+        package = get_package("legacy_snapshot")
+        assert package is not None
+        self.assertIn("allowed_visibility_scopes", package)
+        self.assertIn("minor_protected", package["allowed_visibility_scopes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
                 <ul class="package-list">
                   <li>1 buyer account</li>
                   <li>Up to 10 uploads</li>
-                  <li>1GB private vault</li>
+                  <li>1GB Personal Vault (private originals, app-controlled access)</li>
                   <li>Verification upload path</li>
                   <li>No household builder</li>
                 </ul>
@@ -502,7 +502,7 @@
                   <li>Up to 20 uploads</li>
                   <li>Up to 6 household members</li>
                   <li>2 zoom layers</li>
-                  <li>3GB encrypted vault storage</li>
+                  <li>3GB Household Vault storage (private originals + role-based sharing)</li>
                   <li>Interactive family viewer</li>
                 </ul>
                 <div class="inline-actions">
@@ -534,7 +534,7 @@
                   <li>Up to 50 uploads</li>
                   <li>Up to 15 family members</li>
                   <li>3–4 zoom layers</li>
-                  <li>10GB encrypted vault</li>
+                  <li>10GB Household Vault + Future Message Vault support</li>
                   <li>Narration-ready structure</li>
                 </ul>
                 <div class="inline-actions">
@@ -566,7 +566,7 @@
                   <li>Up to 100 uploads</li>
                   <li>Up to 30 family members</li>
                   <li>Up to 5 zoom layers</li>
-                  <li>25GB encrypted vault</li>
+                  <li>25GB Household + Future Message Vaults</li>
                   <li>Premium archive structure</li>
                 </ul>
                 <div class="inline-actions">
@@ -597,11 +597,11 @@
                   <span class="meta-pill">Custom scope</span>
                 </div>
                 <ul class="package-list">
-                  <li>Up to 3 family branches</li>
-                  <li>High-capacity archival support</li>
-                  <li>Custom structure planning</li>
-                  <li>White-glove project handling</li>
-                  <li>Premium consultation path</li>
+                  <li>Up to 3 linked households / family branches</li>
+                  <li>50GB linked-household vault capacity</li>
+                  <li>Linked household graph + branch access controls</li>
+                  <li>Private/shared/scheduled vault release controls</li>
+                  <li>Narration enabled + scheduled reveal support</li>
                 </ul>
                 <div class="inline-actions">
                   <a


### PR DESCRIPTION
### Motivation
- Provide guided, dropdown-driven intake metadata so customers aren’t guessing relationship, placement, asset, privacy, or release choices and to map friendly UI labels to canonical backend scopes.
- Surface package-aware vault/storage/asset entitlements and clear public-facing package copy so marketing copy matches implemented capabilities and entitlements.
- Centralize a CEO-level admin role mapping for a canonical production identifier while preserving existing admin/bootstrap logic and package/mint policy behavior.

### Description
- Added a guided intake metadata endpoint `GET /intake/options` and corresponding dropdown registry entries in `backend/app/core/dropdown_registry.py` to drive intake UX and map friendly privacy labels to canonical scopes. (new route: `backend/app/routes/intake_options.py`).
- Extended package catalog with vault/storage entitlement metadata and allowed asset/visibility sets in `backend/app/core/package_catalog.py`, added a `GET /packages/public` and `GET /package-catalog/public` route for copy-ready public catalog payloads (new route: `backend/app/routes/package_catalog_public.py`).
- Added `GET /projects/{project_id}/limits` in `backend/app/routes/projects.py` to return entitlement limits and a current upload/storage usage snapshot pulled from `uploaded_files` for package-aware UI enforcement.
- Introduced `ceo_super_admin` role and normalized CEO account alias mapping (`l.robinson@tomboflight.com` canonical plus `l.robinson@tomboflight` alias) in `backend/app/core/admin_permission_registry.py`, and updated bootstrap tests to reflect the normalization.
- Updated homepage package copy in `index.html` to remove unsupported “encrypted vault” claims and to clarify Personal/Household/Future Message/Linked Household vault and scheduled reveal language.
- Added tests and small integration points: new test `backend/tests/test_intake_options_and_public_catalog.py`, updated `backend/tests/test_admin_access_bootstrap.py`, and wired new routers into `backend/app/main.py` without removing or renaming existing routes.

### Testing
- Ran targeted new/updated tests: `cd backend && pytest -q tests/test_intake_options_and_public_catalog.py tests/test_admin_access_bootstrap.py tests/test_legacy_snapshot_package_contract.py tests/test_package_mapping.py` which completed successfully with `38 passed` in ~1.5s.
- Ran dropdown registry regression tests: `cd backend && pytest -q tests/test_dropdown_registry.py` which completed successfully with `7 passed` in ~0.4s.
- No database migrations or destructive schema changes were required for this patch; changes are read-model/catalog expansions and a centralized role mapping update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fc884090832da512c03dd9f10315)