### PR TITLE
Redesign customer portal presentation into premium private operating system

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -8,7 +8,7 @@
       name="description"
       content="Reset or change your Tomb of Light password through the protected account security layer."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body">
     <div class="page-wrap">

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -21,15 +21,22 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
 
     def test_customer_dashboard_upload_center_and_next_step_are_present(self):
         source = (REPO_ROOT / "dashboard.html").read_text(encoding="utf-8")
+        self.assertIn("Tomb of Light Continuity OS", source)
         self.assertIn("What To Do Next", source)
-        self.assertIn("Upload Center", source)
+        self.assertIn("Upload Hub", source)
         self.assertIn("Upload Photos &amp; Family Records", source)
-        self.assertIn("Upload Verification Docs", source)
-        self.assertIn("Continue Intake", source)
+        self.assertIn("Upload Verification Documents", source)
+        self.assertIn("View Intake", source)
         self.assertIn("Portrait / Family Photos", source)
         self.assertIn("Family Records / Documents", source)
         self.assertIn("Verification Documents", source)
         self.assertIn("Optional Narration / Story Materials", source)
+        self.assertIn("Private Vault Files", source)
+        self.assertIn("Lineage Certificate", source)
+        self.assertIn("Members &amp; Access", source)
+        self.assertIn("Billing &amp; Cards", source)
+        self.assertIn("Account Security", source)
+        self.assertIn("Help Center", source)
 
 
 class ClientPrivilegeElevationTests(unittest.TestCase):

--- a/billing.html
+++ b/billing.html
@@ -8,7 +8,7 @@
       name="description"
       content="Manage Tomb of Light billing, payment methods, maintenance subscriptions, and saved cards."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body">
     <div class="page-wrap">

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -319,13 +319,13 @@
     if (state === "complete") {
       item.classList.add("is-complete");
       chip.classList.add("is-complete");
-      chip.textContent = "Complete";
+      chip.textContent = "Open";
       return;
     }
     if (state === "live") {
       item.classList.add("is-live");
       chip.classList.add("is-live");
-      chip.textContent = "In progress";
+      chip.textContent = "Open";
       return;
     }
     if (state === "attention") {
@@ -334,7 +334,7 @@
       chip.textContent = "Needs attention";
       return;
     }
