### PR TITLE
Fix malformed data-cookie-accept attribute

### DIFF
--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -92,6 +92,8 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertIn("localStorage.setItem(COOKIE_CHOICE_KEY, choice)", app_source)
         self.assertGreaterEqual(privacy_choices.count("data-cookie-accept"), 2)
         self.assertGreaterEqual(privacy_choices.count("data-cookie-decline"), 2)
+        self.assertNotIn('data-cookie-accept"', homepage)
+        self.assertNotIn('data-cookie-accept"', platform)
         self.assertNotIn('data-cookie-decline"', homepage)
         self.assertNotIn('data-cookie-decline"', platform)
 

--- a/platform.html
+++ b/platform.html
@@ -476,7 +476,7 @@
           and review your choices at any time.
         </div>
         <div class="cookie-actions">
-          <button class="btn btn-primary" type="button" data-cookie-accept">
+          <button class="btn btn-primary" type="button" data-cookie-accept>
             Accept
           </button>
           <button class="btn btn-secondary" type="button" data-cookie-decline>


### PR DESCRIPTION
Remove a stray double-quote from the data-cookie-accept attribute in platform.html that caused a malformed HTML attribute. Tests were updated to assert that 'data-cookie-accept"' does not appear in homepage and platform outputs, preventing regressions.