### PR TITLE
Harden admin identity mapping, reconcile admin overview metrics, and remove placeholder frontend links

### DIFF
--- a/backend/app/core/admin_permission_registry.py
+++ b/backend/app/core/admin_permission_registry.py
@@ -174,7 +174,6 @@ ROLE_METADATA: dict[str, dict[str, str]] = {
 
 OFFICER_ROLE_MAPPING: dict[str, list[str]] = {
     "l.robinson@tomboflight.com": ["CEO_SUPER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
-    "l.robinson@tomboflight": ["CEO_SUPER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
     "marquis.l.floyd@tomboflight.com": ["CMO_ADMIN"],
     "jenn.wood@tomboflight.com": ["CFO_ADMIN"],
     "k.goffigan@tomboflight.com": ["COO_ADMIN"],

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -2451,8 +2451,13 @@ def _marketing_sections_payload(
 def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
     db = _db()
     users_total = int(db["users"].count_documents({}))
+    users_total_admin = int(db["users"].count_documents({"account_type": "business_admin"}))
+    users_total_customer = max(users_total - users_total_admin, 0)
     active_projects = int(db["projects"].count_documents({"status": {"$ne": "archived"}}))
     paid_orders = int(db["orders"].count_documents({"status": {"$in": list(PAID_ORDER_STATUSES)}}))
+    pending_orders = int(
+        db["orders"].count_documents({"status": {"$in": ["pending", "open", "unpaid", "past_due", "incomplete"]}})
+    )
     now = _now()
     month_start = datetime(now.year, now.month, 1, tzinfo=UTC)
 
@@ -2475,6 +2480,7 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
         "package_without_lane": [],
         "mint_eligible_blocked": [],
     }
+    users_with_orders: set[str] = set()
 
     gross_revenue = 0.0
     successful_payments = 0
@@ -2533,6 +2539,9 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
         "refund",
     }
     for order in db["orders"].find({"status": {"$in": list(finance_statuses)}}).sort("created_at", -1).limit(5000):
+        order_email = _normalize_email(order.get("email"))
+        if order_email:
+            users_with_orders.add(order_email)
         status_value = _normalize(order.get("status")).lower()
         amount = _order_amount_value(order)
         order_dt = _coerce_datetime(order.get("created_at") or order.get("updated_at"))
@@ -2674,6 +2683,32 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
     unresolved_admin_cases = len(mismatches)
     new_accounts = int(db["users"].count_documents({"created_at": {"$gte": seven_days_ago}}))
     new_projects_accounts += new_accounts
+    paid_customers = 0
+    signed_up_no_purchase = 0
+    for user in db["users"].find({}):
+        if _normalize(user.get("account_type")).lower() == "business_admin":
+            continue
+        email = _normalize_email(user.get("email"))
+        if email and email in users_with_orders:
+            paid_customers += 1
+        else:
+            signed_up_no_purchase += 1
+    delivered_projects = int(db["projects"].count_documents({"status": {"$in": ["delivered", "completed"]}}))
+    upload_review_pending_projects = len(
+        {
+            _normalize(item.get("project_id"))
+            for item in db["uploaded_files"].find({"status": {"$in": ["pending", "awaiting_review", "uploaded", "received"]}})
+            if _normalize(item.get("project_id"))
+        }
+    )
+    verification_pending_projects = len(
+        {
+            _normalize(item.get("project_id"))
+            for item in db["verification_records"].find({"status": {"$in": ["pending", "awaiting_review", "in_review"]}})
+            if _normalize(item.get("project_id"))
+        }
+    )
+    mint_blocked_projects = blocked_projects
 
     postmark_token_configured = bool(_normalize(settings.postmark_server_token))
     postmark_from_address_configured = bool(_normalize_email(settings.postmark_from_email))
@@ -2715,11 +2750,21 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
     return {
         "summary": {
             "total_users": users_total,
+            "total_customer_users": users_total_customer,
+            "total_business_admin_users": users_total_admin,
+            "signed_up_no_purchase_users": signed_up_no_purchase,
+            "paid_customer_users": paid_customers,
             "total_active_projects": active_projects,
+            "delivered_projects": delivered_projects,
             "paid_orders": paid_orders,
+            "pending_orders": pending_orders,
             "missing_entitlements": len(missing_entitlements),
+            "missing_package_lane": len(priority_repairs["package_without_lane"]),
             "mint_ready_projects": mint_ready_count,
+            "mint_blocked_projects": mint_blocked_projects,
             "projects_with_data_mismatch": len(mismatches),
+            "upload_review_pending_projects": upload_review_pending_projects,
+            "verification_pending_projects": verification_pending_projects,
             "gross_revenue": round(gross_revenue, 2),
             "net_revenue": round(net_revenue, 2),
             "successful_payments": successful_payments,

--- a/backend/tests/test_admin_access_bootstrap.py
+++ b/backend/tests/test_admin_access_bootstrap.py
@@ -102,10 +102,7 @@ class AdminAccessBootstrapTests(unittest.TestCase):
             mapping["l.robinson@tomboflight.com"],
             ["ceo_super_admin", "executive_tech_admin"],
         )
-        self.assertEqual(
-            mapping["l.robinson@tomboflight"],
-            ["ceo_super_admin", "executive_tech_admin"],
-        )
+        self.assertNotIn("l.robinson@tomboflight", mapping)
         self.assertEqual(mapping["jenn.wood@tomboflight.com"], ["finance_admin"])
         self.assertEqual(mapping["marquis.l.floyd@tomboflight.com"], ["marketing_admin"])
         self.assertEqual(mapping["k.goffigan@tomboflight.com"], ["operations_admin"])
@@ -160,4 +157,3 @@ class AdminAccessBootstrapTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -863,6 +863,43 @@ class SuperAdminControlsTests(unittest.TestCase):
 
 
 class AdminConsoleOverviewTests(unittest.TestCase):
+    def test_overview_summary_counts_customer_and_admin_users_separately(self):
+        db = FakeDatabase(
+            {
+                "users": [
+                    {"_id": ObjectId(), "email": "l.robinson@tomboflight.com", "account_type": "business_admin"},
+                    {"_id": ObjectId(), "email": "customer-paid@example.com", "account_type": "customer"},
+                    {"_id": ObjectId(), "email": "customer-unpaid@example.com", "account_type": "customer"},
+                ],
+                "projects": [],
+                "orders": [
+                    {
+                        "_id": ObjectId(),
+                        "email": "customer-paid@example.com",
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                    }
+                ],
+                "project_entitlements": [],
+                "audit_logs": [],
+                "payroll_runs": [],
+                "finance_events": [],
+                "uploaded_files": [],
+                "verification_records": [],
+                "household_invites": [],
+                "project_members": [],
+            }
+        )
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            payload = admin_control_service.admin_console_overview(limit=5)
+        summary = payload["summary"]
+        self.assertEqual(summary["total_users"], 3)
+        self.assertEqual(summary["total_business_admin_users"], 1)
+        self.assertEqual(summary["total_customer_users"], 2)
+        self.assertEqual(summary["paid_customer_users"], 1)
+        self.assertEqual(summary["signed_up_no_purchase_users"], 1)
+
     def test_admin_overview_includes_postmark_runtime_configuration_flags(self):
         db = FakeDatabase(
             {

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -1,0 +1,39 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLACEHOLDER_HREF_PATTERN = re.compile(r'href\s*=\s*"(#|javascript:void\(0\)|)"', re.IGNORECASE)
+EMPTY_DATA_ACTION_PATTERN = re.compile(r'data-action\s*=\s*""', re.IGNORECASE)
+
+
+class FrontendLinkIntegrityTests(unittest.TestCase):
+    def test_primary_customer_and_admin_pages_do_not_ship_placeholder_links(self):
+        pages = [
+            "index.html",
+            "signup.html",
+            "signin.html",
+            "dashboard.html",
+            "billing.html",
+            "intake-uploads.html",
+            "portrait-upload.html",
+            "verification-upload.html",
+            "tree-view.html",
+            "lineage-certificate.html",
+            "admin-control-center.html",
+            "digital-collectible.html",
+        ]
+        violations: list[str] = []
+        for relative_path in pages:
+            contents = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            if PLACEHOLDER_HREF_PATTERN.search(contents):
+                violations.append(f"{relative_path}: placeholder href detected")
+            if EMPTY_DATA_ACTION_PATTERN.search(contents):
+                violations.append(f"{relative_path}: empty data-action detected")
+
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/billing.html
+++ b/billing.html
@@ -72,7 +72,7 @@
                 </button>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/billing.html#maintenance"
                   data-maintenance-monthly-link
                   style="display: none"
                 >
@@ -80,7 +80,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/billing.html#maintenance"
                   data-maintenance-yearly-link
                   style="display: none"
                 >

--- a/dashboard.html
+++ b/dashboard.html
@@ -513,7 +513,7 @@
               <div class="anchor-proof-preview-shell">
                 <a
                   class="anchor-poster-card"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-anchor-poster-link-wrapper
@@ -533,7 +533,7 @@
               <div class="inline-actions anchor-proof-actions">
                 <a
                   class="btn btn-primary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-anchor-explorer-link
@@ -543,7 +543,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-anchor-metadata-link
@@ -553,7 +553,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-anchor-poster-link

--- a/digital-collectible.html
+++ b/digital-collectible.html
@@ -95,7 +95,7 @@
                 <div class="delivery-asset-poster-block" data-delivery-poster-block data-poster-state="loading" style="display:none">
                   <a
                     class="anchor-poster-card"
-                    href="#"
+                    href="/digital-collectible.html"
                     target="_blank"
                     rel="noopener noreferrer"
                     data-delivery-poster-link-wrapper
@@ -117,7 +117,7 @@
               <div class="inline-actions delivery-action-row" data-delivery-actions>
                 <a
                   class="btn btn-primary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-delivery-btn-poster
@@ -127,7 +127,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-delivery-btn-metadata
@@ -137,7 +137,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-delivery-btn-explorer
@@ -242,7 +242,7 @@
               <div class="inline-actions anchor-proof-actions">
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-delivery-anchor-explorer-link
@@ -252,7 +252,7 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="#"
+                  href="/digital-collectible.html"
                   target="_blank"
                   rel="noopener noreferrer"
                   data-delivery-anchor-metadata-link


### PR DESCRIPTION
### Motivation
- Prevent accidental elevation or identity bleed from malformed internal aliases by only bootstrapping fully-qualified approved business admin emails.
- Make the Super Admin Overview show consistent, actionable system truth by separating business-admin and customer accounts and surfacing paid/no-purchase cohorts and upload/verification/mint-blocking counts.
- Eliminate placeholder frontend links that cause dead navigation and add an automated check to prevent regressions.

### Description
- Removed the malformed officer alias mapping for `l.robinson@tomboflight` so only `l.robinson@tomboflight.com` is used in officer bootstrapping (file: `backend/app/core/admin_permission_registry.py`).
- Expanded `admin_console_overview` to compute and return explicit counts for business admin vs customer users, signed-up-but-no-purchase users, paid customers, pending orders, delivered projects, missing package lanes, upload-review pending projects, verification-pending projects, and mint-blocked projects while preserving existing metrics (file: `backend/app/services/admin_control_service.py`).
- Added unit tests validating officer mapping normalization and the new overview summary behavior (files: `backend/tests/test_admin_access_bootstrap.py`, `backend/tests/test_admin_console.py`).
- Added a frontend integrity unit test that scans primary pages for placeholder `href` and empty `data-action` attributes (file: `backend/tests/test_frontend_link_integrity.py`).
- Replaced production `href="#"` placeholders with concrete fallback routes on visible pages to avoid dead links in the shipped UI (`billing.html`, `dashboard.html`, `digital-collectible.html`).

### Testing
- Ran unit test suite with `cd backend && pytest -q` and observed all tests passing (`230 passed`).
- Added and ran `backend/tests/test_frontend_link_integrity.py`, and verified no placeholder `href` or empty `data-action` violations in the scanned pages.
- Performed a static search for placeholder links in updated HTML files to confirm replacements succeeded (ripgrep checks for `href="#"`/`javascript:void(0)`/`data-action=""` returned no matches for updated files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6996f548832da826cc2d47807db2)