-    chip.textContent = "Pending";
+    chip.textContent = "Awaiting setup";
   }
 
   function updateProjectProgressTracker(context, latestSubmission, needsAttention) {
@@ -465,35 +465,33 @@
 
     text(
       document.querySelector("[data-health-package]"),
-      context?.hasPackageAccess ? "Active" : "Pending",
+      context?.hasPackageAccess ? "Open" : "Awaiting setup",
     );
     text(
       document.querySelector("[data-health-intake]"),
       !latestSubmission
-        ? "Not started"
+        ? "Awaiting setup"
         : needsAttention || status === "rejected"
           ? "Needs attention"
-          : APPROVED_OR_BEYOND_STATUSES.has(status)
-            ? "Approved"
-            : "Submitted",
+          : "Open",
     );
     text(
       document.querySelector("[data-health-uploads]"),
       !latestSubmission
-        ? "Not started"
+        ? "Awaiting setup"
         : PRODUCTION_OR_BEYOND_STATUSES.has(status)
-          ? "Uploads received"
+          ? "Open"
           : uploadsPlanned || UPLOAD_PENDING_REVIEW_STATUSES.has(status)
-            ? "Pending review"
-            : "Not started",
+            ? "Check access"
+            : "Awaiting setup",
     );
     text(
       document.querySelector("[data-health-verification]"),
       needsAttention || status === "rejected"
         ? "Needs attention"
         : PRODUCTION_OR_BEYOND_STATUSES.has(status)
-          ? "Approved"
-          : "Pending",
+          ? "Open"
+          : "Check access",
     );
 
     const viewerReady = Boolean(
@@ -507,19 +505,19 @@
     text(
       document.querySelector("[data-health-viewer]"),
       viewerReady
-        ? "Ready"
+        ? "Open"
         : PRODUCTION_OR_BEYOND_STATUSES.has(status)
-          ? "In production"
-          : "Not ready",
+          ? "Awaiting setup"
+          : "Awaiting setup",
     );
     text(
       document.querySelector("[data-health-certificate]"),
       Boolean(resolved.can_use_lineage_certificate) &&
         (viewerReady || status === "client_review")
-        ? "Ready"
-        : "Not ready",
+        ? "Open"
+        : "Package-gated",
     );
-    text(document.querySelector("[data-health-vault]"), "Active");
+    text(document.querySelector("[data-health-vault]"), "Open");
     text(document.querySelector("[data-health-privacy]"), "Private by default");
   }
 
@@ -527,9 +525,7 @@
     const node = document.querySelector(selector);
     if (!node) return;
     node.dataset.unlockState = isIncluded ? "included" : "locked";
-    node.textContent = isIncluded
-      ? "Included"
-      : "Locked — not included in your active package.";
+    node.textContent = isIncluded ? "Open" : "Package-gated";
   }
 
   function updatePackageUnlocksPanel(context) {
@@ -594,24 +590,24 @@
     text(
       document.querySelector("[data-received-portraits]"),
       PRODUCTION_OR_BEYOND_STATUSES.has(status)
-        ? "Uploads received"
+        ? "Open"
         : hasPortraitPlan
-          ? "Upload plan received — awaiting upload"
-          : "Awaiting upload",
+          ? "Check access"
+          : "Awaiting setup",
     );
     text(
       document.querySelector("[data-received-verification]"),
       PRODUCTION_OR_BEYOND_STATUSES.has(status)
-        ? "Uploads received"
+        ? "Open"
         : hasVerificationPlan
-          ? "Upload plan received — awaiting upload"
-          : "Awaiting upload",
+          ? "Check access"
+          : "Awaiting setup",
     );
     text(
       document.querySelector("[data-received-vault]"),
       hasVerificationPlan || PRODUCTION_OR_BEYOND_STATUSES.has(status)
-        ? "Optional / Pending review"
-        : "Optional / Awaiting upload",
+        ? "Check access"
+        : "Awaiting setup",
     );
     text(
       document.querySelector("[data-received-review]"),
@@ -621,10 +617,10 @@
 
   function getReceivedReviewStatusLabel(status) {
     if (status === "rejected") return "Needs attention";
-    if (REVIEW_PHASE_STATUSES.has(status)) return "Pending review";
-    if (status === "delivered" || status === "archived") return "Approved";
-    if (PRODUCTION_OR_BEYOND_STATUSES.has(status)) return "In production";
-    return "Pending review";
+    if (REVIEW_PHASE_STATUSES.has(status)) return "Check access";
+    if (status === "delivered" || status === "archived") return "Open";
+    if (PRODUCTION_OR_BEYOND_STATUSES.has(status)) return "Open";
+    return "Awaiting setup";
   }
 
   function text(node, value) {
@@ -865,7 +861,7 @@
 
     if (!hasProject) {
       return {
-        badge: "Awaiting Workspace",
+        badge: "Awaiting setup",
         copy: "A provisioned workspace is required before Tomb of Light can prepare your Legacy Anchor.",
         note: "Once your project is provisioned, this panel will show live mint status, public proof links, and wallet verification.",
       };
@@ -873,7 +869,7 @@
 
     if (!policy.product_includes_onchain_anchor) {
       return {
-        badge: "Not Included",
+        badge: "Package-gated",
         copy: "This package does not include an on-chain Legacy Anchor.",
         note: "Upgrade into an eligible package to unlock Base Mainnet anchor minting and public-safe proof records.",
       };
@@ -1505,7 +1501,7 @@
     }
 
     return {
-      text: "Continue Intake",
+      text: "View Intake",
       href: "intake-welcome.html",
       show: canOpenIntake,
     };
@@ -1551,7 +1547,7 @@
         workspaceCopy: canUseLinkKeys
           ? "Your portrait workspace connects package access, portrait uploads, verification records, guided delivery, and link capabilities in one place."
           : "Your portrait workspace connects package access, portrait uploads, verification records, and guided delivery in one place.",
-        primaryActionText: "Upload Portrait",
+        primaryActionText: "Upload Photos & Family Records",
         primaryActionHref: "portrait-upload.html",
         secondaryActionText: "Verification Uploads",
         secondaryActionHref: "verification-upload.html",
@@ -1613,7 +1609,7 @@
         workspaceCopy: hasLinkedOrganizationSupport
           ? "Your organization workspace connects package access, command structure planning, uploads, and linked organization support in one place."
           : "Your organization workspace connects package access, command structure planning, uploads, and guided record handling in one place.",
-        primaryActionText: "Upload Structure Records",
+        primaryActionText: "Upload Verification Documents",
         primaryActionHref: "verification-upload.html",
         secondaryActionText: "Upload Structure Records",
         secondaryActionHref: "verification-upload.html",
@@ -1674,9 +1670,9 @@
         workspaceCopy: canUseLinkKeys
           ? "Your network workspace connects package access, linked branches, lineage structure, verification records, and link capabilities in one place."
           : "Your network workspace connects package access, linked branches, lineage structure, and verification records in one place.",
-        primaryActionText: "Continue Network Build",
+        primaryActionText: "Open Family Tree",
         primaryActionHref: "tree-view.html",
-        secondaryActionText: "Upload Verification Docs",
+        secondaryActionText: "Upload Verification Documents",
         secondaryActionHref: "verification-upload.html",
         showTree: canBuildFamilyTree,
         showCertificate: canUseCertificate,
@@ -1734,9 +1730,9 @@
       workspaceCopy: canUseLinkKeys
         ? "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, verification, and link capabilities in one place."
         : "Your Tomb of Light customer workspace connects package access, onboarding, family structure, lineage tools, and document-backed verification in one place.",
-      primaryActionText: "Continue Family Build",
+      primaryActionText: "Open Family Tree",
       primaryActionHref: "tree-view.html",
-      secondaryActionText: "Upload Verification Docs",
+      secondaryActionText: "Upload Verification Documents",
       secondaryActionHref: "verification-upload.html",
       showTree: canBuildFamilyTree,
       showCertificate: canUseCertificate,

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,7 +8,7 @@
       name="description"
       content="Your private Tomb of Light customer or internal operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-454" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -56,7 +56,7 @@
         <section class="page-hero dashboard-hero portal-dashboard-hero">
           <div class="container">
             <div class="portal-command-bar">
-              <span class="portal-command-label">Private Workspace</span>
+              <span class="portal-command-label">Tomb of Light Continuity OS</span>
               <div class="portal-chip-row portal-chip-row-compact">
                 <span class="portal-chip" data-dashboard-lane-chip>
                   Access Sync
@@ -73,12 +73,12 @@
             <div class="page-hero-panel dashboard-hero-panel portal-core-panel">
               <div class="portal-core-copy">
                 <span class="eyebrow" data-dashboard-hero-eyebrow>
-                  Private Legacy Command Center
+                  Private Continuity OS
                 </span>
                 <h1 class="portal-core-title" data-dashboard-hero-title>Private Legacy Command Center</h1>
-                <p class="portal-core-status" data-dashboard-status>Loading your account...</p>
+                <p class="portal-core-status" data-dashboard-status>Resolving your project, package, and next action...</p>
                 <p class="portal-core-guidance">
-                  Your active package, stage, and next required action are surfaced first in your private workspace.
+                  A private command center for lineage production, protected uploads, verification, vault handling, family tree build, certificate generation, delivery readiness, and support continuity.
                 </p>
 
                 <div class="inline-actions portal-core-actions" data-workspace-action-bar>
@@ -89,7 +89,7 @@
                     data-dashboard-hero-action
                     style="display: none"
                   >
-                    Continue Family Build
+                    Upload Photos &amp; Family Records
                   </a>
                   <a
                     class="btn btn-secondary"
@@ -98,7 +98,7 @@
                     data-dashboard-hero-action
                     style="display: none"
                   >
-                    Verification Uploads
+                    Upload Verification Documents
                   </a>
                   <a
                     class="btn btn-secondary"
@@ -130,7 +130,7 @@
                 </div>
               </div>
 
-              <div class="portal-core-visual" aria-hidden="true">
+              <div class="portal-core-visual portal-os-visual" aria-hidden="true">
                 <div class="portal-orbit portal-orbit-outer"></div>
                 <div class="portal-orbit portal-orbit-mid"></div>
                 <div class="portal-orbit portal-orbit-inner"></div>
@@ -165,6 +165,18 @@
 
             <div class="portal-metric-grid">
               <article
+                class="portal-metric-card portal-metric-card-project"
+                id="dashboard-project-workspace"
+                data-dashboard-section-anchor
+              >
+                <span class="portal-metric-label">Project / Workspace</span>
+                <strong data-command-center-project>Your current workspace</strong>
+                <p>
+                  Private project context stays inside the customer portal while production status is resolved.
+                </p>
+              </article>
+
+              <article
                 class="portal-metric-card"
                 id="dashboard-access-lane"
                 data-dashboard-section-anchor
@@ -184,9 +196,23 @@
               >
                 <span class="portal-metric-label">Active Package</span>
                 <strong data-dashboard-package-display>Checking package scope</strong>
-                <p>
+                <p data-command-center-package>
                   Your workspace will load the exact tools, limits, and
                   workflows attached to your current entitlement.
+                </p>
+              </article>
+
+              <article
+                class="portal-metric-card"
+                id="dashboard-build-stage"
+                data-dashboard-section-anchor
+              >
+                <span class="portal-metric-label">Build Stage</span>
+                <strong data-command-center-stage>
+                  Workspace active — next action required.
+                </strong>
+                <p>
+                  Production stage updates as intake, uploads, verification, and delivery readiness move forward.
                 </p>
               </article>
 
@@ -197,9 +223,22 @@
               >
                 <span class="portal-metric-label">Next Focus</span>
                 <strong data-dashboard-next-focus>Preparing workspace actions</strong>
+                <p data-command-center-next-action>
+                  Upload Photos &amp; Family Records.
+                </p>
+              </article>
+
+              <article
+                class="portal-metric-card portal-metric-card-privacy"
+                id="dashboard-privacy-support"
+                data-dashboard-section-anchor
+              >
+                <span class="portal-metric-label">Privacy &amp; Support</span>
+                <strong data-command-center-security>
+                  Private workspace active. Public sharing remains off unless approved.
+                </strong>
                 <p>
-                  Core actions update in real time once package and role access
-                  have been resolved.
+                  Support continuity: <a href="mailto:support@tomboflight.com">support@tomboflight.com</a>
                 </p>
               </article>
             </div>
@@ -214,42 +253,28 @@
           >
             <div class="form-panel portal-command-center-panel" data-dashboard-customer-only>
               <div class="dashboard-presence-top">
-                <span class="eyebrow">Private Legacy Command Center</span>
+                <span class="eyebrow">Continuity OS Overview</span>
                 <span class="presence-badge">Customer Workspace</span>
               </div>
-              <h2 class="dashboard-presence-title">Your private legacy production workspace is active.</h2>
+              <h2 class="dashboard-presence-title">Your private operating system is organized around the next required move.</h2>
               <p class="dashboard-presence-copy">
-                Your package, project stage, next required action, privacy state, and support channel are shown below.
+                Lineage production, protected uploads, verification, vault handling, family tree build, certificate generation, delivery readiness, and support continuity stay organized in one command view.
               </p>
               <div class="portal-command-center-grid">
                 <div class="portal-command-center-item">
-                  <strong>Active Package</strong>
-                  <p class="card-copy" data-command-center-package>Your active package</p>
+                  <strong>Lineage Production</strong>
+                  <p class="card-copy">Build stage, intake state, and customer review readiness stay visible as production advances.</p>
                 </div>
                 <div class="portal-command-center-item">
-                  <strong>Project / Workspace</strong>
-                  <p class="card-copy" data-command-center-project>Your current workspace</p>
+                  <strong>Protected Materials</strong>
+                  <p class="card-copy">Photos, family records, verification documents, and vault files stay separated by purpose.</p>
                 </div>
                 <div class="portal-command-center-item">
-                  <strong>Current Build Stage</strong>
-                  <p class="card-copy" data-command-center-stage>
-                    Workspace active — next action required.
-                  </p>
+                  <strong>Delivery Readiness</strong>
+                  <p class="card-copy">Family tree, certificate, viewer, and anchor readiness remain package-aware.</p>
                 </div>
                 <div class="portal-command-center-item">
-                  <strong>Next Required Action</strong>
-                  <p class="card-copy" data-command-center-next-action>
-                    Upload Photos &amp; Family Records.
-                  </p>
-                </div>
-                <div class="portal-command-center-item">
-                  <strong>Privacy / Security</strong>
-                  <p class="card-copy" data-command-center-security>
-                    Private workspace active. Public sharing remains off unless approved.
-                  </p>
-                </div>
-                <div class="portal-command-center-item">
-                  <strong>Support Contact</strong>
+                  <strong>Support Continuity</strong>
                   <p class="card-copy">
                     <a href="mailto:support@tomboflight.com">support@tomboflight.com</a><br />
                     <a href="tel:+13468054305">(346) 805-4305</a>
@@ -272,7 +297,7 @@
             </div>
 
             <div class="form-panel portal-primary-actions-panel" data-dashboard-customer-only>
-              <span class="eyebrow">Primary Action Cards</span>
+              <span class="eyebrow">Primary Actions</span>
               <h3>What To Do Next</h3>
               <div class="portal-action-card-grid portal-action-card-grid-primary">
                 <a class="portal-action-card is-primary" href="upload-hub.html">
@@ -280,7 +305,7 @@
                   <span>Open</span>
                 </a>
                 <a class="portal-action-card" href="verification-upload.html">
-                  <strong>Upload Verification Docs</strong>
+                  <strong>Upload Verification Documents</strong>
                   <span>Open</span>
                 </a>
                 <a class="portal-action-card" href="tree-view.html">
@@ -289,36 +314,6 @@
                 </a>
                 <a class="portal-action-card" href="intake-review.html" data-intake-open-action>
                   <strong>View Intake</strong>
-                  <span>Open</span>
-                </a>
-              </div>
-              <div class="portal-action-card-grid">
-                <a class="portal-action-card" href="intake-welcome.html">
-                  <strong>Continue Intake</strong>
-                  <span>Open</span>
-                </a>
-                <a class="portal-action-card" href="vault-upload.html">
-                  <strong>Private Vault Files</strong>
-                  <span>Open</span>
-                </a>
-                <a class="portal-action-card" href="household-access.html" data-dashboard-household-view-members>
-                  <strong>Members &amp; Access</strong>
-                  <span>Open</span>
-                </a>
-                <a class="portal-action-card" href="lineage-certificate.html">
-                  <strong>Lineage Certificate</strong>
-                  <span>Check access</span>
-                </a>
-                <a class="portal-action-card" href="billing.html" data-dashboard-billing-link data-dashboard-customer-only>
-                  <strong>Billing &amp; Cards</strong>
-                  <span>Open</span>
-                </a>
-                <a class="portal-action-card" href="account-security.html">
-                  <strong>Account Security</strong>
-                  <span>Open</span>
-                </a>
-                <a class="portal-action-card" href="faq.html">
-                  <strong>Help Center</strong>
                   <span>Open</span>
                 </a>
               </div>
@@ -333,51 +328,51 @@
               <ol class="portal-progress-list" data-project-progress-list>
                 <li class="portal-progress-item" data-progress-stage="account_created">
                   <span>Account Created</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="account_created">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="account_created">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="package_activated">
                   <span>Package Activated</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="package_activated">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="package_activated">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="intake_started">
                   <span>Intake Started</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_started">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_started">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="intake_submitted">
                   <span>Intake Submitted</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_submitted">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_submitted">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="intake_approved">
                   <span>Intake Approved</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_approved">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="intake_approved">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="uploads_needed">
                   <span>Uploads Needed</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="uploads_needed">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="uploads_needed">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="uploads_under_review">
                   <span>Uploads Under Review</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="uploads_under_review">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="uploads_under_review">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="verification_review">
                   <span>Verification Review</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="verification_review">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="verification_review">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="production_build">
                   <span>Production Build</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="production_build">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="production_build">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="customer_review">
                   <span>Customer Review</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="customer_review">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="customer_review">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="delivered">
                   <span>Delivered</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="delivered">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="delivered">Awaiting setup</span>
                 </li>
                 <li class="portal-progress-item" data-progress-stage="maintenance_continuity">
                   <span>Maintenance / Continuity</span>
-                  <span class="presence-badge portal-progress-chip" data-progress-chip="maintenance_continuity">Pending</span>
+                  <span class="presence-badge portal-progress-chip" data-progress-chip="maintenance_continuity">Awaiting setup</span>
                 </li>
               </ol>
             </div>
@@ -386,38 +381,35 @@
               <span class="eyebrow">Workspace Health Snapshot</span>
               <h3>Operations status</h3>
               <div class="portal-status-list portal-status-list-compact">
-                <p class="card-copy"><strong>Package:</strong> <span data-health-package>Pending</span></p>
-                <p class="card-copy"><strong>Intake:</strong> <span data-health-intake>Not started</span></p>
-                <p class="card-copy"><strong>Uploads:</strong> <span data-health-uploads>Not started</span></p>
-                <p class="card-copy"><strong>Verification:</strong> <span data-health-verification>Pending</span></p>
-                <p class="card-copy"><strong>Viewer:</strong> <span data-health-viewer>Not ready</span></p>
-                <p class="card-copy"><strong>Certificate:</strong> <span data-health-certificate>Not ready</span></p>
-                <p class="card-copy"><strong>Vault:</strong> <span data-health-vault>Active</span></p>
+                <p class="card-copy"><strong>Package:</strong> <span data-health-package>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Intake:</strong> <span data-health-intake>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Uploads:</strong> <span data-health-uploads>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Verification:</strong> <span data-health-verification>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Viewer:</strong> <span data-health-viewer>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Certificate:</strong> <span data-health-certificate>Awaiting setup</span></p>
+                <p class="card-copy"><strong>Vault:</strong> <span data-health-vault>Open</span></p>
                 <p class="card-copy"><strong>Privacy:</strong> <span data-health-privacy>Private by default</span></p>
               </div>
             </div>
 
             <div class="form-panel portal-tools-access-panel" data-dashboard-customer-only>
-              <span class="eyebrow">Tools &amp; Access</span>
-              <h3>Customer controls</h3>
+              <span class="eyebrow">Command Grid</span>
+              <h3>Customer tools</h3>
               <div class="portal-action-card-grid">
-                <a class="portal-action-card" href="upload-hub.html"><strong>Upload Center</strong><span>Open</span></a>
+                <a class="portal-action-card" href="upload-hub.html"><strong>Upload Hub</strong><span>Open</span></a>
                 <a class="portal-action-card" href="portrait-upload.html"><strong>Portrait / Family Photos</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="verification-upload.html"><strong>Verification Documents</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="vault-upload.html"><strong>Private Vault Files</strong><span>Check access</span></a>
-                <a class="portal-action-card" href="intake-uploads.html"><strong>Optional Narration / Story Materials</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="tree-view.html"><strong>Family Tree</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="lineage-certificate.html"><strong>Lineage Certificate</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="household-access.html" data-dashboard-household-invite-co-owner><strong>Members &amp; Access</strong><span>Check access</span></a>
-                <a class="portal-action-card" href="household-access.html" data-dashboard-household-invite-family><strong>Household Invites</strong><span>Open</span></a>
-                <a class="portal-action-card" href="household-access.html" data-dashboard-household-pending-invites><strong>Pending Invites</strong><span>Open</span></a>
                 <a class="portal-action-card" href="link-keys.html"><strong>Link Keys</strong><span>Check access</span></a>
                 <a class="portal-action-card" href="billing.html"><strong>Billing &amp; Cards</strong><span>Open</span></a>
                 <a class="portal-action-card" href="account-security.html"><strong>Account Security</strong><span>Open</span></a>
                 <a class="portal-action-card" href="faq.html"><strong>Help Center</strong><span>Open</span></a>
               </div>
               <p class="card-copy" style="margin-top: 0.9rem">
-                Family Records / Documents should be uploaded with Verification Documents.
+                Family Records / Documents should be uploaded through the Upload Hub with Verification Documents where source review is needed. Optional Narration / Story Materials remain package-gated until access is confirmed.
               </p>
               <div class="portal-tools-access-footnote" data-package-access-panel>
                 <p class="card-copy" data-access-status>Checking your purchase access...</p>
@@ -431,22 +423,22 @@
             <div class="form-panel portal-package-unlocks-panel" data-dashboard-customer-only>
               <span class="eyebrow">Package Unlocks</span>
               <h3>Compact entitlement snapshot</h3>
-              <p class="card-copy">Included in your package</p>
+              <p class="card-copy">Package-controlled access</p>
               <ul class="portal-unlock-list portal-unlock-list-compact">
-                <li><span>Portrait Uploads</span><span data-unlock-portraits>Locked — not included in your active package.</span></li>
-                <li><span>Verification Uploads</span><span data-unlock-verification>Locked — not included in your active package.</span></li>
-                <li><span>Vault Files</span><span data-unlock-vault>Locked — not included in your active package.</span></li>
-                <li><span>Family Intake</span><span data-unlock-intake>Locked — not included in your active package.</span></li>
-                <li><span>Family Tree</span><span data-unlock-tree>Locked — not included in your active package.</span></li>
-                <li><span>Lineage Certificate</span><span data-unlock-certificate>Locked — not included in your active package.</span></li>
-                <li><span>Viewer Access</span><span data-unlock-viewer>Locked — not included in your active package.</span></li>
+                <li><span>Portrait Uploads</span><span data-unlock-portraits>Package-gated</span></li>
+                <li><span>Verification Uploads</span><span data-unlock-verification>Package-gated</span></li>
+                <li><span>Vault Files</span><span data-unlock-vault>Package-gated</span></li>
+                <li><span>Family Intake</span><span data-unlock-intake>Package-gated</span></li>
+                <li><span>Family Tree</span><span data-unlock-tree>Package-gated</span></li>
+                <li><span>Lineage Certificate</span><span data-unlock-certificate>Package-gated</span></li>
+                <li><span>Viewer Access</span><span data-unlock-viewer>Package-gated</span></li>
               </ul>
               <p class="card-copy">Available in higher packages</p>
               <ul class="portal-unlock-list portal-unlock-list-compact">
-                <li><span>Optional Narration / Story Materials</span><span data-unlock-narration>Locked — not included in your active package.</span></li>
-                <li><span>Link Keys</span><span data-unlock-link-keys>Locked — not included in your active package.</span></li>
-                <li><span>Household Access</span><span data-unlock-household>Locked — not included in your active package.</span></li>
-                <li><span>Organization Tools</span><span data-unlock-organization>Locked — not included in your active package.</span></li>
+                <li><span>Optional Narration / Story Materials</span><span data-unlock-narration>Package-gated</span></li>
+                <li><span>Link Keys</span><span data-unlock-link-keys>Package-gated</span></li>
+                <li><span>Household Access</span><span data-unlock-household>Package-gated</span></li>
+                <li><span>Organization Tools</span><span data-unlock-organization>Package-gated</span></li>
               </ul>
             </div>
 
@@ -456,19 +448,19 @@
               <div class="portal-status-list portal-status-list-compact">
                 <p class="card-copy">
                   <strong>Portraits / Family Photos:</strong>
-                  <span data-received-portraits>Awaiting upload</span>
+                  <span data-received-portraits>Awaiting setup</span>
                 </p>
                 <p class="card-copy">
                   <strong>Verification Documents:</strong>
-                  <span data-received-verification>Awaiting upload</span>
+                  <span data-received-verification>Awaiting setup</span>
                 </p>
                 <p class="card-copy">
                   <strong>Vault Files:</strong>
-                  <span data-received-vault>Optional / Awaiting upload</span>
+                  <span data-received-vault>Awaiting setup</span>
                 </p>
                 <p class="card-copy">
                   <strong>Review Status:</strong>
-                  <span data-received-review>Status pending</span>
+                  <span data-received-review>Awaiting setup</span>
                 </p>
               </div>
             </div>
@@ -501,7 +493,7 @@
               <div class="anchor-status-row">
                 <span class="eyebrow">Legacy Anchor</span>
                 <span class="presence-badge anchor-status-badge" data-anchor-status-badge>
-                  Checking Status
+                  Check access
                 </span>
               </div>
 
@@ -670,11 +662,10 @@
                 </a>
                 <a
                   class="btn btn-secondary"
-                  href="admin-control-center.html"
                   data-dashboard-admin-only
                   style="display: none"
                 >
-                  Open Admin Control Center
+                  Internal workspace tools
                 </a>
               </div>
             </div>
@@ -702,7 +693,7 @@
     <script src="config.js?v=20260329-1"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260508-451"></script>
-    <script src="dashboard-intake.js?v=20260508-454"></script>
+    <script src="dashboard-intake.js?v=20260509-portal"></script>
     <script src="dashboard-admin.js?v=20260508-451"></script>
   </body>
 </html>

--- a/household-access.html
+++ b/household-access.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Members &amp; Access | Tomb of Light</title>
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-household-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/intake-review.html
+++ b/intake-review.html
@@ -8,7 +8,7 @@
       name="description"
       content="Review your Tomb of Light intake details before submission."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/intake-uploads.html
+++ b/intake-uploads.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload planning and asset scope for Tomb of Light onboarding. This step plans what you will upload — it does not upload files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/lineage-certificate.html
+++ b/lineage-certificate.html
@@ -8,7 +8,7 @@
       name="description"
       content="Generate and view executive lineage certificates for Tomb of Light family records."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-certificate-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/link-keys.html
+++ b/link-keys.html
@@ -8,7 +8,7 @@
       name="description"
       content="Generate, share, approve, and manage Tomb of Light link keys for eligible portrait, household, and network workspaces."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-link-keys-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload portrait images for your Tomb of Light portrait workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-portrait-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/styles.css
+++ b/styles.css
@@ -3435,7 +3435,413 @@ textarea {
   opacity: 0.96;
 }
 
+/* Customer portal Continuity OS presentation */
+
+.portal-dashboard-body,
+.portal-upload-hub-body {
+  overflow-x: hidden;
+  background:
+    linear-gradient(180deg, rgba(5, 12, 24, 0.98), rgba(8, 15, 29, 0.98) 42%, rgba(3, 8, 17, 1));
+}
+
+.portal-dashboard-body .site-watermark,
+.portal-upload-hub-body .site-watermark {
+  background-size: min(62vw, 620px);
+  background-position: 50% 48%;
+  opacity: 0.055;
+  filter: brightness(1.45) contrast(1.08);
+}
+
+.portal-dashboard-body .container,
+.portal-upload-hub-body .container {
+  width: min(1480px, calc(100% - 48px));
+}
+
+.portal-dashboard-body .site-header,
+.portal-upload-hub-body .site-header {
+  backdrop-filter: blur(22px);
+  background: rgba(3, 8, 18, 0.82);
+  border-bottom-color: rgba(156, 188, 226, 0.14);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
+}
+
+.portal-dashboard-body .site-header-inner,
+.portal-upload-hub-body .site-header-inner {
+  min-height: 78px;
+}
+
+.portal-dashboard-body .brand,
+.portal-upload-hub-body .brand,
+.portal-dashboard-body h1,
+.portal-dashboard-body h2,
+.portal-dashboard-body h3,
+.portal-upload-hub-body h1,
+.portal-upload-hub-body h2,
+.portal-upload-hub-body h3 {
+  letter-spacing: 0;
+}
+
+.portal-dashboard-body .page-hero,
+.portal-upload-hub-body .page-hero {
+  padding-top: 28px;
+  padding-bottom: 10px;
+}
+
+.portal-dashboard-body .page-sections,
+.portal-upload-hub-body .page-sections {
+  padding-top: 10px;
+}
+
+.portal-dashboard-body .page-hero-panel,
+.portal-upload-hub-hero-panel,
+.portal-upload-hub-card,
+.portal-dashboard-body .form-panel {
+  border-radius: 22px;
+  border-color: rgba(166, 197, 232, 0.18);
+  background:
+    linear-gradient(180deg, rgba(12, 23, 42, 0.92), rgba(6, 13, 26, 0.96));
+  box-shadow:
+    0 18px 54px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.portal-dashboard-body .page-hero-panel,
+.portal-dashboard-body .form-panel,
+.portal-upload-hub-hero-panel,
+.portal-upload-hub-card {
+  padding: clamp(20px, 2.2vw, 30px);
+}
+
+.portal-command-bar {
+  border-radius: 18px;
+  padding: 12px 16px;
+  background:
+    linear-gradient(90deg, rgba(120, 217, 255, 0.11), rgba(214, 176, 102, 0.07)),
+    rgba(5, 12, 24, 0.78);
+}
+
+.portal-command-label,
+.portal-metric-label,
+.portal-dashboard-body .eyebrow,
+.portal-upload-hub-body .eyebrow {
+  letter-spacing: 0.14em;
+}
+
+.portal-core-panel {
+  grid-template-columns: minmax(0, 1.28fr) minmax(280px, 0.72fr);
+  align-items: stretch;
+  min-height: 0;
+  gap: 18px;
+}
+
+.portal-core-copy {
+  justify-content: center;
+}
+
+.portal-core-copy h1 {
+  max-width: 15ch;
+  font-size: clamp(2.35rem, 4.2vw, 4.4rem);
+  line-height: 1;
+}
+
+.portal-core-status {
+  color: #eff7ff;
+}
+
+.portal-core-guidance {
+  max-width: 72ch;
+}
+
+.portal-core-actions {
+  gap: 10px;
+}
+
+.portal-core-actions .btn {
+  min-height: 48px;
+  padding-inline: 18px;
+}
+
+.portal-os-visual {
+  min-height: 280px;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  align-content: center;
+  place-items: stretch;
+  opacity: 1 !important;
+  transform: none !important;
+  background:
+    linear-gradient(180deg, rgba(8, 18, 34, 0.88), rgba(5, 11, 22, 0.94));
+}
+
+.portal-os-visual .portal-orbit,
+.portal-os-visual .portal-gridline {
+  display: none;
+}
+
+.portal-os-visual .portal-core,
+.portal-os-visual .portal-node {
+  position: relative;
+  inset: auto;
+  width: auto;
+  aspect-ratio: auto;
+  min-height: 72px;
+  transform: none;
+  animation: none;
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  border-radius: 16px;
+  text-align: left;
+}
+
+.portal-os-visual .portal-core {
+  padding: 18px;
+  background:
+    linear-gradient(135deg, rgba(120, 217, 255, 0.13), rgba(214, 176, 102, 0.08)),
+    rgba(8, 18, 34, 0.92);
+}
+
+.portal-os-visual .portal-core::after {
+  display: none;
+}
+
+.portal-os-visual .portal-node {
+  padding: 14px 16px;
+  color: #e8f4ff;
+  background: rgba(9, 20, 38, 0.78);
+}
+
+.portal-metric-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.portal-metric-card {
+  min-height: 164px;
+}
+
+.portal-metric-card,
+.portal-command-center-item,
+.portal-action-card,
+.portal-progress-item,
+.portal-unlock-list li,
+.portal-status-list-compact .card-copy {
+  border-color: rgba(166, 197, 232, 0.17);
+  background:
+    linear-gradient(180deg, rgba(13, 27, 48, 0.84), rgba(7, 17, 32, 0.9));
+}
+
+.portal-metric-card {
+  grid-column: span 2;
+}
+
+.portal-metric-card-project,
+.portal-metric-card-privacy {
+  grid-column: span 3;
+}
+
+.portal-metric-card a,
+.portal-support-concierge-panel a,
+.portal-command-center-item a {
+  color: #eef7ff;
+  text-decoration: underline;
+  text-decoration-color: rgba(120, 217, 255, 0.45);
+  text-underline-offset: 3px;
+}
+
+.portal-dashboard-shell {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.portal-command-center-panel,
+.portal-primary-actions-panel,
+.portal-tools-access-panel,
+.portal-intake-attention-panel,
+.portal-anchor-panel {
+  grid-column: 1 / -1;
+}
+
+.portal-progress-tracker-panel,
+.portal-package-unlocks-panel,
+.portal-intake-status-panel {
+  grid-column: span 7;
+}
+
+.portal-workspace-health-panel,
+.portal-materials-panel,
+.portal-support-concierge-panel,
+.portal-profile-panel {
+  grid-column: span 5;
+}
+
+.portal-action-card-grid {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.portal-action-card-grid-primary {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.portal-action-card {
+  min-height: 112px;
+  padding: 18px;
+  align-content: space-between;
+  border-radius: 18px;
+}
+
+.portal-action-card strong {
+  font-size: 1rem;
+  line-height: 1.24;
+}
+
+.portal-action-card span,
+.portal-progress-chip,
+.portal-dashboard-body [data-access-status],
+.portal-dashboard-body [data-intake-status-badge],
+.portal-dashboard-body [data-anchor-status-badge] {
+  width: fit-content;
+  max-width: 100%;
+  min-height: 30px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(166, 197, 232, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f3f9ff;
+  line-height: 1.25;
+}
+
+.portal-action-card.is-primary {
+  border-color: rgba(214, 176, 102, 0.48);
+  background:
+    linear-gradient(135deg, rgba(214, 176, 102, 0.18), rgba(120, 217, 255, 0.09)),
+    rgba(12, 31, 52, 0.92);
+}
+
+.portal-action-card.is-primary span {
+  border-color: rgba(214, 176, 102, 0.34);
+  background: rgba(214, 176, 102, 0.14);
+}
+
+.portal-command-center-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.portal-status-list-compact {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.portal-status-list-compact .card-copy {
+  padding: 12px 14px;
+  border-radius: 14px;
+}
+
+.portal-progress-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.portal-progress-item {
+  min-height: 68px;
+}
+
+.portal-unlock-list li {
+  align-items: center;
+}
+
+.portal-dashboard-body input,
+.portal-dashboard-body textarea,
+.portal-dashboard-body select,
+.portal-upload-hub-body input,
+.portal-upload-hub-body textarea,
+.portal-upload-hub-body select {
+  color: #f5f9ff;
+  background: rgba(5, 13, 25, 0.86);
+  border-color: rgba(166, 197, 232, 0.18);
+}
+
+.portal-dashboard-body label,
+.portal-upload-hub-body label {
+  color: #d7e5f6;
+}
+
+.portal-dashboard-body .notice,
+.portal-upload-hub-body .notice {
+  color: #e3efff;
+  background: rgba(214, 176, 102, 0.08);
+  border-color: rgba(214, 176, 102, 0.24);
+}
+
+.portal-dashboard-body .footer-card,
+.portal-upload-hub-body .footer-card {
+  border-color: rgba(166, 197, 232, 0.14);
+  background: rgba(5, 12, 24, 0.72);
+}
+
+@media (max-width: 1280px) {
+  .portal-dashboard-shell,
+  .portal-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-metric-card,
+  .portal-metric-card-project,
+  .portal-metric-card-privacy,
+  .portal-progress-tracker-panel,
+  .portal-package-unlocks-panel,
+  .portal-intake-status-panel,
+  .portal-workspace-health-panel,
+  .portal-materials-panel,
+  .portal-support-concierge-panel,
+  .portal-profile-panel {
+    grid-column: span 1;
+  }
+
+  .portal-command-center-panel,
+  .portal-primary-actions-panel,
+  .portal-tools-access-panel,
+  .portal-intake-attention-panel,
+  .portal-anchor-panel {
+    grid-column: 1 / -1;
+  }
+
+  .portal-command-center-grid,
+  .portal-action-card-grid-primary,
+  .portal-progress-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 980px) {
+  .portal-dashboard-body .container,
+  .portal-upload-hub-body .container {
+    width: min(100% - 28px, 1480px);
+  }
+
+  .portal-core-panel,
+  .portal-dashboard-shell,
+  .portal-metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-os-visual {
+    min-height: 0;
+  }
+
+  .portal-metric-card,
+  .portal-progress-tracker-panel,
+  .portal-package-unlocks-panel,
+  .portal-intake-status-panel,
+  .portal-workspace-health-panel,
+  .portal-materials-panel,
+  .portal-support-concierge-panel,
+  .portal-profile-panel {
+    grid-column: 1 / -1;
+  }
+
   .portal-command-center-grid {
     grid-template-columns: 1fr;
   }

--- a/tree-view.html
+++ b/tree-view.html
@@ -8,7 +8,7 @@
       name="description"
       content="Visual family tree renderer for Tomb of Light lineage data."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
     <style>
       .tree-shell {
         overflow: visible;

--- a/upload-hub.html
+++ b/upload-hub.html
@@ -8,7 +8,7 @@
       name="description"
       content="The Tomb of Light Upload Hub. Choose where to upload portraits, verification documents, or private vault files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-upload-hub-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/vault-upload.html
+++ b/vault-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload private vault files — voice messages, video messages, and protected legacy media — to your Tomb of Light vault."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-vault-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload verification records and supporting family documents to Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260508-451" />
+    <link rel="stylesheet" href="styles.css?v=20260509-portal" />
   </head>
   <body class="portal-dashboard-body portal-verification-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Reframes the customer dashboard as Tomb of Light Continuity OS with a clearer first-screen command bar, project/package/build-stage/next-action/privacy/support status grid, and primary customer actions.
- Adds a shared premium portal visual layer for dashboard, upload, intake, vault, access, link key, tree, certificate, billing, and account security pages without touching public homepage styling.
- Reorganizes dashboard tool cards into a cleaner customer command grid and uses safe labels such as Open, Check access, Package-gated, Needs attention, and Awaiting setup.
- Keeps entitlement-variable package unlock labels driven by `dashboard-intake.js` and preserves existing dashboard data hooks.

## Validation
- `/private/tmp/tol-pytest-venv/bin/python -m pytest backend/tests/test_frontend_link_integrity.py -q`
- `/private/tmp/tol-pytest-venv/bin/python -m pytest backend/tests/test_dashboard_and_client_security_integrity.py -q`
- `/private/tmp/tol-pytest-venv/bin/python -m pytest backend/tests/test_upload_hub_integrity.py -q`
- `rg -n "admin@tomboflight.com" *.html || true` produced no matches.
- `rg -n "Included" dashboard.html` produced no matches.
- Customer-scope scan for `SUPERADMIN|bulk repair|entitlement repair|admin-control|mint queue|repair record` across dashboard/customer scripts produced no matches.
- The requested broad `dashboard.html *.js` scan still reports pre-existing admin-only implementation strings in `admin-control-center.js` and `dashboard-admin.js`; dashboard.html no longer exposes the static admin-control link.
- Browser check confirmed unauthenticated dashboard access still redirects to sign-in.

## Scope Notes
- No backend APIs, auth, entitlement logic, upload logic, intake logic, family tree logic, certificate logic, link key logic, household access logic, billing logic, private viewer security, package pricing, or public homepage content changed.
- `styles.css` cache bumped to `styles.css?v=20260509-portal` on affected portal pages.
- `dashboard-intake.js` cache bumped to `dashboard-intake.js?v=20260509-portal` on dashboard.html.