### PR TITLE
Clean homepage header and simplify Moreland preview presentation

### DIFF
--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -39,22 +39,24 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
     def test_marketing_homepage_uses_non_broken_viewer_preview_block(self):
         contents = (REPO_ROOT / "index.html").read_text(encoding="utf-8")
 
-        self.assertRegex(contents, r'class="[^"]*\bhero-moreland-tree-card\b[^"]*"')
-        self.assertIn('class="btn btn-primary" href="/viewer/?demo=malik-moreland"', contents)
-        self.assertIn("Moreland Family Tree Preview", contents)
+        self.assertRegex(contents, r'class="[^"]*\bhero-moreland-preview-card\b[^"]*"')
         self.assertIn(
-            "Explore linked Moreland branches from Clara and Elias through Selah, Julian, Malik, Imani, Camille, and Micah.",
+            'class="btn btn-primary moreland-preview-cta" href="/viewer/?demo=malik-moreland"',
             contents,
         )
+        self.assertIn("MORELAND FAMILY TREE PREVIEW", contents)
+        self.assertIn(
+            "Preview the Moreland family structure, then open the full demo to explore parent, sibling, spouse, and descendant branches.",
+            contents,
+        )
+        self.assertIn("View Full Demo Tree", contents)
         self.assertNotIn("Scroll through the Moreland demo tree.", contents)
+        self.assertNotIn("Explore linked Moreland branches from Clara and Elias", contents)
         self.assertNotIn("Manifest Required", contents)
-        embed_match = re.search(
-            r'<div class="hero-demo-embed hero-moreland-tree-embed">(.*?)</div>\s*</div>',
-            contents,
-            re.DOTALL,
-        )
-        self.assertIsNotNone(embed_match)
-        self.assertNotIn("<iframe", embed_match.group(1))
+        self.assertNotIn("moreland-list-preview", contents)
+        self.assertNotIn("moreland-graph-preview", contents)
+        self.assertNotIn("moreland-tree-canvas", contents)
+        self.assertNotIn("<iframe", contents)
         self.assertNotIn('viewer/index.html?preview=1', contents)
         self.assertNotIn('href="viewer/?demo=malik-moreland"', contents)
         self.assertNotIn('href="viewer?demo=malik-moreland"', contents)

--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@
       }
     </script>
 
-    <link rel="stylesheet" href="styles.css?v=20260509-1" />
+    <link rel="stylesheet" href="styles.css?v=20260509-homepage" />
   </head>
-  <body>
+  <body class="homepage-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
 
     <div class="site-watermark" aria-hidden="true"></div>
@@ -156,125 +156,58 @@
               </div>
 
               <div class="hero-visual hero-visual-tech hero-visual-moreland">
-                <div class="hero-visual-card hero-demo-card hero-moreland-tree-card">
-                  <div class="hero-demo-card-top hero-demo-card-top-moreland">
-                    <div>
-                      <span class="eyebrow">Moreland Family Tree Preview</span>
-                      <p class="moreland-mobile-instruction">
-                        Explore linked Moreland branches from Clara and Elias through Selah, Julian, Malik, Imani, Camille, and Micah.
-                      </p>
-                    </div>
+                <div class="hero-visual-card hero-demo-card hero-moreland-preview-card">
+                  <div class="moreland-preview-copy">
+                    <span class="eyebrow">Featured demo</span>
+                    <h2>MORELAND FAMILY TREE PREVIEW</h2>
+                    <p>
+                      Preview the Moreland family structure, then open the full demo to explore parent, sibling, spouse, and descendant branches.
+                    </p>
+                    <a class="btn btn-primary moreland-preview-cta" href="/viewer/?demo=malik-moreland">
+                      View Full Demo Tree
+                    </a>
                   </div>
 
