### PR TITLE
Harden homepage package, extras, minting, and maintenance copy for public launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,9 @@
                   <li>Scope: 1 member (self lane workspace)</li>
                   <li>3 uploads + 0.25GB storage</li>
                   <li>Secure Share viewer + verification upload path</li>
+                  <li>Maintenance options after delivery: $3/mo or $30/yr</li>
                   <li>Guided intake, review, and protected delivery</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                   <li>Upgrade path into Portrait, Household, or Network lanes</li>
                 </ul>
                 <div class="inline-actions">
@@ -434,7 +436,9 @@
                   <li>Scope: 1 member (self lane workspace)</li>
                   <li>5 uploads + 0.5GB storage</li>
                   <li>Portrait production workflow + Secure Share viewer</li>
+                  <li>Maintenance options after delivery: $4/mo or $40/yr</li>
                   <li>Guided intake, review, and protected delivery</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                   <li>Upgrade path into higher portrait, household, or network builds</li>
                 </ul>
                 <div class="inline-actions">
@@ -468,7 +472,9 @@
                   <li>Scope: 1 member (self lane workspace)</li>
                   <li>10 uploads + 1GB Personal Vault storage</li>
                   <li>Interactive viewer + link-key-enabled delivery controls</li>
+                  <li>Maintenance options after delivery: $6/mo or $60/yr</li>
                   <li>Includes one controlled on-chain anchor eligibility path</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                   <li>Upgrade path into household and network packages</li>
                 </ul>
                 <div class="inline-actions">
@@ -502,8 +508,10 @@
                   <li>Scope: 1 household, up to 6 members</li>
                   <li>20 uploads + 3GB Household Vault storage</li>
                   <li>2 zoom layers + family tree builder</li>
+                  <li>Maintenance options after delivery: $9/mo or $95/yr</li>
                   <li>Lineage certificate tools + guided family intake</li>
                   <li>Includes one controlled on-chain anchor eligibility path</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                 </ul>
                 <div class="inline-actions">
                   <a
@@ -534,8 +542,10 @@
                   <li>Scope: 1 household, up to 15 members</li>
                   <li>50 uploads + 10GB Household Vault storage</li>
                   <li>4 zoom layers + family tree and relationship tools</li>
+                  <li>Maintenance options after delivery: $18/mo or $180/yr</li>
                   <li>Narration-ready + certificate-ready structure</li>
                   <li>Includes one controlled on-chain anchor eligibility path</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                 </ul>
                 <div class="inline-actions">
                   <a
@@ -566,8 +576,10 @@
                   <li>Scope: 1 household, up to 30 members</li>
                   <li>100 uploads + 25GB Household Vault storage</li>
                   <li>5 zoom layers + premium archive structure</li>
+                  <li>Maintenance options after delivery: $28/mo or $280/yr</li>
                   <li>Narration-ready + certificate-ready delivery path</li>
                   <li>Includes one controlled on-chain anchor eligibility path</li>
+                  <li>What you get now: live checkout and private workspace provisioning handoff</li>
                 </ul>
                 <div class="inline-actions">
                   <a
@@ -598,10 +610,12 @@
                 </div>
                 <ul class="package-list">
                   <li>Scope: up to 3 linked households / branches, up to 999 members</li>
-                  <li>250 uploads + 50GB linked-household storage capacity</li>
-                  <li>Linked household graph, branch controls, and guided white-glove handling</li>
+                  <li>250 uploads + 50GB linked-household storage capacity + deep zoom scope</li>
+                  <li>Linked household graph, branch controls, link keys, and guided white-glove handling</li>
+                  <li>Maintenance options after delivery: $60/mo or $600/yr</li>
                   <li>Narration-ready, certificate-ready, and continuity stewardship tools</li>
                   <li>Includes up to 3 controlled on-chain anchor eligibility paths (custom scope available)</li>
+                  <li>What you get now: live checkout, concierge onboarding, and private network workspace provisioning</li>
                 </ul>
                 <div class="inline-actions">
                   <a
@@ -631,9 +645,11 @@
                 <ul class="package-list">
                   <li>Scope: up to 15 organization nodes</li>
                   <li>25 uploads + 5GB organization storage capacity</li>
-                  <li>Leadership viewer + command-role continuity mapping</li>
-                  <li>Linked organization support and admin seat expansion paths</li>
+                  <li>Leadership viewer + command-role continuity mapping + succession timeline support</li>
+                  <li>Organization intake workflow, linked-unit support, and admin-seat expansion paths</li>
+                  <li>Maintenance options after delivery: $20/mo or $200/yr</li>
                   <li>On-chain anchor path is controlled and opt-in (not default auto-mint)</li>
+                  <li>What you get now: live checkout and protected organization workspace provisioning</li>
                 </ul>
                 <div class="inline-actions">
                   <a
@@ -671,11 +687,11 @@
               <article class="feature-card feature-card-clean">
                 <h3>Portrait / Self-Service Extras</h3>
                 <ul class="package-list">
-                  <li>Extra Upload Pack</li>
-                  <li>Extra Storage</li>
-                  <li>Portrait Polish</li>
-                  <li>Tribute Narration</li>
-                  <li>Rush Delivery (quoted by scope)</li>
+                  <li>Extra Upload Pack — $49</li>
+                  <li>Extra Storage — $50</li>
+                  <li>Portrait Polish — $79</li>
+                  <li>Tribute Narration — $99</li>
+                  <li>Rush Delivery — quoted by scope</li>
                 </ul>
                 <div class="inline-actions">
                   <a class="btn btn-secondary" href="#extras" data-payment-link="extra_upload_pack" target="_blank" rel="noopener noreferrer">Buy Extra Upload Pack</a>
