### PR TITLE
docs/tests: merge Continuity Kernel Phase 5B apply contracts into main

### DIFF
--- a/backend/docs/governance/continuity_kernel_phase5b_apply_contracts.md
+++ b/backend/docs/governance/continuity_kernel_phase5b_apply_contracts.md
@@ -1,0 +1,91 @@
+# Tomb of Light Continuity Kernel — Phase 5B Apply-Mode Implementation Contracts
+
+Status: design/test-only contract specification for future apply-mode implementation. This phase does not enable runtime apply behavior.
+
+## 1) Authorization Contract
+Future apply-mode authorization must enforce all checks below:
+- actor must be authenticated
+- actor must have approved role
+- actor cannot approve their own apply request unless CEO/SUPERADMIN emergency override is documented
+- CMO/marketing_admin cannot approve repair execution
+- officer role must match repair category
+- superadmin-only categories must require SUPERADMIN
+- executor must be separate from requester when risk level is high
+
+## 2) Evidence Packet Contract
+Future apply-mode evidence packets must include this object shape and all required fields:
+- dry_run_id
+- evidence_packet_id
+- actor_user_id
+- requested_by
+- reviewed_by
+- approved_by
+- executed_by
+- approval_role
+- target_type
+- target_id
+- repair_category
+- before_snapshot
+- proposed_after_snapshot
+- diff_summary
+- blocked_reasons
+- risk_level
+- rollback_plan
+- idempotency_key
+- created_at
+- approved_at
+- executed_at
+- audit_context
+
+## 3) Approval Workflow Contract
+Future apply-mode state transitions are restricted to the allowed transitions below:
+- dry_run_created -> review_requested
+- review_requested -> officer_reviewing
+- officer_reviewing -> approved_for_apply
+- officer_reviewing -> rejected
+- approved_for_apply -> apply_scheduled
+- apply_scheduled -> apply_executed
+- apply_scheduled -> apply_failed
+- apply_failed -> rollback_required
+- rollback_required -> rollback_completed
+- apply_executed -> audit_closed
+- rollback_completed -> audit_closed
+
+## 4) Apply Executor Contract
+Future apply executors must enforce these guardrails:
+- must verify evidence packet before execution
+- must verify approval state is approved_for_apply or apply_scheduled
+- must verify idempotency key has not already been consumed
+- must write audit event before and after execution
+- must never queue mint work directly
+- must never mutate immutable issued certificates
+- must never delete customer records
+- must never bypass auth, entitlement, verification, mint readiness, audit logging, or officer permissions
+
+## 5) Rollback Verification Contract
+Future rollback flow must enforce all requirements below:
+- rollback plan must exist before apply
+- rollback plan must reference before_snapshot
+- rollback must not delete audit logs
+- rollback must create a new audit event
+- rollback must not mutate immutable certificate artifacts
+- rollback must verify target selector still matches intended record
+
+## 6) Audit Transition Contract
+Every future apply-mode state transition must include:
+- actor_user_id
+- action
+- target_type
+- target_id
+- previous_state
+- next_state
+- repair_category
+- evidence_packet_id
+- audit_context
+- timestamp
+
+## 7) Non-Implementation Guardrail
+- Phase 5B does not implement apply mode.
+- Phase 5B does not create repair scripts.
+- Phase 5B does not modify runtime services.
+- Phase 5B only defines future implementation contracts and tests the contract documentation.

