### PR TITLE
Introduce public demo viewer, update copy and switch site to light theme

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -106,20 +106,14 @@
                 <article class="policy-card">
                   <h3>Is Tomb of Light live?</h3>
                   <p class="card-copy">
-                    Yes. The public website, customer account system, and
-                    private workspace entry flow are live. Visitors can review
-                    packages, purchase live core packages, create an account,
-                    and enter the platform through protected account access.
+                    Yes. The public website, account creation path, package purchase path, and protected workspace entry flow are live. Visitors can review packages, create an account, and begin through protected access. Package-specific tools and private viewer content unlock after checkout and provisioning. A public sample demo viewer is available for preview using demo-safe data.
                   </p>
                 </article>
 
                 <article class="policy-card">
                   <h3>What can I do right now?</h3>
                   <p class="card-copy">
-                    You can explore the platform pages, review policies,
-                    purchase a package, create an account, and enter your
-                    private workspace. Package-specific tools unlock after
-                    checkout and provisioning.
+                    You can explore the public website, view the sample lineage demo, review packages and policies, create an account, and enter your private workspace. Package-specific tools unlock based on the package purchased and project provisioning status.
                   </p>
                 </article>
 

--- a/index.html
+++ b/index.html
@@ -73,34 +73,38 @@
                 <div class="hero-visual-card hero-demo-card hero-viewer-card hero-viewer-card-main">
                   <div class="hero-demo-card-top hero-demo-card-top-prototype">
                     <div>
-                      <span class="eyebrow">Genesis Prototype Viewer</span>
-                      <h2>Experience the platform interface.</h2>
+                      <span class="eyebrow">Sample demo tree</span>
+                      <h2>See a family lineage come alive.</h2>
                     </div>
 
-                    <a class="mini-link hero-viewer-link" href="platform.html">
-                      View Preview Layer
+                    <a class="mini-link hero-viewer-link" href="viewer/?demo=malik-moreland">
+                      View Demo Tree
                     </a>
                   </div>
 
                   <div class="hero-demo-embed hero-viewer-embed">
                     <div class="hero-demo-stage hero-viewer-stage">
                       <div class="hero-viewer-static" aria-label="Family tree viewer preview showing the Moreland family across multiple generations">
+                        <span class="hero-demo-badge">Sample demo tree</span>
                         <div class="hero-viewer-static-node hero-viewer-static-node-parent">
                           <strong>Generation 1</strong>
-                          <span>Clara + Elias</span>
+                          <span>Elias + Clara Moreland</span>
                         </div>
-                        <div class="hero-viewer-static-line hero-viewer-static-line-main"></div>
-                        <div class="hero-viewer-static-node hero-viewer-static-node-anchor">
-                          <strong>Generation 2</strong>
-                          <span>Malik Moreland</span>
+                        <div class="hero-viewer-static-siblings" aria-label="Children context">
+                          <div class="hero-viewer-static-node hero-viewer-static-node-sibling"><span>Selah Carter</span></div>
+                          <div class="hero-viewer-static-node hero-viewer-static-node-anchor">
+                            <strong>Start node</strong>
+                            <span>Malik Moreland</span>
+                          </div>
+                          <div class="hero-viewer-static-node hero-viewer-static-node-sibling"><span>Julian Moreland</span></div>
                         </div>
                         <div class="hero-viewer-static-line hero-viewer-static-line-branch"></div>
                         <div class="hero-viewer-static-node hero-viewer-static-node-child">
-                          <strong>Generation 3</strong>
-                          <span>Imani + Marcus</span>
+                          <strong>Next focus</strong>
+                          <span>Imani Moreland adult</span>
                         </div>
                         <div class="hero-viewer-static-caption">
-                          Private family tree opens inside the entitled dashboard workspace.
+                          Start at Malik. Zoom out to origin. Zoom in to descendants.
                         </div>
                       </div>
                     </div>
@@ -142,7 +146,7 @@
                   <div class="hero-demo-card-top">
                     <div>
                       <span class="eyebrow">Core Layers</span>
-                      <h2>Production-ready layers for protected continuity.</h2>
+                      <h2>Everything your legacy build includes.</h2>
                     </div>
                   </div>
 
@@ -184,8 +188,8 @@
               </div>
 
               <div class="hero-copy hero-copy-premium hero-copy-tech hero-copy-cosmic hero-copy-prototype">
