### PR TITLE
Polish LIGHT NEVER DIES founder campaign visuals

### DIFF
--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PLACEHOLDER_HREF_PATTERN = re.compile(r'href\s*=\s*"(#|javascript:void\(0\)|)"', re.IGNORECASE)
 EMPTY_DATA_ACTION_PATTERN = re.compile(r'data-action\s*=\s*""', re.IGNORECASE)
+FOUNDER_STYLESHEET_VERSION = "styles.css?v=20260518-founder-polish"
 
 
 class FrontendLinkIntegrityTests(unittest.TestCase):
@@ -142,8 +143,13 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
             self.assertIn(required, homepage)
             self.assertIn(required, founder_page)
 
+        self.assertIn(FOUNDER_STYLESHEET_VERSION, homepage)
+        self.assertIn(FOUNDER_STYLESHEET_VERSION, founder_page)
+
         self.assertEqual(homepage.count("data-founder-access-banner"), 1)
         self.assertEqual(homepage.count("data-founder-access-section"), 1)
+        self.assertEqual(founder_page.count('id="founder-access-title"'), 1)
+        self.assertEqual(founder_page.count("founder-access-strip"), 2)
 
         expected_founder_slugs = [
             "legacy_snapshot",
@@ -162,6 +168,7 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
     def test_checkout_campaign_and_founder_engines_are_not_duplicated(self):
         app_source = (REPO_ROOT / "app.js").read_text(encoding="utf-8")
         thank_you_source = (REPO_ROOT / "thank-you.js").read_text(encoding="utf-8")
+        homepage = (REPO_ROOT / "index.html").read_text(encoding="utf-8")
         order_service = (REPO_ROOT / "backend" / "app" / "services" / "order_service.py").read_text(
             encoding="utf-8"
         )
@@ -184,6 +191,8 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertEqual(maintenance_service.count("def _metadata_project_id("), 1)
         self.assertEqual(app_source.count("const PACKAGE_PROFILES = {"), 1)
         self.assertEqual(config_source.count("const TOL_PRICING = {"), 1)
+        self.assertEqual(homepage.count("data-founder-access-banner"), 1)
+        self.assertEqual(homepage.count("data-founder-access-section"), 1)
 
     def test_public_and_legal_headers_include_platform_nav(self):
         pages = [

--- a/founder-access.html
+++ b/founder-access.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=20260508-1" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
     <link rel="manifest" href="site.webmanifest?v=20260508-1" />
-    <link rel="stylesheet" href="styles.css?v=20260509-visualfix" />
+    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
   </head>
   <body class="homepage-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -61,11 +61,15 @@
       <section class="founder-access-banner" aria-label="Founder access status">
         <div class="container founder-access-banner-inner">
           <p>
-            <strong>Founder Access Active</strong> · LIGHT NEVER DIES — Genesis Founder Release · Founder access closes
-            <time datetime="2026-06-28">June 28, 2026</time>
+            <span class="founder-access-banner-title">LIGHT NEVER DIES</span>
+            <span class="founder-access-banner-subtitle">Genesis Founder Release Now Open</span>
+            <span class="founder-access-banner-meta">
+              10 founder allocations per package · Closes
+              <time datetime="2026-06-28">June 28, 2026</time>
+            </span>
           </p>
           <a class="btn btn-secondary" href="index.html?campaign=LIGHT_NEVER_DIES#founder-access-home">
-            Return to Homepage Founder Section
+            Founder Home
           </a>
         </div>
       </section>
@@ -73,9 +77,10 @@
       <main id="main-content" role="main">
         <section class="section" aria-labelledby="founder-access-title">
           <div class="container">
-            <div class="cta-panel cta-panel-premium">
+            <div class="cta-panel cta-panel-premium founder-cinematic-panel">
               <span class="eyebrow">Genesis Founder Release</span>
-              <h1 id="founder-access-title">LIGHT NEVER DIES Founder Access</h1>
+              <h1 id="founder-access-title">LIGHT NEVER DIES</h1>
+              <p class="founder-hero-release">Genesis Founder Release</p>
               <p class="section-lead">
                 Private digital lineage experience access for founder cohorts, with guided production included and lane-matched package checkout.
               </p>
@@ -84,17 +89,17 @@
                 <time datetime="2026-06-28">June 28, 2026</time>.
               </p>
               <p class="section-lead">
-                Countdown to close date: secure allocation before June 28, 2026.
+                Founder access closes June 28, 2026, or once allocations are claimed.
               </p>
             </div>
 
             <div class="feature-strip founder-access-strip">
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Legacy Snapshot</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$49 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-SNAPSHOT</p>
                 <div class="inline-actions">
@@ -110,12 +115,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Legacy Portrait Intro</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$99 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PORTRAIT</p>
                 <div class="inline-actions">
@@ -131,12 +136,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Digital Legacy Portrait</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$199 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-DIGITAL</p>
                 <div class="inline-actions">
@@ -154,12 +159,12 @@
             </div>
 
             <div class="feature-strip founder-access-strip pricing-row-two">
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Household Foundation</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$399 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HOUSEHOLD</p>
                 <div class="inline-actions">
@@ -175,12 +180,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Heirloom Legacy Tree</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$799 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HEIRLOOM</p>
                 <div class="inline-actions">
@@ -196,12 +201,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
-                <span class="eyebrow">Founder Access</span>
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
+                <span class="eyebrow">Genesis Founder Release</span>
                 <h2>Legacy Plus</h2>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$1,499 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PLUS</p>
                 <div class="inline-actions">

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="styles.css?v=20260509-visualfix" />
+    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
   </head>
   <body class="homepage-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -122,11 +122,15 @@
       >
         <div class="container founder-access-banner-inner">
           <p>
-            <strong>Founder Access Active</strong> · LIGHT NEVER DIES — Genesis Founder Release · Founder access closes
-            <time datetime="2026-06-28">June 28, 2026</time>
+            <span class="founder-access-banner-title">LIGHT NEVER DIES</span>
+            <span class="founder-access-banner-subtitle">Genesis Founder Release Now Open</span>
+            <span class="founder-access-banner-meta">
+              10 founder allocations per package · Closes
+              <time datetime="2026-06-28">June 28, 2026</time>
+            </span>
           </p>
           <a class="btn btn-secondary" href="founder-access.html?campaign=LIGHT_NEVER_DIES">
-            Open Founder Access
+            View Founder Access
           </a>
         </div>
       </section>
@@ -568,7 +572,7 @@
           aria-labelledby="founder-access-home-title"
         >
           <div class="container">
-            <div class="cta-panel cta-panel-premium">
+            <div class="cta-panel cta-panel-premium founder-cinematic-panel">
               <span class="eyebrow">Founder Access Active</span>
               <h2 id="founder-access-home-title">
                 LIGHT NEVER DIES — Genesis Founder Release
@@ -588,12 +592,12 @@
             </div>
 
             <div class="feature-strip founder-access-strip">
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Legacy Snapshot</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$49 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-SNAPSHOT</p>
                 <div class="inline-actions">
@@ -609,12 +613,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Legacy Portrait Intro</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$99 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PORTRAIT</p>
                 <div class="inline-actions">
@@ -630,12 +634,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Digital Legacy Portrait</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$199 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-DIGITAL</p>
                 <div class="inline-actions">
@@ -653,12 +657,12 @@
             </div>
 
             <div class="feature-strip founder-access-strip pricing-row-two">
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Household Foundation</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$399 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HOUSEHOLD</p>
                 <div class="inline-actions">
@@ -674,12 +678,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Heirloom Legacy Tree</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$799 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-HEIRLOOM</p>
                 <div class="inline-actions">
@@ -695,12 +699,12 @@
                 </div>
               </article>
 
-              <article class="feature-card feature-card-clean pricing-card">
+              <article class="feature-card feature-card-clean pricing-card founder-package-card">
                 <span class="eyebrow">Genesis Founder Release</span>
                 <h3>Legacy Plus</h3>
                 <div class="hero-meta" aria-label="Founder package details">
                   <span class="meta-pill">$1,499 founder access</span>
-                  <span class="meta-pill">10 allocations</span>
+                  <span class="meta-pill">10 founder allocations</span>
                 </div>
                 <p class="card-copy founder-access-code">Code: LIGHTNEVERDIES-PLUS</p>
                 <div class="inline-actions">

--- a/styles.css
+++ b/styles.css
@@ -1803,22 +1803,58 @@ select:focus-visible {
 }
 
 .founder-access-banner {
-  border-bottom: 1px solid var(--tol-line);
-  background: linear-gradient(180deg, rgba(11, 18, 32, 0.94), rgba(11, 18, 32, 0.88));
+  border-top: 1px solid rgba(214, 176, 102, 0.24);
+  border-bottom: 1px solid rgba(214, 176, 102, 0.26);
+  background:
+    linear-gradient(180deg, rgba(4, 8, 15, 0.96), rgba(7, 12, 23, 0.9)),
+    radial-gradient(circle at 14% 12%, rgba(214, 176, 102, 0.18), transparent 32%);
 }
 
 .founder-access-banner-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
-  padding: 10px 0;
+  gap: 20px;
+  padding: 14px 0;
 }
 
 .founder-access-banner p {
   margin: 0;
   color: var(--tol-dark-body);
-  font-size: 0.93rem;
+  font-size: 0.95rem;
+  display: grid;
+  gap: 4px;
+}
+
+.founder-access-banner-title {
+  color: var(--tol-dark-heading);
+  font-size: 1.08rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+.founder-access-banner-subtitle {
+  color: var(--tol-gold-soft);
+  font-weight: 800;
+  letter-spacing: 0.03em;
+}
+
+.founder-access-banner-meta {
+  color: var(--tol-dark-body);
+  font-weight: 600;
+}
+
+.founder-access-banner .btn-secondary {
+  background: rgba(10, 18, 33, 0.72);
+  border-color: rgba(214, 176, 102, 0.44);
+  color: var(--tol-dark-cta);
+}
+
+.founder-access-banner .btn-secondary:hover {
+  background: rgba(14, 24, 42, 0.88);
+  border-color: rgba(214, 176, 102, 0.56);
 }
 
 .founder-access-strip {
@@ -1835,6 +1871,12 @@ select:focus-visible {
   .founder-access-banner-inner {
     flex-direction: column;
     align-items: flex-start;
+    gap: 12px;
+    padding: 16px 0;
+  }
+
+  .founder-access-banner p {
+    width: 100%;
   }
 
   .founder-access-banner .btn {
@@ -2103,6 +2145,58 @@ select:focus-visible {
 
 .cta-panel-premium {
   text-align: left;
+}
+
+.founder-cinematic-panel {
+  background:
+    linear-gradient(180deg, rgba(8, 13, 24, 0.95), rgba(5, 10, 18, 0.92)),
+    radial-gradient(circle at 84% 10%, rgba(214, 176, 102, 0.14), transparent 28%),
+    rgba(8, 13, 24, 0.92);
+  border: 1px solid rgba(214, 176, 102, 0.24);
+  box-shadow:
+    var(--shadow),
+    inset 0 1px 0 rgba(214, 176, 102, 0.18),
+    0 24px 54px rgba(0, 0, 0, 0.34);
+}
+
+.founder-cinematic-panel h1,
+.founder-cinematic-panel h2 {
+  color: var(--tol-dark-heading);
+}
+
+.founder-cinematic-panel .section-lead {
+  color: var(--tol-dark-body);
+}
+
+.founder-cinematic-panel .eyebrow {
+  color: var(--tol-gold-soft);
+}
+
+.founder-hero-release {
+  margin: -4px 0 14px;
+  color: var(--tol-gold-soft);
+  font-size: clamp(1.15rem, 2.1vw, 1.35rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.founder-package-card {
+  border-color: rgba(214, 176, 102, 0.24);
+  box-shadow:
+    0 16px 40px rgba(0, 0, 0, 0.24),
+    inset 0 1px 0 rgba(214, 176, 102, 0.16);
+}
+
+.founder-package-card .meta-pill {
+  border-color: rgba(214, 176, 102, 0.3);
+  background: rgba(8, 14, 25, 0.72);
+  color: var(--tol-dark-cta);
+  font-weight: 700;
+}
+
+.founder-package-card .founder-access-code {
+  color: var(--tol-gold-soft);
 }
 
 .founder-copy + .founder-copy {


### PR DESCRIPTION
## Summary
- Updates stylesheet cache-busting on founder-facing pages to `styles.css?v=20260518-founder-polish`.
- Polishes the LIGHT NEVER DIES founder banner into a darker, gold-accented premium/cinematic presentation.
- Updates founder banner copy to emphasize: Genesis Founder Release Now Open; 10 founder allocations per package; closes June 28, 2026.
- Upgrades the founder-access hero panel away from a plain white-card feel into a more unified cinematic dark panel.
- Replaces placeholder countdown language with: Founder access closes June 28, 2026, or once allocations are claimed.
- Updates allocation wording to “10 founder allocations.”
- Keeps package cards visually consistent with the founder hero style.

## Scope Guardrails
- No Stripe/backend/webhook/entitlement logic changed.
- No duplicate checkout engine added.
- No duplicate campaign engine added.
- No duplicate maintenance gate added.

## Files Changed
- `index.html`
- `founder-access.html`
- `styles.css`
- `backend/tests/test_frontend_link_integrity.py`

## Validation
- Passed: `PYTHONPATH=backend python -m unittest backend.tests.test_frontend_link_integrity backend.tests.test_order_service_checkout_context backend.tests.test_maintenance_subscription_checkout_context -v`
- Parallel validation: Code Review + CodeQL reported no findings.