### PR TITLE
Audit and repair customer portal membership access and entitlement routing

### DIFF
--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -1105,8 +1105,8 @@ async def upload_private_media(
         current_user,
         family_id=family_id,
         member_id=member_id,
-        capabilities=("can_upload_verification_docs", "can_upload_portraits"),
-        detail="Your active package does not include upload access.",
+        capabilities=("premium_archive_structure",),
+        detail="Your active package does not include private vault access.",
     )
     require_workspace_member_role(
         context,
@@ -1267,7 +1267,7 @@ def list_family_vault_items(
     context = require_workspace_capability(
         current_user,
         family_id=family_id,
-        capabilities=("can_upload_verification_docs", "can_upload_portraits"),
+        capabilities=("premium_archive_structure",),
         detail="Your active package does not include vault access.",
     )
 

--- a/backend/app/services/household_access_service.py
+++ b/backend/app/services/household_access_service.py
@@ -345,7 +345,11 @@ def ensure_owner_membership(project_id: str) -> None:
 def list_project_members(project_id: str) -> list[dict[str, Any]]:
     ensure_owner_membership(project_id)
     cursor = _members().find({"project_id": _normalize(project_id)}).sort("created_at", 1)
-    return list(cursor)
+    return [
+        membership
+        for membership in cursor
+        if _normalize(membership.get("status") or "active").lower() in ACTIVE_MEMBER_STATUSES
+    ]
 
 
 def list_project_invites(project_id: str) -> list[dict[str, Any]]:

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -1,5 +1,11 @@
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.routes import workspace_access
+from app.services import household_access_service
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -20,6 +26,22 @@ AUDITED_PORTAL_PAGES = [
     "account-security.html",
     "digital-collectible.html",
 ]
+
+
+class _FakeCursor(list):
+    def sort(self, *_args, **_kwargs):
+        return self
+
+
+class _FakeMembersCollection:
+    def __init__(self, documents):
+        self.documents = list(documents)
+
+    def find(self, query):
+        project_id = query.get("project_id")
+        return _FakeCursor(
+            [document for document in self.documents if document.get("project_id") == project_id]
+        )
 
 
 class CustomerDashboardIntegrityTests(unittest.TestCase):
@@ -68,7 +90,9 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
         self.assertIn("No active workspace found. Return to Dashboard or contact support.", source)
         self.assertIn("Members & Access is unavailable for this workspace.", source)
         self.assertIn("isSessionInvalidError", source)
+        self.assertIn('requestUrl.includes("/auth/me")', source)
         self.assertNotIn("statusCode === 401 || (statusCode === 403", source)
+        self.assertRegex(source, r"if \(statusCode === 403\) \{[\s\S]{0,300}setLockedWorkspaceState")
 
     def test_shared_auth_does_not_classify_every_403_as_auth_failure(self):
         source = (REPO_ROOT / "auth.js").read_text(encoding="utf-8")
@@ -91,11 +115,45 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
             "dashboard.html": "dashboard-intake.js",
             "household-access.html": "household-access.js",
             "link-keys.html": "link-keys.js",
+            "portrait-upload.html": "portrait-upload.js",
+            "verification-upload.html": "verification-upload.js",
+            "vault-upload.html": "vault-upload.js",
+            "tree-view.html": "tree-view.js",
+            "lineage-certificate.html": "lineage-certificate.js",
         }
         for page, script in expected_scripts.items():
             with self.subTest(page=page):
                 source = (REPO_ROOT / page).read_text(encoding="utf-8")
                 self.assertIn(f"{script}?v={AUDIT_CACHE_VERSION}", source)
+
+    def test_dashboard_members_access_link_points_to_household_access(self):
+        source = (REPO_ROOT / "dashboard.html").read_text(encoding="utf-8")
+        self.assertIn('href="household-access.html" data-dashboard-tool="household"', source)
+        self.assertNotIn('href="#"', source)
+        self.assertNotIn('javascript:void(0)', source)
+
+    def test_customer_portal_has_no_false_included_or_admin_exposure(self):
+        customer_sources = "\n".join(
+            (REPO_ROOT / page).read_text(encoding="utf-8")
+            for page in (
+                "dashboard.html",
+                "household-access.html",
+                "link-keys.html",
+                "portrait-upload.html",
+                "verification-upload.html",
+                "vault-upload.html",
+                "tree-view.html",
+                "lineage-certificate.html",
+            )
+        )
+        self.assertNotIn(">Included<", customer_sources)
+        self.assertNotIn("admin@tomboflight.com", customer_sources)
+        self.assertNotIn("SUPERADMIN", customer_sources)
+        self.assertNotIn("bulk repair", customer_sources)
+        self.assertNotIn("entitlement repair", customer_sources)
+        self.assertNotIn("admin-control", customer_sources)
+        self.assertNotIn("mint queue", customer_sources)
+        self.assertNotIn("repair record", customer_sources)
 
     def test_household_access_has_customer_nav_and_no_admin_controls(self):
         source = (REPO_ROOT / "household-access.html").read_text(encoding="utf-8")
@@ -104,6 +162,132 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
         self.assertIn('data-logout-btn', source)
         self.assertNotIn("admin-control", source)
         self.assertNotIn("SUPERADMIN", source)
+
+    def test_household_member_service_returns_only_active_members(self):
+        documents = [
+            {
+                "_id": "member-owner",
+                "project_id": "project-robinson",
+                "email": "owner@example.com",
+                "member_role": "billing_owner",
+                "status": "active",
+            },
+            {
+                "_id": "member-spouse",
+                "project_id": "project-robinson",
+                "email": "spouse@example.com",
+                "member_role": "co_owner",
+                "relationship_scope": "spouse",
+                "status": "active",
+            },
+            {
+                "_id": "member-revoked",
+                "project_id": "project-robinson",
+                "email": "former@example.com",
+                "member_role": "viewer",
+                "status": "revoked",
+            },
+        ]
+        with (
+            patch.object(household_access_service, "ensure_owner_membership"),
+            patch.object(
+                household_access_service,
+                "_members",
+                return_value=_FakeMembersCollection(documents),
+            ),
+        ):
+            members = household_access_service.list_project_members("project-robinson")
+
+        self.assertEqual([member["email"] for member in members], ["owner@example.com", "spouse@example.com"])
+        self.assertEqual(members[1]["member_role"], "co_owner")
+
+    def test_workspace_members_route_preserves_active_co_owner_without_user_id(self):
+        member = {
+            "_id": "member-spouse",
+            "project_id": "project-robinson",
+            "email": "spouse@example.com",
+            "member_role": "co_owner",
+            "relationship_scope": "spouse",
+            "status": "active",
+        }
+        with (
+            patch.object(workspace_access, "_assert_project_access"),
+            patch.object(workspace_access, "_assert_household_management_enabled"),
+            patch.object(workspace_access, "list_project_members", return_value=[member]),
+            patch.object(workspace_access, "_with_member_identity_fields", side_effect=lambda items: items),
+        ):
+            payload = workspace_access.get_project_members(
+                "project-robinson",
+                current_user={"id": "owner-1", "email": "larrycr27@gmail.com"},
+            )
+
+        self.assertEqual(len(payload["items"]), 1)
+        self.assertEqual(payload["items"][0]["member_role"], "co_owner")
+        self.assertEqual(payload["items"][0]["status"], "active")
+        self.assertEqual(payload["items"][0]["email"], "spouse@example.com")
+        self.assertIsNone(payload["items"][0]["user_id"])
+
+    def test_workspace_invites_route_keeps_pending_and_historical_invites_separate(self):
+        invites = [
+            {
+                "_id": "invite-pending",
+                "project_id": "project-robinson",
+                "email": "pending@example.com",
+                "member_role": "co_owner",
+                "status": "pending",
+            },
+            {
+                "_id": "invite-accepted",
+                "project_id": "project-robinson",
+                "email": "accepted@example.com",
+                "member_role": "viewer",
+                "status": "accepted",
+            },
+            {
+                "_id": "invite-expired",
+                "project_id": "project-robinson",
+                "email": "expired@example.com",
+                "member_role": "viewer",
+                "status": "expired",
+            },
+            {
+                "_id": "invite-revoked",
+                "project_id": "project-robinson",
+                "email": "revoked@example.com",
+                "member_role": "viewer",
+                "status": "revoked",
+            },
+        ]
+        with (
+            patch.object(workspace_access, "_assert_project_access"),
+            patch.object(workspace_access, "_assert_household_management_enabled"),
+            patch.object(workspace_access, "list_project_invites", return_value=invites),
+        ):
+            payload = workspace_access.get_project_invites(
+                "project-robinson",
+                current_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+
+        statuses = {item["email"]: item["status"] for item in payload["items"]}
+        self.assertEqual(statuses["pending@example.com"], "pending")
+        self.assertEqual(statuses["accepted@example.com"], "accepted")
+        self.assertEqual(statuses["expired@example.com"], "expired")
+        self.assertEqual(statuses["revoked@example.com"], "revoked")
+
+    def test_package_gated_household_access_is_forbidden_not_auth_failure(self):
+        with patch.object(
+            workspace_access,
+            "resolve_workspace_context",
+            return_value={"resolved_entitlements": {"can_build_household": False}},
+        ):
+            with self.assertRaises(HTTPException) as exc:
+                workspace_access._assert_household_management_enabled(
+                    "project-robinson",
+                    {"id": "owner-1", "email": "owner@example.com"},
+                )
+
+        self.assertEqual(exc.exception.status_code, 403)
+        self.assertIn("does not include household", exc.exception.detail)
 
 
 class ClientPrivilegeElevationTests(unittest.TestCase):

--- a/backend/tests/test_upload_hub_integrity.py
+++ b/backend/tests/test_upload_hub_integrity.py
@@ -1,6 +1,9 @@
+import inspect
 import re
 import unittest
 from pathlib import Path
+
+from app.routes import uploads as upload_routes
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -142,15 +145,29 @@ class UploadHubIntegrityTests(unittest.TestCase):
         """vault-upload.js must check entitlements and disable the form when not entitled."""
         contents = self._read("vault-upload.js")
         self.assertIn(
-            "can_upload",
+            "premium_archive_structure",
             contents,
-            "vault-upload.js must check can_upload entitlements",
+            "vault-upload.js must check private vault entitlements",
+        )
+        self.assertIn(
+            "private vault access",
+            contents,
+            "vault-upload.js must show the customer a private vault locked state",
         )
         self.assertIn(
             "disabled",
             contents,
             "vault-upload.js must disable the form when the user lacks entitlement",
         )
+
+    def test_private_media_backend_uses_private_vault_entitlement(self):
+        """Private media upload routes must not unlock vault access via generic upload flags."""
+        upload_source = inspect.getsource(upload_routes.upload_private_media)
+        vault_list_source = inspect.getsource(upload_routes.list_family_vault_items)
+        self.assertIn("premium_archive_structure", upload_source)
+        self.assertIn("premium_archive_structure", vault_list_source)
+        self.assertNotIn("can_upload_verification_docs", upload_source)
+        self.assertNotIn("can_upload_portraits", upload_source)
 
     def test_vault_upload_uses_correct_asset_types(self):
         """vault-upload.js must only submit the two backend-allowed asset types."""

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -517,7 +517,10 @@
         ? "Open"
         : "Package-gated",
     );
-    text(document.querySelector("[data-health-vault]"), "Open");
+    text(
+      document.querySelector("[data-health-vault]"),
+      Boolean(resolved.premium_archive_structure) ? "Open" : "Package-gated",
+    );
     text(document.querySelector("[data-health-privacy]"), "Private by default");
   }
 