-                <span class="eyebrow">Digital Legacy Infrastructure</span>
-                <h1 id="hero-title">Your Family Tree. Alive. Navigable. Forever.</h1>
+                <span class="eyebrow">PRIVATE DIGITAL LINEAGE PLATFORM</span>
+                <h1 id="hero-title">A family legacy you can see, explore, and pass forward.</h1>
 
                 <p class="hero-lead">
                   Tomb of Light transforms family history into a private
@@ -201,8 +205,8 @@
                 </p>
 
                 <div class="hero-actions">
-                  <a class="btn btn-primary" href="viewer/index.html?preview=1">
-                    Enter the Experience
+                  <a class="btn btn-primary" href="viewer/?demo=malik-moreland">
+                    View Demo Tree
                   </a>
                   <a
                     class="btn btn-secondary"
@@ -218,10 +222,10 @@
             </div>
 
             <div class="hero-meta hero-trust-row" aria-label="Trust signals">
-              <span class="meta-pill">Private by Design</span>
-              <span class="meta-pill">Guided Legacy Build</span>
-              <span class="meta-pill">Secure Uploads</span>
-              <span class="meta-pill">Package-Based Access</span>
+              <span class="meta-pill">Private by default</span>
+              <span class="meta-pill">Guided production</span>
+              <span class="meta-pill">Review before delivery</span>
+              <span class="meta-pill">Light Never Dies</span>
             </div>
           </div>
           <!-- Prototype-first customer hero -->
@@ -233,9 +237,9 @@
         >
           <div class="container">
             <div class="section-head section-head-wide">
-              <span class="eyebrow">Why Tomb of Light Exists</span>
+              <span class="eyebrow">What Tomb of Light creates</span>
               <h2 id="section-platform">
-                Built for protected lineage, not public record searching.
+                A Tomb of Light build is not just a file folder or a flat chart.
               </h2>
               <p class="section-lead">
                 Tomb of Light is not primarily a research database. It is a
@@ -247,7 +251,7 @@
             <div class="feature-strip">
               <article class="feature-card feature-card-clean">
                 <div class="card-number" aria-hidden="true">01</div>
-                <h3>Private by Design</h3>
+                <h3>Private by default</h3>
                 <p class="card-copy">
                   This is a protected workspace model, not a public browsing
                   environment for scattered family data.
@@ -352,7 +356,7 @@
 
                   <article class="arch-box">
                     <span class="flow-label">Layer 07</span>
-                    <h3>Viewer Manifest Layer</h3>
+                    <h3>Private viewer delivery</h3>
                     <p>
                       Delivers package-aware viewer manifests, protected preview
                       pathways, and link-key controlled presentation.
@@ -379,7 +383,7 @@
         >
           <div class="container">
             <div class="cta-panel cta-panel-premium manifesto-panel">
-              <span class="eyebrow">Brand Line</span>
+              <span class="eyebrow">Light Never Dies</span>
               <h2 id="section-manifesto">Light Never Dies.</h2>
               <p class="section-lead">
                 Legacy deserves a living form. Tomb of Light preserves lineage,
@@ -397,9 +401,9 @@
         >
           <div class="container">
             <div class="section-head section-head-wide">
-              <span class="eyebrow">What You Receive</span>
+              <span class="eyebrow">How the guided build works</span>
               <h2 id="section-experience">
-                Packages that match the scope of your legacy.
+                From scattered memories to a living lineage
               </h2>
               <p class="section-lead">
                 Every purchase includes a private workspace, guided intake,
@@ -476,9 +480,9 @@
         <section class="section" id="pricing" aria-labelledby="pricing-title">
           <div class="container">
             <div class="section-head section-head-wide">
-              <span class="eyebrow">Pricing &amp; Packages</span>
+              <span class="eyebrow">Choose your legacy scope</span>
               <h2 id="pricing-title">
-                Choose the package lane that fits your legacy.
+                Choose your legacy scope
               </h2>
               <p class="section-lead">
                 Every purchase opens a private workspace, guided intake path,

--- a/platform.html
+++ b/platform.html
@@ -87,7 +87,7 @@
                 >
                   Start Your Legacy Build
                 </a>
-                <a class="btn btn-secondary" href="viewer/">Open Viewer</a>
+                <a class="btn btn-secondary" href="viewer/?demo=malik-moreland">View Demo Tree</a>
               </div>
 
               <div class="hero-meta" aria-label="Platform highlights">
@@ -137,7 +137,7 @@
 
               <article class="feature-card feature-card-clean">
                 <div class="card-number" aria-hidden="true">03</div>
-                <h3>Package-Aware Delivery Controls</h3>
+                <h3>Your package controls what is included</h3>
                 <p class="card-copy">
                   Tools, limits, branch or organization scope, and launch
                   actions are enforced by package policy instead of generic
