### PR TITLE
Audit and repair customer portal routes, buttons, and entitlement states

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -8,7 +8,7 @@
       name="description"
       content="Reset or change your Tomb of Light password through the protected account security layer."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -397,7 +397,7 @@
 
     <script src="config.js?v=20260331-2"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="account-security.js?v=20260413-1"></script>
   </body>
 </html>

--- a/auth.js
+++ b/auth.js
@@ -243,19 +243,31 @@
 
   function isAuthFailure(error) {
     const message = getErrorMessage(error).toLowerCase();
+    const statusCode = Number(error?.status || 0);
+    const requestUrl = String(error?.requestUrl || error?.endpoint || "").toLowerCase();
+    const isAuthEndpoint =
+      requestUrl.includes("/auth/me") ||
+      requestUrl.includes("/auth/login") ||
+      requestUrl.includes("/auth/mfa") ||
+      requestUrl.includes("/auth/refresh");
 
-    return (
+    if (statusCode === 401) return true;
+    if (statusCode === 403 && isAuthEndpoint) return true;
+
+    if (
       message.includes("invalid or expired token") ||
       message.includes("invalid token") ||
       message.includes("invalid token payload") ||
       message.includes("user not found") ||
       message.includes("inactive") ||
       message.includes("unauthorized") ||
-      message.includes("forbidden") ||
       message.includes("401") ||
-      message.includes("403") ||
       message.includes("not authenticated")
-    );
+    ) {
+      return true;
+    }
+
+    return Boolean(isAuthEndpoint && message.includes("403"));
   }
 
   function sleep(ms) {
@@ -1697,7 +1709,9 @@
     const canUploadRecords = Boolean(
       resolved.can_upload_verification_docs || resolved.can_upload_portraits,
     );
-    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
+    const canUseLinkKeys = Boolean(
+      resolved.can_use_link_keys || resolved.can_manage_link_keys,
+    );
     const canOpenFamilyIntake = Boolean(resolved.can_open_family_intake);
     const upgradeTargets = Array.isArray(resolved.upgrade_targets)
       ? resolved.upgrade_targets
@@ -2612,7 +2626,10 @@
         return;
       }
 