-                  <div class="hero-demo-embed hero-moreland-tree-embed">
-                    <div class="hero-demo-stage hero-moreland-tree-stage">
-                      <div class="moreland-list-preview" aria-label="Moreland family list preview">
-                        <ul class="moreland-list-cards">
-                          <li class="moreland-list-card"><span>Clara Moreland</span><span>Born: 1964</span></li>
-                          <li class="moreland-list-card"><span>Elias Moreland</span><span>Born: 1962</span></li>
-                          <li class="moreland-list-card"><span>Andre Carter</span><span>Born: 1991</span></li>
-                          <li class="moreland-list-card"><span>Selah Carter</span><span>Born: 1992</span></li>
-                          <li class="moreland-list-card"><span>Julian Moreland</span><span>Born: 1990</span></li>
-                          <li class="moreland-list-card"><span>Malik Moreland</span><span>Born: 1994</span></li>
-                          <li class="moreland-list-card"><span>Naomi Moreland</span><span>Born: 1995</span></li>
-                          <li class="moreland-list-card"><span>Zara Carter</span><span>Born: 2018</span></li>
-                          <li class="moreland-list-card"><span>Eli Moreland</span><span>Born: 2016</span></li>
-                          <li class="moreland-list-card"><span>Imani Moreland</span><span>Born: 2014</span></li>
-                          <li class="moreland-list-card"><span>Marcus Benton</span><span>Born: 2012</span></li>
-                          <li class="moreland-list-card"><span>Camille Benton</span><span>Born: 2036</span></li>
-                          <li class="moreland-list-card"><span>Micah Benton</span><span>Born: 2038</span></li>
-                        </ul>
-                      </div>
+                  <div
+                    class="hero-demo-embed hero-moreland-preview-embed"
+                    aria-label="Simplified Moreland family tree preview"
+                  >
+                    <div class="hero-demo-stage hero-moreland-preview-stage">
+                      <div class="moreland-teaser-tree">
+                        <div class="moreland-teaser-generation moreland-teaser-generation-founders">
+                          <article class="moreland-teaser-node moreland-teaser-node-primary">
+                            <span>Clara Moreland</span>
+                            <small>and Elias Moreland</small>
+                          </article>
+                        </div>
 
-                      <div
-                        class="moreland-tree-scroll moreland-graph-preview"
-                        role="region"
-                        aria-label="Moreland family tree preview showing linked parent-child and spouse relationships"
-                        tabindex="0"
-                      >
-                        <div class="moreland-tree-canvas" aria-label="Linked Moreland family topology">
-                          <svg
-                            class="moreland-tree-connectors"
-                            viewBox="0 0 1260 760"
-                            preserveAspectRatio="xMidYMid meet"
-                            aria-hidden="true"
-                          >
-                            <g class="moreland-parent-links">
-                              <line x1="610" y1="130" x2="610" y2="180"></line>
-                              <line x1="356" y1="180" x2="796" y2="180"></line>
-                              <line x1="356" y1="180" x2="356" y2="220"></line>
-                              <line x1="596" y1="180" x2="596" y2="220"></line>
-                              <line x1="796" y1="180" x2="796" y2="220"></line>
-                              <line x1="276" y1="310" x2="276" y2="360"></line>
-                              <line x1="276" y1="360" x2="276" y2="400"></line>
-                              <line x1="876" y1="310" x2="876" y2="360"></line>
-                              <line x1="796" y1="360" x2="956" y2="360"></line>
-                              <line x1="796" y1="360" x2="796" y2="400"></line>
-                              <line x1="956" y1="360" x2="956" y2="400"></line>
-                              <line x1="1036" y1="490" x2="1036" y2="540"></line>
-                              <line x1="956" y1="540" x2="1116" y2="540"></line>
-                              <line x1="956" y1="540" x2="956" y2="580"></line>
-                              <line x1="1116" y1="540" x2="1116" y2="580"></line>
-                            </g>
-                            <g class="moreland-spouse-links">
-                              <line x1="506" y1="90" x2="716" y2="90"></line>
-                              <line x1="196" y1="270" x2="356" y2="270"></line>
-                              <line x1="796" y1="270" x2="956" y2="270"></line>
-                              <line x1="956" y1="450" x2="1116" y2="450"></line>
-                            </g>
-                          </svg>
+                        <div class="moreland-teaser-branch" aria-hidden="true"></div>
 
