### PR TITLE
prototype

### DIFF
--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -41,9 +41,10 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
 
         self.assertRegex(
             contents,
-            r'<a[^>]*class="[^"]*\bhero-viewer-link\b[^"]*"[^>]*href="viewer/viewer-preview\.html"',
+            r'<a[^>]*class="[^"]*\bhero-viewer-link\b[^"]*"[^>]*href="viewer/index\.html\?preview=1"',
         )
-        self.assertIn('src="viewer/viewer-preview.html"', contents)
+        self.assertIn('src="viewer/index.html?preview=1&embed=1"', contents)
+        self.assertIn('class="btn btn-primary" href="viewer/index.html?preview=1"', contents)
         self.assertNotIn('class="mini-link hero-viewer-link" href="viewer/"', contents)
 
 

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                   <div class="hero-demo-embed hero-viewer-embed">
                     <div class="hero-demo-stage hero-viewer-stage">
                       <iframe
-                        src="viewer/viewer-preview.html"
+                        src="viewer/index.html?preview=1&embed=1"
                         title="Tomb of Light Prototype Viewer - Interactive family lineage experience"
                         loading="eager"
                         allowfullscreen
@@ -188,7 +188,7 @@
                 </p>
 
                 <div class="hero-actions">
-                  <a class="btn btn-primary" href="viewer/viewer-preview.html">
+                  <a class="btn btn-primary" href="viewer/index.html?preview=1">
                     Enter the Experience
                   </a>
                   <a

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -15,7 +15,7 @@
           const isPreviewParam = params.get("preview") === "1";
           const isInIframe = window.self !== window.top;
 