--- a/backend/tests/contracts/test_continuity_kernel_phase5b_apply_contracts.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase5b_apply_contracts.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC_PATH = REPO_ROOT / "backend/docs/governance/continuity_kernel_phase5b_apply_contracts.md"
+
+
+class TestContinuityKernelPhase5BApplyContracts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.doc_text = DOC_PATH.read_text(encoding="utf-8")
+        cls.doc_lower = cls.doc_text.lower()
+
+    def test_phase5b_contract_doc_exists(self) -> None:
+        self.assertTrue(DOC_PATH.is_file(), "Phase 5B contract doc must exist.")
+
+    def test_doc_includes_authorization_contract(self) -> None:
+        self.assertIn("Authorization Contract", self.doc_text)
+
+    def test_doc_includes_evidence_packet_contract(self) -> None:
+        self.assertIn("Evidence Packet Contract", self.doc_text)
+
+    def test_doc_includes_approval_workflow_contract(self) -> None:
+        self.assertIn("Approval Workflow Contract", self.doc_text)
+
+    def test_doc_includes_apply_executor_contract(self) -> None:
+        self.assertIn("Apply Executor Contract", self.doc_text)
+
+    def test_doc_includes_rollback_verification_contract(self) -> None:
+        self.assertIn("Rollback Verification Contract", self.doc_text)
+
+    def test_doc_includes_audit_transition_contract(self) -> None:
+        self.assertIn("Audit Transition Contract", self.doc_text)
+
+    def test_doc_states_cmo_marketing_admin_cannot_approve_execution(self) -> None:
+        self.assertIn("cmo/marketing_admin cannot approve repair execution", self.doc_lower)
+
+    def test_doc_includes_all_evidence_packet_fields(self) -> None:
+        required_fields = [
+            "dry_run_id",
+            "evidence_packet_id",
+            "actor_user_id",
+            "requested_by",
+            "reviewed_by",
+            "approved_by",
+            "executed_by",
+            "approval_role",
+            "target_type",
+            "target_id",
+            "repair_category",
+            "before_snapshot",
+            "proposed_after_snapshot",
+            "diff_summary",
+            "blocked_reasons",
+            "risk_level",
+            "rollback_plan",
+            "idempotency_key",
+            "created_at",
+            "approved_at",
+            "executed_at",
+            "audit_context",
+        ]
+        missing = [field for field in required_fields if field not in self.doc_text]
+        self.assertFalse(missing, f"Missing required evidence packet fields: {missing}")
+
+    def test_doc_includes_all_allowed_workflow_transitions(self) -> None:
+        required_transitions = [
+            "dry_run_created -> review_requested",
+            "review_requested -> officer_reviewing",
+            "officer_reviewing -> approved_for_apply",
+            "officer_reviewing -> rejected",
+            "approved_for_apply -> apply_scheduled",
+            "apply_scheduled -> apply_executed",
+            "apply_scheduled -> apply_failed",
+            "apply_failed -> rollback_required",
+            "rollback_required -> rollback_completed",
+            "apply_executed -> audit_closed",
+            "rollback_completed -> audit_closed",
+        ]
+        missing = [
+            transition
+            for transition in required_transitions
+            if re.search(rf"\b{re.escape(transition)}\b", self.doc_text) is None
+        ]
+        self.assertFalse(missing, f"Missing workflow transitions: {missing}")
+
+    def test_doc_prohibits_guardrail_violations(self) -> None:
+        required_phrases = [
+            "must never queue mint work directly",
+            "must never mutate immutable issued certificates",
+            "must never delete customer records",
+            "must never bypass auth, entitlement, verification, mint readiness, audit logging, or officer permissions",
+        ]
+        missing = [phrase for phrase in required_phrases if phrase not in self.doc_lower]
+        self.assertFalse(missing, f"Missing prohibited behavior language: {missing}")
+
+    def test_doc_states_non_implementation_guardrail(self) -> None:
+        self.assertIn("phase 5b does not implement apply mode", self.doc_lower)
+        self.assertIn("phase 5b does not create repair scripts", self.doc_lower)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Merges Phase 5B apply-mode implementation contracts for the Tomb of Light Continuity Kernel into `main`.

This PR is design/test-only. It does not implement apply mode, does not create repair scripts, and does not change production behavior.

## Added

- Phase 5B apply-mode implementation contracts document
- Standard-library-only contract tests for Phase 5B documentation

## Contract areas covered

- Authorization Contract
- Evidence Packet Contract
- Approval Workflow Contract
- Apply Executor Contract
- Rollback Verification Contract
- Audit Transition Contract
- Non-Implementation Guardrail

## Safety

- No production code changed
- No backend/app files changed
- No frontend files changed
- No backend/scripts files changed
- No requirements changed
- No database behavior changed
- No executable repair scripts created
- No apply-mode behavior created
- No files deleted
- No customer-specific production values added

## Expected changed files

- `backend/docs/governance/continuity_kernel_phase5b_apply_contracts.md`
- `backend/tests/contracts/test_continuity_kernel_phase5b_apply_contracts.py`

## Notes

Phase 5B maps Phase 5A governance into future implementation contracts only. Live apply behavior remains out of scope.