@@ -173,7 +173,7 @@
               </article>
 
               <article class="policy-card">
-                <h3>Runtime and Approval Gating</h3>
+                <h3>Advanced production policy</h3>
                 <p class="card-copy">
                   Automatic mint execution is not live by default. Any
                   auto-mint behavior requires package policy support, runtime
@@ -182,7 +182,7 @@
               </article>
 
               <article class="policy-card">
-                <h3>Non-GA Reveal Status</h3>
+                <h3>Advanced production policy</h3>
                 <p class="card-copy">
                   Scheduled reveal automation is planned and currently private
                   beta / in development. Automatic timed release is not live
@@ -291,14 +291,14 @@
                     A family experience designed to be explored, not just stored.
                   </h2>
                 </div>
-                <a class="mini-link" href="viewer/">Open Full Viewer</a>
+                <a class="mini-link" href="viewer/?demo=malik-moreland">Open Demo Viewer</a>
               </div>
 
               <div class="platform-prototype-wrap">
                 <div class="platform-prototype-stage">
                   <div class="platform-prototype-frame">
                     <iframe
-                      src="viewer/?embed=1&preview=1&v=20260326-4"
+                      src="viewer/?embed=1&demo=malik-moreland&v=20260502-1"
                       title="Tomb of Light Prototype Viewer"
                       loading="lazy"
                       allowfullscreen

--- a/security.html
+++ b/security.html
@@ -283,7 +283,7 @@
                 <p class="card-copy">
                   Security is an ongoing discipline, not a one-time claim. No
                   website, platform, storage system, transmission method, or