-      if (linkKeyPages.has(page) && !resolved.can_use_link_keys) {
+      if (
+        linkKeyPages.has(page) &&
+        !(resolved.can_use_link_keys || resolved.can_manage_link_keys)
+      ) {
         return;
       }
 

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -3,6 +3,23 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_CACHE_VERSION = "20260509-audit"
+AUDITED_PORTAL_PAGES = [
+    "dashboard.html",
+    "upload-hub.html",
+    "portrait-upload.html",
+    "verification-upload.html",
+    "vault-upload.html",
+    "household-access.html",
+    "link-keys.html",
+    "tree-view.html",
+    "lineage-certificate.html",
+    "intake-review.html",
+    "intake-uploads.html",
+    "billing.html",
+    "account-security.html",
+    "digital-collectible.html",
+]
 
 
 class CustomerDashboardIntegrityTests(unittest.TestCase):
@@ -37,6 +54,56 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
         self.assertIn("Billing &amp; Cards", source)
         self.assertIn("Account Security", source)
         self.assertIn("Help Center", source)
+
+    def test_customer_dashboard_link_keys_follow_resolved_entitlements(self):
+        source = (REPO_ROOT / "dashboard-intake.js").read_text(encoding="utf-8")
+        self.assertIn("canUseLinkKeyTools", source)
+        self.assertIn("can_manage_link_keys", source)
+        self.assertNotIn('showLinkKeys: canUseLinkKeys || packageCode === "legacy_plus"', source)
+        self.assertNotIn('navLinkKeys: canUseLinkKeys || packageCode === "legacy_plus"', source)
+
+    def test_household_access_keeps_forbidden_workspace_errors_in_portal(self):
+        source = (REPO_ROOT / "household-access.js").read_text(encoding="utf-8")
+        self.assertIn("Members & Access is not included in your active package.", source)
+        self.assertIn("No active workspace found. Return to Dashboard or contact support.", source)
+        self.assertIn("Members & Access is unavailable for this workspace.", source)
+        self.assertIn("isSessionInvalidError", source)
+        self.assertNotIn("statusCode === 401 || (statusCode === 403", source)
+
+    def test_shared_auth_does_not_classify_every_403_as_auth_failure(self):
+        source = (REPO_ROOT / "auth.js").read_text(encoding="utf-8")
+        is_auth_failure_body = source.split("function isAuthFailure(error)", 1)[1].split(
+            "function sleep", 1
+        )[0]
+        self.assertIn("statusCode === 403 && isAuthEndpoint", is_auth_failure_body)
+        self.assertNotIn('message.includes("forbidden")', is_auth_failure_body)
+        self.assertNotIn('message.includes("403") ||', is_auth_failure_body)
+
+    def test_audited_portal_pages_use_audit_css_and_auth_cache_versions(self):
+        for page in AUDITED_PORTAL_PAGES:
+            with self.subTest(page=page):
+                source = (REPO_ROOT / page).read_text(encoding="utf-8")
+                self.assertIn(f"styles.css?v={AUDIT_CACHE_VERSION}", source)
+                self.assertIn(f"auth.js?v={AUDIT_CACHE_VERSION}", source)
+
+    def test_changed_page_scripts_use_audit_cache_versions(self):
+        expected_scripts = {
+            "dashboard.html": "dashboard-intake.js",
+            "household-access.html": "household-access.js",
+            "link-keys.html": "link-keys.js",
+        }
+        for page, script in expected_scripts.items():
+            with self.subTest(page=page):
+                source = (REPO_ROOT / page).read_text(encoding="utf-8")
+                self.assertIn(f"{script}?v={AUDIT_CACHE_VERSION}", source)
+
+    def test_household_access_has_customer_nav_and_no_admin_controls(self):
+        source = (REPO_ROOT / "household-access.html").read_text(encoding="utf-8")
+        self.assertIn('href="dashboard.html">Dashboard</a>', source)
+        self.assertIn('href="link-keys.html">Link Keys</a>', source)
+        self.assertIn('data-logout-btn', source)
+        self.assertNotIn("admin-control", source)
+        self.assertNotIn("SUPERADMIN", source)
 
 
 class ClientPrivilegeElevationTests(unittest.TestCase):

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -21,8 +21,11 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
             "portrait-upload.html",
             "verification-upload.html",
             "vault-upload.html",
+            "household-access.html",
+            "link-keys.html",
             "tree-view.html",
             "lineage-certificate.html",
+            "account-security.html",
             "admin-control-center.html",
             "digital-collectible.html",
         ]

--- a/billing.html
+++ b/billing.html
@@ -8,7 +8,7 @@
       name="description"
       content="Manage Tomb of Light billing, payment methods, maintenance subscriptions, and saved cards."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -158,7 +158,7 @@
     <script src="https://js.stripe.com/v3/"></script>
     <script src="config.js?v=20260331-2"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="billing.js?v=20260331-2"></script>
   </body>
 </html>

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -528,6 +528,18 @@
     node.textContent = isIncluded ? "Open" : "Package-gated";
   }
 
+  function canUseLinkKeyTools(resolved) {
+    return Boolean(resolved?.can_use_link_keys || resolved?.can_manage_link_keys);
+  }
+
+  function canUseHouseholdAccess(resolved) {
+    return Boolean(
+      resolved?.can_build_household ||
+        resolved?.family_household_scope ||
+        resolved?.can_link_households,
+    );
+  }
+
   function updatePackageUnlocksPanel(context) {
     const resolved = context?.resolvedEntitlements || {};
     setUnlockState("[data-unlock-portraits]", Boolean(resolved.can_upload_portraits));
@@ -549,14 +561,10 @@
       Boolean(resolved.can_use_lineage_certificate),
     );
     setUnlockState("[data-unlock-narration]", Boolean(resolved.can_use_narration));