-          if (isEmbedParam || isPreviewParam || isInIframe) {
+          if (isEmbedParam || isInIframe) {
             document.documentElement.classList.add("embed-mode");
           }
 
@@ -270,6 +270,7 @@
 
     <script src="../config.js"></script>
     <script src="../app.js"></script>
+    <script src="js/genesis-prototype-manifest.js?v=20260428-1"></script>
     <script src="js/script.js?v=20260427-1"></script>
   </body>
 </html>

--- a/viewer/js/genesis-prototype-manifest.js
+++ b/viewer/js/genesis-prototype-manifest.js
@@ -1,0 +1,213 @@
+// viewer/js/genesis-prototype-manifest.js
+// Public Genesis prototype manifest used only when preview=1.
+
+(() => {
+  window.GENESIS_PROTOTYPE_MANIFEST = {
+    mode: "preview",
+    navigation_mode: "graph",
+    hero_kicker: "Genesis Prototype Viewer",
+    hero_title: "Malik Moreland Genesis Prototype",
+    hero_body:
+      "Public preview of the cinematic lineage experience for the Moreland prototype family.",
+    instructions:
+      "Use Origins and Future Line navigation, then branch options, to move through each lineage layer.",
+    path_title: "Prototype Path",
+    path_items: [
+      "Malik Moreland anchor",
+      "Elias and Clara Moreland origins",
+      "Malik descendant layer",
+      "Imani Moreland adult profile",
+      "Imani descendant branch",
+      "Selah Carter branch",
+      "Julian Moreland branch",
+    ],
+    nav_labels: {
+      left: "Origins",
+      right: "Future Line",
+    },
+    initial_state_id: "malik_anchor",
+    controls: {
+      allow_lineage_navigation: true,
+      allow_zoom: true,
+      allow_reset: true,
+      allow_narration_auto_advance: true,
+      allow_gaze_navigation: true,
+      allow_branch_navigation: true,
+      max_zoom_layers: 4,
+    },
+    family: {
+      family_name: "Moreland Family",
+      anchor_name: "Malik Moreland",
+    },
+    states: [
+      {
+        id: "malik_anchor",
+        image: "../images/malik.jpg",
+        title: "Malik Moreland",
+        status: "Genesis anchor",
+        node: "Malik Moreland",
+        description:
+          "Main prototype buyer and anchor. Spouse: Naomi Moreland. Children: Eli Moreland and Imani Moreland.",
+        narration:
+          "Malik Moreland is the cinematic anchor for this Genesis prototype lineage experience.",
+        left_state_id: "moreland_parents",
+        right_state_id: "malik_descendants",
+        eye_targets: {
+          left: { x: 20, y: 50 },
+          right: { x: 80, y: 50 },
+        },
+      },
+      {
+        id: "moreland_parents",
+        image: "../images/parents.jpg",
+        title: "Elias Moreland + Clara Moreland",
+        status: "Origin node",
+        node: "Moreland parents",
+        description:
+          "Origin of this family line. Children: Malik Moreland, Julian Moreland, and Selah Carter.",
+        narration:
+          "Elias and Clara Moreland are the root origin for the branch pathways in this preview.",
+        left_state_id: "",
+        right_state_id: "malik_anchor",
+        eye_targets: {
+          left: { x: 28, y: 50 },
+          right: { x: 72, y: 50 },
+        },
+      },
+      {
+        id: "malik_descendants",
+        image: "../images/malik_descendants.jpg",
+        title: "Malik Descendants",
+        status: "Future line",
+        node: "Malik descendant branch",
+        description:
+          "Descendant view of Malik and Naomi's line, including daughter Imani Moreland.",
+        narration:
+          "From Malik, the future line expands to descendants and then into Imani's adult branch.",
+        left_state_id: "malik_anchor",
+        right_state_id: "imani_anchor",
+        eye_targets: {
+          left: { x: 24, y: 50 },
+          right: { x: 78, y: 50 },
+        },
+      },
+      {
+        id: "imani_anchor",
+        image: "../images/imani.jpg",
+        title: "Imani Moreland / Imani Benton",
+        status: "Adult profile",
+        node: "Imani Moreland",
+        description:
+          "Adult daughter of Malik Moreland and Naomi Moreland. Spouse: Marcus Benton.",
+        narration:
+          "Imani Moreland appears as the adult anchor for her branch before moving to descendants.",
+        left_state_id: "malik_descendants",
+        right_state_id: "imani_descendants",
+        eye_targets: {
+          left: { x: 23, y: 50 },
+          right: { x: 77, y: 50 },
+        },
+      },
+      {
+        id: "imani_descendants",
+        image: "../images/imani_descendants.jpg",
+        title: "Imani Descendants",
+        status: "Future line",
+        node: "Imani descendant branch",
+        description:
+          "Children of Imani Benton and Marcus Benton: Micah Benton and Zara Benton.",
+        narration:
+          "Imani's descendants represent the next generation continuity in this public preview.",
+        left_state_id: "imani_anchor",
+        right_state_id: "",
+        eye_targets: {
+          left: { x: 24, y: 50 },
+          right: { x: 76, y: 50 },
+        },
+      },
+      {
+        id: "julian_anchor",
+        image: "../images/julian.jpg",
+        title: "Julian Moreland",
+        status: "Sibling branch",
+        node: "Julian Moreland",
+        description:
+          "Malik's brother. This branch has no descendants in the Genesis prototype.",
+        narration:
+          "Julian Moreland is a sibling branch with no descendant layer in this prototype.",
+        left_state_id: "moreland_parents",
+        right_state_id: "",
+        eye_targets: {
+          left: { x: 25, y: 50 },
+          right: { x: 75, y: 50 },
+        },
+      },
+      {
+        id: "selah_anchor",
+        image: "../images/selah.jpg",
+        title: "Selah Carter",
+        status: "Sibling branch",
+        node: "Selah Carter",
+        description:
+          "Malik's sister. Spouse: Andre Carter. Child: Camille Carter.",
+        narration:
+          "Selah Carter is a sibling branch that leads into her own descendant layer.",
+        left_state_id: "moreland_parents",
+        right_state_id: "selah_descendants",
+        eye_targets: {
+          left: { x: 23, y: 50 },
+          right: { x: 77, y: 50 },
+        },
+      },
+      {
+        id: "selah_descendants",
+        image: "../images/selah_descendants.jpg",
+        title: "Selah Descendants",
+        status: "Future line",
+        node: "Selah descendant branch",
+        description:
+          "Descendant layer for Selah Carter and her household line.",
+        narration:
+          "Selah's branch extends to descendants, then returns back to Selah and to the parents node.",
+        left_state_id: "selah_anchor",
+        right_state_id: "",
+        eye_targets: {
+          left: { x: 24, y: 50 },
+          right: { x: 76, y: 50 },
+        },
+      },
+    ],
+    branch_options_by_state: {
+      moreland_parents: [
+        { label: "Enter Malik Moreland", target_state_id: "malik_anchor" },
+        { label: "Enter Selah Carter", target_state_id: "selah_anchor" },
+        { label: "Enter Julian Moreland", target_state_id: "julian_anchor" },
+      ],
+      malik_anchor: [
+        { label: "Zoom Out to Origins", target_state_id: "moreland_parents" },
+        { label: "Zoom In to Descendants", target_state_id: "malik_descendants" },
+      ],
+      malik_descendants: [
+        { label: "Enter Imani Moreland", target_state_id: "imani_anchor" },
+        { label: "Return to Malik Moreland", target_state_id: "malik_anchor" },
+      ],
+      imani_anchor: [
+        { label: "Zoom In to Imani Descendants", target_state_id: "imani_descendants" },
+        { label: "Return to Malik Descendants", target_state_id: "malik_descendants" },
+      ],
+      imani_descendants: [
+        { label: "Return to Imani Moreland", target_state_id: "imani_anchor" },
+      ],
+      julian_anchor: [
+        { label: "Return to Elias and Clara", target_state_id: "moreland_parents" },
+      ],
+      selah_anchor: [
+        { label: "Zoom In to Selah Descendants", target_state_id: "selah_descendants" },
+        { label: "Return to Elias and Clara", target_state_id: "moreland_parents" },
+      ],
+      selah_descendants: [
+        { label: "Return to Selah Carter", target_state_id: "selah_anchor" },
+      ],
+    },
+  };
+})();

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -37,16 +37,7 @@
 
   const params = new URLSearchParams(window.location.search);
   const PREVIEW_MODE = params.get("preview") === "1";
-  const EMBED_MODE =
-    PREVIEW_MODE || params.get("embed") === "1" || window.self !== window.top;
-  const SEED_MODE = String(params.get("seed") || "").trim().toLowerCase();
-  const FORCE_PUBLIC_PREVIEW =
-    PREVIEW_MODE ||
-    SEED_MODE === "malik_moreland" ||
-    (EMBED_MODE &&
-      !params.get("project_id") &&
-      !params.get("family_id") &&
-      params.get("preview") !== "0");
+  const EMBED_MODE = params.get("embed") === "1" || window.self !== window.top;
 
   const NARRATION_DISPLAY_DURATION_MS = 4500;
   const AUTO_ADVANCE_INTERVAL_MS = 5000;
@@ -93,207 +84,13 @@
       },
     ],
   };