@@ -526,6 +529,150 @@
     if (!node) return;
     node.dataset.unlockState = isIncluded ? "included" : "locked";
     node.textContent = isIncluded ? "Open" : "Package-gated";
+  }
+
+  function hasResolvedFlag(resolved, key) {
+    return Object.prototype.hasOwnProperty.call(resolved || {}, key);
+  }
+
+  function accessStateFromFlag(flag, known, options = {}) {
+    if (!known) return "check";
+    if (!flag) return "locked";
+    if (options.awaitingSetup) return "awaiting";
+    return "open";
+  }
+
+  function dashboardToolState(context, tool) {
+    const resolved = context?.resolvedEntitlements || {};
+    const hasWorkspaceFamily = Boolean(getContextFamilyId(context));
+    const hasAnyResolvedEntitlements = Object.keys(resolved).length > 0;
+    const hasPackageAccess = Boolean(context?.hasPackageAccess);
+
+    if (tool === "billing" || tool === "account_security" || tool === "help_center") {
+      return "open";
+    }
+    if (tool === "upload_hub") {
+      if (!hasPackageAccess && !hasAnyResolvedEntitlements) return "check";
+      return hasPackageAccess ? "open" : "locked";
+    }
+    if (tool === "portrait") {
+      return accessStateFromFlag(
+        Boolean(resolved.can_upload_portraits),
+        hasResolvedFlag(resolved, "can_upload_portraits"),
+      );
+    }
+    if (tool === "verification") {
+      return accessStateFromFlag(
+        Boolean(resolved.can_upload_verification_docs),
+        hasResolvedFlag(resolved, "can_upload_verification_docs"),
+      );
+    }
+    if (tool === "vault") {
+      return accessStateFromFlag(
+        Boolean(resolved.premium_archive_structure),
+        hasResolvedFlag(resolved, "premium_archive_structure"),
+      );
+    }
+    if (tool === "tree") {
+      return accessStateFromFlag(
+        Boolean(resolved.can_build_family_tree),
+        hasResolvedFlag(resolved, "can_build_family_tree"),
+        { awaitingSetup: !hasWorkspaceFamily },
+      );
+    }
+    if (tool === "certificate") {
+      return accessStateFromFlag(
+        Boolean(resolved.can_use_lineage_certificate),
+        hasResolvedFlag(resolved, "can_use_lineage_certificate"),
+        { awaitingSetup: !hasWorkspaceFamily },
+      );
+    }
+    if (tool === "household") {
+      return accessStateFromFlag(
+        canUseHouseholdAccess(resolved),
+        hasResolvedFlag(resolved, "can_build_household") ||
+          hasResolvedFlag(resolved, "family_household_scope") ||
+          hasResolvedFlag(resolved, "can_link_households"),
+      );
+    }
+    if (tool === "link_keys") {
+      return accessStateFromFlag(
+        canUseLinkKeyTools(resolved),
+        hasResolvedFlag(resolved, "can_use_link_keys") ||
+          hasResolvedFlag(resolved, "can_manage_link_keys"),
+      );
+    }
+    if (tool === "intake") {
+      return accessStateFromFlag(
+        Boolean(
+          resolved.can_open_family_intake ||
+            resolved.can_open_org_intake ||
+            context?.latestSubmission,
+        ),
+        hasResolvedFlag(resolved, "can_open_family_intake") ||
+          hasResolvedFlag(resolved, "can_open_org_intake") ||
+          Boolean(context?.latestSubmission),
+      );
+    }
+    return "check";
+  }
+
+  function dashboardToolHref(context, tool) {
+    const hrefs = {
+      account_security: "account-security.html",
+      billing: "billing.html",
+      certificate: "lineage-certificate.html",
+      help_center: "faq.html",
+      household: "household-access.html",
+      intake: "intake-review.html",
+      link_keys: "link-keys.html",
+      portrait: "portrait-upload.html",
+      tree: "tree-view.html",
+      upload_hub: "upload-hub.html",
+      vault: "vault-upload.html",
+      verification: "verification-upload.html",
+    };
+    const href = hrefs[tool] || "";
+    if (!href) return "";
+    if (tool === "certificate" || tool === "link_keys" || tool === "tree") {
+      return withFamilyId(href, context);
+    }
+    if (tool === "household") {
+      return withFamilyId(href, context);
+    }
+    return href;
+  }
+
+  function updateDashboardToolCardStates(context) {
+    const stateLabels = {
+      awaiting: "Awaiting setup",
+      check: "Check access",
+      locked: "Package-gated",
+      open: "Open",
+    };
+    const stateKinds = {
+      awaiting: "warning",
+      check: "info",
+      locked: "warning",
+      open: "success",
+    };
+
+    document.querySelectorAll("[data-dashboard-tool]").forEach(function (node) {
+      const tool = normalizeValue(node.dataset.dashboardTool);
+      const state = dashboardToolState(context, tool);
+      const href = dashboardToolHref(context, tool);
+      node.dataset.toolState = state;
+      node.style.display = "";
+      if (href && node.tagName === "A") {
+        node.setAttribute("href", href);
+      }
+
+      const status = node.querySelector(".portal-action-status");
+      if (status) {
+        status.textContent = stateLabels[state] || "Check access";
+        status.dataset.state = stateKinds[state] || "info";
+      }
+    });
   }
 
   function canUseLinkKeyTools(resolved) {
@@ -2227,6 +2374,7 @@
     applyPortalTheme(contextWithMembership, config);
     applyDashboardHierarchy(contextWithMembership, []);
     updatePackageUnlocksPanel(contextWithMembership);
+    updateDashboardToolCardStates(contextWithMembership);
     updateCommandCenterPanel(contextWithMembership, null, {
       text: "Upload Photos & Family Records",
     });
@@ -2273,6 +2421,7 @@
       updateLaneUi(contextWithLatest, config, latest);
       applyDashboardHierarchy(contextWithLatest, history);
       updatePackageUnlocksPanel(contextWithLatest);
+      updateDashboardToolCardStates(contextWithLatest);
       updateCommandCenterPanel(contextWithLatest, latest, primaryAction);
       updateProjectProgressTracker(
         contextWithLatest,
@@ -2346,6 +2495,7 @@
     } catch (error) {
       applyDashboardHierarchy(contextWithMembership, []);
       updatePackageUnlocksPanel(contextWithMembership);
+      updateDashboardToolCardStates(contextWithMembership);
       updateCommandCenterPanel(contextWithMembership, null, null);
       updateProjectProgressTracker(contextWithMembership, null, false);
       updateWorkspaceHealthPanel(contextWithMembership, null);

--- a/dashboard.html
+++ b/dashboard.html
@@ -300,25 +300,25 @@
               <span class="eyebrow">Primary Actions</span>
               <h3>What To Do Next</h3>
               <div class="portal-action-card-grid portal-action-card-grid-primary">
-                <a class="portal-action-card is-primary" href="upload-hub.html">
+                <a class="portal-action-card is-primary" href="upload-hub.html" data-dashboard-tool="upload_hub">
                   <strong>Upload Photos &amp; Family Records</strong>
                   <p>Send portraits, family images, and source records into the protected upload lanes.</p>
                   <span class="portal-action-status">Open</span>
                   <span class="portal-action-cta">Open Upload Hub</span>
                 </a>
-                <a class="portal-action-card" href="verification-upload.html">
+                <a class="portal-action-card" href="verification-upload.html" data-dashboard-tool="verification">
                   <strong>Upload Verification Documents</strong>
                   <p>Add certificates, identity evidence, and supporting records for review.</p>
                   <span class="portal-action-status">Open</span>
                   <span class="portal-action-cta">Upload Evidence</span>
                 </a>
-                <a class="portal-action-card" href="tree-view.html">
+                <a class="portal-action-card" href="tree-view.html" data-dashboard-tool="tree">
                   <strong>Open Family Tree</strong>
                   <p>Review the lineage graph as production data becomes available.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Open Tree</span>
                 </a>
-                <a class="portal-action-card" href="intake-review.html" data-intake-open-action>
+                <a class="portal-action-card" href="intake-review.html" data-dashboard-tool="intake" data-intake-open-action>
                   <strong>View Intake</strong>
                   <p>Confirm household, family map, upload plan, and consent details.</p>
                   <span class="portal-action-status">Ready</span>
@@ -404,67 +404,67 @@
               <span class="eyebrow">Command Grid</span>
               <h3>Customer tools</h3>
               <div class="portal-action-card-grid">
-                <a class="portal-action-card" href="upload-hub.html">
+                <a class="portal-action-card" href="upload-hub.html" data-dashboard-tool="upload_hub">
                   <strong>Upload Hub</strong>
                   <p>Choose the correct lane for photos, Family Records / Documents, and vault media.</p>
                   <span class="portal-action-status">Open</span>
                   <span class="portal-action-cta">Open Hub</span>
                 </a>
-                <a class="portal-action-card" href="portrait-upload.html">
+                <a class="portal-action-card" href="portrait-upload.html" data-dashboard-tool="portrait">
                   <strong>Portrait / Family Photos</strong>
                   <p>Submit cinematic portraits and family images for production review.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Upload Photos</span>
                 </a>
-                <a class="portal-action-card" href="verification-upload.html">
+                <a class="portal-action-card" href="verification-upload.html" data-dashboard-tool="verification">
                   <strong>Verification Documents</strong>
                   <p>Provide records that support lineage, identity, and source verification.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Upload Records</span>
                 </a>
-                <a class="portal-action-card" href="vault-upload.html">
+                <a class="portal-action-card" href="vault-upload.html" data-dashboard-tool="vault">
                   <strong>Private Vault Files</strong>
                   <p>Store voice, video, and protected legacy files with private scope controls.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Open Vault</span>
                 </a>
-                <a class="portal-action-card" href="tree-view.html">
+                <a class="portal-action-card" href="tree-view.html" data-dashboard-tool="tree">
                   <strong>Family Tree</strong>
                   <p>Open the working lineage graph when your package and project state allow it.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Open Tree</span>
                 </a>
-                <a class="portal-action-card" href="lineage-certificate.html">
+                <a class="portal-action-card" href="lineage-certificate.html" data-dashboard-tool="certificate">
                   <strong>Lineage Certificate</strong>
                   <p>Generate the certificate view from verified family structure data.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">View Certificate</span>
                 </a>
-                <a class="portal-action-card" href="household-access.html" data-dashboard-household-invite-co-owner>
+                <a class="portal-action-card" href="household-access.html" data-dashboard-tool="household" data-dashboard-household-invite-co-owner>
                   <strong>Members &amp; Access</strong>
                   <p>Invite trusted roles and review private collaboration permissions.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Manage Members</span>
                 </a>
-                <a class="portal-action-card" href="link-keys.html">
+                <a class="portal-action-card" href="link-keys.html" data-dashboard-tool="link_keys">
                   <strong>Link Keys</strong>
                   <p>Create protected keys for controlled family or workspace handshakes.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Manage Keys</span>
                 </a>
-                <a class="portal-action-card" href="billing.html">
+                <a class="portal-action-card" href="billing.html" data-dashboard-tool="billing">
                   <strong>Billing &amp; Cards</strong>
                   <p>Manage saved cards, subscriptions, and maintenance billing continuity.</p>
                   <span class="portal-action-status">Open</span>
                   <span class="portal-action-cta">Open Billing</span>
                 </a>
-                <a class="portal-action-card" href="account-security.html">
+                <a class="portal-action-card" href="account-security.html" data-dashboard-tool="account_security">
                   <strong>Account Security</strong>
                   <p>Reset passwords, update credentials, and manage authenticator protection.</p>
                   <span class="portal-action-status">Open</span>
                   <span class="portal-action-cta">Secure Account</span>
                 </a>
-                <a class="portal-action-card" href="faq.html">
+                <a class="portal-action-card" href="faq.html" data-dashboard-tool="help_center">
                   <strong>Help Center</strong>
                   <p>Review support guidance and continuity questions without leaving the portal.</p>
                   <span class="portal-action-status">Open</span>

--- a/household-access.js
+++ b/household-access.js
@@ -111,6 +111,7 @@
   };
 
   const ROLE_CAN_MANAGE_ACCESS = new Set(["billing_owner", "co_owner", "family_manager"]);
+  const ACTIVE_MEMBER_STATUSES = new Set(["active"]);
 
   let currentProjectId = "";
   let currentUser = null;
@@ -565,6 +566,15 @@
       });
   }
 
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
   function formatDateTime(value) {
     const normalized = normalizeValue(value);
     if (!normalized) return "—";
@@ -679,6 +689,33 @@
 
   function roleCanManageAccess(role) {
     return ROLE_CAN_MANAGE_ACCESS.has(normalizeRole(role));
+  }
+
+  function isActiveMember(member) {
+    return ACTIVE_MEMBER_STATUSES.has(normalizeLower(member?.status || "active"));
+  }
+
+  function memberIdentityKey(member) {
+    const membershipId = normalizeValue(member?.id || member?._id || member?.membership_id);
+    if (membershipId) return `membership:${membershipId}`;
+    const userId = normalizeValue(member?.user_id);
+    if (userId) return `user:${userId}`;
+    const email = normalizeLower(member?.email);
+    if (email) return `email:${email}`;
+    return "";
+  }
+
+  function dedupeActiveMembers(items) {
+    const seen = new Set();
+    const activeItems = [];
+    (Array.isArray(items) ? items : []).forEach(function (member) {
+      if (!isActiveMember(member)) return;
+      const identityKey = memberIdentityKey(member);
+      if (identityKey && seen.has(identityKey)) return;
+      if (identityKey) seen.add(identityKey);
+      activeItems.push(member);
+    });
+    return activeItems;
   }
 
   function currentUserIdentity() {
@@ -1017,14 +1054,15 @@
   function renderMembers(items) {
     if (!membersList) return;
     membersList.innerHTML = "";
-    if (!Array.isArray(items) || !items.length) {
+    const activeMembers = dedupeActiveMembers(items);
+    if (!activeMembers.length) {
       if (membersEmpty) membersEmpty.style.display = "block";
       return;
     }
     if (membersEmpty) membersEmpty.style.display = "none";
     const canManage = roleCanManageAccess(currentMemberRole);
     const actorRank = roleRank(currentMemberRole);
-    items.forEach((member) => {
+    activeMembers.forEach((member) => {
       const card = document.createElement("article");
       card.className = "form-panel";
 
@@ -1048,7 +1086,7 @@
       const options = ROLE_OPTIONS.map(
         (roleCode) => {
           const disabled = !canManage || !roleCanAssign(currentMemberRole, roleCode);
-          return `<option value="${roleCode}" ${roleCode === role ? "selected" : ""} ${disabled ? "disabled" : ""}>${roleLabel(roleCode)}</option>`;
+          return `<option value="${escapeHtml(roleCode)}" ${roleCode === role ? "selected" : ""} ${disabled ? "disabled" : ""}>${escapeHtml(roleLabel(roleCode))}</option>`;
         },
       ).join("");
       const memberActionMarkup = canTouchTarget
@@ -1067,13 +1105,13 @@
           ? `<p class="card-copy">Billing Owner is the highest household role. To pass ownership, set another active member's role to Billing Owner.</p>`
           : `<p class="card-copy">You can only change or remove members with lower active roles.</p>`;
       card.innerHTML = `
-        <strong>${fullName}</strong>
-        <p class="card-copy">Email: ${emailLabel}</p>
-        <p class="card-copy">Role: ${roleLabel(role)}</p>
-        ${parityNote ? `<p class="card-copy">${parityNote}</p>` : ""}
-        <p class="card-copy">Relationship: ${relationshipLabel(member.relationship_scope || "household_member")}</p>
-        <p class="card-copy">Privacy: ${privacyLabel(member.privacy_scope || "household_private")}</p>
-        <p class="card-copy">Status: ${member.status || "active"}</p>
+        <strong>${escapeHtml(fullName)}</strong>
+        <p class="card-copy">Email: ${escapeHtml(emailLabel)}</p>
+        <p class="card-copy">Role: ${escapeHtml(roleLabel(role))}</p>
+        ${parityNote ? `<p class="card-copy">${escapeHtml(parityNote)}</p>` : ""}
+        <p class="card-copy">Relationship: ${escapeHtml(relationshipLabel(member.relationship_scope || "household_member"))}</p>
+        <p class="card-copy">Privacy: ${escapeHtml(privacyLabel(member.privacy_scope || "household_private"))}</p>
+        <p class="card-copy">Status: ${escapeHtml(member.status || "active")}</p>
         ${memberActionMarkup}
       `;
 
@@ -1154,15 +1192,15 @@
         ? ""
         : `<p class="card-copy">Invite actions are unavailable because this invite record is missing an id on this API host.</p>`;
       card.innerHTML = `
-        <strong>${invite.email || "Invite"}</strong>
-        <p class="card-copy">Role: ${roleLabel(invite.member_role || "viewer")}</p>
-        <p class="card-copy">Relationship: ${relationshipLabel(invite.relationship_scope || "household_member")}</p>
-        <p class="card-copy">Privacy: ${privacyLabel(invite.privacy_scope || "household_private")}</p>
-        <p class="card-copy">Status: ${normalizeInviteStatus(invite.status || "pending")}</p>
-        <p class="card-copy">${deliveryText}</p>
-        <p class="card-copy">Created: ${formatDateTime(invite.created_at)}</p>
-        <p class="card-copy">Accepted: ${formatDateTime(invite.accepted_at)}</p>
-        <p class="card-copy">Expires: ${formatDateTime(invite.expires_at)}</p>
+        <strong>${escapeHtml(invite.email || "Invite")}</strong>
+        <p class="card-copy">Role: ${escapeHtml(roleLabel(invite.member_role || "viewer"))}</p>
+        <p class="card-copy">Relationship: ${escapeHtml(relationshipLabel(invite.relationship_scope || "household_member"))}</p>
+        <p class="card-copy">Privacy: ${escapeHtml(privacyLabel(invite.privacy_scope || "household_private"))}</p>
+        <p class="card-copy">Status: ${escapeHtml(normalizeInviteStatus(invite.status || "pending"))}</p>
+        <p class="card-copy">${escapeHtml(deliveryText)}</p>
+        <p class="card-copy">Created: ${escapeHtml(formatDateTime(invite.created_at))}</p>
+        <p class="card-copy">Accepted: ${escapeHtml(formatDateTime(invite.accepted_at))}</p>
+        <p class="card-copy">Expires: ${escapeHtml(formatDateTime(invite.expires_at))}</p>
         ${missingInviteIdNote}
         <div class="inline-actions" style="margin-top:0.75rem;">
           <button class="btn btn-secondary" type="button" data-invite-resend ${canResend ? "" : "disabled"}>Resend Invite</button>

--- a/lineage-certificate.html
+++ b/lineage-certificate.html
@@ -132,6 +132,6 @@
     <script src="config.js?v=20260322-7"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="lineage-certificate.js?v=20260508-451"></script>
+    <script src="lineage-certificate.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/lineage-certificate.js
+++ b/lineage-certificate.js
@@ -34,17 +34,13 @@
 
     function setStatus(message, type) {
       if (!statusNode) return;
+      if (window.TOLAuth && typeof window.TOLAuth.setStatus === "function") {
+        window.TOLAuth.setStatus(statusNode, message, type || "info");
+        return;
+      }
       statusNode.style.display = "block";
       statusNode.textContent = message;
       statusNode.dataset.state = type || "info";
-
-      if (type === "error") {
-        statusNode.style.color = "#ffb3b3";
-      } else if (type === "success") {
-        statusNode.style.color = "#cfe8cf";
-      } else {
-        statusNode.style.color = "#d6e6ff";
-      }
     }
 
     function clearStatus() {

--- a/link-keys.js
+++ b/link-keys.js
@@ -55,17 +55,14 @@
 
   function setStatus(node, message, type) {
     if (!node) return;
+    if (typeof app.setStatus === "function") {
+      app.setStatus(node, message, type || "info");
+      return;
+    }
 
     node.style.display = "block";
     node.textContent = message;
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
+    node.dataset.state = type || "info";
   }
 
   function clearStatus(node) {

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -345,6 +345,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="portrait-upload.js?v=20260508-451"></script>
+    <script src="portrait-upload.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/portrait-upload.js
+++ b/portrait-upload.js
@@ -43,17 +43,14 @@
 
   function setStatus(node, message, type) {
     if (!node) return;
+    if (typeof app.setStatus === "function") {
+      app.setStatus(node, message, type || "info");
+      return;
+    }
 
     node.style.display = "block";
     node.textContent = message;
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
+    node.dataset.state = type || "info";
   }
 
   function clearStatus(node) {

--- a/styles.css
+++ b/styles.css
@@ -5473,10 +5473,10 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 .portal-dashboard-body .site-watermark,
 .portal-upload-hub-body .site-watermark {
   background-image: url("images/tol-watermark-clean.png");
-  background-size: min(58vw, 720px);
+  background-size: min(60vw, 760px);
   background-position: 50% 42%;
-  opacity: 0.11;
-  filter: saturate(0.82) brightness(1.02) contrast(1.04);
+  opacity: 0.16;
+  filter: saturate(0.9) brightness(1.04) contrast(1.06);
   pointer-events: none;
 }
 
@@ -5970,6 +5970,25 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
   font-size: 0.82rem;
   font-weight: 800;
   line-height: 1.2;
+}
+
+.portal-action-card[data-tool-state="open"] .portal-action-status {
+  color: #14583b;
+  border-color: rgba(31, 122, 84, 0.32);
+  background: #eaf8f1;
+}
+
+.portal-action-card[data-tool-state="locked"] .portal-action-status,
+.portal-action-card[data-tool-state="awaiting"] .portal-action-status {
+  color: #70460d;
+  border-color: rgba(138, 92, 22, 0.34);
+  background: #fff3dc;
+}
+
+.portal-action-card[data-tool-state="check"] .portal-action-status {
+  color: var(--tol-portal-blue-deep);
+  border-color: rgba(35, 109, 168, 0.34);
+  background: #eaf6ff;
 }
 
 .portal-action-card .portal-action-cta {

--- a/tree-view.html
+++ b/tree-view.html
@@ -562,6 +562,6 @@
     <script src="config.js?v=20260415-1"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="tree-view.js?v=20260508-451"></script>
+    <script src="tree-view.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/tree-view.js
+++ b/tree-view.js
@@ -106,11 +106,14 @@
 
   function showStatus(node, message, type) {
     if (!node) return;
+    if (window.TOLAuth && typeof window.TOLAuth.setStatus === "function") {
+      window.TOLAuth.setStatus(node, message, type || "info");
+      return;
+    }
 
     node.style.display = "block";
     node.textContent = message;
-    node.style.color =
-      type === "error" ? "#ffb3b3" : type === "success" ? "#cfe8cf" : "#d6e6ff";
+    node.dataset.state = type || "info";
   }
 
   function hideStatus(node) {

--- a/vault-upload.html
+++ b/vault-upload.html
@@ -388,6 +388,6 @@
     <script src="config.js?v=20260326-3"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="vault-upload.js?v=20260508-451"></script>
+    <script src="vault-upload.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/vault-upload.js
+++ b/vault-upload.js
@@ -55,15 +55,13 @@
 
   function setStatus(node, message, type) {
     if (!node) return;
+    if (typeof app.setStatus === "function") {
+      app.setStatus(node, message, type || "info");
+      return;
+    }
     node.style.display = "block";
     node.textContent = message;
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
+    node.dataset.state = type || "info";
   }
 
   function clearStatus(node) {
@@ -74,7 +72,8 @@
 
   function isEntitlementError(msg) {
     return (
-      msg.includes("can_upload") ||
+      msg.includes("premium_archive_structure") ||
+      msg.includes("vault") ||
       msg.includes("entitlement") ||
       msg.includes("package") ||
       msg.includes("permission")
@@ -175,7 +174,7 @@
       if (isEntitlementError(msg)) {
         setStatus(
           familyStatus,
-          "Your active package does not include vault file access. Contact support if you believe this is an error.",
+          "Your active package does not include private vault access. Contact support if you believe this is an error.",
           "error",
         );
       } else {
@@ -221,25 +220,54 @@
     }
   }
 
+  async function getCurrentContext() {
+    if (
+      !authPages ||
+      typeof authPages.fetchOrders !== "function" ||
+      (typeof authPages.getDashboardContextForCurrentPage !== "function" &&
+        typeof authPages.getDashboardContext !== "function")
+    ) {
+      return null;
+    }
+
+    const me = await app.apiRequest("/auth/me", { method: "GET" });
+    const orders = await authPages.fetchOrders();
+
+    if (typeof authPages.getDashboardContextForCurrentPage === "function") {
+      return await authPages.getDashboardContextForCurrentPage(me, orders);
+    }
+
+    const hints =
+      typeof authPages.getWorkspaceSelectionHints === "function"
+        ? authPages.getWorkspaceSelectionHints()
+        : undefined;
+
+    return await authPages.getDashboardContext(me, orders, hints);
+  }
+
   async function initPage() {
     const pageStatus = document.querySelector("[data-vault-page-status]");
 
     try {
-      const context = await app.apiRequest("/auth/context", { method: "GET" });
+      const context = await getCurrentContext();
       currentContext = context;
 
-      const entitlements = context?.resolved_entitlements || {};
-      // The backend /uploads/private-media endpoint requires can_upload_portraits
-      // OR can_upload_verification_docs — vault access is gated by the same
-      // entitlements, so we mirror that check here.
-      const canUpload =
-        entitlements.can_upload_portraits ||
-        entitlements.can_upload_verification_docs;
+      const entitlements = context?.resolvedEntitlements || {};
+      const hasResolvedVaultAccess = Object.prototype.hasOwnProperty.call(
+        entitlements,
+        "premium_archive_structure",
+      );
+      const canUpload = Boolean(entitlements.premium_archive_structure);
 
       if (!canUpload) {
         if (pageStatus) {
-          pageStatus.textContent =
-            "Your active package does not include vault file access. Upgrade your package to enable vault uploads.";
+          setStatus(
+            pageStatus,
+            hasResolvedVaultAccess
+              ? "Your active package does not include private vault access."
+              : "Unable to verify private vault access. Please return to Dashboard or try again shortly.",
+            hasResolvedVaultAccess ? "warning" : "info",
+          );
         }
         const form = document.querySelector("[data-vault-upload-form]");
         if (form) {
@@ -261,8 +289,11 @@
       }
     } catch (error) {
       if (pageStatus) {
-        pageStatus.textContent =
-          "Unable to load your workspace. Please sign in and try again.";
+        setStatus(
+          pageStatus,
+          "Unable to load your workspace. Please return to Dashboard or try again shortly.",
+          "error",
+        );
       }
     }
   }

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -569,6 +569,6 @@
       });
     </script>
 
-    <script src="verification-upload.js?v=20260508-451"></script>
+    <script src="verification-upload.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/verification-upload.js
+++ b/verification-upload.js
@@ -50,17 +50,14 @@
 
   function setStatus(node, message, type) {
     if (!node) return;
+    if (typeof app.setStatus === "function") {
+      app.setStatus(node, message, type || "info");
+      return;
+    }
 
     node.style.display = "block";
     node.textContent = message;
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
+    node.dataset.state = type || "info";
   }
 
   function clearStatus(node) {


### PR DESCRIPTION
## Summary
- Prevent Members & Access from treating package-gated 403s or missing workspace context as logout, while preserving true invalid-token redirects.
- Preserve and display active `project_members` records, including `co_owner` records with email-only identity, while keeping pending/accepted/expired/revoked invites separate.
- Align private vault frontend/backend gating to `premium_archive_structure`, add package-aware dashboard tool states, improve portal status readability, and strengthen the background watermark without changing pricing, checkout, admin controls, or viewer protections.

## Data integrity notes
- `project_members` remains the source of active household membership, with active `co_owner` records preserved by role/status/project/email/user id when present.
- `household_invites` remains separate invite history; pending, accepted, expired, and revoked states are not rendered as active members.
- No production customer data was modified and no live customer-specific value was hard-coded into production UI.
- Entitlement definitions were not changed; portal routing now reads the existing entitlement flags more exactly.

## Validation
- `/private/tmp/tol-audit-venv/bin/python -m pytest backend/tests/test_frontend_link_integrity.py -q`
- `/private/tmp/tol-audit-venv/bin/python -m pytest backend/tests/test_dashboard_and_client_security_integrity.py -q`
- `/private/tmp/tol-audit-venv/bin/python -m pytest backend/tests/test_upload_hub_integrity.py -q`
- Additional focused pytest coverage for private media uploads, household invites, workspace UI roles, and household access model.
- Static sweeps for placeholder links, admin strings, false Included labels, and cache-version coverage.
- `node --check` on changed portal JS files and `git diff --check`.