### PR TITLE
Harden LIGHT NEVER DIES founder checkout maintenance flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,8 @@
   const USER_KEY = "tol_user";
   const COOKIE_CHOICE_KEY = "tol_cookie_choice";
   const PENDING_CHECKOUT_KEY = "tol_pending_checkout";
+  const FOUNDER_MAINTENANCE_PENDING_KEY = "tol_founder_maintenance_pending";
+  const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";
   const API_BASE_URL_STORAGE_KEY = "tol_api_base_url";
   const API_REQUEST_TIMEOUT_MS = 15000;
 
@@ -507,6 +509,174 @@
 
   function getPaymentLinks() {
     return (window.TOL_CONFIG && window.TOL_CONFIG.PAYMENT_LINKS) || {};
+  }
+
+  function getActiveCampaignCode() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const campaign =
+        params.get("campaign") ||
+        params.get("utm_campaign") ||
+        params.get("source_campaign") ||
+        "";
+      return String(campaign || "").trim().toUpperCase();
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function isLightNeverDiesCampaign(value) {
+    return String(value || "").trim().toUpperCase() === LIGHT_NEVER_DIES_CAMPAIGN;
+  }
+
+  function sanitizeMaintenanceCheckoutUrl(url) {
+    const normalized = String(url || "").trim();
+    if (!normalized) return "";
+    try {
+      const parsed = new URL(normalized, window.location.origin);
+      [
+        "prefilled_promo_code",
+        "promo_code",
+        "promotion_code",
+        "coupon",
+        "discount_code",
+      ].forEach(function (key) {
+        parsed.searchParams.delete(key);
+      });
+      return parsed.toString();
+    } catch (_error) {
+      return normalized;
+    }
+  }
+
+  function getSavedUserProjectId(user) {
+    const source = user && typeof user === "object" ? user : getSavedUser() || {};
+    return String(
+      source.active_project_id ||
+        source.activeProjectId ||
+        source.project_id ||
+        source.projectId ||
+        "",
+    ).trim();
+  }
+
+  function inferBillingInterval(purchaseType, slug) {
+    const type = String(purchaseType || "").trim().toLowerCase();
+    const normalizedSlug = String(slug || "").trim().toLowerCase();
+    if (type === "maintenance") {
+      if (normalizedSlug.endsWith("_yearly")) return "yearly";
+      return "monthly";
+    }
+    return "one_time";
+  }
+
+  function buildCheckoutClientReference(payload) {
+    const input = payload && typeof payload === "object" ? payload : {};
+    const params = new URLSearchParams();
+    const packageCode = stripMaintenanceSuffix(input.packageCode || input.slug || "");
+    params.set("v", "1");
+    if (input.userId) params.set("u", String(input.userId).trim());
+    if (input.projectId) params.set("p", String(input.projectId).trim());
+    if (packageCode) params.set("k", packageCode);
+    if (input.itemType) params.set("t", String(input.itemType).trim().toLowerCase());
+    if (input.billingInterval) {
+      params.set("b", String(input.billingInterval).trim().toLowerCase());
+    }
+    if (input.campaign) params.set("c", String(input.campaign).trim().toUpperCase());
+    return `tol:${params.toString()}`;
+  }
+
+  function buildCheckoutLinkWithContext(url, options = {}) {
+    const normalizedUrl = String(url || "").trim();
+    if (!normalizedUrl) return "";
+    const user = getSavedUser() || {};
+    const slug = String(options.slug || "").trim().toLowerCase();
+    const purchaseType =
+      String(options.purchaseType || inferPurchaseTypeFromSlug(slug))
+        .trim()
+        .toLowerCase() || "package";
+    const campaign = String(options.campaign || "").trim().toUpperCase();
+    const userId = String(user.id || user._id || user.user_id || "").trim();
+    const projectId = String(options.projectId || getSavedUserProjectId(user)).trim();
+    const email = String(user.email || "").trim().toLowerCase();
+    const billingInterval = inferBillingInterval(purchaseType, slug);
+    const contextReference = buildCheckoutClientReference({
+      userId,
+      projectId,
+      packageCode: slug,
+      itemType: purchaseType,
+      billingInterval,
+      campaign,
+    });
+    try {
+      const parsed = new URL(normalizedUrl, window.location.origin);
+      parsed.searchParams.set("client_reference_id", contextReference);
+      if (email) {
+        parsed.searchParams.set("prefilled_email", email);
+      }
+      if (purchaseType === "maintenance") {
+        return sanitizeMaintenanceCheckoutUrl(parsed.toString());
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return purchaseType === "maintenance"
+        ? sanitizeMaintenanceCheckoutUrl(normalizedUrl)
+        : normalizedUrl;
+    }
+  }
+
+  function getFounderMaintenancePending() {
+    try {
+      const raw = localStorage.getItem(FOUNDER_MAINTENANCE_PENDING_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function setFounderMaintenancePending(payload) {
+    try {
+      localStorage.setItem(
+        FOUNDER_MAINTENANCE_PENDING_KEY,
+        JSON.stringify(payload || {}),
+      );
+    } catch (_error) {
+      // Ignore storage errors.
+    }
+  }
+
+  function clearFounderMaintenancePending() {
+    try {
+      localStorage.removeItem(FOUNDER_MAINTENANCE_PENDING_KEY);
+    } catch (_error) {
+      // Ignore storage errors.
+    }
+  }
+
+  function enforceFounderMaintenanceGate() {
+    const pending = getFounderMaintenancePending();
+    if (!pending || !isLightNeverDiesCampaign(pending.campaign)) return;
+    const currentPage =
+      String(window.location.pathname || "").split("/").pop() || "index.html";
+    if (
+      [
+        "billing.html",
+        "thank-you.html",
+        "signin.html",
+        "signup.html",
+        "index.html",
+      ].includes(currentPage)
+    ) {
+      return;
+    }
+    const packageCode = stripMaintenanceSuffix(pending.packageCode || "");
+    const params = new URLSearchParams();
+    params.set("maintenance_required", "1");
+    if (packageCode) params.set("package", packageCode);
+    params.set("campaign", LIGHT_NEVER_DIES_CAMPAIGN);
+    window.location.replace(`billing.html?${params.toString()}`);
   }
 
   function inferPurchaseTypeFromSlug(slug) {
@@ -1146,16 +1316,46 @@
       const originalLabel = link.textContent.trim() || "Start Checkout";
       const purchaseType =
         link.dataset.paymentType || inferPurchaseTypeFromSlug(slug);
+      const campaign = getActiveCampaignCode();
 
       if (resolved) {
-        link.href = resolved;
+        link.href = buildCheckoutLinkWithContext(resolved, {
+          slug,
+          purchaseType,
+          campaign,
+        });
         link.target = "_blank";
         link.rel = "noopener noreferrer";
-        link.addEventListener("click", function () {
+        link.addEventListener("click", function (event) {
+          const founderCampaign = isLightNeverDiesCampaign(campaign);
+          if (founderCampaign && purchaseType === "package" && !getToken()) {
+            event.preventDefault();
+            const next = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+            window.location.href = `signin.html?next=${encodeURIComponent(next)}`;
+            return;
+          }
+          const checkoutHref = buildCheckoutLinkWithContext(resolved, {
+            slug,
+            purchaseType,
+            campaign,
+          });
+          if (checkoutHref) {
+            link.href = checkoutHref;
+          }
+          const normalizedSlug = stripMaintenanceSuffix(slug);
+          if (founderCampaign && purchaseType === "package" && normalizedSlug) {
+            setFounderMaintenancePending({
+              campaign: LIGHT_NEVER_DIES_CAMPAIGN,
+              packageCode: normalizedSlug,
+              requiredBillingInterval: "monthly",
+              createdAt: new Date().toISOString(),
+            });
+          }
           savePendingCheckout({
             packageCode: slug,
             purchaseType,
-            paymentLink: resolved,
+            paymentLink: checkoutHref || resolved,
+            campaign: campaign || "",
             selectedAt: new Date().toISOString(),
           });
           link.dataset.originalLabel = link.dataset.originalLabel || originalLabel;
@@ -1214,6 +1414,7 @@
   }
 
   document.addEventListener("DOMContentLoaded", function () {
+    enforceFounderMaintenanceGate();
     setupMobileMenu();
     setupHeaderScrollState();
     markActiveNavLink();
@@ -1250,6 +1451,12 @@
     packageSupportsLinkKeys,
     inferPurchaseTypeFromSlug,
     savePendingCheckout,
+    buildCheckoutLinkWithContext,
+    getActiveCampaignCode,
+    isLightNeverDiesCampaign,
+    getFounderMaintenancePending,
+    setFounderMaintenancePending,
+    clearFounderMaintenancePending,
     getReadableErrorMessage,
   };
 

--- a/app.js
+++ b/app.js
@@ -1319,11 +1319,10 @@
       const campaign = getActiveCampaignCode();
 
       if (resolved) {
-        link.href = buildCheckoutLinkWithContext(resolved, {
-          slug,
-          purchaseType,
-          campaign,
-        });
+        link.href =
+          purchaseType === "maintenance"
+            ? sanitizeMaintenanceCheckoutUrl(resolved)
+            : resolved;
         link.target = "_blank";
         link.rel = "noopener noreferrer";
         link.addEventListener("click", function (event) {

--- a/backend/app/services/maintenance_subscription_service.py
+++ b/backend/app/services/maintenance_subscription_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import parse_qsl
 
 from app.database import get_database
 from app.services.project_entitlement_service import (
@@ -25,11 +26,20 @@ def _to_datetime(value: Any) -> datetime | None:
 
 def _metadata_project_id(payload: dict[str, Any]) -> str:
     metadata = payload.get("metadata") or {}
+    client_reference_id = _normalize(payload.get("client_reference_id"))
+    context_project_id = ""
+    if client_reference_id.startswith("tol:"):
+        try:
+            parsed = dict(parse_qsl(client_reference_id[4:], keep_blank_values=False))
+            context_project_id = _normalize(parsed.get("p"))
+        except Exception:
+            context_project_id = ""
     return _normalize(
         metadata.get("project_id")
         or metadata.get("upgrade_project_id")
         or metadata.get("existing_project_id")
         or metadata.get("target_project_id")
+        or context_project_id
     )
 
 

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -873,6 +873,19 @@ def _infer_purchase_fields(session: dict[str, Any]) -> tuple[str, str, str, str,
         package_code = _normalize_package_code(raw_code)
         if package_name and price_label:
             return item_type, package_code, package_name, price_label, billing_plan
+        if context.get("item_type") or context.get("billing_interval"):
+            fallback_name = package_name or package_code.replace("_", " ").title()
+            fallback_price_label = price_label or _format_price_label(
+                session.get("amount_subtotal"),
+                billing_plan,
+            )
+            return (
+                item_type,
+                package_code,
+                fallback_name,
+                fallback_price_label,
+                billing_plan,
+            )
 
     product_name = _extract_product_name_from_session(session) or ""
     name_lower = product_name.lower()

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -1097,7 +1097,6 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         }
         _set_if_present(update_fields, "stripe_payment_link_id", stripe_payment_link_id)
         _set_if_present(update_fields, "campaign", campaign)
-        _set_if_present(update_fields, "campaign_code", campaign)
         orders.update_one({"_id": existing["_id"]}, {"$set": update_fields})
 
         order_doc = orders.find_one({"_id": existing["_id"]}) or {
@@ -1148,7 +1147,6 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
     }
     _set_if_present(order_doc, "stripe_payment_link_id", stripe_payment_link_id)
     _set_if_present(order_doc, "campaign", campaign)
-    _set_if_present(order_doc, "campaign_code", campaign)
 
     result = orders.insert_one(order_doc)
     order_doc["_id"] = result.inserted_id

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -2,6 +2,7 @@ import re
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, cast
+from urllib.parse import parse_qsl
 
 import stripe
 from bson import ObjectId
@@ -768,6 +769,33 @@ def _extract_billing_plan_from_session(session: dict[str, Any]) -> str:
     return "one_time"
 
 
+def _extract_checkout_context(session: dict[str, Any]) -> dict[str, str]:
+    raw_reference = _normalize(session.get("client_reference_id"))
+    if not raw_reference:
+        return {}
+    if not raw_reference.startswith("tol:"):
+        return {}
+    try:
+        parsed = dict(parse_qsl(raw_reference[4:], keep_blank_values=False))
+    except Exception:
+        return {}
+
+    context: dict[str, str] = {}
+    if parsed.get("u"):
+        context["user_id"] = _normalize(parsed.get("u"))
+    if parsed.get("p"):
+        context["project_id"] = _normalize(parsed.get("p"))
+    if parsed.get("k"):
+        context["package_code"] = _normalize_package_code(parsed.get("k"))
+    if parsed.get("t"):
+        context["item_type"] = _normalize(parsed.get("t")).lower()
+    if parsed.get("b"):
+        context["billing_interval"] = _normalize(parsed.get("b")).lower()
+    if parsed.get("c"):
+        context["campaign"] = _normalize(parsed.get("c")).upper()
+    return {k: v for k, v in context.items() if v}
+
+
 def _format_price_label(amount_subtotal: Any, billing_plan: str) -> str:
     if not isinstance(amount_subtotal, int):
         return "paid"
@@ -808,26 +836,38 @@ def _schedule_maintenance_start(
 
 def _extract_target_project_id(session: dict[str, Any]) -> str:
     metadata = session.get("metadata") or {}
+    context = _extract_checkout_context(session)
     return _normalize(
         metadata.get("project_id")
         or metadata.get("upgrade_project_id")
         or metadata.get("existing_project_id")
         or metadata.get("target_project_id")
+        or context.get("project_id")
     )
 
 
 def _infer_purchase_fields(session: dict[str, Any]) -> tuple[str, str, str, str, str]:
     metadata = session.get("metadata") or {}
+    context = _extract_checkout_context(session)
 
     raw_code = (
         metadata.get("package_code")
         or metadata.get("package_slug")
         or metadata.get("package")
+        or context.get("package_code")
     )
     package_name = _normalize(metadata.get("package_name"))
     price_label = _normalize(metadata.get("price_label"))
-    item_type = _normalize(metadata.get("item_type") or metadata.get("type")) or "package"
-    billing_plan = _normalize(metadata.get("billing_plan")) or _extract_billing_plan_from_session(session)
+    item_type = _normalize(
+        metadata.get("item_type")
+        or metadata.get("type")
+        or context.get("item_type")
+    ) or "package"
+    billing_plan = (
+        _normalize(metadata.get("billing_plan"))
+        or _normalize(context.get("billing_interval"))
+        or _extract_billing_plan_from_session(session)
+    )
 
     if raw_code:
         package_code = _normalize_package_code(raw_code)
@@ -1020,6 +1060,8 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             pass
 
     orders = _get_orders_collection()
+    checkout_context = _extract_checkout_context(session)
+    campaign = _normalize((session.get("metadata") or {}).get("campaign") or checkout_context.get("campaign")).upper()
 
     item_type, package_code, package_name, price_label, billing_plan = _infer_purchase_fields(session)
     stripe_payment_link_id = session.get("payment_link")
@@ -1041,6 +1083,8 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "stripe_session_id": session_id,
         }
         _set_if_present(update_fields, "stripe_payment_link_id", stripe_payment_link_id)
+        _set_if_present(update_fields, "campaign", campaign)
+        _set_if_present(update_fields, "campaign_code", campaign)
         orders.update_one({"_id": existing["_id"]}, {"$set": update_fields})
 
         order_doc = orders.find_one({"_id": existing["_id"]}) or {
@@ -1090,6 +1134,8 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         "created_at": datetime.now(UTC),
     }
     _set_if_present(order_doc, "stripe_payment_link_id", stripe_payment_link_id)
+    _set_if_present(order_doc, "campaign", campaign)
+    _set_if_present(order_doc, "campaign_code", campaign)
 
     result = orders.insert_one(order_doc)
     order_doc["_id"] = result.inserted_id

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -121,6 +121,9 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertIn('link.target = "_blank"', app_source)
         self.assertIn('link.rel = "noopener noreferrer"', app_source)
         self.assertIn("Opening secure checkout...", app_source)
+        self.assertIn('client_reference_id', app_source)
+        self.assertIn("sanitizeMaintenanceCheckoutUrl", app_source)
+        self.assertIn("LIGHT_NEVER_DIES", app_source)
 
     def test_public_and_legal_headers_include_platform_nav(self):
         pages = [

--- a/backend/tests/test_maintenance_subscription_checkout_context.py
+++ b/backend/tests/test_maintenance_subscription_checkout_context.py
@@ -1,0 +1,18 @@
+import unittest
+
+from app.services import maintenance_subscription_service
+
+
+class MaintenanceSubscriptionCheckoutContextTests(unittest.TestCase):
+    def test_metadata_project_id_reads_client_reference_context(self):
+        payload = {
+            "client_reference_id": "tol:v=1&u=user-1&p=project-ctx-1&k=legacy_plus&t=maintenance&b=monthly&c=LIGHT_NEVER_DIES"
+        }
+        self.assertEqual(
+            maintenance_subscription_service._metadata_project_id(payload),
+            "project-ctx-1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_order_service_checkout_context.py
+++ b/backend/tests/test_order_service_checkout_context.py
@@ -1,0 +1,39 @@
+import unittest
+
+from app.services import order_service
+
+
+class OrderServiceCheckoutContextTests(unittest.TestCase):
+    def test_extract_checkout_context_parses_tol_reference(self):
+        session = {
+            "client_reference_id": "tol:v=1&u=user-1&p=project-1&k=legacy_plus&t=maintenance&b=monthly&c=light_never_dies"
+        }
+        context = order_service._extract_checkout_context(session)
+        self.assertEqual(context.get("user_id"), "user-1")
+        self.assertEqual(context.get("project_id"), "project-1")
+        self.assertEqual(context.get("package_code"), "legacy_plus")
+        self.assertEqual(context.get("item_type"), "maintenance")
+        self.assertEqual(context.get("billing_interval"), "monthly")
+        self.assertEqual(context.get("campaign"), "LIGHT_NEVER_DIES")
+
+    def test_extract_target_project_id_falls_back_to_checkout_context(self):
+        session = {
+            "client_reference_id": "tol:v=1&p=project-abc&k=legacy_snapshot&t=package&b=one_time"
+        }
+        self.assertEqual(order_service._extract_target_project_id(session), "project-abc")
+
+    def test_infer_purchase_fields_prefers_checkout_context_when_metadata_missing(self):
+        session = {
+            "client_reference_id": "tol:v=1&k=legacy_portrait_intro&t=maintenance&b=monthly&c=LIGHT_NEVER_DIES",
+            "line_items": {"data": []},
+        }
+        item_type, package_code, _package_name, _price_label, billing_plan = (
+            order_service._infer_purchase_fields(session)
+        )
+        self.assertEqual(item_type, "maintenance")
+        self.assertEqual(package_code, "legacy_portrait_intro")
+        self.assertEqual(billing_plan, "monthly")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thank-you.js
+++ b/thank-you.js
@@ -11,6 +11,7 @@
     return;
   }
   const PENDING_CHECKOUT_KEY = "tol_pending_checkout";
+  const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";
   const PORTRAIT_PACKAGE_CODES = new Set([
     "legacy_snapshot",
     "legacy_portrait_intro",
@@ -59,6 +60,12 @@
     } catch (_error) {
       return null;
     }
+  }
+
+  function normalizeCampaign(value) {
+    return String(value || "")
+      .trim()
+      .toUpperCase();
   }
 
   function clearPendingCheckout() {
@@ -273,11 +280,23 @@
 
     const sessionId = getParam("session_id");
     const packageCode = getParam("package") || (pendingCheckout && pendingCheckout.packageCode) || "";
+    const campaign = normalizeCampaign(
+      getParam("campaign") ||
+        (pendingCheckout && pendingCheckout.campaign) ||
+        (app.getActiveCampaignCode ? app.getActiveCampaignCode() : ""),
+    );
     const type =
       getParam("type") ||
       (pendingCheckout && pendingCheckout.purchaseType) ||
       inferType("", packageCode);
+    const normalizedType = inferType(type, packageCode);
     const actions = actionConfig(type, packageCode);
+    const normalizedPackageCode = normalizePackageCode(packageCode);
+    const basePackage = basePackageCode(normalizedPackageCode);
+    const isFounderCampaign = normalizeCampaign(campaign) === LIGHT_NEVER_DIES_CAMPAIGN;
+    const paymentLinks = (window.TOL_CONFIG && window.TOL_CONFIG.PAYMENT_LINKS) || {};
+    const requiredMonthlyMaintenanceSlug = `${basePackage}_maintenance_monthly`;
+    const requiredMonthlyMaintenanceUrl = paymentLinks[requiredMonthlyMaintenanceSlug] || "";
 
     if (sessionNode) {
       sessionNode.textContent = sessionId || "Not provided";
@@ -295,14 +314,64 @@
       nextStepNode.textContent = nextStepMessage(type, packageCode);
     }
 
-    if (primaryAction) {
-      primaryAction.setAttribute("href", actions.primary.href);
-      primaryAction.textContent = actions.primary.label;
+    if (isFounderCampaign && normalizedType === "package") {
+      if (
+        app &&
+        typeof app.setFounderMaintenancePending === "function" &&
+        basePackage
+      ) {
+        app.setFounderMaintenancePending({
+          campaign: LIGHT_NEVER_DIES_CAMPAIGN,
+          packageCode: basePackage,
+          requiredBillingInterval: "monthly",
+          createdAt: new Date().toISOString(),
+        });
+      }
+      if (nextStepNode) {
+        nextStepNode.textContent =
+          "Your founder package payment was received. Monthly maintenance setup is required now to keep your Tomb of Light continuity active.";
+      }
+      const checkoutUrl =
+        requiredMonthlyMaintenanceUrl &&
+        app &&
+        typeof app.buildCheckoutLinkWithContext === "function"
+          ? app.buildCheckoutLinkWithContext(requiredMonthlyMaintenanceUrl, {
+              slug: requiredMonthlyMaintenanceSlug,
+              purchaseType: "maintenance",
+              campaign: LIGHT_NEVER_DIES_CAMPAIGN,
+            })
+          : requiredMonthlyMaintenanceUrl;
+      if (primaryAction) {
+        if (checkoutUrl) {
+          primaryAction.setAttribute("href", checkoutUrl);
+          primaryAction.setAttribute("target", "_blank");
+          primaryAction.setAttribute("rel", "noopener noreferrer");
+          primaryAction.textContent = "Start Required Monthly Maintenance";
+        } else {
+          primaryAction.setAttribute("href", "billing.html");
+          primaryAction.textContent = "Open Billing";
+        }
+      }
+      if (secondaryAction) {
+        secondaryAction.setAttribute("href", "billing.html");
+        secondaryAction.textContent = "Open Billing";
+      }
+    } else {
+      if (primaryAction) {
+        primaryAction.setAttribute("href", actions.primary.href);
+        primaryAction.textContent = actions.primary.label;
+      }
+
+      if (secondaryAction) {
+        secondaryAction.setAttribute("href", actions.secondary.href);
+        secondaryAction.textContent = actions.secondary.label;
+      }
     }
 
-    if (secondaryAction) {
-      secondaryAction.setAttribute("href", actions.secondary.href);
-      secondaryAction.textContent = actions.secondary.label;
+    if (isFounderCampaign && normalizedType === "maintenance") {
+      if (app && typeof app.clearFounderMaintenancePending === "function") {
+        app.clearFounderMaintenancePending();
+      }
     }
 
     if (packageCode) {


### PR DESCRIPTION
## Summary
- Adds LIGHT NEVER DIES founder campaign detection and required monthly-maintenance follow-through state in the frontend.
- Drives founder package success users into required monthly maintenance setup and adds gating to prevent skipping setup during normal app navigation.
- Propagates compact checkout context through Stripe Payment Links via `client_reference_id`, including user, project when available, package, item type, billing interval, and campaign context.
- Prefills customer email when available and strips promo/coupon query parameters from maintenance checkout URLs.
- Extends backend Stripe order and maintenance sync to parse checkout context when metadata is missing.
- Adds/updates tests for frontend link integrity, order checkout context parsing, and maintenance subscription checkout context parsing.

## Validation
- Passed: `PYTHONPATH=backend python -m unittest backend.tests.test_stripe_webhooks backend.tests.test_frontend_link_integrity backend.tests.test_order_service_checkout_context backend.tests.test_maintenance_subscription_checkout_context -v`
- Code review: passed after fixes.
- CodeQL: timed out in tool run and was not re-run per tool output instruction.

## Review Notes
- Package checkout links and maintenance links remain separate; this PR hardens the flow so founder package purchases are directed into the required monthly maintenance setup.
- Do not merge until GitHub CI/CodeQL status is reviewed in the PR checks.