@@ -688,13 +704,13 @@
               <article class="feature-card feature-card-clean">
                 <h3>Household / Lineage Extras</h3>
                 <ul class="package-list">
-                  <li>Extra Mapped Person</li>
-                  <li>Extra Zoom Layer</li>
-                  <li>Additional Narration Minute</li>
-                  <li>On-Site Photo Scanning</li>
-                  <li>Extra Linked Household</li>
-                  <li>Extra Branch</li>
-                  <li>White-Glove Archive Support</li>
+                  <li>Extra Mapped Person — $35</li>
+                  <li>Extra Zoom Layer — $175</li>
+                  <li>Additional Narration Minute — $200</li>
+                  <li>On-Site Photo Scanning — $499</li>
+                  <li>Extra Linked Household — $1,000</li>
+                  <li>Extra Branch — $1,000</li>
+                  <li>White-Glove Archive Support — $1,499</li>
                 </ul>
                 <div class="inline-actions">
                   <a class="btn btn-secondary" href="#extras" data-payment-link="extra_mapped_person" target="_blank" rel="noopener noreferrer">Buy Extra Mapped Person</a>
@@ -710,10 +726,10 @@
               <article class="feature-card feature-card-clean">
                 <h3>Organization Extras</h3>
                 <ul class="package-list">
-                  <li>Extra Organization Node</li>
-                  <li>Extra Organization Level</li>
-                  <li>Extra Admin Seat</li>
-                  <li>Command Report Add-On</li>
+                  <li>Extra Organization Node — $45</li>
+                  <li>Extra Organization Level — $175</li>
+                  <li>Extra Admin Seat — $99</li>
+                  <li>Command Report Add-On — $149</li>
                 </ul>
                 <div class="inline-actions">
                   <a class="btn btn-secondary" href="#extras" data-payment-link="extra_org_node" target="_blank" rel="noopener noreferrer">Buy Extra Org Node</a>
@@ -738,6 +754,8 @@
                 <li>Minting covers collectible preparation, metadata setup, mint execution, and applicable blockchain network fees.</li>
                 <li>Private vault materials are not minted by default.</li>
                 <li>Only approved delivery-safe collectible assets are eligible for minting.</li>
+                <li>Included mint paths: Digital Legacy Portrait, Household Foundation, Heirloom Legacy Tree, Legacy Plus (1), Family Estate Concierge (up to 3).</li>
+                <li>Command Structure Network minting is opt-in and fee-based (service + network), not included by default.</li>
                 <li>Automatic mint execution is not live by default; runtime flags, approvals, and fee readiness can still block execution.</li>
                 <li>Scheduled reveal automation and automatic timed release remain planned/private beta unless a live executor is confirmed.</li>
               </ul>
@@ -774,6 +792,19 @@
                   <li>Genealogy research</li>
                   <li>Major redesign work</li>
                   <li>Add-ons or expansion scope not purchased</li>
+                </ul>
+              </article>
+              <article class="feature-card feature-card-clean">
+                <h3>Maintenance By Package</h3>
+                <ul class="package-list">
+                  <li>Legacy Snapshot: $3/mo or $30/yr</li>
+                  <li>Legacy Portrait Intro: $4/mo or $40/yr</li>
+                  <li>Digital Legacy Portrait: $6/mo or $60/yr</li>
+                  <li>Household Foundation: $9/mo or $95/yr</li>
+                  <li>Heirloom Legacy Tree: $18/mo or $180/yr</li>
+                  <li>Legacy Plus: $28/mo or $280/yr</li>
+                  <li>Family Estate Concierge: $60/mo or $600/yr</li>
+                  <li>Command Structure Network: $20/mo or $200/yr</li>
                 </ul>
               </article>
             </div>


### PR DESCRIPTION
### Motivation
- Align the public homepage presentation to the authoritative backend package and add-on truth so live customers see accurate pricing, scope, and inclusion details.
- Restore customer-facing clarity that was softened for testing (what customers receive, extras/add-ons, maintenance, and controlled minting) while preserving launch guardrails and not flipping runtime flags.

### Description
- Updated `index.html` to enrich each package card with explicit maintenance pricing, uploads/storage/lane scope, and a "What you get now" provisioning handoff line to reflect live checkout and provisioning behavior.
- Strengthened `Family Estate Concierge` and `Command Structure Network` package detail blocks to reflect backend capabilities and limits, and added a per-package maintenance pricing matrix and a fuller maintenance coverage section.
- Restored the Extras/Add-Ons homepage section with grouped lanes and prices sourced from the backend `ADDON_CATALOG`, and updated the minting section to list included vs opt‑in mint paths while preserving non‑GA guardrails.
- No runtime flags, backend policy code, or payment-link wiring were changed; checkout wiring remains driven by existing `config.js`/`app.js` payment links and `data-payment-link` attributes.

### Testing
- Ran `git diff --check` which returned no whitespace or diff-check errors and passed successfully.
- Verified repository state with `git status --short` showing `index.html` modified and then committed the change successfully.
- Applied and validated the patch locally (`apply_patch` succeeded) and confirmed the homepage copy changes match backend package and addon values inspected in `backend/app/core/package_catalog.py` and `backend/app/services/mint_policy_service.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea475ad1e4832da0b5392dd279af03)