-  const PREVIEW_MANIFEST = {
-    mode: "prototype",
-    navigation_mode: "graph",
-    hero_kicker: "Genesis Prototype Viewer",
-    hero_title: "Moreland Family Lineage Prototype",
-    hero_body:
-      "Preview a cinematic legacy flow anchored by Malik Moreland and mapped through parent structure and descendant branches.",
-    instructions:
-      "Use Origins, Future Line, or branch choices to move through the lineage prototype.",
-    path_title: "Prototype Path",
-    path_items: [
-      "Anchor Portrait — Malik Moreland",
-      "Parent Structure — Moreland Family Origins",
-      "Descendant Branches — Future Legacy Layers",
-      "Family Profiles — Imani, Julian, Selah",
-      "Guided Legacy Build — Package-aware delivery paths",
-    ],
-    nav_labels: {
-      left: "Origins",
-      right: "Future Line",
-    },
-    initial_state_id: "malik_anchor",
-    controls: {
-      allow_lineage_navigation: true,
-      allow_zoom: true,
-      allow_reset: true,
-      allow_narration_auto_advance: true,
-      allow_gaze_navigation: true,
-      allow_branch_navigation: true,
-      max_zoom_layers: 4,
-    },
-    family: {
-      family_name: "Moreland Family",
-      anchor_name: "Malik Moreland",
-    },
-    states: [
-      {
-        id: "malik_anchor",
-        image: "images/malik.jpg",
-        title: "Malik Moreland — Legacy Anchor",
-        status: "Genesis node active",
-        node: "Malik Moreland",
-        description:
-          "Anchor portrait and entry node for the Moreland family lineage experience.",
-        narration:
-          "This prototype begins with Malik Moreland as the anchor portrait for a protected lineage build.",
-        left_state_id: "moreland_origins",
-        right_state_id: "moreland_descendants",
-        eye_targets: {
-          left: { x: 20, y: 50 },
-          right: { x: 80, y: 50 },
-        },
-      },
-      {
-        id: "moreland_origins",
-        image: "images/parents.jpg",
-        title: "Moreland Family Origins",
-        status: "Parent structure",
-        node: "Moreland Parent Structure",
-        description:
-          "Parent nodes and source records are arranged into a protected family origin layer.",
-        narration:
-          "Origins map the parent structure and evidence trail that supports continuity across generations.",
-        left_state_id: "",
-        right_state_id: "malik_anchor",
-        eye_targets: {
-          left: { x: 28, y: 50 },
-          right: { x: 72, y: 50 },
-        },
-      },
-      {
-        id: "moreland_descendants",
-        image: "images/malik_descendants.jpg",
-        title: "Future Legacy Layers",
-        status: "Descendant branches",
-        node: "Moreland Descendant Branches",
-        description:
-          "Descendant pathways extend forward with package-aware viewer flows and stewardship continuity.",
-        narration:
-          "Future layers carry memory, identity, and lineage structure forward through descendant branches.",
-        left_state_id: "malik_anchor",
-        right_state_id: "imani_portrait",
-        eye_targets: {
-          left: { x: 24, y: 50 },
-          right: { x: 78, y: 50 },
-        },
-      },
-      {
-        id: "imani_portrait",
-        image: "images/imani.jpg",
-        title: "Imani Moreland — Profile Node",
-        status: "Family profile",
-        node: "Imani Moreland",
-        description:
-          "Imani profile node for identity, relationship, and future branch continuity.",
-        narration:
-          "Imani Moreland appears as a profile layer connected to the main descendant flow.",
-        left_state_id: "moreland_descendants",
-        right_state_id: "julian_portrait",
-        eye_targets: {
-          left: { x: 24, y: 50 },
-          right: { x: 77, y: 50 },
-        },
-      },
-      {
-        id: "julian_portrait",
-        image: "images/julian.jpg",
-        title: "Julian Moreland — Profile Node",
-        status: "Family profile",
-        node: "Julian Moreland",
-        description:
-          "Julian profile node extends the family record and supports future continuity paths.",
-        narration:
-          "Julian Moreland extends the lineage map and demonstrates profile-level branch continuity.",
-        left_state_id: "imani_portrait",
-        right_state_id: "selah_portrait",
-        eye_targets: {
-          left: { x: 24, y: 50 },
-          right: { x: 77, y: 50 },
-        },
-      },
-      {
-        id: "selah_portrait",
-        image: "images/selah.jpg",
-        title: "Selah Moreland — Profile Node",
-        status: "Family profile",
-        node: "Selah Moreland",
-        description:
-          "Selah profile node adds future-facing continuity and contextual branch expansion.",
-        narration:
-          "Selah Moreland completes the profile path before branching into future legacy layers.",
-        left_state_id: "julian_portrait",
-        right_state_id: "imani_branch",
-        eye_targets: {
-          left: { x: 24, y: 50 },
-          right: { x: 77, y: 50 },
-        },
-      },
-      {
-        id: "imani_branch",
-        image: "images/imani_descendants.jpg",
-        title: "Family Branch — Imani",
-        status: "Branch node",
-        node: "Imani Branch",
-        description:
-          "Branch nodes model how family sub-lines can be explored while preserving protected access boundaries.",
-        narration:
-          "Branch navigation shows how the lineage engine supports guided exploration without exposing private vault content.",
-        left_state_id: "selah_portrait",
-        right_state_id: "selah_branch",
-        eye_targets: {
-          left: { x: 24, y: 50 },
-          right: { x: 77, y: 50 },
-        },
-      },
-      {
-        id: "selah_branch",
-        image: "images/selah_descendants.jpg",
-        title: "Future Legacy Branch — Selah",
-        status: "Continuity branch",
-        node: "Selah Branch",
-        description:
-          "Future legacy branches represent long-horizon continuity with controlled narrative and entitlement-aware access.",
-        narration:
-          "This final prototype branch demonstrates continuity planning for future generations in the Moreland family archive.",
-        left_state_id: "imani_branch",
-        right_state_id: "",
-        eye_targets: {
-          left: { x: 25, y: 50 },
-          right: { x: 75, y: 50 },
-        },
-      },
-    ],
-    branch_options_by_state: {
-      malik_anchor: [
-        { label: "Open Origins Layer", target_state_id: "moreland_origins" },
-        { label: "Open Descendant Layer", target_state_id: "moreland_descendants" },
-      ],
-      moreland_descendants: [
-        { label: "Open Imani Profile", target_state_id: "imani_portrait" },
-        { label: "Open Imani Branch", target_state_id: "imani_branch" },
-        { label: "Return to Anchor", target_state_id: "malik_anchor" },
-      ],
-      imani_portrait: [
-        { label: "Open Julian Profile", target_state_id: "julian_portrait" },
-        { label: "Back to Descendants", target_state_id: "moreland_descendants" },
-      ],
-      julian_portrait: [
-        { label: "Open Selah Profile", target_state_id: "selah_portrait" },
-        { label: "Back to Imani Profile", target_state_id: "imani_portrait" },
-      ],
-      selah_portrait: [
-        { label: "Open Imani Branch", target_state_id: "imani_branch" },
-        { label: "Back to Julian Profile", target_state_id: "julian_portrait" },
-      ],
-      imani_branch: [
-        { label: "Open Selah Branch", target_state_id: "selah_branch" },
-        { label: "Back to Descendants", target_state_id: "moreland_descendants" },
-      ],
-    },
-  };
+  function getPreviewManifest() {
+    const manifest = window.GENESIS_PROTOTYPE_MANIFEST;
+    if (manifest && Array.isArray(manifest.states) && manifest.states.length) {
+      return manifest;
+    }
+    return UNAVAILABLE_MANIFEST;
+  }
 
   let currentManifest = null;
   let statesById = {};