-                  account system can be guaranteed to be absolutely secure at
+                  account system can be guaranteed to remain fully protected at
                   all times.
                 </p>
               </article>

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,25 @@
 :root {
-  --bg: #03060d;
-  --bg-soft: #07101d;
-  --panel: rgba(10, 16, 28, 0.82);
-  --panel-2: rgba(7, 12, 22, 0.92);
-  --panel-3: rgba(255, 255, 255, 0.025);
-  --border: rgba(255, 255, 255, 0.1);
-  --border-soft: rgba(255, 255, 255, 0.06);
-  --border-strong: rgba(214, 176, 102, 0.24);
-  --text: #f4f7fb;
-  --muted: #c8d1e0;
-  --muted-2: #8d9aae;
-  --gold: #d6b066;
-  --white-btn: #f4f5f8;
-  --white-btn-text: #12161f;
-  --shadow: 0 24px 70px rgba(0, 0, 0, 0.42);
+  --tol-ink: #0B1220;
+  --tol-text: #1C2938;
+  --tol-muted: #5D6B7C;
+  --tol-mist: #F6FAFD;
+  --tol-white: #FFFFFF;
+  --tol-smoke: #E9EEF4;
+  --tol-line: #D8E3EC;
+  --tol-blue-soft: #B8DFFF;
+  --tol-blue: #2A6FA8;
+  --tol-gold: #C6A66A;
+  --tol-gold-soft: #E8D5A3;
+  --tol-shadow: 0 24px 70px rgba(11, 18, 32, 0.12);
+  --bg: var(--tol-mist);
+  --panel: var(--tol-white);
+  --border: var(--tol-line);
+  --text: var(--tol-text);
+  --muted: var(--tol-muted);
+  --gold: var(--tol-gold);
+  --white-btn: var(--tol-blue);
+  --white-btn-text: var(--tol-white);
+  --shadow: var(--tol-shadow);
   --radius: 28px;
   --radius-sm: 18px;
   --container: 1240px;
@@ -37,18 +43,7 @@ html {
 body {
   margin: 0;
   color: var(--text);
-  background:
-    radial-gradient(
-      circle at top left,
-      rgba(21, 48, 108, 0.12),
-      transparent 28%
-    ),
-    radial-gradient(
-      circle at top right,
-      rgba(7, 20, 58, 0.14),
-      transparent 30%
-    ),
-    linear-gradient(180deg, #010309 0%, #04070e 44%, #02050b 100%);
+  background: radial-gradient(circle at top left, rgba(184,223,255,0.32), transparent 28%), radial-gradient(circle at top right, rgba(42,111,168,0.10), transparent 34%), linear-gradient(180deg, #ffffff 0%, #f6fafd 56%, #f2f7fb 100%);
   font-family:
     Inter,
     ui-sans-serif,
@@ -60,7 +55,7 @@ body {
   line-height: 1.6;
   min-height: 100vh;
   position: relative;
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 body.menu-open {
@@ -105,6 +100,7 @@ body.menu-open {
 }
 
 .site-watermark {
+  opacity: 0.06;
   position: fixed;
   inset: 0;
   z-index: 0;
@@ -172,8 +168,8 @@ a {
   top: 0;
   z-index: 1000;
   backdrop-filter: blur(18px);
-  background: rgba(2, 6, 14, 0.76);
-  border-bottom: 1px solid var(--border-soft);
+  background: rgba(246, 250, 253, 0.92);
+  border-bottom: 1px solid var(--tol-line);
 }
 
 .site-header-inner {
@@ -229,7 +225,7 @@ a {
 }
 
 .site-nav a {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 700;
   letter-spacing: -0.01em;
   position: relative;
@@ -299,7 +295,7 @@ a {
   border-radius: 999px;
   border: 1px solid var(--border);
   color: var(--text);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
   font-weight: 700;
   transition:
     transform var(--transition),
@@ -318,7 +314,7 @@ a {
 .btn:hover {
   transform: translateY(-1px);
   border-color: rgba(255, 255, 255, 0.18);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 12px 24px rgba(11, 18, 32, 0.08);
 }
 
 .btn:focus {
@@ -367,12 +363,12 @@ select:focus-visible {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
 }
 
 .btn-ghost {
   background: transparent;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .btn-ghost:hover {
@@ -380,7 +376,7 @@ select:focus-visible {
 }
 
 .mini-link {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 700;
   font-size: 0.94rem;
   text-decoration: none;
@@ -449,12 +445,8 @@ select:focus-visible {
 .form-panel,
 .architecture-panel,
 .thank-you-card {
-  background: linear-gradient(
-    180deg,
-    rgba(10, 16, 28, 0.82),
-    rgba(6, 10, 18, 0.92)
-  );
-  border: 1px solid var(--border);
+  background: linear-gradient(180deg, #ffffff, #f8fbff);
+  border: 1px solid var(--tol-smoke);
   border-radius: 32px;
   box-shadow: var(--shadow);
   backdrop-filter: blur(12px);
@@ -504,7 +496,7 @@ select:focus-visible {
 .section-lead,
 .card-copy,
 .footer-copy {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 1.04rem;
 }
 
@@ -531,9 +523,9 @@ select:focus-visible {
 .meta-pill {
   padding: 10px 14px;
   border-radius: 999px;
-  color: var(--muted);
+  color: var(--tol-muted);
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
   font-size: 0.94rem;
   font-weight: 600;
 }
@@ -543,7 +535,7 @@ select:focus-visible {
   flex-wrap: wrap;
   gap: 10px 16px;
   margin-top: 18px;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.97rem;
   font-weight: 600;
 }
@@ -765,16 +757,16 @@ select:focus-visible {
   align-content: center;
   justify-items: center;
   background:
-    radial-gradient(circle at 18% 12%, rgba(214, 176, 102, 0.18), transparent 38%),
-    radial-gradient(circle at 88% 84%, rgba(114, 188, 255, 0.18), transparent 34%),
-    linear-gradient(180deg, rgba(8, 13, 24, 0.94), rgba(4, 8, 16, 0.98));
+    radial-gradient(circle at 18% 12%, rgba(198, 166, 106, 0.16), transparent 38%),
+    radial-gradient(circle at 88% 84%, rgba(184, 223, 255, 0.42), transparent 34%),
+    linear-gradient(180deg, #ffffff, #f5f9fe);
 }
 
 .hero-viewer-static-node {
   width: min(280px, 90%);
   border-radius: 16px;
-  border: 1px solid rgba(214, 176, 102, 0.3);
-  background: rgba(9, 15, 28, 0.9);
+  border: 1px solid var(--tol-line);
+  background: #ffffff;
   padding: 12px 14px;
   display: grid;
   gap: 2px;
@@ -782,14 +774,14 @@ select:focus-visible {
 }
 
 .hero-viewer-static-node strong {
-  color: #f5f6fa;
+  color: var(--tol-blue);
   font-size: 0.8rem;
   letter-spacing: 0.11em;
   text-transform: uppercase;
 }
 
 .hero-viewer-static-node span {
-  color: #d7deea;
+  color: var(--tol-ink);
   font-size: 0.95rem;
   font-weight: 600;
 }
@@ -797,7 +789,7 @@ select:focus-visible {
 .hero-viewer-static-line {
   width: 3px;
   border-radius: 999px;
-  background: rgba(214, 176, 102, 0.85);
+  background: rgba(42, 111, 168, 0.55);
 }
 
 .hero-viewer-static-line-main {
@@ -806,17 +798,39 @@ select:focus-visible {
 
 .hero-viewer-static-line-branch {
   height: 24px;
-  border-left: 3px dashed rgba(255, 255, 255, 0.5);
+  border-left: 3px dashed rgba(42, 111, 168, 0.35);
   background: transparent;
   width: 0;
 }
 
 .hero-viewer-static-caption {
   margin-top: 4px;
-  color: #b8c3d4;
+  color: var(--tol-muted);
   font-size: 0.82rem;
   text-align: center;
   max-width: 36ch;
+}
+
+.hero-demo-badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #eef7ff;
+  border: 1px solid var(--tol-line);
+  color: var(--tol-blue);
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+
+.hero-viewer-static-siblings {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  align-items: center;
+}
+
+.hero-viewer-static-node-sibling {
+  width: 100%;
 }
 
 .hero-trust-row {
@@ -825,7 +839,7 @@ select:focus-visible {
 }
 
 .hero-trust-row .meta-pill {
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
   border-color: rgba(255, 255, 255, 0.16);
 }
 
@@ -1170,7 +1184,7 @@ select:focus-visible {
 
 .receive-item p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.96rem;
 }
 
@@ -1243,7 +1257,7 @@ select:focus-visible {
 }
 
 .hero-visual-main p {
-  color: var(--muted);
+  color: var(--tol-muted);
   margin: 0;
 }
 
@@ -1325,7 +1339,7 @@ select:focus-visible {
 
 .mini-stack-item p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .section {
@@ -1391,7 +1405,7 @@ select:focus-visible {
 .policy-list {
   margin: 16px 0 0;
   padding-left: 20px;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .section-note {
@@ -1453,7 +1467,7 @@ select:focus-visible {
 
 .arch-box p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .arch-arrow {
@@ -1489,7 +1503,7 @@ select:focus-visible {
   padding: 22px;
   border-radius: 24px;
   border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
   transition: all var(--transition);
   overflow: hidden;
 }
@@ -1511,7 +1525,7 @@ select:focus-visible {
 
 .viewer-step p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .trust-grid {
@@ -1574,7 +1588,7 @@ select:focus-visible {
 label {
   display: grid;
   gap: 8px;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 600;
   min-width: 0;
 }
@@ -1589,7 +1603,7 @@ select {
   font-size: 16px;
   border-radius: 16px;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
   color: var(--text);
   padding: 14px 16px;
   transition: all var(--transition);
@@ -1667,7 +1681,7 @@ textarea {
 
 .family-record-card p {
   margin: 0 0 10px;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .family-record-card p:last-child {
@@ -1728,7 +1742,7 @@ textarea {
   padding: 18px;
   border-radius: 22px;
   border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
 }
 
 .workspace-stage-node strong,
@@ -1743,7 +1757,7 @@ textarea {
 }
 
 .workspace-stage-node small {
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .workspace-stage-dot {
@@ -1911,7 +1925,7 @@ textarea {
   border-radius: 999px;
   border: 1px solid rgba(138, 169, 213, 0.18);
   background: rgba(255, 255, 255, 0.04);
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.85rem;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -2057,7 +2071,7 @@ textarea {
 .portal-signal-card p,
 .portal-metric-card p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .portal-visual,
@@ -2225,7 +2239,7 @@ textarea {
 .portal-access-top p,
 .portal-access-note {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .portal-access-form {
@@ -2274,7 +2288,7 @@ textarea {
 
 .portal-mfa-top p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .portal-mfa-secret-card {
@@ -2363,7 +2377,7 @@ textarea {
   padding: 14px 16px;
   border-radius: 18px;
   border: 1px solid rgba(138, 169, 213, 0.16);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
 }
 
 .portal-dashboard-hero {
@@ -2459,7 +2473,7 @@ textarea {
   padding: 16px 18px;
   border-radius: 18px;
   border: 1px solid rgba(138, 169, 213, 0.18);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
@@ -2497,7 +2511,7 @@ textarea {
 
 .portal-admin-mode [data-admin-tools-panel] .family-record-card {
   border-color: rgba(255, 155, 103, 0.16);
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
 }
 
 /*
@@ -2589,7 +2603,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   }
 
   .btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.02);
+    background: #f7fbff;
   }
 
   .portal-login-body .btn-secondary:hover,
@@ -2607,7 +2621,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   .btn-ghost:hover,
   .small-link-row a:hover,
   .footer-links a:hover {
-    color: var(--muted);
+    color: var(--tol-muted);
   }
 }
 
@@ -2631,7 +2645,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .notice {
   padding: 16px 18px;
   border-radius: 18px;
-  color: var(--muted);
+  color: var(--tol-muted);
   border: 1px solid rgba(214, 176, 102, 0.2);
   background: rgba(214, 176, 102, 0.06);
   overflow: hidden;
@@ -2645,7 +2659,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 }
 
 .small-link-row a {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 600;
   transition: color var(--transition);
   text-decoration: none;
@@ -2864,7 +2878,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 }
 
 .footer-links a {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 600;
   text-decoration: none;
   transition: color var(--transition);
@@ -2935,7 +2949,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
 .cookie-copy {
   flex: 1 1 620px;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.96rem;
 }
 
@@ -2978,7 +2992,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .thank-you-copy {
   margin: 0 0 2rem;
   max-width: 62ch;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 1.05rem;
   line-height: 1.75;
 }
@@ -2993,7 +3007,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   padding: 1.15rem 1.15rem 1rem;
   border: 1px solid var(--border-soft);
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
 }
 
 .thank-you-status-item strong {
@@ -3005,7 +3019,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
 .thank-you-status-item p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
   line-height: 1.7;
 }
 
@@ -3055,7 +3069,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   padding: 1rem;
   border-radius: 20px;
   border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
 }
 
 .anchor-proof-item .card-copy {
@@ -3092,7 +3106,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
 .anchor-poster-empty {
   max-width: 28rem;
-  color: var(--muted);
+  color: var(--tol-muted);
   text-align: center;
   line-height: 1.7;
 }
@@ -3245,6 +3259,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   }
 
   .site-watermark {
+  opacity: 0.06;
     background-size: min(84vw, 500px);
     background-position: center 38%;
     opacity: 0.1;
@@ -3467,6 +3482,15 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     aspect-ratio: 16 / 10;
     min-height: clamp(250px, 58vw, 360px);
     max-height: none;
+  }
+
+  .hero-viewer-static {
+    min-height: 280px;
+    padding: 14px;
+  }
+
+  .hero-viewer-static-siblings {
+    grid-template-columns: 1fr;
   }
 
   .platform-model-card .lineage-node {
@@ -4234,7 +4258,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
 .admin-command-copy p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .admin-command-search {
@@ -4245,7 +4269,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 }
 
 .admin-command-search label {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-weight: 800;
 }
 
@@ -4469,7 +4493,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
 .admin-case-primary p {
   margin: 3px 0 0;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.86rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4665,7 +4689,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   padding: 12px;
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.07);
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
 }
 
 .admin-field strong {
@@ -4691,7 +4715,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   display: grid;
   gap: 3px;
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
 }
 
 .admin-record-list > span {
@@ -4791,14 +4815,14 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 }
 
 .admin-guidance-empty span {
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.84rem;
   line-height: 1.4;
 }
 
 .admin-guidance-item p {
   margin: 0;
-  color: var(--muted);
+  color: var(--tol-muted);
   font-size: 0.84rem;
   line-height: 1.45;
 }
@@ -5017,7 +5041,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   padding: 0.7rem 0.85rem;
   border-radius: 16px;
   border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.02);
+  background: #f7fbff;
   text-decoration: none;
   color: inherit;
 }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -12,7 +12,7 @@
         try {
           const params = new URLSearchParams(window.location.search);
           const isEmbedParam = params.get("embed") === "1";
-          const isPreviewParam = params.get("preview") === "1";
+          const isPreviewParam = params.get("preview") === "1" || params.get("demo") === "malik-moreland";
           const isInIframe = window.self !== window.top;
 
           if (isEmbedParam || isInIframe) {
@@ -179,10 +179,9 @@
 
           <div class="viewer-header-copy">
             <span class="viewer-kicker" id="viewerHeaderKicker">Private Viewer</span>
-            <h1 id="viewerHeroTitle">Viewer Access Required</h1>
+            <h1 id="viewerHeroTitle">Private viewer locked</h1>
             <p id="viewerHeroBody">
-              Your private Tomb of Light viewer loads only after authenticated
-              manifest validation.
+              This family viewer is protected. Open it from your Tomb of Light workspace after your project has been approved and provisioned.
             </p>
 
             <p class="viewer-instructions" id="viewerInstructions">
@@ -200,7 +199,7 @@
                 <h2 id="viewerTitle">Private Viewer</h2>
               </div>
 
-              <div class="viewer-status" id="viewerStatus">Manifest Required</div>
+              <div class="viewer-status" id="viewerStatus">Private Viewer</div>
             </div>
 
           <div class="viewer-stage-shell" id="viewerStage">
@@ -213,7 +212,7 @@
                 alt="Private viewer"
               />
               <div class="viewer-empty-note" id="viewerEmptyState" hidden>
-                No approved viewer manifest is available for this project yet.
+                Private project content is not loaded on public routes.
               </div>
               <div class="parents-overlay" id="parentsOverlay" hidden>
                 <button
@@ -268,6 +267,7 @@
             <button type="button" id="zoomOutBtn" onclick="zoomOut()">Zoom Out</button>
             <button type="button" id="zoomInBtn" onclick="zoomIn()">Zoom In</button>
             <button type="button" id="resetViewerBtn" onclick="resetViewer()">Reset</button>
+            <a class="btn" href="../signup.html" style="min-height:42px;">Start Your Legacy Build</a>
             <button
               type="button"
               id="narrationToggleBtn"
@@ -283,14 +283,14 @@
               <span class="panel-kicker">Current Node</span>
               <h3 id="currentNode">Private Viewer</h3>
               <p id="currentDescription">
-                No approved viewer manifest is available for this project yet.
+                Private project content is not loaded on public routes.
               </p>
             </div>
 
             <div class="side-card">
               <span class="panel-kicker" id="pathListTitle">Viewer Status</span>
               <div class="path-list" id="pathList">
-                <div class="path-item">No approved viewer manifest is available for this project yet.</div>
+                <div class="path-item">Private project content is not loaded on public routes.</div>
               </div>
             </div>
         </aside>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -39,14 +39,13 @@
   const eyeRight = document.getElementById("eyeRight");
 
   const params = new URLSearchParams(window.location.search);
-  const PREVIEW_MODE = params.get("preview") === "1";
+  const DEMO_MODE = params.get("demo") === "malik-moreland" || params.get("preview") === "1";
   const EMBED_MODE = params.get("embed") === "1" || window.self !== window.top;
 
   const NARRATION_DISPLAY_DURATION_MS = 4500;
   const AUTO_ADVANCE_INTERVAL_MS = 5000;
   const PARENT_OVERLAY_HIDE_DELAY_MS = 5000;
-  const MISSING_ASSET_COPY =
-    "Approved image unavailable for this viewer node.";
+  const MISSING_ASSET_COPY = "Demo image placeholder";
   const DEFAULT_ZOOM_LAYERS = 2;
   const DEFAULT_DYNAMIC_EYE_TARGETS = {
     left: { x: 18, y: 50 },
@@ -56,41 +55,41 @@
     mode: "unavailable",
     navigation_mode: "sequence",
     hero_kicker: "Private Viewer",
-    hero_title: "Viewer Access Required",
-    hero_body: "No approved viewer manifest is available for this project yet.",
+    hero_title: "Private viewer locked",
+    hero_body: "This family viewer is protected. Open it from your Tomb of Light workspace after your project has been approved and provisioned.",
     instructions:
-      "Return to your dashboard and open the viewer from your entitled project workspace.",
-    path_title: "Viewer Status",
-    path_items: ["No approved viewer manifest is available for this project yet."],
-    nav_labels: {
-      left: "Previous",
-      right: "Next",
-    },
+      "Private project content is not loaded on public routes.",
+    path_title: "Private Viewer",
+    path_items: ["Private project content is not loaded on public routes."],
+    nav_labels: { left: "Origins", right: "Future Line" },
     initial_state_id: "unavailable",
-    controls: {
-      allow_lineage_navigation: false,
-      allow_zoom: false,
-      allow_reset: false,
-      allow_narration_auto_advance: false,
-      allow_gaze_navigation: false,
-      allow_branch_navigation: false,
-    },
-    states: [
-      {
-        id: "unavailable",
-        image: "",
-        title: "Viewer Unavailable",
-        status: "Manifest required",
-        node: "Private viewer",
-        description: "No approved viewer manifest is available for this project yet.",
-        narration: "",
-        left_state_id: "",
-        right_state_id: "",
-        eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS,
-      },
-    ],
+    controls: { allow_lineage_navigation: false, allow_zoom: false, allow_reset: true, allow_narration_auto_advance: false, allow_gaze_navigation: false, allow_branch_navigation: false },
+    states: [{ id: "unavailable", image: "", title: "Private viewer locked", status: "Private Viewer", node: "Private viewer", description: "This family viewer is protected. Open it from your Tomb of Light workspace after your project has been approved and provisioned.", narration: "", left_state_id: "", right_state_id: "", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS }],
   };
+  
+  const MORELAND_DEMO_MANIFEST = {
+    mode: "dynamic",
+    navigation_mode: "explicit",
+    hero_kicker: "Sample demo tree",
+    hero_title: "See a family lineage come alive.",
+    hero_body: "Start at Malik. Zoom out to origin. Zoom in to descendants.",
+    instructions: "Demo-safe family data for public preview. Current view: Malik Moreland",
+    path_title: "Moreland demo flow",
+    path_items: ["Root: Elias + Clara Moreland", "Start node: Malik Moreland", "Malik’s descendants", "Imani Moreland adult", "Imani’s descendants"],
+    nav_labels: { left: "Origins", right: "Future Line" },
+    initial_state_id: "malik",
+    controls: { allow_lineage_navigation: true, allow_zoom: true, allow_reset: true, allow_narration_auto_advance: false, allow_gaze_navigation: false, allow_branch_navigation: false },
+    states: [
+      {id:"root", image:"images/parents.jpg", title:"Elias + Clara Moreland", status:"Generation 1 · Family origin view", node:"Elias + Clara Moreland", description:"Visible nodes: Elias + Clara Moreland, Malik Moreland, Selah Carter, Julian Moreland", left_state_id:"root", right_state_id:"malik", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS},
+      {id:"malik", image:"images/malik.jpg", title:"Malik Moreland", status:"Start node · Focused branch", node:"Malik Moreland", description:"Current view: Malik Moreland", left_state_id:"root", right_state_id:"malik_descendants", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS},
+      {id:"malik_descendants", image:"images/malik_descendants.jpg", title:"Malik’s descendants", status:"Descendant branch", node:"Malik’s descendants", description:"Visible nodes include Imani Moreland adult and protected future branches.", left_state_id:"malik", right_state_id:"imani_adult", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS},
+      {id:"imani_adult", image:"images/malik_descendants.jpg", title:"Imani Moreland adult", status:"Next generation focus", node:"Imani Moreland adult", description:"Visible nodes: Malik Moreland, Imani Moreland adult, Imani’s descendants.", left_state_id:"malik_descendants", right_state_id:"imani_descendants", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS},
+      {id:"imani_descendants", image:"images/imani_descendants.jpg", title:"Imani’s descendants", status:"Protected future branch", node:"Imani’s descendants", description:"Protected descendant branch preview.", left_state_id:"imani_adult", right_state_id:"imani_descendants", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS}
+    ]
+  };
+
   function getPreviewManifest() {
+    if (DEMO_MODE) return MORELAND_DEMO_MANIFEST;
     const manifest = window.GENESIS_PROTOTYPE_MANIFEST;
     if (manifest && Array.isArray(manifest.states) && manifest.states.length) {
       return manifest;
@@ -1045,7 +1044,7 @@
 
   async function boot() {
     let selectedManifest = UNAVAILABLE_MANIFEST;
-    if (PREVIEW_MODE) {
+    if (DEMO_MODE) {
       selectedManifest = getPreviewManifest();
     } else {
       const liveManifest = await loadDynamicManifest();


### PR DESCRIPTION
### Motivation
- Provide a safe, public-facing demo of the family viewer while keeping private project content gated behind workspace entitlement. 
- Clarify messaging across the site to explain protected workspaces and package-driven delivery. 
- Refresh the global visual design from a dark prototype skin to a lighter, production-oriented theme. 

### Description
- Replace many copy strings across `index.html`, `platform.html`, `faq.html`, and `security.html` to emphasize protected workspaces, demo preview availability, and updated brand phrasing. 
- Add a `demo=malik-moreland` preview path and wire it into front-end links and iframe sources so the homepage and platform pages open the demo tree (`viewer/?demo=malik-moreland`). 
- Update `styles.css` with a large theme overhaul: replace dark variables with new `--tol-*` light-theme variables, update backgrounds, borders, button styles, and add new demo-related UI classes (`.hero-demo-badge`, `.hero-viewer-static-siblings`, etc.). 
- Extend viewer behavior: in `viewer/index.html` treat `demo=malik-moreland` as a preview flag and update header/placeholder copy; in `viewer/js/script.js` add `DEMO_MODE`, include a `MORELAND_DEMO_MANIFEST` with demo states and images, return that manifest in preview/demo mode, and update the unavailable-manifest fallback messages and controls; also add a signup CTA to the viewer controls. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d3975550832d9030562da4d41de3)