### PR TITLE
Polish homepage card readability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1178,11 +1178,11 @@ select:focus-visible {
   border: 1px solid rgba(214, 176, 102, 0.2);
   border-radius: 28px;
   background:
-    linear-gradient(135deg, rgba(10, 16, 28, 0.9), rgba(4, 8, 16, 0.94)),
-    rgba(255, 255, 255, 0.025);
+    radial-gradient(circle at 10% 14%, rgba(184, 223, 255, 0.34), transparent 42%),
+    linear-gradient(180deg, #ffffff, #f7fbff);
   box-shadow:
-    0 22px 62px rgba(0, 0, 0, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    0 22px 62px rgba(11, 18, 32, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 .google-trust-copy h2,
@@ -1196,6 +1196,7 @@ select:focus-visible {
 .google-trust-copy .section-lead,
 .reviews-copy .section-lead {
   margin: 0;
+  color: var(--tol-text);
 }
 
 .google-rating-lockup {
@@ -1205,7 +1206,7 @@ select:focus-visible {
   padding: 18px 20px;
   border-radius: 22px;
   border: 1px solid rgba(214, 176, 102, 0.2);
-  background: rgba(255, 255, 255, 0.03);
+  background: linear-gradient(180deg, #ffffff, #f7fbff);
   text-align: center;
 }
 
@@ -1218,7 +1219,7 @@ select:focus-visible {
 }
 
 .rating-label {
-  color: var(--text);
+  color: var(--tol-ink);
   font-weight: 800;
   line-height: 1.25;
 }
@@ -1254,7 +1255,7 @@ select:focus-visible {
       rgba(214, 176, 102, 0.09),
       transparent 28%
     ),
-    linear-gradient(135deg, rgba(9, 15, 26, 0.92), rgba(5, 9, 17, 0.97));
+    linear-gradient(180deg, #ffffff, #f8fbff);
 }
 
 .architecture-panel-home h2 {
@@ -1309,8 +1310,7 @@ select:focus-visible {
 .platform-model-card,
 .core-layers-card,
 .architecture-panel-home,
-.manifesto-panel,
-.feature-card-clean {
+.manifesto-panel {
   color: var(--tol-dark-body);
 }
 
@@ -1330,10 +1330,7 @@ select:focus-visible {
 .architecture-panel-home h3,
 .manifesto-panel h1,
 .manifesto-panel h2,
-.manifesto-panel h3,
-.feature-card-clean h1,
-.feature-card-clean h2,
-.feature-card-clean h3 {
+.manifesto-panel h3 {
   color: var(--tol-dark-heading);
   opacity: 1;
 }
@@ -1344,9 +1341,7 @@ select:focus-visible {
 .core-layers-card p,
 .architecture-panel-home p,
 .architecture-panel-home li,
-.manifesto-panel p,
-.feature-card-clean p,
-.feature-card-clean li {
+.manifesto-panel p {
   color: var(--tol-dark-body);
   opacity: 1;
 }
@@ -1355,10 +1350,42 @@ select:focus-visible {
 .hero-demo-card-top .eyebrow,
 .architecture-panel-home .eyebrow,
 .manifesto-panel .eyebrow,
-.feature-card-clean .eyebrow,
 .architecture-panel-home .flow-label {
   color: var(--tol-gold-soft);
   opacity: 1;
+}
+
+.feature-card-clean,
+.feature-card-clean h1,
+.feature-card-clean h2,
+.feature-card-clean h3 {
+  color: var(--tol-ink);
+}
+
+.feature-card-clean p,
+.feature-card-clean li {
+  color: var(--tol-text);
+}
+
+.feature-card-clean .eyebrow {
+  color: var(--gold);
+}
+
+.architecture-panel-home,
+.architecture-panel-home p,
+.architecture-panel-home li {
+  color: var(--tol-text);
+}
+
+.architecture-panel-home h1,
+.architecture-panel-home h2,
+.architecture-panel-home h3 {
+  color: var(--tol-ink);
+}
+
+.architecture-panel-home .eyebrow,
+.architecture-panel-home .flow-label {
+  color: var(--gold);
 }
 
 .hero-copy-cosmic {
@@ -1931,11 +1958,11 @@ select:focus-visible {
 
 .feature-card-clean,
 .trust-grid-clean .trust-card {
-  background: linear-gradient(
-    180deg,
-    rgba(10, 15, 25, 0.76),
-    rgba(5, 9, 17, 0.86)
-  );
+  background:
+    radial-gradient(circle at 12% 16%, rgba(184, 223, 255, 0.22), transparent 34%),
+    linear-gradient(180deg, #ffffff, #f8fbff);
+  border-color: rgba(169, 197, 218, 0.62);
+  box-shadow: 0 18px 44px rgba(11, 18, 32, 0.1);
 }
 
 .package-list,
@@ -2078,8 +2105,8 @@ select:focus-visible {
   border-top: 1px solid rgba(214, 176, 102, 0.16);
   border-bottom: 1px solid rgba(214, 176, 102, 0.14);
   background:
-    linear-gradient(180deg, rgba(4, 7, 13, 0.52), rgba(9, 14, 25, 0.86)),
-    rgba(255, 255, 255, 0.015);
+    radial-gradient(circle at 8% 16%, rgba(184, 223, 255, 0.2), transparent 40%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(246, 250, 253, 0.9));
 }
 
 .reviews-layout {
@@ -2105,9 +2132,9 @@ select:focus-visible {
   border-radius: 26px;
   border: 1px solid rgba(214, 176, 102, 0.18);
   background:
-    linear-gradient(180deg, rgba(10, 15, 25, 0.82), rgba(4, 8, 16, 0.94)),
-    rgba(255, 255, 255, 0.025);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+    radial-gradient(circle at 14% 12%, rgba(214, 176, 102, 0.1), transparent 38%),
+    linear-gradient(180deg, #ffffff, #f8fbff);
+  box-shadow: 0 18px 48px rgba(11, 18, 32, 0.12);
 }
 
 .review-source-card {
@@ -2124,7 +2151,7 @@ select:focus-visible {
 }
 
 .review-source {
-  color: var(--muted-2);
+  color: var(--tol-muted);
   font-size: 0.88rem;
   font-weight: 800;
   letter-spacing: 0.16em;
@@ -2133,7 +2160,7 @@ select:focus-visible {
 
 .review-quote {
   margin: 18px 0 0;
-  color: var(--muted);
+  color: var(--tol-text);
   font-size: 1.06rem;
   line-height: 1.7;
 }
@@ -2149,27 +2176,27 @@ select:focus-visible {
 
 .founder-cinematic-panel {
   background:
-    linear-gradient(180deg, rgba(8, 13, 24, 0.95), rgba(5, 10, 18, 0.92)),
-    radial-gradient(circle at 84% 10%, rgba(214, 176, 102, 0.14), transparent 28%),
-    rgba(8, 13, 24, 0.92);
+    radial-gradient(circle at 82% 14%, rgba(214, 176, 102, 0.16), transparent 34%),
+    radial-gradient(circle at 10% 16%, rgba(184, 223, 255, 0.2), transparent 38%),
+    linear-gradient(180deg, #ffffff, #f8fbff);
   border: 1px solid rgba(214, 176, 102, 0.24);
   box-shadow:
     var(--shadow),
-    inset 0 1px 0 rgba(214, 176, 102, 0.18),
-    0 24px 54px rgba(0, 0, 0, 0.34);
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    0 24px 54px rgba(11, 18, 32, 0.12);
 }
 
 .founder-cinematic-panel h1,
 .founder-cinematic-panel h2 {
-  color: var(--tol-dark-heading);
+  color: var(--tol-ink);
 }
 
 .founder-cinematic-panel .section-lead {
-  color: var(--tol-dark-body);
+  color: var(--tol-text);
 }
 
 .founder-cinematic-panel .eyebrow {
-  color: var(--tol-gold-soft);
+  color: var(--gold);
 }
 
 .founder-hero-release {
@@ -2184,19 +2211,19 @@ select:focus-visible {
 .founder-package-card {
   border-color: rgba(214, 176, 102, 0.24);
   box-shadow:
-    0 16px 40px rgba(0, 0, 0, 0.24),
-    inset 0 1px 0 rgba(214, 176, 102, 0.16);
+    0 16px 40px rgba(11, 18, 32, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
 .founder-package-card .meta-pill {
   border-color: rgba(214, 176, 102, 0.3);
-  background: rgba(8, 14, 25, 0.72);
-  color: var(--tol-dark-cta);
+  background: rgba(214, 176, 102, 0.14);
+  color: var(--tol-ink);
   font-weight: 700;
 }
 
 .founder-package-card .founder-access-code {
-  color: var(--tol-gold-soft);
+  color: #8c6a2d;
 }
 
 .founder-copy + .founder-copy {
@@ -5030,6 +5057,11 @@ body[data-portal-mode="customer"] [data-dashboard-admin-only] {
 
   .google-reviews-section {
     padding: 42px 0;
+  }
+
+  .review-quote {
+    font-size: 1rem;
+    line-height: 1.62;
   }
 
   .reviews-grid {

--- a/styles.css
+++ b/styles.css
@@ -1309,7 +1309,6 @@ select:focus-visible {
 .hero-viewer-card-main,
 .platform-model-card,
 .core-layers-card,
-.architecture-panel-home,
 .manifesto-panel {
   color: var(--tol-dark-body);
 }
@@ -1325,9 +1324,6 @@ select:focus-visible {
 .core-layers-card h1,
 .core-layers-card h2,
 .core-layers-card h3,
-.architecture-panel-home h1,
-.architecture-panel-home h2,
-.architecture-panel-home h3,
 .manifesto-panel h1,
 .manifesto-panel h2,
 .manifesto-panel h3 {
@@ -1339,8 +1335,6 @@ select:focus-visible {
 .hero-viewer-card-main p,
 .platform-model-card p,
 .core-layers-card p,
-.architecture-panel-home p,
-.architecture-panel-home li,
 .manifesto-panel p {
   color: var(--tol-dark-body);
   opacity: 1;
@@ -1348,9 +1342,7 @@ select:focus-visible {
 
 .hero-copy-cosmic .eyebrow,
 .hero-demo-card-top .eyebrow,
-.architecture-panel-home .eyebrow,
-.manifesto-panel .eyebrow,
-.architecture-panel-home .flow-label {
+.manifesto-panel .eyebrow {
   color: var(--tol-gold-soft);
   opacity: 1;
 }
@@ -2223,7 +2215,7 @@ select:focus-visible {
 }
 
 .founder-package-card .founder-access-code {
-  color: #8c6a2d;
+  color: var(--gold);
 }
 
 .founder-copy + .founder-copy {


### PR DESCRIPTION
## Summary
- Keeps the LIGHT NEVER DIES founder banner dark/premium.
- Converts key non-banner card surfaces to light glass/white with dark text for better mobile readability.
- Improves Google reviews readability and contrast.
- Tunes review quote sizing/line-height on mobile.
- Keeps gold labels/accent language where it supports the Tomb of Light brand.

## Scope Guardrails
- CSS-only readability polish.
- No Stripe logic changed.
- No backend/webhook/entitlement logic changed.
- No checkout/campaign/maintenance engine changes.
- No markup duplication introduced.

## Files Changed
- `styles.css`

## Validation
- Passed: `PYTHONPATH=backend python -m unittest backend.tests.test_frontend_link_integrity backend.tests.test_order_service_checkout_context backend.tests.test_maintenance_subscription_checkout_context -v`
- Parallel validation: Code Review + CodeQL reported no findings.