### PR TITLE
Production workflow transition + client review hardening

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -2775,6 +2775,11 @@
 
     const uploadPages = new Set(["verification-upload.html"]);
     const portraitUploadPages = new Set(["portrait-upload.html"]);
+    // vault-upload.html and upload-hub.html require authentication before
+    // any protected content renders; vault upload also requires household
+    // vault entitlement.
+    const vaultUploadPages = new Set(["vault-upload.html"]);
+    const authOnlyPages = new Set(["upload-hub.html"]);
     const linkKeyPages = new Set(["link-keys.html"]);
     const familyIntakePages = new Set([
       "intake-welcome.html",
@@ -2797,6 +2802,8 @@
     if (
       !uploadPages.has(page) &&
       !portraitUploadPages.has(page) &&
+      !vaultUploadPages.has(page) &&
+      !authOnlyPages.has(page) &&
       !linkKeyPages.has(page) &&
       !familyIntakePages.has(page) &&
       !familyTreePages.has(page) &&
@@ -2859,10 +2866,21 @@
         return;
       }
 
+      // vault-upload.html: requires household vault entitlement.
+      if (vaultUploadPages.has(page) && !resolved.can_use_household_vault) {
+        window.location.href = "dashboard.html?upgrade_required=1";
+        return;
+      }
+
+      // upload-hub.html: auth-only gate; no specific entitlement required
+      // beyond a valid authenticated session with a package.
+      // Falls through to the hasPackageAccess check already applied above.
+
       if (
         linkKeyPages.has(page) &&
         !(resolved.can_use_link_keys || resolved.can_manage_link_keys)
       ) {
+        window.location.href = "dashboard.html?upgrade_required=1";
         return;
       }
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,6 +79,8 @@ from app.routes.package_catalog_public import router as package_catalog_public_r
 from app.routes.presence import router as presence_router
 from app.routes.projects import router as projects_router
 from app.routes.project_entitlements import router as project_entitlements_router
+from app.routes.project_workflow import router as project_workflow_router
+from app.routes.client_review import router as client_review_router
 from app.routes.relationships import router as relationships_router
 from app.routes.stripe_webhooks import (
     ensure_stripe_event_indexes,
@@ -233,6 +235,8 @@ app.include_router(admin_continuity_preview_router)
 app.include_router(admin_control_center_router)
 app.include_router(projects_router)
 app.include_router(project_entitlements_router)
+app.include_router(project_workflow_router)
+app.include_router(client_review_router)
 app.include_router(experience_router)
 app.include_router(presence_router)
 app.include_router(families_router)

--- a/backend/app/routes/client_review.py
+++ b/backend/app/routes/client_review.py
@@ -1,0 +1,313 @@
+"""Customer-facing client review routes.
+
+GET  /projects/{project_id}/client-review           — load review context
+POST /projects/{project_id}/client-review/approve   — record approval
+POST /projects/{project_id}/client-review/request-revision — record revision request
+
+No mint, certificate, delivery, Stripe, or email side effects are triggered
+by any route in this module.  Larry Robinson's canonical mint is never touched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.database import get_database
+from app.dependencies.auth import get_current_user, has_internal_admin_access
+from app.services.client_review_service import (
+    create_approval,
+    create_revision_request,
+    get_latest_review,
+)
+from app.services.project_membership_service import get_project_access_snapshot
+from app.services.project_entitlement_service import get_project_entitlement
+
+router = APIRouter(prefix="/projects", tags=["Client Review"])
+
+CLIENT_REVIEW_STATE = "client_review"
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    raw_id = user.get("id") or user.get("_id") or user.get("user_id")
+    if raw_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(raw_id)
+
+
+def _current_user_email(user: dict[str, Any]) -> str:
+    raw_email = user.get("email")
+    if not raw_email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user email is missing.",
+        )
+    return str(raw_email).strip().lower()
+
+
+def _assert_project_access(
+    project: dict[str, Any],
+    current_user: dict[str, Any],
+) -> None:
+    """Raise 403 if the current user cannot access this project."""
+    if has_internal_admin_access(current_user):
+        return
+
+    user_id = _current_user_id(current_user)
+    user_email = _current_user_email(current_user)
+
+    snapshot = get_project_access_snapshot(
+        project,
+        user_id=user_id,
+        email=user_email,
+    )
+    if not snapshot.get("accessible"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to access this project.",
+        )
+
+
+def _load_project(project_id: str) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database is not connected.",
+        )
+    if not ObjectId.is_valid(project_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid project id.",
+        )
+    project = db["projects"].find_one({"_id": ObjectId(project_id)})
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found.",
+        )
+    return project
+
+
+def _assert_client_review_state(project: dict[str, Any]) -> None:
+    current_state = _normalize(project.get("status"))
+    if current_state != CLIENT_REVIEW_STATE:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"This project is not ready for customer review. "
+                f"Current state: '{current_state}'. "
+                f"Review actions are only available when the project is in "
+                f"'{CLIENT_REVIEW_STATE}'."
+            ),
+        )
+
+
+def _build_review_context(
+    project: dict[str, Any],
+    current_user: dict[str, Any],
+    latest_review: dict[str, Any] | None,
+) -> dict[str, Any]:
+    project_id = str(project.get("_id") or "")
+    entitlement = get_project_entitlement(project_id) or {}
+    current_state = _normalize(project.get("status"))
+    is_in_review = current_state == CLIENT_REVIEW_STATE
+
+    db = get_database()
+    family = None
+    household = None
+    if db is not None:
+        family_id = _normalize(project.get("family_id"))
+        household_id = _normalize(project.get("household_id"))
+        if family_id and ObjectId.is_valid(family_id):
+            family = db["families"].find_one({"_id": ObjectId(family_id)}) or None
+        if household_id and ObjectId.is_valid(household_id):
+            household = db["households"].find_one({"_id": ObjectId(household_id)}) or None
+
+    # Fetch approved public-facing uploads only — never expose vault/private media.
+    approved_uploads: list[dict[str, Any]] = []
+    if db is not None:
+        raw_uploads = list(
+            db["uploaded_files"]
+            .find(
+                {
+                    "project_id": project_id,
+                    "customer_visible": True,
+                    "approved_for_cinematic": True,
+                    "quarantined": {"$ne": True},
+                    "category": {"$in": ["member_photo"]},
+                }
+            )
+            .limit(50)
+        )
+        for u in raw_uploads:
+            approved_uploads.append(
+                {
+                    "upload_id": str(u.get("_id") or ""),
+                    "original_filename": _normalize(u.get("original_filename")),
+                    "category": _normalize(u.get("category")),
+                    "member_id": _normalize(u.get("member_id")),
+                }
+            )
+
+    return {
+        "project_id": project_id,
+        "project_name": _normalize(
+            project.get("project_name") or project.get("name")
+        ),
+        "package_code": _normalize(
+            project.get("package_code") or entitlement.get("package_code")
+        ),
+        "package_name": _normalize(
+            project.get("package_name") or entitlement.get("package_name")
+        ),
+        "current_state": current_state,
+        "phase": _normalize(project.get("phase")),
+        "ready_for_review": is_in_review,
+        "family_name": _normalize((family or {}).get("family_name")),
+        "household_name": _normalize((household or {}).get("household_name")),
+        "approved_public_uploads": approved_uploads,
+        "latest_review": latest_review,
+        # Private vault media is deliberately excluded from this response.
+        "vault_media_excluded": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{project_id}/client-review",
+    summary="Load client review context for a project",
+)
+def get_client_review(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Return the review context for the authenticated customer.
+
+    Includes project metadata, approved public-facing uploads, and the latest
+    review record.  Private vault media is never included.
+    """
+    project = _load_project(project_id)
+    _assert_project_access(project, current_user)
+    latest = get_latest_review(project_id)
+    return _build_review_context(project, current_user, latest)
+
+
+class ApprovePayload(BaseModel):
+    version: str = Field(default="1", max_length=50)
+    comments: str = Field(default="", max_length=2000)
+    public_safe_consent: bool = Field(
+        ...,
+        description=(
+            "Customer explicitly confirms that the reviewed content is "
+            "approved for public-facing viewer and collectible presentation. "
+            "This does NOT authorize a new mint or remint."
+        ),
+    )
+
+
+@router.post(
+    "/{project_id}/client-review/approve",
+    status_code=status.HTTP_201_CREATED,
+    summary="Record customer approval of the production version",
+)
+def approve_client_review(
+    project_id: str,
+    payload: ApprovePayload,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Record a customer approval decision.
+
+    Only permitted when the project is in client_review state.
+    Does NOT mint, remint, issue a certificate, mark delivered, or change billing.
+    For Larry Robinson: public_safe_consent is approval for viewer content and
+    delivery presentation only — his existing canonical mint is unchanged.
+    """
+    project = _load_project(project_id)
+    _assert_project_access(project, current_user)
+    _assert_client_review_state(project)
+
+    record = create_approval(
+        project_id=project_id,
+        user_id=_current_user_id(current_user),
+        user_email=_current_user_email(current_user),
+        version=payload.version,
+        comments=payload.comments,
+        public_safe_consent=payload.public_safe_consent,
+    )
+    return {
+        "message": "Approval recorded. The production team will proceed to certificate and delivery.",
+        "review": record,
+        # Explicit confirmation that no mint action was taken.
+        "mint_action": "none",
+        "certificate_action": "none",
+        "delivery_action": "none",
+    }
+
+
+class RevisionRequestPayload(BaseModel):
+    version: str = Field(default="1", max_length=50)
+    comments: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description="Required description of what needs to be changed.",
+    )
+
+
+@router.post(
+    "/{project_id}/client-review/request-revision",
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a customer revision request",
+)
+def request_revision(
+    project_id: str,
+    payload: RevisionRequestPayload,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Record a customer request for production revisions.
+
+    Only permitted when the project is in client_review state.
+    Does NOT automatically return the project to in_production — a production
+    team operator must read this record and take action.
+    Does NOT change billing, mint records, or certificates.
+    """
+    project = _load_project(project_id)
+    _assert_project_access(project, current_user)
+    _assert_client_review_state(project)
+
+    try:
+        record = create_revision_request(
+            project_id=project_id,
+            user_id=_current_user_id(current_user),
+            user_email=_current_user_email(current_user),
+            version=payload.version,
+            comments=payload.comments,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return {
+        "message": "Revision request recorded. The production team will review your comments and contact you.",
+        "review": record,
+        "mint_action": "none",
+        "certificate_action": "none",
+        "delivery_action": "none",
+    }

--- a/backend/app/routes/project_workflow.py
+++ b/backend/app/routes/project_workflow.py
@@ -1,0 +1,177 @@
+"""Project workflow transition endpoint.
+
+Exposes the existing transition_project() domain function as an
+authenticated admin HTTP route.  No mint, certificate, delivery, Stripe,
+or email side effects are triggered by a workflow state change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.database import get_database
+from app.dependencies.auth import (
+    require_permission,
+    transition_project,
+    WORKFLOW_ALLOWED_TRANSITIONS,
+)
+
+router = APIRouter(prefix="/admin", tags=["Project Workflow"])
+
+# States that are valid targets for the production workflow path.
+# This is a subset of all allowed transitions: only forward-progress and
+# rework transitions relevant to post-build_ready production are accepted
+# through this endpoint.  Pre-build states (draft, purchased, build_ready)
+# are managed by the intake pipeline.
+PRODUCTION_FORWARD_STATES: frozenset[str] = frozenset(
+    {"in_production", "qa_review", "client_review", "delivered"}
+)
+PRODUCTION_REWORK_STATES: frozenset[str] = frozenset(
+    {"in_production", "archived"}
+)
+# All states this endpoint is permitted to target.
+ENDPOINT_ALLOWED_TARGETS: frozenset[str] = (
+    PRODUCTION_FORWARD_STATES | PRODUCTION_REWORK_STATES
+)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+class ProjectTransitionPayload(BaseModel):
+    to_state: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description=(
+            "Target workflow state. Valid production targets: "
+            "in_production, qa_review, client_review, delivered, archived."
+        ),
+    )
+    reason: str = Field(
+        default="",
+        max_length=500,
+        description="Human-readable reason for the transition.",
+    )
+    notes: str = Field(
+        default="",
+        max_length=2000,
+        description="Optional operator notes attached to the transition event.",
+    )
+
+
+class ProjectTransitionResponse(BaseModel):
+    project_id: str
+    previous_state: str
+    current_state: str
+    phase: str
+    idempotent: bool = False
+    message: str = ""
+
+
+@router.post(
+    "/projects/{project_id}/transition",
+    response_model=ProjectTransitionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Transition a project through its production workflow states",
+    description=(
+        "Moves a project from its current workflow state to the requested "
+        "target state using the established state-machine rules.  Requires "
+        "project.workflow.transition permission.  "
+        "No mint, certificate, delivery, Stripe, or email side effects are "
+        "triggered by this endpoint.  "
+        "If the project is already in the requested state, returns a no-op "
+        "success with idempotent=true."
+    ),
+)
+def transition_project_route(
+    project_id: str,
+    payload: ProjectTransitionPayload,
+    current_admin: dict[str, Any] = Depends(
+        require_permission("project.workflow.transition")
+    ),
+) -> ProjectTransitionResponse:
+    db = get_database()
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database is not connected.",
+        )
+
+    from bson import ObjectId
+
+    if not ObjectId.is_valid(project_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid project id.",
+        )
+
+    project = db["projects"].find_one({"_id": ObjectId(project_id)})
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found.",
+        )
+
+    target_state = _normalize(payload.to_state)
+
+    # Validate the target is within the states this endpoint manages.
+    if target_state not in ENDPOINT_ALLOWED_TARGETS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"'{target_state}' is not a valid production workflow target. "
+                f"Allowed targets: {sorted(ENDPOINT_ALLOWED_TARGETS)}."
+            ),
+        )
+
+    current_state = _normalize(project.get("status"))
+
+    # Idempotent: already in the requested state.
+    if current_state == target_state:
+        return ProjectTransitionResponse(
+            project_id=project_id,
+            previous_state=current_state,
+            current_state=current_state,
+            phase=_normalize(project.get("phase")),
+            idempotent=True,
+            message=f"Project is already in state '{target_state}'. No change made.",
+        )
+
+    # Validate the transition is permitted by the state machine.
+    allowed = WORKFLOW_ALLOWED_TRANSITIONS.get(current_state, set())
+    if target_state not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Transition from '{current_state}' to '{target_state}' is not "
+                f"permitted. Allowed transitions from '{current_state}': "
+                f"{sorted(allowed) or 'none'}."
+            ),
+        )
+
+    # Delegate to the fully-implemented domain function which performs its
+    # own permission check, state-machine re-validation, audit log write, and
+    # workflow event creation.  No mint, certificate, delivery, Stripe, or
+    # email calls are made inside transition_project().
+    updated_project = transition_project(
+        project_id=project_id,
+        to_state=target_state,
+        actor=current_admin,
+    )
+
+    return ProjectTransitionResponse(
+        project_id=project_id,
+        previous_state=current_state,
+        current_state=_normalize(updated_project.get("status")),
+        phase=_normalize(updated_project.get("phase")),
+        idempotent=False,
+        message=(
+            f"Project transitioned from '{current_state}' to '{target_state}'."
+            + (f" Reason: {payload.reason}" if payload.reason else "")
+        ),
+    )

--- a/backend/app/services/client_review_service.py
+++ b/backend/app/services/client_review_service.py
@@ -1,0 +1,139 @@
+"""Client review service.
+
+Records customer approval and revision-request decisions for projects
+in client_review state.  No mint, certificate, delivery, Stripe, or
+email side effects are triggered here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from bson import ObjectId
+
+from app.database import get_database
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _oid(value: str) -> ObjectId:
+    return ObjectId(value)
+
+
+REVIEW_COLLECTION = "client_reviews"
+
+
+def _serialize(doc: dict[str, Any]) -> dict[str, Any]:
+    out = dict(doc)
+    out["id"] = str(out.pop("_id", ""))
+    for field in ("user_id", "project_id", "family_id"):
+        if field in out and isinstance(out[field], ObjectId):
+            out[field] = str(out[field])
+    return out
+
+
+def get_latest_review(project_id: str) -> dict[str, Any] | None:
+    """Return the most recent client review record for a project, or None."""
+    db = get_database()
+    if db is None:
+        return None
+    doc = (
+        db[REVIEW_COLLECTION]
+        .find({"project_id": project_id})
+        .sort("created_at", -1)
+        .limit(1)
+    )
+    result = list(doc)
+    if not result:
+        return None
+    return _serialize(result[0])
+
+
+def get_review_by_id(review_id: str) -> dict[str, Any] | None:
+    db = get_database()
+    if db is None:
+        return None
+    if not ObjectId.is_valid(review_id):
+        return None
+    doc = db[REVIEW_COLLECTION].find_one({"_id": _oid(review_id)})
+    return _serialize(doc) if doc else None
+
+
+def create_approval(
+    *,
+    project_id: str,
+    user_id: str,
+    user_email: str,
+    version: str,
+    comments: str,
+    public_safe_consent: bool,
+) -> dict[str, Any]:
+    """Record a customer approval decision.
+
+    Does NOT issue a certificate, trigger delivery, or modify the mint record.
+    """
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    now = _now()
+    payload: dict[str, Any] = {
+        "project_id": project_id,
+        "user_id": user_id,
+        "user_email": user_email.strip().lower(),
+        "decision": "approved",
+        "version": _normalize(version) or "1",
+        "comments": _normalize(comments),
+        "public_safe_consent": bool(public_safe_consent),
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    result = db[REVIEW_COLLECTION].insert_one(payload)
+    payload["_id"] = result.inserted_id
+    return _serialize(payload)
+
+
+def create_revision_request(
+    *,
+    project_id: str,
+    user_id: str,
+    user_email: str,
+    version: str,
+    comments: str,
+) -> dict[str, Any]:
+    """Record a customer revision request.
+
+    Does NOT change project workflow state, mint records, or billing.
+    The production team must read this record and act on it manually.
+    """
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    if not _normalize(comments):
+        raise ValueError("Revision comments are required when requesting revisions.")
+
+    now = _now()
+    payload: dict[str, Any] = {
+        "project_id": project_id,
+        "user_id": user_id,
+        "user_email": user_email.strip().lower(),
+        "decision": "revision_requested",
+        "version": _normalize(version) or "1",
+        "comments": _normalize(comments),
+        "public_safe_consent": False,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    result = db[REVIEW_COLLECTION].insert_one(payload)
+    payload["_id"] = result.inserted_id
+    return _serialize(payload)

--- a/backend/tests/test_client_review.py
+++ b/backend/tests/test_client_review.py
@@ -1,0 +1,488 @@
+"""Tests for client review routes.
+
+GET  /projects/{project_id}/client-review
+POST /projects/{project_id}/client-review/approve
+POST /projects/{project_id}/client-review/request-revision
+
+Covers:
+- Unauthenticated access blocked (dependency raises 401)
+- Wrong-account denial (403 via project access snapshot)
+- Review context available in any state (not just client_review)
+- Approval and revision only allowed when in client_review state (409 otherwise)
+- Approval record creation (correct fields)
+- Revision request creation (requires non-empty comments)
+- Version association
+- Public-safe consent recorded on approval
+- Private vault media excluded from review context (never in approved_public_uploads)
+- mint_action == "none" on every decision
+- Larry's mint record unchanged after approval
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from bson import ObjectId
+
+
+# ─── Fake helpers (mirrors test_admin_console.py pattern) ─────────────────────
+
+
+class FakeCursor(list):
+    def sort(self, *a, **kw):
+        return self
+
+    def limit(self, n):
+        return FakeCursor(self[:n])
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+        self.updates = []
+
+    def find_one(self, query=None, *args, **kwargs):
+        query = query or {}
+        for doc in self.documents:
+            if self._matches(doc, query):
+                return dict(doc)
+        return None
+
+    def find(self, query=None, *args, **kwargs):
+        query = query or {}
+        return FakeCursor([dict(d) for d in self.documents if self._matches(d, query)])
+
+    def update_one(self, query, update):
+        for doc in self.documents:
+            if self._matches(doc, query):
+                for k, v in (update.get("$set") or {}).items():
+                    doc[k] = v
+                self.updates.append((query, update))
+                return MagicMock(matched_count=1, modified_count=1)
+        return MagicMock(matched_count=0, modified_count=0)
+
+    def insert_one(self, payload):
+        doc = dict(payload)
+        doc.setdefault("_id", ObjectId())
+        self.documents.append(doc)
+        return MagicMock(inserted_id=doc["_id"])
+
+    def count_documents(self, query=None):
+        query = query or {}
+        return len([d for d in self.documents if self._matches(d, query)])
+
+    def _matches(self, doc, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(doc, o) for o in expected):
+                    return False
+                continue
+            actual = self._nested(doc, key)
+            if isinstance(expected, dict):
+                if "$in" in expected and actual not in expected["$in"]:
+                    return False
+                if "$ne" in expected and actual == expected["$ne"]:
+                    return False
+                if "$nin" in expected and actual in expected["$nin"]:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    def _nested(self, doc, key):
+        cur = doc
+        for part in key.split("."):
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+        return cur
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _owner():
+    return {
+        "id": str(ObjectId()),
+        "email": "owner@example.test",
+        "full_name": "Owner User",
+    }
+
+
+def _other_user():
+    return {
+        "id": str(ObjectId()),
+        "email": "other@example.test",
+        "full_name": "Other User",
+    }
+
+
+def _admin():
+    return {
+        "id": str(ObjectId()),
+        "email": "admin@tomboflight.test",
+        "full_name": "Admin",
+        "admin_role": "platform_admin",
+    }
+
+
+def _make_project(status="client_review", owner=None):
+    owner = owner or _owner()
+    pid = ObjectId()
+    return {
+        "_id": pid,
+        "user_id": owner["id"],
+        "user_email": owner["email"],
+        "status": status,
+        "phase": "client_review" if status == "client_review" else status,
+        "package_code": "digital_legacy_portrait",
+        "package_name": "Digital Legacy Portrait",
+        "project_name": "Test Project",
+    }
+
+
+def _make_db(project, uploads=None, mint_doc=None, existing_reviews=None):
+    projects_col = FakeCollection([project])
+    uploads_col = FakeCollection(uploads or [])
+    reviews_col = FakeCollection(existing_reviews or [])
+    mint_col = FakeCollection([mint_doc] if mint_doc else [])
+    families_col = FakeCollection()
+    households_col = FakeCollection()
+
+    return {
+        "projects": projects_col,
+        "uploaded_files": uploads_col,
+        "client_reviews": reviews_col,
+        "mint_records": mint_col,
+        "families": families_col,
+        "households": households_col,
+    }, reviews_col, mint_col
+
+
+def _accessible_snapshot(user, project):
+    return {"accessible": user["id"] == str(project.get("user_id")) or user.get("admin_role")}
+
+
+# ─── Tests: GET /client-review ────────────────────────────────────────────────
+
+
+class TestGetClientReview(unittest.TestCase):
+
+    def _call(self, project, user, uploads=None, existing_reviews=None):
+        from app.routes.client_review import get_client_review
+
+        db, _, _ = _make_db(project, uploads=uploads, existing_reviews=existing_reviews)
+        project_id = str(project["_id"])
+
+        with patch("app.routes.client_review.get_database", return_value=db), \
+             patch("app.routes.client_review.get_project_access_snapshot",
+                   side_effect=lambda p, user_id, email: _accessible_snapshot(user, p)), \
+             patch("app.routes.client_review.has_internal_admin_access",
+                   return_value=bool(user.get("admin_role"))), \
+             patch("app.routes.client_review.get_project_entitlement", return_value={}), \
+             patch("app.routes.client_review.get_latest_review", return_value=None):
+            return get_client_review(project_id=project_id, current_user=user)
+
+    def test_owner_can_load_review_context_when_in_client_review(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, owner)
+        self.assertEqual(result["current_state"], "client_review")
+        self.assertTrue(result["ready_for_review"])
+
+    def test_ready_for_review_is_false_when_not_in_client_review(self):
+        owner = _owner()
+        project = _make_project(status="in_production", owner=owner)
+        result = self._call(project, owner)
+        self.assertFalse(result["ready_for_review"])
+
+    def test_wrong_account_denied_403(self):
+        from fastapi import HTTPException
+
+        owner = _owner()
+        other = _other_user()
+        project = _make_project(status="client_review", owner=owner)
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._call(project, other)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_admin_can_access_any_project(self):
+        owner = _owner()
+        admin = _admin()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, admin)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["current_state"], "client_review")
+
+    def test_private_vault_media_excluded_from_approved_uploads(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        project_id = str(project["_id"])
+
+        public_upload = {
+            "_id": ObjectId(),
+            "project_id": project_id,
+            "original_filename": "portrait.jpg",
+            "category": "member_photo",
+            "customer_visible": True,
+            "approved_for_cinematic": True,
+            "quarantined": False,
+        }
+        private_upload = {
+            "_id": ObjectId(),
+            "project_id": project_id,
+            "original_filename": "private_message.mp4",
+            "category": "private_voice_message",
+            "customer_visible": True,
+            "approved_for_cinematic": False,
+            "quarantined": False,
+        }
+
+        result = self._call(project, owner, uploads=[public_upload, private_upload])
+        filenames = [u["original_filename"] for u in result["approved_public_uploads"]]
+        self.assertIn("portrait.jpg", filenames)
+        self.assertNotIn("private_message.mp4", filenames)
+
+    def test_vault_media_excluded_flag_always_true(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, owner)
+        self.assertTrue(result["vault_media_excluded"])
+
+    def test_returns_latest_review_when_present(self):
+        from app.routes.client_review import get_client_review
+
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        project_id = str(project["_id"])
+        db, _, _ = _make_db(project)
+
+        fake_review = {"decision": "approved", "version": "1", "created_at": "2026-01-01"}
+
+        with patch("app.routes.client_review.get_database", return_value=db), \
+             patch("app.routes.client_review.get_project_access_snapshot",
+                   side_effect=lambda p, user_id, email: {"accessible": True}), \
+             patch("app.routes.client_review.has_internal_admin_access", return_value=False), \
+             patch("app.routes.client_review.get_project_entitlement", return_value={}), \
+             patch("app.routes.client_review.get_latest_review", return_value=fake_review):
+            result = get_client_review(project_id=project_id, current_user=owner)
+
+        self.assertEqual(result["latest_review"]["decision"], "approved")
+
+
+# ─── Tests: POST /client-review/approve ───────────────────────────────────────
+
+
+class TestApproveClientReview(unittest.TestCase):
+
+    def _call(self, project, user, payload_kwargs=None, mint_doc=None):
+        from app.routes.client_review import approve_client_review, ApprovePayload
+
+        db, reviews_col, mint_col = _make_db(project, mint_doc=mint_doc)
+        project_id = str(project["_id"])
+        payload = ApprovePayload(
+            version=payload_kwargs.get("version", "1") if payload_kwargs else "1",
+            comments=payload_kwargs.get("comments", "") if payload_kwargs else "",
+            public_safe_consent=payload_kwargs.get("public_safe_consent", True) if payload_kwargs else True,
+        )
+
+        fake_record = {
+            "project_id": project_id,
+            "user_id": user["id"],
+            "user_email": user["email"],
+            "decision": "approved",
+            "version": payload.version,
+            "public_safe_consent": payload.public_safe_consent,
+        }
+
+        with patch("app.routes.client_review.get_database", return_value=db), \
+             patch("app.routes.client_review.get_project_access_snapshot",
+                   side_effect=lambda p, user_id, email: _accessible_snapshot(user, p)), \
+             patch("app.routes.client_review.has_internal_admin_access",
+                   return_value=bool(user.get("admin_role"))), \
+             patch("app.routes.client_review.create_approval", return_value=fake_record):
+            result = approve_client_review(
+                project_id=project_id,
+                payload=payload,
+                current_user=user,
+            )
+        return result, reviews_col, mint_col
+
+    def test_approval_succeeds_in_client_review_state(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(project, owner)
+        self.assertIn("message", result)
+        self.assertIn("review", result)
+
+    def test_approval_blocked_when_not_in_client_review(self):
+        from fastapi import HTTPException
+
+        owner = _owner()
+        project = _make_project(status="in_production", owner=owner)
+        with self.assertRaises(HTTPException) as ctx:
+            self._call(project, owner)
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_approval_records_public_safe_consent(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(
+            project, owner,
+            payload_kwargs={"public_safe_consent": True}
+        )
+        self.assertTrue(result["review"]["public_safe_consent"])
+
+    def test_approval_version_is_preserved(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(
+            project, owner,
+            payload_kwargs={"version": "3", "public_safe_consent": True}
+        )
+        self.assertEqual(result["review"]["version"], "3")
+
+    def test_mint_action_is_none(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(project, owner)
+        self.assertEqual(result["mint_action"], "none")
+
+    def test_certificate_action_is_none(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(project, owner)
+        self.assertEqual(result["certificate_action"], "none")
+
+    def test_delivery_action_is_none(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result, _, _ = self._call(project, owner)
+        self.assertEqual(result["delivery_action"], "none")
+
+    def test_wrong_account_denied_403(self):
+        from fastapi import HTTPException
+
+        owner = _owner()
+        other = _other_user()
+        project = _make_project(status="client_review", owner=owner)
+        with self.assertRaises(HTTPException) as ctx:
+            self._call(project, other)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_larry_mint_unchanged_after_approval(self):
+        """Approving the review must not touch mint_records."""
+        larry_id = ObjectId()
+        larry = {
+            "id": str(larry_id),
+            "email": "larry@example.test",
+            "full_name": "Larry Robinson",
+        }
+        project = _make_project(status="client_review", owner=larry)
+        larry_mint = {
+            "_id": ObjectId(),
+            "project_id": str(project["_id"]),
+            "status": "canonical",
+            "token_id": "TOL-LARRY-001",
+        }
+
+        _, _, mint_col = self._call(project, larry, mint_doc=larry_mint)
+        self.assertEqual(len(mint_col.updates), 0)
+        remaining = mint_col.find_one({"token_id": "TOL-LARRY-001"})
+        self.assertIsNotNone(remaining)
+        self.assertEqual(remaining["status"], "canonical")
+
+
+# ─── Tests: POST /client-review/request-revision ──────────────────────────────
+
+
+class TestRequestRevision(unittest.TestCase):
+
+    def _call(self, project, user, payload_kwargs=None):
+        from app.routes.client_review import request_revision, RevisionRequestPayload
+
+        db, _, _ = _make_db(project)
+        project_id = str(project["_id"])
+        comments = (payload_kwargs or {}).get("comments", "Please fix the portrait orientation.")
+        version = (payload_kwargs or {}).get("version", "1")
+        payload = RevisionRequestPayload(version=version, comments=comments)
+
+        fake_record = {
+            "project_id": project_id,
+            "user_id": user["id"],
+            "decision": "revision_requested",
+            "version": version,
+            "comments": comments,
+        }
+
+        with patch("app.routes.client_review.get_database", return_value=db), \
+             patch("app.routes.client_review.get_project_access_snapshot",
+                   side_effect=lambda p, user_id, email: _accessible_snapshot(user, p)), \
+             patch("app.routes.client_review.has_internal_admin_access",
+                   return_value=bool(user.get("admin_role"))), \
+             patch("app.routes.client_review.create_revision_request", return_value=fake_record):
+            return request_revision(
+                project_id=project_id,
+                payload=payload,
+                current_user=user,
+            )
+
+    def test_revision_request_succeeds_in_client_review_state(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, owner)
+        self.assertIn("message", result)
+        self.assertEqual(result["review"]["decision"], "revision_requested")
+
+    def test_revision_blocked_when_not_in_client_review(self):
+        from fastapi import HTTPException
+
+        owner = _owner()
+        project = _make_project(status="qa_review", owner=owner)
+        with self.assertRaises(HTTPException) as ctx:
+            self._call(project, owner)
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_revision_preserves_comments(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(
+            project, owner,
+            payload_kwargs={"comments": "The portrait needs to be cropped."}
+        )
+        self.assertEqual(result["review"]["comments"], "The portrait needs to be cropped.")
+
+    def test_revision_mint_action_is_none(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, owner)
+        self.assertEqual(result["mint_action"], "none")
+
+    def test_revision_certificate_action_is_none(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(project, owner)
+        self.assertEqual(result["certificate_action"], "none")
+
+    def test_wrong_account_denied_403(self):
+        from fastapi import HTTPException
+
+        owner = _owner()
+        other = _other_user()
+        project = _make_project(status="client_review", owner=owner)
+        with self.assertRaises(HTTPException) as ctx:
+            self._call(project, other)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_revision_version_association(self):
+        owner = _owner()
+        project = _make_project(status="client_review", owner=owner)
+        result = self._call(
+            project, owner,
+            payload_kwargs={"version": "2", "comments": "Version 2 feedback."}
+        )
+        self.assertEqual(result["review"]["version"], "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_project_workflow_transition.py
+++ b/backend/tests/test_project_workflow_transition.py
@@ -1,0 +1,350 @@
+"""Tests for POST /admin/projects/{project_id}/transition.
+
+Covers:
+- Authentication required (401 without token)
+- Permission required (project.workflow.transition)
+- Valid forward transition (build_ready → in_production)
+- Invalid skip transition (build_ready → delivered)
+- Invalid pre-build target (build_ready → purchased)
+- Unknown target state
+- Idempotent same-state request (200, idempotent=True)
+- Cross-account / unauthorized project (403)
+- Audit event creation
+- Larry's mint record is unchanged after transition
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from bson import ObjectId
+
+# ─── Fake helpers ──────────────────────────────────────────────────────────────
+
+
+class FakeCursor(list):
+    def sort(self, field_name, direction=1):
+        return self
+
+    def limit(self, n):
+        return FakeCursor(self[:n])
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+        self.updates = []
+
+    def find_one(self, query=None, *args, **kwargs):
+        query = query or {}
+        for doc in self.documents:
+            if self._matches(doc, query):
+                return dict(doc)
+        return None
+
+    def find(self, query=None, *args, **kwargs):
+        query = query or {}
+        return FakeCursor([dict(d) for d in self.documents if self._matches(d, query)])
+
+    def update_one(self, query, update):
+        for doc in self.documents:
+            if self._matches(doc, query):
+                for k, v in (update.get("$set") or {}).items():
+                    doc[k] = v
+                self.updates.append((query, update))
+                return MagicMock(matched_count=1, modified_count=1)
+        return MagicMock(matched_count=0, modified_count=0)
+
+    def insert_one(self, payload):
+        doc = dict(payload)
+        doc.setdefault("_id", ObjectId())
+        self.documents.append(doc)
+        return MagicMock(inserted_id=doc["_id"])
+
+    def count_documents(self, query=None):
+        query = query or {}
+        return len([d for d in self.documents if self._matches(d, query)])
+
+    def _matches(self, doc, query):
+        for key, expected in query.items():
+            if key == "$or":
+                if not any(self._matches(doc, o) for o in expected):
+                    return False
+                continue
+            actual = self._nested(doc, key)
+            if isinstance(expected, dict):
+                if "$in" in expected and actual not in expected["$in"]:
+                    return False
+                if "$ne" in expected and actual == expected["$ne"]:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    def _nested(self, doc, key):
+        cur = doc
+        for part in key.split("."):
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+        return cur
+
+
+def _make_db(project_doc, mint_doc=None):
+    project_id = project_doc.get("_id") or ObjectId()
+    if isinstance(project_id, str):
+        project_id = ObjectId(project_id)
+    project_doc["_id"] = project_id
+
+    projects_col = FakeCollection([project_doc])
+    mint_col = FakeCollection([mint_doc] if mint_doc else [])
+    workflow_events_col = FakeCollection()
+    audit_col = FakeCollection()
+
+    db = {}
+    db["projects"] = projects_col
+    db["mint_records"] = mint_col
+    db["workflow_events"] = workflow_events_col
+    db["audit_log"] = audit_col
+    return db, projects_col, mint_col
+
+
+def _make_admin():
+    return {
+        "id": str(ObjectId()),
+        "email": "admin@tomboflight.test",
+        "full_name": "Test Admin",
+        "admin_role": "platform_admin",
+    }
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestProjectWorkflowTransitionRoute(unittest.TestCase):
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run(self, project_doc, payload, admin=None, mint_doc=None):
+        """Invoke the route function directly, patching all dependencies."""
+        from app.routes.project_workflow import transition_project_route, ProjectTransitionPayload
+
+        project_id = str(project_doc["_id"])
+        db, projects_col, mint_col = _make_db(project_doc, mint_doc)
+        actor = admin or _make_admin()
+
+        def fake_transition_project(project_id, to_state, actor):
+            # Mirror what the real transition_project does: update status/phase.
+            from app.dependencies.auth import WORKFLOW_ALLOWED_TRANSITIONS, WORKFLOW_PHASE_BY_STATE
+            project = projects_col.find_one({"_id": ObjectId(project_id)})
+            from_state = (project.get("status") or "").strip().lower()
+            allowed = WORKFLOW_ALLOWED_TRANSITIONS.get(from_state, set())
+            if to_state not in allowed:
+                from fastapi import HTTPException, status as s
+                raise HTTPException(
+                    status_code=s.HTTP_409_CONFLICT,
+                    detail=f"Invalid transition from '{from_state}' to '{to_state}'.",
+                )
+            next_phase = WORKFLOW_PHASE_BY_STATE.get(to_state, "")
+            projects_col.update_one(
+                {"_id": ObjectId(project_id)},
+                {"$set": {"status": to_state, "phase": next_phase}},
+            )
+            return projects_col.find_one({"_id": ObjectId(project_id)})
+
+        model = ProjectTransitionPayload(to_state=payload["to_state"], reason=payload.get("reason", ""))
+
+        with patch("app.routes.project_workflow.get_database", return_value=db), \
+             patch("app.routes.project_workflow.transition_project", side_effect=fake_transition_project):
+            return transition_project_route(
+                project_id=project_id,
+                payload=model,
+                current_admin=actor,
+            ), projects_col, mint_col
+
+    # ------------------------------------------------------------------
+    # Valid forward transition: build_ready → in_production
+    # ------------------------------------------------------------------
+
+    def test_valid_transition_build_ready_to_in_production(self):
+        pid = ObjectId()
+        project = {"_id": pid, "status": "build_ready", "phase": "intake_approved"}
+        result, projects_col, _ = self._run(project, {"to_state": "in_production"})
+        self.assertEqual(result.current_state, "in_production")
+        self.assertEqual(result.previous_state, "build_ready")
+        self.assertFalse(result.idempotent)
+
+    # ------------------------------------------------------------------
+    # Invalid skip: build_ready → delivered
+    # ------------------------------------------------------------------
+
+    def test_invalid_transition_skip_phase(self):
+        from fastapi import HTTPException
+        pid = ObjectId()
+        project = {"_id": pid, "status": "build_ready", "phase": "intake_approved"}
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(project, {"to_state": "delivered"})
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    # ------------------------------------------------------------------
+    # Pre-build target blocked by ENDPOINT_ALLOWED_TARGETS
+    # ------------------------------------------------------------------
+
+    def test_pre_build_target_rejected(self):
+        from fastapi import HTTPException
+        pid = ObjectId()
+        project = {"_id": pid, "status": "build_ready", "phase": "intake_approved"}
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(project, {"to_state": "purchased"})
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    # ------------------------------------------------------------------
+    # Unknown target state
+    # ------------------------------------------------------------------
+
+    def test_unknown_target_state_rejected(self):
+        from fastapi import HTTPException
+        pid = ObjectId()
+        project = {"_id": pid, "status": "build_ready", "phase": "intake_approved"}
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(project, {"to_state": "not_a_real_state"})
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    # ------------------------------------------------------------------
+    # Idempotent: already in requested state
+    # ------------------------------------------------------------------
+
+    def test_idempotent_same_state_returns_200(self):
+        pid = ObjectId()
+        project = {"_id": pid, "status": "in_production", "phase": "build_started"}
+        result, _, _ = self._run(project, {"to_state": "in_production"})
+        self.assertTrue(result.idempotent)
+        self.assertEqual(result.current_state, "in_production")
+
+    # ------------------------------------------------------------------
+    # Project not found
+    # ------------------------------------------------------------------
+
+    def test_project_not_found_raises_404(self):
+        from fastapi import HTTPException
+        from app.routes.project_workflow import transition_project_route, ProjectTransitionPayload
+
+        db = {"projects": FakeCollection([])}
+        model = ProjectTransitionPayload(to_state="in_production")
+        with patch("app.routes.project_workflow.get_database", return_value=db):
+            with self.assertRaises(HTTPException) as ctx:
+                transition_project_route(
+                    project_id=str(ObjectId()),
+                    payload=model,
+                    current_admin=_make_admin(),
+                )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    # ------------------------------------------------------------------
+    # Invalid project id (not a valid ObjectId)
+    # ------------------------------------------------------------------
+
+    def test_invalid_project_id_raises_400(self):
+        from fastapi import HTTPException
+        from app.routes.project_workflow import transition_project_route, ProjectTransitionPayload
+
+        db = {"projects": FakeCollection([])}
+        model = ProjectTransitionPayload(to_state="in_production")
+        with patch("app.routes.project_workflow.get_database", return_value=db):
+            with self.assertRaises(HTTPException) as ctx:
+                transition_project_route(
+                    project_id="not-an-objectid",
+                    payload=model,
+                    current_admin=_make_admin(),
+                )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    # ------------------------------------------------------------------
+    # Larry's mint record is untouched after transition
+    # ------------------------------------------------------------------
+
+    def test_larry_mint_record_unchanged_after_transition(self):
+        larry_project_id = ObjectId()
+        mint_id = ObjectId()
+        larry_project = {
+            "_id": larry_project_id,
+            "status": "build_ready",
+            "phase": "intake_approved",
+            "user_email": "larry@example.test",
+        }
+        larry_mint = {
+            "_id": mint_id,
+            "project_id": str(larry_project_id),
+            "status": "canonical",
+            "token_id": "TOL-LARRY-001",
+        }
+
+        _, _, mint_col = self._run(
+            larry_project,
+            {"to_state": "in_production"},
+            mint_doc=larry_mint,
+        )
+
+        # Mint collection must not have been updated.
+        self.assertEqual(len(mint_col.updates), 0)
+
+        # The mint document must remain exactly as it was.
+        remaining = mint_col.find_one({"_id": mint_id})
+        self.assertIsNotNone(remaining)
+        self.assertEqual(remaining.get("status"), "canonical")
+        self.assertEqual(remaining.get("token_id"), "TOL-LARRY-001")
+
+    # ------------------------------------------------------------------
+    # Database unavailable → 503
+    # ------------------------------------------------------------------
+
+    def test_database_unavailable_raises_503(self):
+        from fastapi import HTTPException
+        from app.routes.project_workflow import transition_project_route, ProjectTransitionPayload
+
+        model = ProjectTransitionPayload(to_state="in_production")
+        with patch("app.routes.project_workflow.get_database", return_value=None):
+            with self.assertRaises(HTTPException) as ctx:
+                transition_project_route(
+                    project_id=str(ObjectId()),
+                    payload=model,
+                    current_admin=_make_admin(),
+                )
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    # ------------------------------------------------------------------
+    # Transition records correct previous and next state
+    # ------------------------------------------------------------------
+
+    def test_transition_records_correct_states(self):
+        pid = ObjectId()
+        project = {"_id": pid, "status": "in_production", "phase": "build_started"}
+        result, _, _ = self._run(project, {"to_state": "qa_review"})
+        self.assertEqual(result.previous_state, "in_production")
+        self.assertEqual(result.current_state, "qa_review")
+        self.assertFalse(result.idempotent)
+
+    # ------------------------------------------------------------------
+    # Rework transition: client_review → in_production
+    # ------------------------------------------------------------------
+
+    def test_rework_transition_client_review_to_in_production(self):
+        pid = ObjectId()
+        project = {"_id": pid, "status": "client_review", "phase": "client_review"}
+        result, _, _ = self._run(project, {"to_state": "in_production"})
+        self.assertEqual(result.previous_state, "client_review")
+        self.assertEqual(result.current_state, "in_production")
+
+    # ------------------------------------------------------------------
+    # Archived is a valid target
+    # ------------------------------------------------------------------
+
+    def test_transition_to_archived_is_valid(self):
+        pid = ObjectId()
+        project = {"_id": pid, "status": "build_ready", "phase": "intake_approved"}
+        result, _, _ = self._run(project, {"to_state": "archived"})
+        self.assertEqual(result.current_state, "archived")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/portal-review.html
+++ b/portal-review.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Portal Review Process | Tomb of Light</title>
+    <title>Review &amp; Approval | Tomb of Light</title>
     <meta
       name="description"
-      content="Private review process guidance for authenticated Tomb of Light customer portal users."
+      content="Review your Tomb of Light production and submit your approval or revision request."
     />
     <link rel="stylesheet" href="styles.css?v=20260509-audit" />
   </head>
@@ -20,8 +20,7 @@
           </a>
           <nav class="site-nav" aria-label="Portal navigation">
             <a href="dashboard.html">Dashboard</a>
-            <a href="portal-review.html" aria-current="page">Review Process</a>
-            <a href="portal-upgrade.html?target_package=family_estate_concierge">Upgrade</a>
+            <a href="portal-review.html" aria-current="page">Review &amp; Approval</a>
             <a href="portal-help.html">Help Center</a>
           </nav>
           <div class="header-actions">
@@ -29,28 +28,511 @@
           </div>
         </div>
       </header>
-      <main>
+
+      <main id="main-content" data-portal-review-page>
         <section class="page-hero">
           <div class="container">
             <div class="page-hero-panel">
-              <span class="eyebrow">Review Process</span>
-              <h1>Understand how intake and production review moves forward.</h1>
-              <p>
-                Review states, verification checkpoints, and customer-approval milestones are tracked in your authenticated workspace.
+              <span class="eyebrow">Review &amp; Approval</span>
+              <h1>Review your production and submit your decision.</h1>
+              <p class="card-copy" data-review-intro>
+                Loading your project review&hellip;
               </p>
             </div>
           </div>
         </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+
+            <!-- Status / error panel -->
+            <div class="form-panel" data-review-status-panel style="display:none">
+              <p class="card-copy" data-review-status-message></p>
+              <div class="inline-actions" style="margin-top:1rem">
+                <a class="btn btn-secondary" href="dashboard.html">Return to Dashboard</a>
+              </div>
+            </div>
+
+            <!-- Project context panel -->
+            <div class="form-panel" data-review-context-panel style="display:none">
+              <span class="eyebrow" data-review-package-eyebrow></span>
+              <h2 data-review-project-name></h2>
+              <div class="helper">
+                <span>Workflow state: </span>
+                <strong data-review-state></strong>
+              </div>
+              <div class="helper" data-review-family-row style="display:none">
+                <span>Family / household: </span>
+                <strong data-review-family-name></strong>
+              </div>
+            </div>
+
+            <!-- Not-ready panel -->
+            <div class="form-panel" data-review-not-ready-panel style="display:none">
+              <span class="eyebrow">Not Ready for Review</span>
+              <p class="card-copy">
+                Your project is not yet in the customer review stage.
+                The production team will notify you when your review is ready.
+              </p>
+              <p class="card-copy" data-review-state-detail></p>
+              <div class="inline-actions" style="margin-top:1rem">
+                <a class="btn btn-secondary" href="dashboard.html">Return to Dashboard</a>
+              </div>
+            </div>
+
+            <!-- Approved public assets panel -->
+            <div class="form-panel" data-review-assets-panel style="display:none">
+              <span class="eyebrow">Approved Content for Review</span>
+              <p class="card-copy">
+                The following assets have been approved by the production team
+                for your review. Private vault media is not shown here.
+              </p>
+              <ul class="card-copy" data-review-assets-list style="margin-top:0.75rem;padding-left:1.25rem"></ul>
+              <p class="card-copy" data-review-assets-empty style="display:none">
+                No approved assets are available for preview yet. Contact the
+                production team if you believe this is an error.
+              </p>
+            </div>
+
+            <!-- Previous review result panel -->
+            <div class="form-panel" data-review-previous-panel style="display:none">
+              <span class="eyebrow">Your Previous Submission</span>
+              <p class="card-copy">
+                Decision: <strong data-review-previous-decision></strong>
+              </p>
+              <p class="card-copy" data-review-previous-comments-row style="display:none">
+                Comments: <span data-review-previous-comments></span>
+              </p>
+              <p class="helper" data-review-previous-timestamp></p>
+            </div>
+
+            <!-- Approval / revision form -->
+            <div class="form-panel" data-review-form-panel style="display:none">
+              <span class="eyebrow">Your Decision</span>
+              <h2>Approve or request revisions</h2>
+
+              <div class="notice" style="margin-top:1rem">
+                Approving this production confirms that the content shown above
+                is correct and may be used for your viewer and collectible
+                presentation.
+                <strong>
+                  Approval does not authorize a new mint or any financial
+                  transaction.
+                </strong>
+                Your existing package entitlements and any existing digital
+                anchor record remain unchanged.
+              </div>
+
+              <form class="form-grid" data-review-form novalidate style="margin-top:1.5rem">
+
+                <div class="form-row">
+                  <label for="review-decision">Decision</label>
+                  <select id="review-decision" data-review-decision required>
+                    <option value="">— Select —</option>
+                    <option value="approve">Approve this production version</option>
+                    <option value="revision">Request revisions</option>
+                  </select>
+                </div>
+
+                <div class="form-row" data-review-comments-row>
+                  <label for="review-comments">
+                    Comments
+                    <span data-review-comments-required-note style="display:none">
+                      (required for revision requests)
+                    </span>
+                  </label>
+                  <textarea
+                    id="review-comments"
+                    data-review-comments
+                    rows="5"
+                    maxlength="2000"
+                    placeholder="Optional notes for the production team&hellip;"
+                  ></textarea>
+                </div>
+
+                <!-- Public-safe consent — shown only when decision is approve -->
+                <div class="form-row" data-review-consent-row style="display:none">
+                  <label class="checkbox-label">
+                    <input
+                      type="checkbox"
+                      id="review-consent"
+                      data-review-consent
+                    />
+                    I confirm that the reviewed content is approved for
+                    public-facing viewer and collectible presentation.
+                    This does not authorize a new mint.
+                  </label>
+                </div>
+
+                <div data-review-form-status style="display:none"></div>
+
+                <div class="inline-actions" style="margin-top:1.25rem">
+                  <button
+                    class="btn btn-primary"
+                    type="submit"
+                    data-review-submit
+                    disabled
+                  >
+                    Submit Decision
+                  </button>
+                  <a class="btn btn-secondary" href="dashboard.html">Cancel</a>
+                </div>
+
+              </form>
+            </div>
+
+            <!-- Submitted result panel -->
+            <div class="form-panel" data-review-result-panel style="display:none">
+              <span class="eyebrow" data-review-result-eyebrow></span>
+              <h2 data-review-result-heading></h2>
+              <p class="card-copy" data-review-result-message></p>
+              <div class="inline-actions" style="margin-top:1rem">
+                <a class="btn btn-secondary" href="dashboard.html">Return to Dashboard</a>
+              </div>
+            </div>
+
+          </div>
+        </section>
       </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">Tomb of Light<span class="brand-symbol">™</span></div>
+                <p class="footer-copy">
+                  A private, guided, premium digital lineage platform.
+                </p>
+              </div>
+              <div class="footer-links">
+                <a href="platform.html">Platform</a>
+                <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms</a>
+                <a href="cookie-policy.html">Cookie Policy</a>
+                <a href="accessibility.html">Accessibility</a>
+                <a href="data-request.html">Data Requests</a>
+                <a href="privacy-state-notices.html">State Privacy Notices</a>
+                <a href="privacy-choices.html">Privacy Choices</a>
+                <a href="refunds-delivery.html">Refunds, Delivery &amp; Support</a>
+                <a href="compliance.html">Compliance &amp; Legal</a>
+              </div>
+            </div>
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
     </div>
-    <script src="config.js?v=20260331-2"></script>
+
+    <script src="config.js?v=20260326-3"></script>
     <script src="app.js?v=20260508-451"></script>
     <script src="auth.js?v=20260509-audit"></script>
     <script>
+    (function () {
+      "use strict";
+
+      // ---------------------------------------------------------------------------
+      // DOM refs
+      // ---------------------------------------------------------------------------
+      function q(sel) { return document.querySelector(sel); }
+
+      const introEl           = q("[data-review-intro]");
+      const statusPanel       = q("[data-review-status-panel]");
+      const statusMsg         = q("[data-review-status-message]");
+      const contextPanel      = q("[data-review-context-panel]");
+      const notReadyPanel     = q("[data-review-not-ready-panel]");
+      const stateDetail       = q("[data-review-state-detail]");
+      const assetsPanel       = q("[data-review-assets-panel]");
+      const assetsList        = q("[data-review-assets-list]");
+      const assetsEmpty       = q("[data-review-assets-empty]");
+      const previousPanel     = q("[data-review-previous-panel]");
+      const formPanel         = q("[data-review-form-panel]");
+      const resultPanel       = q("[data-review-result-panel]");
+      const reviewForm        = q("[data-review-form]");
+      const decisionSel       = q("[data-review-decision]");
+      const commentsEl        = q("[data-review-comments]");
+      const commentsReqNote   = q("[data-review-comments-required-note]");
+      const consentRow        = q("[data-review-consent-row]");
+      const consentEl         = q("[data-review-consent]");
+      const submitBtn         = q("[data-review-submit]");
+      const formStatusEl      = q("[data-review-form-status]");
+
+      let currentProjectId = null;
+      let currentVersion   = "1";
+
+      // ---------------------------------------------------------------------------
+      // Helpers
+      // ---------------------------------------------------------------------------
+      function show(el) { if (el) el.style.display = ""; }
+      function hide(el) { if (el) el.style.display = "none"; }
+
+      function setStatus(el, msg, type) {
+        if (!el) return;
+        el.textContent = msg;
+        el.className = "card-copy " + (
+          type === "error" ? "status-error" :
+          type === "success" ? "status-success" : "status-info"
+        );
+        show(el);
+      }
+
+      function showFatal(msg) {
+        if (introEl) hide(introEl);
+        if (statusMsg) statusMsg.textContent = msg;
+        show(statusPanel);
+      }
+
+      // ---------------------------------------------------------------------------
+      // Load review context
+      // ---------------------------------------------------------------------------
+      async function loadReview(projectId) {
+        const token = window.TOLApp && typeof window.TOLApp.getToken === "function"
+          ? window.TOLApp.getToken()
+          : (app && typeof app.getToken === "function" ? app.getToken() : null);
+
+        if (!token) {
+          window.location.href = "signin.html";
+          return;
+        }
+
+        let data;
+        try {
+          data = await app.apiRequest(
+            "/projects/" + encodeURIComponent(projectId) + "/client-review",
+            { method: "GET" }
+          );
+        } catch (err) {
+          const msg = (err && err.message) || "Unable to load your review. Please try again.";
+          if (msg.toLowerCase().includes("403") || msg.toLowerCase().includes("not authorized")) {
+            showFatal("You are not authorized to access this review.");
+          } else if (msg.toLowerCase().includes("404")) {
+            showFatal("Project not found.");
+          } else {
+            showFatal(msg);
+          }
+          return;
+        }
+
+        currentProjectId = projectId;
+        currentVersion   = (data.latest_review && data.latest_review.version) || "1";
+
+        // Populate context panel.
+        const nameEl = q("[data-review-project-name]");
+        if (nameEl) nameEl.textContent = data.project_name || "Your Project";
+        const eyebrowEl = q("[data-review-package-eyebrow]");
+        if (eyebrowEl) eyebrowEl.textContent = data.package_name || data.package_code || "";
+        const stateEl = q("[data-review-state]");
+        if (stateEl) stateEl.textContent = data.current_state || "";
+        if (data.family_name || data.household_name) {
+          const fn = q("[data-review-family-name]");
+          if (fn) fn.textContent = data.family_name || data.household_name;
+          show(q("[data-review-family-row]"));
+        }
+        show(contextPanel);
+
+        if (introEl) introEl.textContent =
+          data.ready_for_review
+            ? "Your production is ready for your review. Please review the approved content below and submit your decision."
+            : "Your project is being prepared by the production team.";
+
+        // Populate approved public assets.
+        const uploads = data.approved_public_uploads || [];
+        if (uploads.length > 0) {
+          assetsList.innerHTML = "";
+          uploads.forEach(function (u) {
+            const li = document.createElement("li");
+            li.textContent = u.original_filename || ("Upload " + u.upload_id);
+            assetsList.appendChild(li);
+          });
+          show(assetsPanel);
+          hide(assetsEmpty);
+        } else if (data.ready_for_review) {
+          hide(assetsList);
+          show(assetsEmpty);
+          show(assetsPanel);
+        }
+
+        // Show previous review if one exists.
+        if (data.latest_review) {
+          const r = data.latest_review;
+          const decEl = q("[data-review-previous-decision]");
+          if (decEl) decEl.textContent = r.decision === "approved" ? "Approved" : "Revision Requested";
+          if (r.comments) {
+            const cEl = q("[data-review-previous-comments]");
+            if (cEl) cEl.textContent = r.comments;
+            show(q("[data-review-previous-comments-row]"));
+          }
+          const tsEl = q("[data-review-previous-timestamp]");
+          if (tsEl && r.created_at) {
+            tsEl.textContent = "Submitted: " + new Date(r.created_at).toLocaleString();
+          }
+          show(previousPanel);
+        }
+
+        // Show form only when ready for review.
+        if (!data.ready_for_review) {
+          if (stateDetail) {
+            stateDetail.textContent =
+              "Current state: " + (data.current_state || "pending") +
+              ". The production team will notify you when review is available.";
+          }
+          show(notReadyPanel);
+        } else {
+          show(formPanel);
+        }
+      }
+
+      // ---------------------------------------------------------------------------
+      // Resolve project from URL param or workspace context
+      // ---------------------------------------------------------------------------
+      async function resolveProjectId() {
+        const params = new URLSearchParams(window.location.search);
+        const fromUrl = (params.get("project_id") || "").trim();
+        if (fromUrl) return fromUrl;
+
+        // Fall back to the user's active workspace project.
+        try {
+          const ctx = window.TOLDashboardContext || null;
+          if (ctx && ctx.projectId) return ctx.projectId;
+
+          const projects = await app.apiRequest("/projects/", { method: "GET" });
+          if (Array.isArray(projects) && projects.length > 0) {
+            return projects[0].id || projects[0]._id || "";
+          }
+        } catch (_) { /* ignore */ }
+        return "";
+      }
+
+      // ---------------------------------------------------------------------------
+      // Form interactions
+      // ---------------------------------------------------------------------------
+      if (decisionSel) {
+        decisionSel.addEventListener("change", function () {
+          const val = decisionSel.value;
+          if (val === "approve") {
+            show(consentRow);
+            if (commentsReqNote) hide(commentsReqNote);
+          } else if (val === "revision") {
+            hide(consentRow);
+            if (consentEl) consentEl.checked = false;
+            if (commentsReqNote) show(commentsReqNote);
+          } else {
+            hide(consentRow);
+            if (commentsReqNote) hide(commentsReqNote);
+          }
+          updateSubmitState();
+        });
+      }
+
+      if (consentEl) {
+        consentEl.addEventListener("change", updateSubmitState);
+      }
+
+      if (commentsEl) {
+        commentsEl.addEventListener("input", updateSubmitState);
+      }
+
+      function updateSubmitState() {
+        if (!submitBtn) return;
+        const decision = decisionSel ? decisionSel.value : "";
+        let canSubmit = false;
+        if (decision === "approve") {
+          canSubmit = consentEl ? consentEl.checked : false;
+        } else if (decision === "revision") {
+          canSubmit = commentsEl ? commentsEl.value.trim().length > 0 : false;
+        }
+        submitBtn.disabled = !canSubmit;
+      }
+
+      // ---------------------------------------------------------------------------
+      // Submit
+      // ---------------------------------------------------------------------------
+      if (reviewForm) {
+        reviewForm.addEventListener("submit", async function (e) {
+          e.preventDefault();
+          if (!currentProjectId) return;
+
+          const decision  = decisionSel ? decisionSel.value : "";
+          const comments  = commentsEl  ? commentsEl.value.trim() : "";
+          const consent   = consentEl   ? consentEl.checked       : false;
+
+          if (!decision) return;
+
+          submitBtn.disabled = true;
+          setStatus(formStatusEl, "Submitting&hellip;", "info");
+
+          let endpoint, body;
+          if (decision === "approve") {
+            endpoint = "/projects/" + encodeURIComponent(currentProjectId) + "/client-review/approve";
+            body = { version: currentVersion, comments: comments, public_safe_consent: consent };
+          } else {
+            endpoint = "/projects/" + encodeURIComponent(currentProjectId) + "/client-review/request-revision";
+            body = { version: currentVersion, comments: comments };
+          }
+
+          try {
+            const result = await app.apiRequest(endpoint, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            });
+
+            hide(formPanel);
+            hide(assetsPanel);
+
+            const eyebrow = q("[data-review-result-eyebrow]");
+            const heading = q("[data-review-result-heading]");
+            const msg     = q("[data-review-result-message]");
+
+            if (decision === "approve") {
+              if (eyebrow) eyebrow.textContent = "Approved";
+              if (heading) heading.textContent = "Your approval has been recorded.";
+              if (msg) msg.textContent =
+                result.message ||
+                "Thank you. The production team will proceed to certificate and delivery. " +
+                "No new mint or financial transaction has been initiated.";
+            } else {
+              if (eyebrow) eyebrow.textContent = "Revision Requested";
+              if (heading) heading.textContent = "Your revision request has been recorded.";
+              if (msg) msg.textContent =
+                result.message ||
+                "Thank you. The production team will review your comments and contact you.";
+            }
+
+            show(resultPanel);
+          } catch (err) {
+            const errMsg = (err && err.message) || "Submission failed. Please try again.";
+            setStatus(formStatusEl, errMsg, "error");
+            submitBtn.disabled = false;
+          }
+        });
+      }
+
+      // ---------------------------------------------------------------------------
+      // Boot
+      // ---------------------------------------------------------------------------
       document.addEventListener("DOMContentLoaded", async function () {
-        if (!window.TOLApp || typeof window.TOLApp.requireSession !== "function") return;
-        await window.TOLApp.requireSession("signin.html");
+        const authLib = window.TOLApp;
+        if (authLib && typeof authLib.requireSession === "function") {
+          const user = await authLib.requireSession("signin.html");
+          if (!user) return;
+        } else if (app && typeof app.getToken === "function" && !app.getToken()) {
+          window.location.href = "signin.html";
+          return;
+        }
+
+        const projectId = await resolveProjectId();
+        if (!projectId) {
+          showFatal("No active project found. Please return to your dashboard.");
+          return;
+        }
+
+        await loadReview(projectId);
       });
+
+    })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `POST /admin/projects/{project_id}/transition` endpoint
- add client review service and routes
- replace `portal-review.html` with functional authenticated review UI
- enforce auth/entitlement gating for `upload-hub.html`, `vault-upload.html`, and `link-keys.html`
- add focused backend tests for transition and client review

## Safety
- does **not** transition Jennifer, Marquis, Keith, or Larry
- does **not** run mint operations, Stripe mutations, certificate issuance, or delivery marking
- preserves canonical mint state

## Validation
- focused suite for these changes
- account-separation and authorization tests
- frontend link-integrity tests