-                          <article class="moreland-person-card moreland-node moreland-node-clara">
-                            <h3>Clara Moreland</h3>
-                            <p>Born: 1964</p>
+                        <div class="moreland-teaser-generation moreland-teaser-generation-children">
+                          <article class="moreland-teaser-node">
+                            <span>Selah Carter</span>
+                            <small>Sibling branch</small>
                           </article>
-                          <article class="moreland-person-card moreland-node moreland-node-elias">
-                            <h3>Elias Moreland</h3>
-                            <p>Born: 1962</p>
+                          <article class="moreland-teaser-node moreland-teaser-node-primary">
+                            <span>Malik Moreland</span>
+                            <small>Demo focus</small>
                           </article>
-                          <article class="moreland-person-card moreland-node moreland-node-andre">
-                            <h3>Andre Carter</h3>
-                            <p>Born: 1991</p>
+                          <article class="moreland-teaser-node">
+                            <span>Julian Moreland</span>
+                            <small>Sibling branch</small>
                           </article>
-                          <article class="moreland-person-card moreland-node moreland-node-selah">
-                            <h3>Selah Carter</h3>
-                            <p>Born: 1992</p>
+                        </div>
+
+                        <div class="moreland-teaser-branch moreland-teaser-branch-short" aria-hidden="true"></div>
+
+                        <div class="moreland-teaser-generation moreland-teaser-generation-descendants">
+                          <article class="moreland-teaser-node">
+                            <span>Imani Moreland</span>
+                            <small>Descendant branch</small>
                           </article>
-                          <article class="moreland-person-card moreland-node moreland-node-julian">
-                            <h3>Julian Moreland</h3>
-                            <p>Born: 1990</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-malik">
-                            <h3>Malik Moreland</h3>
-                            <p>Born: 1994</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-naomi">
-                            <h3>Naomi Moreland</h3>
-                            <p>Born: 1995</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-zara">
-                            <h3>Zara Carter</h3>
-                            <p>Born: 2018</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-eli">
-                            <h3>Eli Moreland</h3>
-                            <p>Born: 2016</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-imani">
-                            <h3>Imani Moreland</h3>
-                            <p>Born: 2014</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-marcus">
-                            <h3>Marcus Benton</h3>
-                            <p>Born: 2012</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-camille">
-                            <h3>Camille Benton</h3>
-                            <p>Born: 2036</p>
-                          </article>
-                          <article class="moreland-person-card moreland-node moreland-node-micah">
-                            <h3>Micah Benton</h3>
-                            <p>Born: 2038</p>
+                          <article class="moreland-teaser-node">
+                            <span>Eli Moreland</span>
+                            <small>Descendant branch</small>
                           </article>
                         </div>
                       </div>

--- a/styles.css
+++ b/styles.css
@@ -269,6 +269,65 @@ a {
   flex-wrap: wrap;
 }
 
