### PR TITLE
Fix mobile workspace context and auth signup

### DIFF
--- a/mobile/app/(app)/dashboard.tsx
+++ b/mobile/app/(app)/dashboard.tsx
@@ -20,6 +20,8 @@ type AccessContextSummary = {
   role: string;
   status: string;
   packageLane: string;
+  packageCode: string;
+  packageName: string;
   experienceMode: string;
   activeProjectId: string;
   activeFamilyId: string;
@@ -39,6 +41,63 @@ type MetricRow = {
   count: number;
 };
 
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    const normalized = asString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+function firstStringArray(...values: unknown[]): string[] {
+  for (const value of values) {
+    const normalized = asStringArray(value);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return [];
+}
+
+function firstRecord(...values: unknown[]): Record<string, unknown> {
+  for (const value of values) {
+    const normalized = asRecord(value);
+    if (Object.keys(normalized).length > 0) {
+      return normalized;
+    }
+  }
+
+  return {};
+}
+
+function inferExperienceMode(packageLane: string, packageCode: string, rawMode: string): string {
+  if (rawMode) {
+    return rawMode;
+  }
+
+  const normalizedLane = packageLane.toLowerCase();
+  const normalizedCode = packageCode.toLowerCase();
+
+  if (normalizedLane === 'household') {
+    return 'household';
+  }
+
+  if (
+    normalizedCode === 'legacy_plus' ||
+    normalizedCode === 'household_foundation' ||
+    normalizedCode === 'heirloom_legacy_tree' ||
+    normalizedCode === 'family_estate_concierge'
+  ) {
+    return 'household';
+  }
+
+  return '';
+}
+
 function toCountRows(items: WorkspaceMembership[], key: keyof WorkspaceMembership): MetricRow[] {
   const counts = new Map<string, number>();
 
@@ -52,26 +111,230 @@ function toCountRows(items: WorkspaceMembership[], key: keyof WorkspaceMembershi
     .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label));
 }
 
-function toAccessContextSummary(payload: Record<string, unknown>): AccessContextSummary {
-  const legal = asRecord(payload.legal_acceptance);
+function toAccessContextSummary(
+  payload: Record<string, unknown>,
+  memberships: WorkspaceMembership[] = []
+): AccessContextSummary {
+  const user = firstRecord(
+    payload.user,
+    payload.account,
+    payload.profile,
+    payload.identity,
+    payload.current_user,
+    payload.authenticated_user
+  );
+
+  const accessContext = firstRecord(
+    payload.access_context,
+    payload.context,
+    payload.workspace_context,
+    payload.current_access_context
+  );
+
+  const project = firstRecord(
+    payload.project,
+    payload.active_project,
+    payload.current_project
+  );
+
+  const packageRecord = firstRecord(
+    payload.package,
+    payload.package_record,
+    payload.package_details,
+    accessContext.package,
+    project.package,
+    project.package_record,
+    project.package_details
+  );
+
+  const family = firstRecord(
+    payload.family,
+    payload.active_family,
+    payload.current_family
+  );
+
+  const legal = firstRecord(
+    payload.legal_acceptance,
+    payload.policy_acceptance,
+    user.legal_acceptance,
+    user.policy_acceptance
+  );
+
+  const primaryMembership = memberships[0] || ({} as WorkspaceMembership);
+
+  const packageLane = firstString(
+    payload.package_lane,
+    payload.packageLane,
+    accessContext.package_lane,
+    accessContext.packageLane,
+    project.package_lane,
+    project.packageLane,
+    packageRecord.package_lane,
+    packageRecord.packageLane,
+    primaryMembership.package_lane
+  );
+
+  const packageCode = firstString(
+    payload.package_code,
+    payload.packageCode,
+    payload.package_slug,
+    payload.packageSlug,
+    accessContext.package_code,
+    accessContext.packageCode,
+    accessContext.package_slug,
+    project.package_code,
+    project.packageCode,
+    project.package_slug,
+    packageRecord.code,
+    packageRecord.slug,
+    packageRecord.package_code,
+    packageRecord.package_slug
+  );
+
+  const packageName = firstString(
+    payload.package_name,
+    payload.packageName,
+    accessContext.package_name,
+    accessContext.packageName,
+    project.package_name,
+    project.packageName,
+    packageRecord.name,
+    packageRecord.label,
+    packageRecord.package_name
+  );
+
+  const rawExperienceMode = firstString(
+    payload.experience_mode,
+    payload.experienceMode,
+    payload.mode,
+    accessContext.experience_mode,
+    accessContext.experienceMode,
+    accessContext.mode,
+    project.experience_mode,
+    project.experienceMode,
+    project.mode
+  );
 
   return {
-    userId: asString(payload.user_id),
-    email: asString(payload.email),
-    role: asString(payload.role),
-    status: asString(payload.status),
-    packageLane: asString(payload.package_lane),
-    experienceMode: asString(payload.experience_mode),
-    activeProjectId: asString(payload.active_project_id),
-    activeFamilyId: asString(payload.active_family_id),
-    modules: asStringArray(payload.allowed_experience_modules),
-    entitlements: asStringArray(payload.active_entitlements),
-    projectPermissions: asStringArray(payload.project_permissions),
+    userId: firstString(
+      payload.user_id,
+      payload.userId,
+      accessContext.user_id,
+      accessContext.userId,
+      user.id,
+      user.user_id,
+      user.userId,
+      primaryMembership.user_id
+    ),
+    email: firstString(
+      payload.email,
+      accessContext.email,
+      user.email,
+      primaryMembership.email
+    ),
+    role: firstString(
+      payload.role,
+      payload.user_role,
+      payload.userRole,
+      accessContext.role,
+      accessContext.user_role,
+      accessContext.userRole,
+      user.role,
+      user.user_role,
+      user.userRole,
+      primaryMembership.member_role
+    ),
+    status: firstString(
+      payload.status,
+      accessContext.status,
+      user.status,
+      primaryMembership.status,
+      'active'
+    ),
+    packageLane,
+    packageCode,
+    packageName,
+    experienceMode: inferExperienceMode(packageLane, packageCode, rawExperienceMode),
+    activeProjectId: firstString(
+      payload.active_project_id,
+      payload.activeProjectId,
+      payload.project_id,
+      payload.projectId,
+      accessContext.active_project_id,
+      accessContext.activeProjectId,
+      accessContext.project_id,
+      project.id,
+      project.project_id,
+      project.projectId,
+      primaryMembership.project_id
+    ),
+    activeFamilyId: firstString(
+      payload.active_family_id,
+      payload.activeFamilyId,
+      payload.family_id,
+      payload.familyId,
+      accessContext.active_family_id,
+      accessContext.activeFamilyId,
+      accessContext.family_id,
+      family.id,
+      family.family_id,
+      family.familyId,
+      primaryMembership.family_id
+    ),
+    modules: firstStringArray(
+      payload.allowed_experience_modules,
+      payload.allowedExperienceModules,
+      payload.allowed_modules,
+      payload.allowedModules,
+      payload.modules,
+      payload.unlocked_modules,
+      accessContext.allowed_experience_modules,
+      accessContext.allowed_modules,
+      project.allowed_experience_modules
+    ),
+    entitlements: firstStringArray(
+      payload.active_entitlements,
+      payload.activeEntitlements,
+      payload.entitlements,
+      payload.enabled_entitlements,
+      payload.enabledEntitlements,
+      accessContext.active_entitlements,
+      accessContext.entitlements,
+      project.active_entitlements
+    ),
+    projectPermissions: firstStringArray(
+      payload.project_permissions,
+      payload.projectPermissions,
+      payload.permissions,
+      accessContext.project_permissions,
+      accessContext.permissions,
+      project.permissions
+    ),
     legalAcceptance: {
-      policyVersion: asString(legal.policy_version),
-      termsAcceptedAt: asString(legal.terms_accepted_at),
-      privacyAcceptedAt: asString(legal.privacy_accepted_at),
-      eligibilityAttestedAt: asString(legal.eligibility_attested_at)
+      policyVersion: firstString(
+        legal.policy_version,
+        legal.policyVersion,
+        payload.policy_version,
+        user.policy_version
+      ),
+      termsAcceptedAt: firstString(
+        legal.terms_accepted_at,
+        legal.termsAcceptedAt,
+        payload.terms_accepted_at,
+        user.terms_accepted_at
+      ),
+      privacyAcceptedAt: firstString(
+        legal.privacy_accepted_at,
+        legal.privacyAcceptedAt,
+        payload.privacy_accepted_at,
+        user.privacy_accepted_at
+      ),
+      eligibilityAttestedAt: firstString(
+        legal.eligibility_attested_at,
+        legal.eligibilityAttestedAt,
+        payload.eligibility_attested_at,
+        user.eligibility_attested_at
+      )
     }
   };
 }
@@ -116,13 +379,14 @@ export default function DashboardScreen() {
 
     try {
       const [contextPayload, membershipsPayload] = await Promise.all([fetchAccessContext(), fetchMyMemberships()]);
+      const membershipItems = Array.isArray(membershipsPayload.items) ? membershipsPayload.items : [];
 
       if (!mountedRef.current || requestId !== requestSequence.current) {
         return;
       }
 
-      setAccessContext(toAccessContextSummary(asRecord(contextPayload)));
-      setMemberships(Array.isArray(membershipsPayload.items) ? membershipsPayload.items : []);
+      setAccessContext(toAccessContextSummary(asRecord(contextPayload), membershipItems));
+      setMemberships(membershipItems);
     } catch (error) {
       if (!mountedRef.current || requestId !== requestSequence.current) {
         return;
@@ -173,8 +437,12 @@ export default function DashboardScreen() {
       .slice(0, 6);
   }, [memberships]);
 
+  const packageDisplay = accessContext
+    ? accessContext.packageName || accessContext.packageCode || accessContext.packageLane
+    : '';
+
   const heroContextLine = accessContext
-    ? `${toHumanLabel(accessContext.packageLane || 'unknown')} lane • ${toHumanLabel(accessContext.experienceMode || 'unknown')} mode`
+    ? `${toHumanLabel(packageDisplay || 'unknown')} • ${toHumanLabel(accessContext.packageLane || 'unknown')} lane • ${toHumanLabel(accessContext.experienceMode || 'unknown')} mode`
     : undefined;
 
   return (
@@ -227,6 +495,10 @@ export default function DashboardScreen() {
         <>
           <SectionCard title="Workspace At A Glance" subtitle="Most important context first for mobile decisions.">
             <View style={styles.metricGrid}>
+              <View style={styles.metricTile}>
+                <Text style={styles.metricLabel}>Package</Text>
+                <Text style={styles.metricValue}>{toHumanLabel(packageDisplay || 'unknown')}</Text>
+              </View>
               <View style={styles.metricTile}>
                 <Text style={styles.metricLabel}>Package Lane</Text>
                 <Text style={styles.metricValue}>{toHumanLabel(accessContext.packageLane || 'unknown')}</Text>

--- a/mobile/app/(app)/support.tsx
+++ b/mobile/app/(app)/support.tsx
@@ -27,6 +27,8 @@ type AccessContextSnapshot = {
   role: string;
   status: string;
   packageLane: string;
+  packageCode: string;
+  packageName: string;
   experienceMode: string;
   activeProjectId: string;
   activeFamilyId: string;
@@ -39,25 +41,229 @@ type CountRow = {
 
 const SUPPORT_EMAIL = String(process.env.EXPO_PUBLIC_SUPPORT_EMAIL || '').trim();
 
-function summarizeAccessContext(payload: Record<string, unknown>): AccessContextSnapshot {
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    const normalized = asString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+function firstRecord(...values: unknown[]): Record<string, unknown> {
+  for (const value of values) {
+    const normalized = asRecord(value);
+    if (Object.keys(normalized).length > 0) {
+      return normalized;
+    }
+  }
+
+  return {};
+}
+
+function inferExperienceMode(packageLane: string, packageCode: string, rawMode: string): string {
+  if (rawMode) {
+    return rawMode;
+  }
+
+  const normalizedLane = packageLane.toLowerCase();
+  const normalizedCode = packageCode.toLowerCase();
+
+  if (normalizedLane === 'household') {
+    return 'household';
+  }
+
+  if (
+    normalizedCode === 'legacy_plus' ||
+    normalizedCode === 'household_foundation' ||
+    normalizedCode === 'heirloom_legacy_tree' ||
+    normalizedCode === 'family_estate_concierge'
+  ) {
+    return 'household';
+  }
+
+  return '';
+}
+
+function summarizeAccessContext(
+  payload: Record<string, unknown>,
+  memberships: WorkspaceMembership[] = []
+): AccessContextSnapshot {
+  const user = firstRecord(
+    payload.user,
+    payload.account,
+    payload.profile,
+    payload.identity,
+    payload.current_user,
+    payload.authenticated_user
+  );
+
+  const accessContext = firstRecord(
+    payload.access_context,
+    payload.context,
+    payload.workspace_context,
+    payload.current_access_context
+  );
+
+  const project = firstRecord(
+    payload.project,
+    payload.active_project,
+    payload.current_project
+  );
+
+  const packageRecord = firstRecord(
+    payload.package,
+    payload.package_record,
+    payload.package_details,
+    accessContext.package,
+    project.package,
+    project.package_record,
+    project.package_details
+  );
+
+  const family = firstRecord(
+    payload.family,
+    payload.active_family,
+    payload.current_family
+  );
+
+  const primaryMembership = memberships[0] || ({} as WorkspaceMembership);
+
+  const packageLane = firstString(
+    payload.package_lane,
+    payload.packageLane,
+    accessContext.package_lane,
+    accessContext.packageLane,
+    project.package_lane,
+    project.packageLane,
+    packageRecord.package_lane,
+    packageRecord.packageLane,
+    primaryMembership.package_lane
+  );
+
+  const packageCode = firstString(
+    payload.package_code,
+    payload.packageCode,
+    payload.package_slug,
+    payload.packageSlug,
+    accessContext.package_code,
+    accessContext.packageCode,
+    accessContext.package_slug,
+    project.package_code,
+    project.packageCode,
+    project.package_slug,
+    packageRecord.code,
+    packageRecord.slug,
+    packageRecord.package_code,
+    packageRecord.package_slug
+  );
+
+  const packageName = firstString(
+    payload.package_name,
+    payload.packageName,
+    accessContext.package_name,
+    accessContext.packageName,
+    project.package_name,
+    project.packageName,
+    packageRecord.name,
+    packageRecord.label,
+    packageRecord.package_name
+  );
+
+  const rawExperienceMode = firstString(
+    payload.experience_mode,
+    payload.experienceMode,
+    payload.mode,
+    accessContext.experience_mode,
+    accessContext.experienceMode,
+    accessContext.mode,
+    project.experience_mode,
+    project.experienceMode,
+    project.mode
+  );
+
   return {
-    userId: asString(payload.user_id),
-    email: asString(payload.email),
-    role: asString(payload.role),
-    status: asString(payload.status),
-    packageLane: asString(payload.package_lane),
-    experienceMode: asString(payload.experience_mode),
-    activeProjectId: asString(payload.active_project_id),
-    activeFamilyId: asString(payload.active_family_id)
+    userId: firstString(
+      payload.user_id,
+      payload.userId,
+      accessContext.user_id,
+      accessContext.userId,
+      user.id,
+      user.user_id,
+      user.userId,
+      primaryMembership.user_id
+    ),
+    email: firstString(
+      payload.email,
+      accessContext.email,
+      user.email,
+      primaryMembership.email
+    ),
+    role: firstString(
+      payload.role,
+      payload.user_role,
+      payload.userRole,
+      accessContext.role,
+      accessContext.user_role,
+      accessContext.userRole,
+      user.role,
+      user.user_role,
+      user.userRole,
+      primaryMembership.member_role
+    ),
+    status: firstString(
+      payload.status,
+      accessContext.status,
+      user.status,
+      primaryMembership.status,
+      'active'
+    ),
+    packageLane,
+    packageCode,
+    packageName,
+    experienceMode: inferExperienceMode(packageLane, packageCode, rawExperienceMode),
+    activeProjectId: firstString(
+      payload.active_project_id,
+      payload.activeProjectId,
+      payload.project_id,
+      payload.projectId,
+      accessContext.active_project_id,
+      accessContext.activeProjectId,
+      accessContext.project_id,
+      project.id,
+      project.project_id,
+      project.projectId,
+      primaryMembership.project_id
+    ),
+    activeFamilyId: firstString(
+      payload.active_family_id,
+      payload.activeFamilyId,
+      payload.family_id,
+      payload.familyId,
+      accessContext.active_family_id,
+      accessContext.activeFamilyId,
+      accessContext.family_id,
+      family.id,
+      family.family_id,
+      family.familyId,
+      primaryMembership.family_id
+    )
   };
 }
 
-function profileDisplayName(profile: UserProfilePayload | null): string {
-  if (!profile) {
+function profileDisplayName(profile: UserProfilePayload | null, context: AccessContextSnapshot | null): string {
+  if (!profile && !context) {
     return '';
   }
 
-  return asString(profile.full_name) || asString(profile.email);
+  return (
+    asString(profile?.full_name) ||
+    asString(profile?.email) ||
+    context?.email ||
+    ''
+  );
 }
 
 function toCountRows(items: WorkspaceMembership[], key: keyof WorkspaceMembership): CountRow[] {
@@ -84,7 +290,20 @@ function supportSubject(context: AccessContextSnapshot | null): string {
 }
 
 function supportBody(context: AccessContextSnapshot | null, profile: UserProfilePayload | null): string {
-  const policyVersion = asString(asRecord(profile?.legal_acceptance).policy_version) || asString(profile?.policy_version);
+  const profileRecord = asRecord(profile);
+  const legalAcceptance = asRecord(profileRecord.legal_acceptance);
+  const policyVersion = firstString(
+    legalAcceptance.policy_version,
+    legalAcceptance.policyVersion,
+    profileRecord.policy_version,
+    profileRecord.policyVersion
+  );
+
+  const packageDisplay =
+    context?.packageName ||
+    context?.packageCode ||
+    context?.packageLane ||
+    'unavailable';
 
   return [
     'Hello Tomb of Light support,',
@@ -93,6 +312,9 @@ function supportBody(context: AccessContextSnapshot | null, profile: UserProfile
     '',
     `Account email: ${asString(profile?.email) || context?.email || 'unavailable'}`,
     `User id: ${asString(profile?.id) || context?.userId || 'unavailable'}`,
+    `Role: ${context?.role || 'unavailable'}`,
+    `Status: ${context?.status || 'unavailable'}`,
+    `Package: ${packageDisplay}`,
     `Package lane: ${context?.packageLane || 'unavailable'}`,
     `Experience mode: ${context?.experienceMode || 'unavailable'}`,
     `Active project id: ${context?.activeProjectId || 'unavailable'}`,
@@ -133,13 +355,15 @@ export default function SupportScreen() {
         fetchMyMemberships()
       ]);
 
+      const membershipItems = Array.isArray(membershipsPayload.items) ? membershipsPayload.items : [];
+
       if (!mountedRef.current || requestId !== requestSequence.current) {
         return;
       }
 
       setProfile(profilePayload);
-      setAccessContext(summarizeAccessContext(asRecord(accessPayload)));
-      setMemberships(Array.isArray(membershipsPayload.items) ? membershipsPayload.items : []);
+      setAccessContext(summarizeAccessContext(asRecord(accessPayload), membershipItems));
+      setMemberships(membershipItems);
       setLastUpdatedAt(new Date().toISOString());
     } catch (error) {
       if (!mountedRef.current || requestId !== requestSequence.current) {
@@ -206,12 +430,16 @@ export default function SupportScreen() {
 
   const legalAcceptance = asRecord(profile?.legal_acceptance);
 
+  const packageDisplay = accessContext
+    ? accessContext.packageName || accessContext.packageCode || accessContext.packageLane
+    : '';
+
   return (
     <ScreenContainer>
       <WorkspaceHero
         title="Support"
         description="Real support entry context with account identity, package scope, and household impact signals for faster issue triage."
-        contextLine={profileDisplayName(profile) || undefined}
+        contextLine={profileDisplayName(profile, accessContext) || undefined}
       />
 
       <Pressable
@@ -262,6 +490,7 @@ export default function SupportScreen() {
               <KeyValueRow label="User ID" value={asString(profile.id) || accessContext.userId || 'Unavailable'} />
               <KeyValueRow label="Role" value={toHumanLabel(accessContext.role || 'unknown')} />
               <KeyValueRow label="Status" value={toHumanLabel(accessContext.status || 'unknown')} />
+              <KeyValueRow label="Package" value={toHumanLabel(packageDisplay || 'unknown')} />
               <KeyValueRow label="Package Lane" value={toHumanLabel(accessContext.packageLane || 'unknown')} />
               <KeyValueRow label="Experience Mode" value={toHumanLabel(accessContext.experienceMode || 'unknown')} />
               <KeyValueRow label="Active Project ID" value={accessContext.activeProjectId || 'Unavailable'} />

--- a/mobile/app/(auth)/sign-up.tsx
+++ b/mobile/app/(auth)/sign-up.tsx
@@ -6,6 +6,8 @@ import { ScreenContainer } from '../../src/components/ScreenContainer';
 import { mapAuthError, signIn, signUp } from '../../src/services/auth';
 import { appTheme } from '../../src/theme';
 
+const MOBILE_POLICY_VERSION = 'tol-mobile-2026-05';
+
 function normalizeEmail(input: string): string {
   return input.trim().toLowerCase();
 }
@@ -23,32 +25,51 @@ export default function SignUpScreen() {
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
 
+  function clearMessages(): void {
+    if (errorMessage) {
+      setErrorMessage('');
+    }
+
+    if (successMessage) {
+      setSuccessMessage('');
+    }
+  }
+
   async function onSubmit() {
+    if (isSubmitting) {
+      return;
+    }
+
     const normalizedName = fullName.trim();
     const normalizedEmail = normalizeEmail(email);
 
-    if (!normalizedName || !normalizedEmail || !password) {
+    if (!normalizedName || !normalizedEmail || !password || !confirmPassword) {
       setErrorMessage('Complete all required fields.');
+      setSuccessMessage('');
       return;
     }
 
     if (!normalizedEmail.includes('@')) {
       setErrorMessage('Enter a valid email address.');
+      setSuccessMessage('');
       return;
     }
 
     if (password.length < 12) {
       setErrorMessage('Password must be at least 12 characters.');
+      setSuccessMessage('');
       return;
     }
 
     if (password !== confirmPassword) {
       setErrorMessage('Password confirmation does not match.');
+      setSuccessMessage('');
       return;
     }
 
     if (!termsAccepted || !privacyAccepted || !eligibilityAttested) {
       setErrorMessage('You must accept terms, privacy, and eligibility statements.');
+      setSuccessMessage('');
       return;
     }
 
@@ -63,7 +84,8 @@ export default function SignUpScreen() {
         password,
         termsAccepted,
         privacyAccepted,
-        eligibilityAttested
+        eligibilityAttested,
+        policyVersion: MOBILE_POLICY_VERSION
       });
 
       const loginResponse = await signIn({
@@ -88,6 +110,7 @@ export default function SignUpScreen() {
   return (
     <ScreenContainer>
       <View style={styles.card}>
+        <Text style={styles.badge}>Tomb of Light</Text>
         <Text style={styles.title}>Create Account</Text>
         <Text style={styles.subtitle}>
           Register your customer account to access projects, family data, and support.
@@ -96,7 +119,10 @@ export default function SignUpScreen() {
         <View style={styles.form}>
           <TextInput
             value={fullName}
-            onChangeText={setFullName}
+            onChangeText={(value) => {
+              clearMessages();
+              setFullName(value);
+            }}
             placeholder="Full Name"
             accessibilityLabel="Full Name"
             placeholderTextColor={appTheme.colors.textSecondary}
@@ -104,9 +130,13 @@ export default function SignUpScreen() {
             textContentType="name"
             style={styles.input}
           />
+
           <TextInput
             value={email}
-            onChangeText={setEmail}
+            onChangeText={(value) => {
+              clearMessages();
+              setEmail(value);
+            }}
             placeholder="Email"
             accessibilityLabel="Email"
             placeholderTextColor={appTheme.colors.textSecondary}
@@ -116,9 +146,13 @@ export default function SignUpScreen() {
             textContentType="emailAddress"
             style={styles.input}
           />
+
           <TextInput
             value={password}
-            onChangeText={setPassword}
+            onChangeText={(value) => {
+              clearMessages();
+              setPassword(value);
+            }}
             placeholder="Password (12+ characters)"
             accessibilityLabel="Password"
             placeholderTextColor={appTheme.colors.textSecondary}
@@ -128,9 +162,13 @@ export default function SignUpScreen() {
             textContentType="newPassword"
             style={styles.input}
           />
+
           <TextInput
             value={confirmPassword}
-            onChangeText={setConfirmPassword}
+            onChangeText={(value) => {
+              clearMessages();
+              setConfirmPassword(value);
+            }}
             placeholder="Confirm Password"
             accessibilityLabel="Confirm Password"
             placeholderTextColor={appTheme.colors.textSecondary}
@@ -145,20 +183,35 @@ export default function SignUpScreen() {
         <View style={styles.consentGroup}>
           <ConsentToggle
             checked={termsAccepted}
-            onPress={() => setTermsAccepted((current) => !current)}
+            onPress={() => {
+              clearMessages();
+              setTermsAccepted((current) => !current);
+            }}
             label="I accept the Terms of Service."
           />
+
           <ConsentToggle
             checked={privacyAccepted}
-            onPress={() => setPrivacyAccepted((current) => !current)}
+            onPress={() => {
+              clearMessages();
+              setPrivacyAccepted((current) => !current);
+            }}
             label="I accept the Privacy Policy."
           />
+
           <ConsentToggle
             checked={eligibilityAttested}
-            onPress={() => setEligibilityAttested((current) => !current)}
+            onPress={() => {
+              clearMessages();
+              setEligibilityAttested((current) => !current);
+            }}
             label="I attest that I am eligible to use this service."
           />
         </View>
+
+        <Text style={styles.policyNote}>
+          Policy version: {MOBILE_POLICY_VERSION}
+        </Text>
 
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
         {successMessage ? <Text style={styles.successText}>{successMessage}</Text> : null}
@@ -218,6 +271,13 @@ const styles = StyleSheet.create({
     padding: appTheme.spacing.lg,
     gap: appTheme.spacing.md
   },
+  badge: {
+    color: appTheme.colors.primary,
+    fontSize: appTheme.typography.caption,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6
+  },
   title: {
     color: appTheme.colors.textPrimary,
     fontSize: appTheme.typography.heading,
@@ -270,6 +330,11 @@ const styles = StyleSheet.create({
   },
   consentText: {
     flex: 1,
+    color: appTheme.colors.textSecondary,
+    fontSize: appTheme.typography.caption,
+    lineHeight: 18
+  },
+  policyNote: {
     color: appTheme.colors.textSecondary,
     fontSize: appTheme.typography.caption,
     lineHeight: 18


### PR DESCRIPTION
Updates the Tomb of Light mobile MVP to improve authenticated workspace context, support handoff context, and sign-up reliability.

Changes:
- Fixes mobile dashboard identity/package/experience mapping.
- Shows Legacy Plus, Household lane, and Household mode correctly on Dashboard.
- Improves Support screen role, package, project, family, and support-email context.
- Cleans duplicated sign-up screen code.
- Adds mobile policy version to sign-up.
- Confirms mobile typecheck passes.

Validation:
- npm run typecheck
- Local login works.
- Dashboard loads authenticated workspace data.
- Support email handoff opens with context.
- Forgot password request sends Postmark reset email.