### PR TITLE
Add LIGHT NEVER DIES founder marketing layer

### DIFF
--- a/app.js
+++ b/app.js
@@ -596,6 +596,7 @@
         .trim()
         .toLowerCase() || "package";
     const campaign = String(options.campaign || "").trim().toUpperCase();
+    const promoCode = String(options.promoCode || "").trim();
     const userId = String(user.id || user._id || user.user_id || "").trim();
     const projectId = String(options.projectId || getSavedUserProjectId(user)).trim();
     const email = String(user.email || "").trim().toLowerCase();
@@ -613,6 +614,9 @@
       parsed.searchParams.set("client_reference_id", contextReference);
       if (email) {
         parsed.searchParams.set("prefilled_email", email);
+      }
+      if (purchaseType !== "maintenance" && promoCode) {
+        parsed.searchParams.set("prefilled_promo_code", promoCode);
       }
       if (purchaseType === "maintenance") {
         return sanitizeMaintenanceCheckoutUrl(parsed.toString());
@@ -1316,7 +1320,12 @@
       const originalLabel = link.textContent.trim() || "Start Checkout";
       const purchaseType =
         link.dataset.paymentType || inferPurchaseTypeFromSlug(slug);
-      const campaign = getActiveCampaignCode();
+      const campaign = String(
+        link.dataset.campaign || getActiveCampaignCode(),
+      )
+        .trim()
+        .toUpperCase();
+      const promoCode = String(link.dataset.promoCode || "").trim();
 
       if (resolved) {
         link.href =
@@ -1337,6 +1346,7 @@
             slug,
             purchaseType,
             campaign,
+            promoCode,
           });
           if (checkoutHref) {
             link.href = checkoutHref;

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -124,6 +124,66 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertIn('client_reference_id', app_source)
         self.assertIn("sanitizeMaintenanceCheckoutUrl", app_source)
         self.assertIn("LIGHT_NEVER_DIES", app_source)
+        self.assertIn('id="pricing"', homepage)
+        self.assertIn("Choose your legacy scope", homepage)
+        self.assertEqual(homepage.count('id="pricing"'), 1)
+
+    def test_founder_access_marketing_layer_is_present_and_campaign_ready(self):
+        homepage = (REPO_ROOT / "index.html").read_text(encoding="utf-8")
+        founder_page = (REPO_ROOT / "founder-access.html").read_text(encoding="utf-8")
+
+        for required in [
+            "LIGHT NEVER DIES",
+            "Genesis Founder Release",
+            "Founder Access",
+            "June 28, 2026",
+            "campaign=LIGHT_NEVER_DIES",
+        ]:
+            self.assertIn(required, homepage)
+            self.assertIn(required, founder_page)
+
+        self.assertEqual(homepage.count("data-founder-access-banner"), 1)
+        self.assertEqual(homepage.count("data-founder-access-section"), 1)
+
+        expected_founder_slugs = [
+            "legacy_snapshot",
+            "legacy_portrait_intro",
+            "digital_legacy_portrait",
+            "household_foundation",
+            "heirloom_legacy_tree",
+            "legacy_plus",
+        ]
+        for slug in expected_founder_slugs:
+            self.assertIn(f'data-payment-link="{slug}"', founder_page)
+
+        self.assertIn("LIGHTNEVERDIES-PORTRAIT", founder_page)
+        self.assertNotIn("LIGHTNEVERDIES- PORTRAIT", founder_page)
+
+    def test_checkout_campaign_and_founder_engines_are_not_duplicated(self):
+        app_source = (REPO_ROOT / "app.js").read_text(encoding="utf-8")
+        thank_you_source = (REPO_ROOT / "thank-you.js").read_text(encoding="utf-8")
+        order_service = (REPO_ROOT / "backend" / "app" / "services" / "order_service.py").read_text(
+            encoding="utf-8"
+        )
+        maintenance_service = (
+            REPO_ROOT / "backend" / "app" / "services" / "maintenance_subscription_service.py"
+        ).read_text(encoding="utf-8")
+        config_source = (REPO_ROOT / "config.js").read_text(encoding="utf-8")
+
+        self.assertEqual(
+            app_source.count('const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";'),
+            1,
+        )
+        self.assertEqual(
+            thank_you_source.count('const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";'),
+            1,
+        )
+        self.assertEqual(app_source.count("function enforceFounderMaintenanceGate()"), 1)
+        self.assertEqual(app_source.count("function buildCheckoutLinkWithContext("), 1)
+        self.assertEqual(order_service.count("def _extract_checkout_context("), 1)
+        self.assertEqual(maintenance_service.count("def _metadata_project_id("), 1)
+        self.assertEqual(app_source.count("const PACKAGE_PROFILES = {"), 1)
+        self.assertEqual(config_source.count("const TOL_PRICING = {"), 1)
 
     def test_public_and_legal_headers_include_platform_nav(self):
         pages = [

--- a/backend/tests/test_maintenance_subscription_checkout_context.py
+++ b/backend/tests/test_maintenance_subscription_checkout_context.py
@@ -1,6 +1,9 @@
 import unittest
+from pathlib import Path
 
 from app.services import maintenance_subscription_service
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class MaintenanceSubscriptionCheckoutContextTests(unittest.TestCase):
@@ -12,6 +15,12 @@ class MaintenanceSubscriptionCheckoutContextTests(unittest.TestCase):
             maintenance_subscription_service._metadata_project_id(payload),
             "project-ctx-1",
         )
+
+    def test_maintenance_subscription_service_keeps_single_checkout_context_parser(self):
+        source = (
+            REPO_ROOT / "backend" / "app" / "services" / "maintenance_subscription_service.py"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(source.count("def _metadata_project_id("), 1)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_order_service_checkout_context.py
+++ b/backend/tests/test_order_service_checkout_context.py
@@ -1,6 +1,9 @@
 import unittest
+from pathlib import Path
 
 from app.services import order_service
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class OrderServiceCheckoutContextTests(unittest.TestCase):
@@ -33,6 +36,12 @@ class OrderServiceCheckoutContextTests(unittest.TestCase):
         self.assertEqual(item_type, "maintenance")
         self.assertEqual(package_code, "legacy_portrait_intro")
         self.assertEqual(billing_plan, "monthly")
+
+    def test_order_service_keeps_single_checkout_context_builder(self):
+        source = (REPO_ROOT / "backend" / "app" / "services" / "order_service.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(source.count("def _extract_checkout_context("), 1)
 
 
 if __name__ == "__main__":

--- a/founder-access.html
+++ b/founder-access.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tomb of Light | LIGHT NEVER DIES Founder Access</title>
+    <meta
+      name="description"
+      content="LIGHT NEVER DIES — Genesis Founder Release founder-access packages for private digital lineage experience with guided production included."
+    />
+    <link rel="icon" href="favicon.ico?v=20260508-1" sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=20260508-1" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=20260508-1" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
+    <link rel="manifest" href="site.webmanifest?v=20260508-1" />
+    <link rel="stylesheet" href="styles.css?v=20260509-visualfix" />
+  </head>
+  <body class="homepage-body">
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+    <div class="site-watermark" aria-hidden="true"></div>
+
+    <div class="page-wrap">
+      <header class="site-header" role="banner">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="platform.html">Platform</a>
+            <a href="how-it-works.html">How It Works</a>
+            <a href="security.html">Security</a>
+            <a href="compliance.html">Compliance</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+          <div class="header-actions">
+            <span class="trust-badge header-trust-badge" aria-label="5.0 Google Rating">
+              ⭐ 5.0 Google Rating
+            </span>
+            <a
+              class="btn btn-primary"
+              href="signup.html"
+              data-auth-cta
+              data-logged-in-href="dashboard.html"
+              data-logged-in-label="Enter Private Portal"
+            >
+              Start Your Legacy Build
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <section class="founder-access-banner" aria-label="Founder access status">
+        <div class="container founder-access-banner-inner">
+          <p>
+            <strong>Founder Access Active</strong> · LIGHT NEVER DIES — Genesis Founder Release · Founder access closes
+            <time datetime="2026-06-28">June 28, 2026</time>
+          </p>
+          <a class="btn btn-secondary" href="index.html?campaign=LIGHT_NEVER_DIES#founder-access-home">
+            Return to Homepage Founder Section
+          </a>
+        </div>
+      </section>
+
+      <main id="main-content" role="main">
+        <section class="section" aria-labelledby="founder-access-title">
+          <div class="container">
+            <div class="cta-panel cta-panel-premium">
+              <span class="eyebrow">Genesis Founder Release</span>
+              <h1 id="founder-access-title">LIGHT NEVER DIES Founder Access</h1>
+              <p class="section-lead">
+                Private digital lineage experience access for founder cohorts, with guided production included and lane-matched package checkout.
+              </p>
+              <p class="section-lead">
+                Limited founder allocations: only 10 founder allocations per package. Founder access closes
+                <time datetime="2026-06-28">June 28, 2026</time>.
+              </p>
+              <p class="section-lead">
+                Countdown to close date: secure allocation before June 28, 2026.
+              </p>
+            </div>
+
+            <div class="feature-strip founder-access-strip">
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Legacy Snapshot</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$49 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-SNAPSHOT</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_snapshot"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-SNAPSHOT"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Legacy Portrait Intro</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$99 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PORTRAIT</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_portrait_intro"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-PORTRAIT"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Digital Legacy Portrait</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$199 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-DIGITAL</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="digital_legacy_portrait"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-DIGITAL"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+            </div>
+
+            <div class="feature-strip founder-access-strip pricing-row-two">
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Household Foundation</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$399 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HOUSEHOLD</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="household_foundation"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-HOUSEHOLD"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Heirloom Legacy Tree</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$799 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HEIRLOOM</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="heirloom_legacy_tree"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-HEIRLOOM"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Founder Access</span>
+                <h2>Legacy Plus</h2>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$1,499 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PLUS</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_plus"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-PLUS"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer" role="contentinfo">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">
+                  Tomb of Light<span class="brand-symbol">™</span>
+                </div>
+                <p class="footer-copy">
+                  A private, guided, premium digital lineage platform for protecting memory, lineage, and identity across generations.
+                </p>
+                <div class="cookie-status" data-cookie-status>
+                  Your cookie preference has not been set yet.
+                </div>
+                <div class="footer-trust-stack">
+                  <span class="trust-badge footer-trust-badge">
+                    ⭐ 5.0 Google Rating
+                  </span>
+                </div>
+              </div>
+
+              <div class="footer-links">
+                <a href="platform.html">Platform</a>
+                <a href="reviews/">Reviews</a>
+                <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms</a>
+                <a href="cookie-policy.html">Cookie Policy</a>
+                <a href="accessibility.html">Accessibility</a>
+                <a href="data-request.html">Data Requests</a>
+                <a href="privacy-state-notices.html">State Privacy Notices</a>
+                <a href="privacy-choices.html">Privacy Choices</a>
+                <a href="refunds-delivery.html">Refunds, Delivery &amp; Support</a>
+                <a href="compliance.html">Compliance &amp; Legal</a>
+              </div>
+            </div>
+
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+              <span>Tomb of Light technology and platform design are proprietary.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <div
+      class="cookie-banner"
+      data-cookie-banner
+      role="contentinfo"
+      aria-label="Cookie preferences"
+    >
+      <div class="cookie-inner">
+        <div class="cookie-copy">
+          We use essential site technologies and may use optional analytics tools only where permitted. You can accept or decline optional analytics cookies and review your choices at any time.
+        </div>
+        <div class="cookie-actions">
+          <button class="btn btn-primary" type="button" data-cookie-accept>
+            Accept
+          </button>
+          <button class="btn btn-secondary" type="button" data-cookie-decline>
+            Decline
+          </button>
+          <a class="btn btn-ghost" href="privacy-choices.html">
+            Privacy Choices
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <script src="config.js?v=20260509-visualfix"></script>
+    <script src="app.js?v=20260509-visualfix"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -115,6 +115,22 @@
         </div>
       </header>
 
+      <section
+        class="founder-access-banner"
+        data-founder-access-banner
+        aria-label="LIGHT NEVER DIES Genesis Founder Release"
+      >
+        <div class="container founder-access-banner-inner">
+          <p>
+            <strong>Founder Access Active</strong> · LIGHT NEVER DIES — Genesis Founder Release · Founder access closes
+            <time datetime="2026-06-28">June 28, 2026</time>
+          </p>
+          <a class="btn btn-secondary" href="founder-access.html?campaign=LIGHT_NEVER_DIES">
+            Open Founder Access
+          </a>
+        </div>
+      </section>
+
       <main id="main-content" role="main">
         <section
           class="hero hero-premium hero-tech-fixed hero-moreland"
@@ -540,6 +556,164 @@
                   <li>Structured organization continuity lineage</li>
                   <li>Admin-seat and organization add-on expansion paths</li>
                 </ul>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section
+          class="section"
+          id="founder-access-home"
+          data-founder-access-section
+          aria-labelledby="founder-access-home-title"
+        >
+          <div class="container">
+            <div class="cta-panel cta-panel-premium">
+              <span class="eyebrow">Founder Access Active</span>
+              <h2 id="founder-access-home-title">
+                LIGHT NEVER DIES — Genesis Founder Release
+              </h2>
+              <p class="section-lead">
+                Limited founder allocations for private digital lineage experience packages with guided production included.
+              </p>
+              <p class="section-lead">
+                Only 10 founder allocations per package. Founder access closes
+                <time datetime="2026-06-28">June 28, 2026</time>.
+              </p>
+              <div class="cta-actions">
+                <a class="btn btn-secondary" href="founder-access.html?campaign=LIGHT_NEVER_DIES">
+                  Review Full Founder Access
+                </a>
+              </div>
+            </div>
+
+            <div class="feature-strip founder-access-strip">
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Legacy Snapshot</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$49 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-SNAPSHOT</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_snapshot"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-SNAPSHOT"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Legacy Portrait Intro</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$99 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PORTRAIT</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_portrait_intro"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-PORTRAIT"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Digital Legacy Portrait</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$199 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-DIGITAL</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="digital_legacy_portrait"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-DIGITAL"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+            </div>
+
+            <div class="feature-strip founder-access-strip pricing-row-two">
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Household Foundation</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$399 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HOUSEHOLD</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="household_foundation"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-HOUSEHOLD"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Heirloom Legacy Tree</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$799 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HEIRLOOM</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="heirloom_legacy_tree"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-HEIRLOOM"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
+              </article>
+
+              <article class="feature-card feature-card-clean pricing-card">
+                <span class="eyebrow">Genesis Founder Release</span>
+                <h3>Legacy Plus</h3>
+                <div class="hero-meta" aria-label="Founder package details">
+                  <span class="meta-pill">$1,499 founder access</span>
+                  <span class="meta-pill">10 allocations</span>
+                </div>
+                <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PLUS</p>
+                <div class="inline-actions">
+                  <a
+                    class="btn btn-primary"
+                    href="founder-access.html?campaign=LIGHT_NEVER_DIES"
+                    data-payment-link="legacy_plus"
+                    data-campaign="LIGHT_NEVER_DIES"
+                    data-promo-code="LIGHTNEVERDIES-PLUS"
+                  >
+                    Secure Founder Access
+                  </a>
+                </div>
               </article>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1802,6 +1802,46 @@ select:focus-visible {
   padding: 28px 0 10px;
 }
 
+.founder-access-banner {
+  border-bottom: 1px solid var(--tol-line);
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.94), rgba(11, 18, 32, 0.88));
+}
+
+.founder-access-banner-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 0;
+}
+
+.founder-access-banner p {
+  margin: 0;
+  color: var(--tol-dark-body);
+  font-size: 0.93rem;
+}
+
+.founder-access-strip {
+  margin-top: 22px;
+}
+
+.founder-access-code {
+  margin-top: 14px;
+  color: var(--tol-dark-body);
+  font-weight: 700;
+}
+
+@media (max-width: 860px) {
+  .founder-access-banner-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .founder-access-banner .btn {
+    width: 100%;
+  }
+}
+
 .section-tight {
   padding-top: 12px;
 }


### PR DESCRIPTION
## Summary
- Adds the visible LIGHT NEVER DIES Genesis Founder Release marketing layer without recreating the already-merged PR #525 checkout/maintenance engine.
- Adds a slim homepage founder announcement banner and premium homepage founder-access section.
- Adds a dedicated public founder-access page at `founder-access.html`.
- Shows founder pricing, allocation messaging, June 28, 2026 close messaging, corrected public promo codes, and package CTAs using existing payment-link behavior with `campaign=LIGHT_NEVER_DIES`.
- Preserves the existing Tomb of Light design system and avoids exposing internal Stripe IDs.

## Files Changed
- `index.html`
- `founder-access.html`
- `styles.css`
- `app.js`
- `backend/tests/test_frontend_link_integrity.py`
- `backend/tests/test_order_service_checkout_context.py`
- `backend/tests/test_maintenance_subscription_checkout_context.py`

## Validation
- Passed: `PYTHONPATH=backend python -m unittest backend.tests.test_frontend_link_integrity backend.tests.test_order_service_checkout_context backend.tests.test_maintenance_subscription_checkout_context`
- Parallel validation: Code Review + CodeQL reported no issues.

## Review Notes
- This PR is intended to be marketing-layer only.
- PR #525 checkout/maintenance hardening should remain the source of truth for founder campaign flow logic.
- Legacy Plus founder price is displayed as `$1,499`.