+@media (min-width: 861px) {
+  .homepage-body .site-header {
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(246, 250, 253, 0.9));
+    border-bottom-color: rgba(216, 227, 236, 0.72);
+    box-shadow: 0 18px 42px rgba(11, 18, 32, 0.06);
+  }
+
+  .homepage-body .site-header-inner {
+    min-height: 92px;
+    gap: 24px;
+  }
+
+  .homepage-body .brand {
+    font-size: 1.52rem;
+    letter-spacing: 0;
+  }
+
+  .homepage-body .site-nav {
+    gap: 22px;
+    justify-content: center;
+    margin-left: 0;
+  }
+
+  .homepage-body .site-nav a {
+    font-size: 0.94rem;
+    letter-spacing: 0;
+  }
+
+  .homepage-body .header-actions {
+    flex-wrap: nowrap;
+  }
+
+  .homepage-body .header-trust-badge {
+    display: none;
+  }
+
+  .homepage-body .header-actions .btn {
+    min-height: 48px;
+    padding-inline: 22px;
+    white-space: nowrap;
+  }
+}
+
+@media (min-width: 1181px) {
+  .homepage-body .site-header-inner {
+    min-height: 98px;
+    gap: 34px;
+  }
+
+  .homepage-body .brand {
+    font-size: 1.62rem;
+  }
+
+  .homepage-body .site-nav {
+    gap: 30px;
+  }
+}
+
 .menu-toggle {
   display: none;
   appearance: none;
@@ -750,8 +809,10 @@ select:focus-visible {
   gap: 0;
 }
 
-.hero-moreland-tree-card {
-  padding: 24px;
+.hero-moreland-preview-card {
+  display: grid;
+  gap: 22px;
+  padding: 26px;
   border-color: rgba(114, 188, 255, 0.24);
   background:
     radial-gradient(
@@ -765,221 +826,131 @@ select:focus-visible {
       transparent 26%
     ),
     linear-gradient(180deg, rgba(8, 13, 24, 0.94), rgba(4, 8, 16, 0.98));
+  overflow: hidden;
 }
 
-.hero-demo-card-top-moreland {
-  margin-bottom: 14px;
+.moreland-preview-copy {
+  display: grid;
+  gap: 12px;
+  max-width: 640px;
 }
 
-.hero-demo-card-top-moreland h2 {
-  max-width: 22ch;
+.moreland-preview-copy .eyebrow {
   margin: 0;
-  font-size: clamp(1.35rem, 2.1vw, 1.9rem);
+  color: rgba(232, 241, 255, 0.68);
+}
+
+.moreland-preview-copy h2 {
+  margin: 0;
   color: var(--tol-dark-heading);
+  font-size: 1.48rem;
+  line-height: 1.12;
+  letter-spacing: 0;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
-.moreland-mobile-instruction {
-  margin: 8px 0 0;
+.moreland-preview-copy p {
+  margin: 0;
   color: rgba(232, 241, 255, 0.86);
-  font-size: 0.9rem;
-  line-height: 1.5;
+  font-size: 0.98rem;
+  line-height: 1.62;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
-.hero-moreland-tree-embed {
+.moreland-preview-cta {
+  width: fit-content;
+  margin-top: 4px;
+}
+
+.hero-moreland-preview-embed {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(3, 8, 16, 0.84);
   border-radius: 24px;
   overflow: hidden;
 }
 
-.hero-moreland-tree-stage {
-  min-height: clamp(500px, 60vh, 720px);
-  aspect-ratio: auto;
+.hero-moreland-preview-stage {
+  min-height: 382px;
+  aspect-ratio: 16 / 10;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background:
     radial-gradient(circle at 14% 8%, rgba(198, 166, 106, 0.18), transparent 30%),
     radial-gradient(circle at 86% 86%, rgba(114, 188, 255, 0.24), transparent 30%),
     linear-gradient(180deg, rgba(3, 7, 15, 0.98), rgba(4, 8, 16, 0.98));
   border: 0;
+  overflow: hidden;
 }
 
-.moreland-tree-scroll {
+.moreland-teaser-tree {
   width: 100%;
-  height: 100%;
-  max-width: 100%;
-  overflow-x: auto;
-  overflow-y: auto;
-  padding: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(214, 176, 102, 0.75) rgba(255, 255, 255, 0.08);
-}
-
-.moreland-tree-scroll::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-.moreland-tree-scroll::-webkit-scrollbar-thumb {
-  background: rgba(214, 176, 102, 0.75);
-  border-radius: 999px;
-}
-
-.moreland-tree-scroll::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
-}
-
-.moreland-tree-scroll:focus-visible {
-  outline: 2px solid var(--gold);
-  outline-offset: 2px;
-}
-
-.moreland-list-preview {
-  display: none;
-  width: 100%;
-  padding: 14px;
-}
-
-.moreland-list-cards {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  max-width: 720px;
+  margin: auto;
   display: grid;
-  gap: 10px;
+  gap: 18px;
 }
 
-.moreland-list-card {
-  margin: 0;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(114, 188, 255, 0.3);
-  background: rgba(6, 12, 23, 0.84);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.moreland-teaser-generation {
+  display: grid;
+  gap: 14px;
+  align-items: stretch;
+  justify-content: center;
 }
 
-.moreland-list-card span:first-child {
-  color: #ffffff;
-  font-weight: 700;
-  line-height: 1.25;
+.moreland-teaser-generation-founders {
+  grid-template-columns: minmax(220px, 320px);
 }
 
-.moreland-list-card span:last-child {
-  color: var(--tol-dark-muted);
-  font-size: 0.86rem;
-  font-weight: 500;
+.moreland-teaser-generation-children {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.moreland-graph-preview {
-  display: block;
+.moreland-teaser-generation-descendants {
+  width: min(100%, 480px);
+  margin-inline: auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.moreland-tree-canvas {
+.moreland-teaser-branch {
   position: relative;
-  width: min(100%, 1260px);
-  max-width: 1260px;
-  aspect-ratio: 1260 / 760;
-  min-width: 0;
-  min-height: 0;
+  width: min(72%, 520px);
+  height: 34px;
+  margin: -2px auto;
 }
 
-.moreland-tree-connectors {
+.moreland-teaser-branch::before,
+.moreland-teaser-branch::after {
+  content: "";
   position: absolute;
-  inset: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(214, 176, 102, 0.78);
+}
+
+.moreland-teaser-branch::before {
+  top: 0;
+  bottom: 0;
+  width: 2px;
+}
+
+.moreland-teaser-branch::after {
+  top: 50%;
   width: 100%;
-  height: 100%;
+  height: 2px;
 }
 
-.moreland-parent-links line {
-  stroke: rgba(214, 176, 102, 0.92);
-  stroke-width: 3;
-  stroke-linecap: round;
+.moreland-teaser-branch-short {
+  width: min(48%, 340px);
 }
 
-.moreland-spouse-links line {
-  stroke: rgba(114, 188, 255, 0.82);
-  stroke-width: 2.5;
-  stroke-linecap: round;
-  stroke-dasharray: 8 7;
-}
-
-.moreland-node {
-  position: absolute;
-  width: 15.24%;
-}
-
-.moreland-node-clara {
-  top: 5.263%;
-  left: 32.54%;
-}
-
-.moreland-node-elias {
-  top: 5.263%;
-  left: 49.206%;
-}
-
-.moreland-node-andre {
-  top: 28.947%;
-  left: 7.937%;
-}
-
-.moreland-node-selah {
-  top: 28.947%;
-  left: 20.635%;
-}
-
-.moreland-node-julian {
-  top: 28.947%;
-  left: 39.683%;
-}
-
-.moreland-node-malik {
-  top: 28.947%;
-  left: 55.556%;
-}
-
-.moreland-node-naomi {
-  top: 28.947%;
-  left: 68.254%;
-}
-
-.moreland-node-zara {
-  top: 52.632%;
-  left: 14.286%;
-}
-
-.moreland-node-eli {
-  top: 52.632%;
-  left: 55.556%;
-}
-
-.moreland-node-imani {
-  top: 52.632%;
-  left: 68.254%;
-}
-
-.moreland-node-marcus {
-  top: 52.632%;
-  left: 80.952%;
-}
-
-.moreland-node-camille {
-  top: 76.316%;
-  left: 68.254%;
-}
-
-.moreland-node-micah {
-  top: 76.316%;
-  left: 80.952%;
-}
-
-.moreland-person-card {
+.moreland-teaser-node {
   min-height: 88px;
   margin: 0;
-  padding: 14px 14px 12px;
+  padding: 16px 14px;
   border-radius: 16px;
   border: 1px solid rgba(114, 188, 255, 0.34);
   background:
@@ -988,22 +959,36 @@ select:focus-visible {
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.03),
     0 16px 26px rgba(1, 4, 10, 0.34);
+  display: grid;
+  gap: 5px;
+  align-content: center;
+  text-align: center;
 }
 
-.moreland-person-card h3 {
-  margin: 0 0 4px;
+.moreland-teaser-node-primary {
+  border-color: rgba(214, 176, 102, 0.54);
+  background:
+    linear-gradient(180deg, rgba(214, 176, 102, 0.14), rgba(255, 255, 255, 0.03)),
+    rgba(6, 12, 23, 0.9);
+}
+
+.moreland-teaser-node span {
   color: #ffffff;
-  font-size: 1rem;
-  line-height: 1.2;
+  font-size: 0.98rem;
+  line-height: 1.22;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
-.moreland-person-card p {
-  margin: 0;
+.moreland-teaser-node small {
   color: var(--tol-dark-muted);
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 500;
+  line-height: 1.35;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .platform-model-card {
@@ -4272,42 +4257,12 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     grid-area: auto;
   }
 
-  .hero-moreland-tree-card {
-    padding: 24px 24px 20px;
+  .hero-moreland-preview-card {
+    padding: 24px;
   }
 
-  .hero-moreland-tree-stage {
-    min-height: clamp(420px, 45vw, 620px);
-  }
-
-  .moreland-tree-scroll {
-    padding: 16px;
-  }
-
-  .moreland-tree-canvas {
-    width: min(100%, 1260px);
-    max-width: 1260px;
-    aspect-ratio: 1260 / 760;
-    min-width: 0;
-    min-height: 0;
-    margin: 0;
-  }
-
-  .moreland-node {
-    position: absolute;
-    width: 15.24%;
-  }
-
-  .moreland-tree-connectors {
-    display: block;
-  }
-
-  .moreland-list-preview {
-    display: none;
-  }
-
-  .moreland-graph-preview {
-    display: block;
+  .hero-moreland-preview-stage {
+    min-height: 360px;
   }
 }
 
@@ -4632,23 +4587,48 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     max-height: none;
   }
 
-  .hero-moreland-tree-stage {
-    min-height: 500px;
+  .hero-moreland-preview-card {
+    padding: 20px;
   }
 
-  .moreland-tree-scroll {
-    padding: 14px 12px;
+  .moreland-preview-copy h2 {
+    font-size: 1.28rem;
   }
 
-  .moreland-tree-canvas {
-    width: min(100%, 1260px);
-    max-width: 1260px;
-    aspect-ratio: 1260 / 760;
-    min-width: 0;
+  .moreland-preview-cta {
+    width: 100%;
+    justify-content: center;
   }
 
-  .moreland-person-card {
-    width: 15.24%;
+  .hero-moreland-preview-stage {
+    aspect-ratio: auto;
+    min-height: 0;
+    padding: 16px;
+    align-items: stretch;
+  }
+
+  .moreland-teaser-tree {
+    gap: 12px;
+    margin: 0;
+    max-width: none;
+  }
+
+  .moreland-teaser-generation,
+  .moreland-teaser-generation-founders,
+  .moreland-teaser-generation-children,
+  .moreland-teaser-generation-descendants {
+    width: 100%;
+    grid-template-columns: 1fr;
+  }
+
+  .moreland-teaser-branch {
+    display: none;
+  }
+
+  .moreland-teaser-node {
+    min-height: 0;
+    padding: 14px;
+    text-align: left;
   }
 
   .hero-viewer-static {
@@ -4903,34 +4883,17 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     max-height: none;
   }
 
-  .hero-demo-card-top-moreland h2 {
-    font-size: clamp(1.2rem, 6.2vw, 1.45rem);
+  .moreland-preview-copy h2 {
+    font-size: 1.16rem;
     line-height: 1.2;
   }
 
-  .hero-moreland-tree-stage {
-    min-height: 460px;
+  .moreland-teaser-node span {
+    font-size: 0.92rem;
   }
 
-  .moreland-tree-canvas {
-    width: min(100%, 1260px);
-    max-width: 1260px;
-    aspect-ratio: 1260 / 760;
-    min-width: 0;
-    min-height: 0;
-  }
-
-  .moreland-person-card {
-    min-height: 78px;
-    padding: 11px 10px;
-  }
-
-  .moreland-person-card h3 {
-    font-size: 0.87rem;
-  }
-
-  .moreland-person-card p {
-    font-size: 0.74rem;
+  .moreland-teaser-node small {
+    font-size: 0.78rem;
   }
 
   .architecture-panel-home h2 {
@@ -4944,30 +4907,8 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 }
 
 @media (max-width: 768px) {
-  .hero-moreland-tree-stage {
-    aspect-ratio: auto;
-    min-height: 480px;
-    height: auto;
-  }
-
-  .moreland-tree-scroll {
-    height: 100%;
-  }
-
-  .moreland-tree-canvas {
-    width: min(100%, 1260px);
-    max-width: 1260px;
-    aspect-ratio: 1260 / 760;
-    min-width: 0;
-    min-height: 0;
-  }
-
-  .moreland-person-card h3 {
-    font-size: 0.84rem;
-  }
-
-  .moreland-person-card p {
-    font-size: 0.72rem;
+  .hero-moreland-preview-embed {
+    border-radius: 20px;
   }
 }
 
@@ -4984,28 +4925,32 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     align-items: start;
   }
 
-  .moreland-list-preview {
-    display: block;
-  }
-
-  .moreland-graph-preview {
-    display: none;
-  }
-
-  .moreland-graph-preview .moreland-tree-canvas,
-  .moreland-graph-preview .moreland-tree-connectors,
-  .moreland-graph-preview .moreland-node {
-    display: none;
-  }
-
-  .hero-moreland-tree-stage {
+  .hero-moreland-preview-stage {
+    aspect-ratio: auto;
     min-height: 0;
     height: auto;
     overflow: visible;
   }
 
-  .hero-moreland-tree-embed {
+  .hero-moreland-preview-embed {
     overflow: visible;
+  }
+
+  .moreland-teaser-generation,
+  .moreland-teaser-generation-founders,
+  .moreland-teaser-generation-children,
+  .moreland-teaser-generation-descendants {
+    width: 100%;
+    grid-template-columns: 1fr;
+  }
+
+  .moreland-teaser-branch {
+    display: none;
+  }
+
+  .moreland-teaser-node {
+    min-height: 0;
+    text-align: left;
   }
 }
 
@@ -5017,7 +4962,7 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
   .hero-copy-moreland,
   .hero-visual-moreland,
-  .hero-moreland-tree-card {
+  .hero-moreland-preview-card {
     grid-column: 1 / -1;
     width: 100%;
   }
@@ -5027,31 +4972,13 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
     align-self: stretch;
   }
 
-  .moreland-list-preview {
-    display: none;
-  }
-
-  .moreland-graph-preview {
-    display: block;
-  }
-
-  .hero-moreland-tree-stage {
-    min-height: min(72vh, 620px);
+  .hero-moreland-preview-stage {
+    min-height: 360px;
     height: auto;
   }
 
-  .moreland-tree-scroll {
-    align-items: flex-start;
-    justify-content: center;
-    overflow: auto;
-  }
-
-  .moreland-tree-canvas {
-    width: 100%;
-    max-width: 1260px;
-    min-width: 0;
-    min-height: 0;
-    margin: 0 auto;
+  .moreland-teaser-tree {
+    max-width: 780px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Cleans up the public homepage desktop header with more breathing room, evenly spaced nav links, and the primary legacy-build CTA preserved.
- Replaces the crowded Moreland full-tree homepage preview with a simplified cinematic teaser, exact full-demo CTA, and responsive teaser structure.
- Updates the frontend link-integrity expectation so it protects the new homepage teaser copy and route.

## Validation
- `/private/tmp/tol-pytest-venv/bin/python -m pytest backend/tests/test_frontend_link_integrity.py -q`
- `/private/tmp/tol-pytest-venv/bin/python -m pytest backend/tests/test_viewer_rendering_safety.py -q`
- Browser checked homepage at desktop, tablet, and mobile viewport sizes: preview card present, no old graph/list DOM, menu behavior present on tablet/mobile, and all nav links remain present.
- Browser checked `/viewer/?demo=malik-moreland`: Moreland demo content loads and does not show the locked/manifest-required fallback.
- Browser checked `/viewer/`: private viewer remains locked/protected without the demo query.

## Scope Notes
- No package pricing, checkout/payment, backend API, auth, entitlement, private viewer runtime, refund/legal/privacy copy, or demo viewer traversal logic changes.