-    setUnlockState("[data-unlock-link-keys]", Boolean(resolved.can_use_link_keys));
+    setUnlockState("[data-unlock-link-keys]", canUseLinkKeyTools(resolved));
     setUnlockState(
       "[data-unlock-household]",
-      Boolean(
-        resolved.family_household_scope ||
-          resolved.can_build_household ||
-          resolved.can_link_households,
-      ),
+      canUseHouseholdAccess(resolved),
     );
     setUnlockState(
       "[data-unlock-organization]",
@@ -1510,7 +1518,6 @@
   function getEntitlementConfig(context) {
     const resolved = context?.resolvedEntitlements || {};
     const lane = normalizeValue(context?.packageLane || resolved?.package_lane);
-    const packageCode = normalizeValue(context?.packageCode || resolved?.package_code);
     const packageName = context?.packageName || "Active Package";
 
     const canBuildFamilyTree = Boolean(resolved.can_build_family_tree);
@@ -1518,7 +1525,8 @@
     const canUploadRecords = Boolean(
       resolved.can_upload_verification_docs || resolved.can_upload_portraits,
     );
-    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
+    const canUseLinkKeys = canUseLinkKeyTools(resolved);
+    const canUseHousehold = canUseHouseholdAccess(resolved);
     const hasLinkedOrganizationSupport = Boolean(
       resolved.linked_organization_support || resolved.can_link_org_units,
     );
@@ -1678,7 +1686,7 @@
         showCertificate: canUseCertificate,
         showVerification: true,
         showLinkKeys: canUseLinkKeys,
-        showHouseholdAccess: true,
+        showHouseholdAccess: canUseHousehold,
         navTree: canBuildFamilyTree,
         navCertificate: canUseCertificate,
         navIntake: canOpenFamilyIntake,
@@ -1737,13 +1745,12 @@
       showTree: canBuildFamilyTree,
       showCertificate: canUseCertificate,
       showVerification: true,
-      // Keep the action visible for Legacy Plus even when link keys are lane-restricted.
-      showLinkKeys: canUseLinkKeys || packageCode === "legacy_plus",
-      showHouseholdAccess: true,
+      showLinkKeys: canUseLinkKeys,
+      showHouseholdAccess: canUseHousehold,
       navTree: canBuildFamilyTree,
       navCertificate: canUseCertificate,
       navIntake: canOpenFamilyIntake,
-      navLinkKeys: canUseLinkKeys || packageCode === "legacy_plus",
+      navLinkKeys: canUseLinkKeys,
       buildPathEyebrow: "Your Family Build Path",
       buildSteps: [
         {
@@ -1776,7 +1783,7 @@
       context?.packageLane || resolved.package_lane,
     );
     const normalizedStatus = normalizeStatus(status);
-    const canUseLinkKeys = Boolean(resolved.can_use_link_keys);
+    const canUseLinkKeys = canUseLinkKeyTools(resolved);
 
     if (normalizedLane === "portrait") {
       if (normalizedStatus === "build_ready") {

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,7 +8,7 @@
       name="description"
       content="Your private Tomb of Light customer or internal operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -755,8 +755,8 @@
 
     <script src="config.js?v=20260329-1"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
-    <script src="dashboard-intake.js?v=20260509-luminous"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="dashboard-intake.js?v=20260509-audit"></script>
     <script src="dashboard-admin.js?v=20260508-451"></script>
   </body>
 </html>

--- a/digital-collectible.html
+++ b/digital-collectible.html
@@ -9,7 +9,7 @@
       content="Your Tomb of Light NFT-authenticated digital collectible delivery page. Access and download your delivered digital asset files."
     />
     <link rel="canonical" href="https://tomboflight.com/digital-collectible.html" />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -324,7 +324,7 @@
     </div>
 
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="digital-collectible.js?v=20260414-2"></script>
   </body>
 </html>

--- a/household-access.html
+++ b/household-access.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Members &amp; Access | Tomb of Light</title>
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-household-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -15,6 +15,15 @@
       <header class="site-header">
         <div class="container site-header-inner">
           <a class="brand" href="dashboard.html">Tomb of Light<span class="brand-symbol">™</span></a>
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
           <nav class="site-nav" id="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html">Dashboard</a>
             <a href="household-access.html" aria-current="page">Members &amp; Access</a>
@@ -159,7 +168,7 @@
     </div>
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
-    <script src="household-access.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="household-access.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/household-access.js
+++ b/household-access.js
@@ -129,10 +129,59 @@
     return {};
   }
 
+  function canUseHouseholdAccess(resolved) {
+    return Boolean(
+      resolved?.can_build_household ||
+        resolved?.family_household_scope ||
+        resolved?.can_link_households,
+    );
+  }
+
+  function errorDetail(error) {
+    return readableMessage(
+      error?.detail || error?.message || error?.data || error?.responseBody,
+      "",
+    ).toLowerCase();
+  }
+
+  function isSessionInvalidError(error) {
+    const statusCode = Number(error?.status || 0);
+    const detail = errorDetail(error);
+    const requestUrl = String(error?.requestUrl || error?.endpoint || "").toLowerCase();
+
+    if (statusCode === 401) return true;
+    if (
+      detail.includes("invalid or expired token") ||
+      detail.includes("invalid token") ||
+      detail.includes("invalid token payload") ||
+      detail.includes("not authenticated") ||
+      detail.includes("user not found") ||
+      detail.includes("inactive")
+    ) {
+      return true;
+    }
+
+    return Boolean(statusCode === 403 && requestUrl.includes("/auth/me"));
+  }
+
+  function isPackageAccessError(error) {
+    const detail = errorDetail(error);
+    return (
+      detail.includes("package") ||
+      detail.includes("entitlement") ||
+      detail.includes("not included") ||
+      detail.includes("plan does not include")
+    );
+  }
+
   function setLockedWorkspaceState(message) {
     if (statusNode) statusNode.textContent = message;
     setText(inviteStatus, message, "warning");
     setText(acceptStatus, message, "warning");
+    setLoadErrorState(message);
+    renderMembers([]);
+    renderInvites([]);
+    setLoadingState(false);
 
     [inviteForm, acceptForm].forEach(function (form) {
       if (!form) return;
@@ -140,6 +189,27 @@
         field.disabled = true;
       });
     });
+  }
+
+  function setNoWorkspaceState(inviteKey) {
+    const message = inviteKey
+      ? "No active workspace found. Accept the invite below to activate workspace access."
+      : "No active workspace found. Return to Dashboard or contact support.";
+    if (statusNode) statusNode.textContent = message;
+    setLoadErrorState(message);
+    renderMembers([]);
+    renderInvites([]);
+    setLoadingState(false);
+    hasResolvedMemberRole = false;
+    applyInviteFormRoleAccess();
+    setText(inviteStatus, message, inviteKey ? "info" : "warning");
+    setText(
+      acceptStatus,
+      inviteKey
+        ? "Confirm the invite below to activate this workspace."
+        : "If you received an invite, enter the invite code below. Otherwise return to Dashboard or contact support.",
+      "info",
+    );
   }
 
   function inviteApiFallbackBaseUrls() {
@@ -1480,7 +1550,11 @@
       }
 
       const resolved = getResolvedEntitlements(currentContext);
-      if (currentContext && currentContext.hasPackageAccess && !resolved.can_build_household) {
+      if (
+        currentContext &&
+        currentContext.hasPackageAccess &&
+        !canUseHouseholdAccess(resolved)
+      ) {
         setLockedWorkspaceState(
           "Members & Access is not included in your active package.",
         );
@@ -1535,11 +1609,7 @@
       }
 
       if (!currentProjectId) {
-        if (statusNode) {
-          statusNode.textContent = inviteKey
-            ? "No active workspace project was detected yet. Accept the invite key below to activate workspace access."
-            : "No active workspace project was detected. Open this page from your dashboard workspace.";
-        }
+        setNoWorkspaceState(inviteKey);
         return;
       }
 
@@ -1579,9 +1649,17 @@
       }
     } catch (error) {
       const statusCode = Number(error?.status || 0);
-      if (statusCode === 401 || (statusCode === 403 && !inviteKeyFromQuery())) {
+      if (isSessionInvalidError(error)) {
         if (typeof app.clearSession === "function") app.clearSession();
         window.location.href = signinRedirectUrlWithInviteContext();
+        return;
+      }
+      if (statusCode === 403) {
+        setLockedWorkspaceState(
+          isPackageAccessError(error)
+            ? "Members & Access is not included in your active package."
+            : "Members & Access is unavailable for this workspace. Return to Dashboard or contact support.",
+        );
         return;
       }
       const detail = householdLoadFailureMessage(error);

--- a/intake-review.html
+++ b/intake-review.html
@@ -8,7 +8,7 @@
       name="description"
       content="Review your Tomb of Light intake details before submission."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -258,7 +258,7 @@
 
     <script src="config.js?v=20260322-10"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="intake.js?v=20260508-451"></script>
   </body>
 </html>

--- a/intake-uploads.html
+++ b/intake-uploads.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload planning and asset scope for Tomb of Light onboarding. This step plans what you will upload — it does not upload files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -319,7 +319,7 @@
 
     <script src="config.js?v=20260326-3"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="intake.js?v=20260508-451"></script>
   </body>
 </html>

--- a/lineage-certificate.html
+++ b/lineage-certificate.html
@@ -8,7 +8,7 @@
       name="description"
       content="Generate and view executive lineage certificates for Tomb of Light family records."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-certificate-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -131,7 +131,7 @@
 
     <script src="config.js?v=20260322-7"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="lineage-certificate.js?v=20260508-451"></script>
   </body>
 </html>

--- a/link-keys.html
+++ b/link-keys.html
@@ -8,7 +8,7 @@
       name="description"
       content="Generate, share, approve, and manage Tomb of Light link keys for eligible portrait, household, and network workspaces."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-link-keys-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -259,7 +259,7 @@
 
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
-    <script src="link-keys.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="link-keys.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/link-keys.js
+++ b/link-keys.js
@@ -126,6 +126,10 @@
     return {};
   }
 
+  function canUseLinkKeyTools(resolved) {
+    return Boolean(resolved?.can_use_link_keys || resolved?.can_manage_link_keys);
+  }
+
   function updateNav(context) {
     const resolved = getResolvedEntitlements(context);
 
@@ -676,7 +680,7 @@
       }
 
       const resolved = getResolvedEntitlements(currentContext);
-      if (!resolved.can_use_link_keys) {
+      if (!canUseLinkKeyTools(resolved)) {
         throw new Error(
           "Link Keys are not included in your active package.",
         );

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload portrait images for your Tomb of Light portrait workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-portrait-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -344,7 +344,7 @@
 
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="portrait-upload.js?v=20260508-451"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -5473,10 +5473,10 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .portal-dashboard-body .site-watermark,
 .portal-upload-hub-body .site-watermark {
   background-image: url("images/tol-watermark-clean.png");
-  background-size: min(54vw, 680px);
-  background-position: 50% 46%;
-  opacity: 0.045;
-  filter: saturate(0.7) brightness(1.08) contrast(0.96);
+  background-size: min(58vw, 720px);
+  background-position: 50% 42%;
+  opacity: 0.11;
+  filter: saturate(0.82) brightness(1.02) contrast(1.04);
   pointer-events: none;
 }
 
@@ -5495,6 +5495,25 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .portal-dashboard-body .site-header-inner,
 .portal-upload-hub-body .site-header-inner {
   min-height: 76px;
+}
+
+.portal-dashboard-body .site-nav,
+.portal-upload-hub-body .site-nav {
+  justify-content: flex-end;
+  align-content: center;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.portal-dashboard-body .site-nav a,
+.portal-upload-hub-body .site-nav a {
+  line-height: 1.2;
+  padding-block: 6px;
+}
+
+.portal-dashboard-body .header-actions,
+.portal-upload-hub-body .header-actions {
+  margin-left: 4px;
 }
 
 .portal-dashboard-body .brand,
@@ -5612,6 +5631,57 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .portal-upload-hub-body .cookie-status {
   color: var(--tol-portal-muted);
   opacity: 1;
+}
+
+.portal-dashboard-body [data-state],
+.portal-upload-hub-body [data-state] {
+  font-weight: 800;
+}
+
+.portal-dashboard-body [data-state="success"],
+.portal-upload-hub-body [data-state="success"] {
+  color: #14583b !important;
+}
+
+.portal-dashboard-body [data-state="error"],
+.portal-upload-hub-body [data-state="error"] {
+  color: #8f2e28 !important;
+}
+
+.portal-dashboard-body [data-state="warning"],
+.portal-upload-hub-body [data-state="warning"] {
+  color: #70460d !important;
+}
+
+.portal-dashboard-body [data-state="info"],
+.portal-upload-hub-body [data-state="info"] {
+  color: var(--tol-portal-blue-deep) !important;
+}
+
+.portal-dashboard-body .helper[data-state],
+.portal-upload-hub-body .helper[data-state] {
+  padding: 10px 12px;
+  border: 1px solid rgba(169, 197, 218, 0.68);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.portal-dashboard-body .helper[data-state="error"],
+.portal-upload-hub-body .helper[data-state="error"] {
+  border-color: rgba(166, 61, 55, 0.32);
+  background: #fff1ef;
+}
+
+.portal-dashboard-body .helper[data-state="warning"],
+.portal-upload-hub-body .helper[data-state="warning"] {
+  border-color: rgba(138, 92, 22, 0.34);
+  background: #fff6e4;
+}
+
+.portal-dashboard-body .helper[data-state="success"],
+.portal-upload-hub-body .helper[data-state="success"] {
+  border-color: rgba(31, 122, 84, 0.32);
+  background: #edf8f2;
 }
 
 .portal-dashboard-body a:not(.btn):not(.portal-action-card),

--- a/tree-view.html
+++ b/tree-view.html
@@ -8,7 +8,7 @@
       name="description"
       content="Visual family tree renderer for Tomb of Light lineage data."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
     <style>
       .tree-shell {
         overflow: visible;
@@ -561,7 +561,7 @@
 
     <script src="config.js?v=20260415-1"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="tree-view.js?v=20260508-451"></script>
   </body>
 </html>

--- a/upload-hub.html
+++ b/upload-hub.html
@@ -8,7 +8,7 @@
       name="description"
       content="The Tomb of Light Upload Hub. Choose where to upload portraits, verification documents, or private vault files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-upload-hub-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -354,6 +354,6 @@
 
     <script src="config.js?v=20260326-3"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/vault-upload.html
+++ b/vault-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload private vault files — voice messages, video messages, and protected legacy media — to your Tomb of Light vault."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-vault-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -387,7 +387,7 @@
 
     <script src="config.js?v=20260326-3"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
     <script src="vault-upload.js?v=20260508-451"></script>
   </body>
 </html>

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -8,7 +8,7 @@
       name="description"
       content="Upload verification records and supporting family documents to Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-luminous" />
+    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
   <body class="portal-dashboard-body portal-verification-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -413,7 +413,7 @@
 
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260508-451"></script>
+    <script src="auth.js?v=20260509-audit"></script>
 
     <script>
       document.addEventListener("DOMContentLoaded", async function () {


### PR DESCRIPTION
## Summary
- Audited customer portal buttons/routes and repaired Members & Access so package/workspace 403s stay inside the portal as locked or unavailable states instead of clearing the customer session.
- Tightened entitlement handling for Link Keys and Members & Access to follow resolved entitlements, including `can_manage_link_keys` and household access equivalents.
- Improved portal nav spacing, mobile menu coverage for Members & Access, readable status/helper states, watermark visibility, and cache versions for audited portal pages.
- Added integrity tests for route safety, cache versioning, placeholder links, admin-control exposure, and entitlement-driven Link Keys visibility.

## Validation
- `backend/venv/bin/python -m pytest backend/tests/test_frontend_link_integrity.py -q`
- `backend/venv/bin/python -m pytest backend/tests/test_dashboard_and_client_security_integrity.py -q`
- `backend/venv/bin/python -m pytest backend/tests/test_upload_hub_integrity.py -q`
- `node --check auth.js dashboard-intake.js household-access.js link-keys.js`
- `git diff --check`
- Requested `rg` safety scans for admin email, admin-control terms, placeholder links, and hard-coded `Included` text.

## Notes
- Entitlement definitions, package pricing, checkout/payment logic, upload validation, private viewer protections, and backend APIs were not changed.
- The broader admin-term scan still finds existing admin-only JS files; customer pages checked in this PR do not expose admin controls.