@@ -372,6 +169,9 @@
     const source = String(image || "").trim();
     if (!source) return "";
     if (/^https?:\/\//i.test(source)) return source;
+    if (source.startsWith("../images/")) {
+      return `images/${source.slice("../images/".length)}`;
+    }
     if (source.startsWith("/")) {
       const base = getApiBaseUrl();
       return base ? `${base}${source}` : source;
@@ -523,6 +323,8 @@
 
     if (manifest.mode === "dynamic") {
       document.title = `Tomb of Light | ${manifest.heroTitle}`;
+    } else if (manifest.mode === "preview") {
+      document.title = `Tomb of Light | ${manifest.heroTitle}`;
     } else {
       document.title = "Tomb of Light | Private Viewer";
     }
@@ -535,7 +337,9 @@
     const canZoom =
       !isSecureShareMode(manifest) &&
       isControlEnabled("allow_zoom", true);
-    const canReset = !isSecureShareMode(manifest);
+    const canReset =
+      !isSecureShareMode(manifest) &&
+      isControlEnabled("allow_reset", true);
     const canNarration =
       !isSecureShareMode(manifest) &&
       isControlEnabled("allow_narration_auto_advance", true);
@@ -1077,7 +881,6 @@
   }
 
   async function loadDynamicManifest() {
-    if (EMBED_MODE) return null;
     if (!app || typeof app.apiRequest !== "function") return null;
     if (!app.getToken || !app.getToken()) return null;
 
@@ -1143,10 +946,13 @@
   }
 
   async function boot() {
-    const liveManifest = FORCE_PUBLIC_PREVIEW ? null : await loadDynamicManifest();
-    const selectedManifest = FORCE_PUBLIC_PREVIEW
-      ? PREVIEW_MANIFEST
-      : liveManifest || UNAVAILABLE_MANIFEST;
+    let selectedManifest = UNAVAILABLE_MANIFEST;
+    if (PREVIEW_MODE) {
+      selectedManifest = getPreviewManifest();
+    } else {
+      const liveManifest = await loadDynamicManifest();
+      selectedManifest = liveManifest || UNAVAILABLE_MANIFEST;
+    }
     applyManifest(selectedManifest);
     bindEvents();
     await applyState(currentManifest.initialStateId || stateOrder[0] || "");

--- a/viewer/viewer-preview.html
+++ b/viewer/viewer-preview.html
@@ -13,7 +13,7 @@
   <main class="viewer-preview-shell">
     <div class="viewer-preview-stage">
       <iframe
-        src="index.html?embed=1&preview=1&seed=malik_moreland&v=20260427-1"
+        src="index.html?preview=1&embed=1"
         title="Tomb of Light Viewer Preview"
         loading="lazy"
         allowfullscreen>


### PR DESCRIPTION
This pull request updates the public preview experience for the "Genesis Prototype Viewer" by standardizing the preview route, introducing a dedicated manifest for the preview mode, and refactoring how manifests are loaded and selected. The changes ensure that all preview and embed links use a consistent URL pattern, improve manifest management for the preview experience, and clean up legacy prototype logic.

**Key changes include:**

**1. Preview Mode Manifest Refactor**
- Introduced a new file, `viewer/js/genesis-prototype-manifest.js`, which contains a dedicated manifest object (`GENESIS_PROTOTYPE_MANIFEST`) for the public preview mode, detailing the structure, navigation, and content for the Moreland family prototype. The viewer now loads this manifest when `preview=1` is present in the URL. [[1]](diffhunk://#diff-b8c833df9550f217a21bfc42f8babef09a6fea297638e4f06b18601fa4446f43R1-R213) [[2]](diffhunk://#diff-186c18f63f167ebe31c7bc635f04f8b9ebd873fd69333bdf665558e0a6474f70R273) [[3]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L96-R93) [[4]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L1146-R955)
- Removed the old inline `PREVIEW_MANIFEST` from `viewer/js/script.js` and replaced it with a function that loads the new manifest from the global window object.

**2. URL and Link Standardization**
- Updated all homepage and test links to use the new pattern: `viewer/index.html?preview=1` for preview mode and `viewer/index.html?preview=1&embed=1` for embedded preview, replacing references to `viewer/viewer-preview.html`. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L88-R88) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L191-R191) [[3]](diffhunk://#diff-68313441bdda86a7991e52ee827d626196d319a8437becd4e47e1f1d3fe55933L44-R47) [[4]](diffhunk://#diff-49a2dc643d4aa3dace8e3cc805913dbc9de5613db7343ab346e20aff92d53145L16-R16)

**3. Manifest Loading and Mode Detection Logic**
- Refactored viewer boot logic to select the manifest based strictly on the `preview=1` parameter, simplifying previous logic that mixed preview, embed, and seed parameters. [[1]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L40-R40) [[2]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L1080) [[3]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L1146-R955)
- The `EMBED_MODE` flag is now only set if `embed=1` is present or the viewer is in an iframe, decoupling it from preview mode. [[1]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L40-R40) [[2]](diffhunk://#diff-186c18f63f167ebe31c7bc635f04f8b9ebd873fd69333bdf665558e0a6474f70L18-R18)

**4. Image Path Handling**
- Updated image path resolution to correctly handle manifest images that use `../images/` by mapping them to the correct relative path within the viewer.

**5. Minor UI and Logic Fixes**
- Ensured that document titles are set correctly based on the manifest mode, and improved reset and control logic for preview mode. [[1]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380R326-R327) [[2]](diffhunk://#diff-0a78a1a69f809f0796bb7a645e82f0271efea858b19024a4410d9963cf333380L538-R342)

These changes collectively provide a more maintainable, explicit, and robust public preview experience for the Genesis prototype viewer.