### PR TITLE
Master Admin control center completion

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -66,6 +66,7 @@
               </button>
             </div>
             <div class="helper" data-admin-control-action-status aria-live="polite"></div>
+            <div data-admin-impersonation-banner aria-live="polite"></div>
           </div>
 
           <div class="admin-case-console-shell">
@@ -142,14 +143,15 @@
                   </div>
 
                   <div class="admin-case-tabs" role="tablist" aria-label="Case sections">
-                    <button type="button" role="tab" data-admin-case-tab="identity" class="is-active">Identity</button>
-                    <button type="button" role="tab" data-admin-case-tab="package_lane">Package &amp; Lane</button>
-                    <button type="button" role="tab" data-admin-case-tab="orders_billing">Orders &amp; Billing</button>
-                    <button type="button" role="tab" data-admin-case-tab="project">Project</button>
-                    <button type="button" role="tab" data-admin-case-tab="entitlements">Entitlements</button>
-                    <button type="button" role="tab" data-admin-case-tab="uploads_verification">Uploads / Verification</button>
-                    <button type="button" role="tab" data-admin-case-tab="mint_readiness">Mint Readiness</button>
-                    <button type="button" role="tab" data-admin-case-tab="audit_timeline">Audit Timeline</button>
+                    <button type="button" role="tab" data-admin-case-tab="overview" class="is-active">Overview</button>
+                    <button type="button" role="tab" data-admin-case-tab="package_services">Package &amp; Services</button>
+                    <button type="button" role="tab" data-admin-case-tab="family_household">Family / Household</button>
+                    <button type="button" role="tab" data-admin-case-tab="production">Production</button>
+                    <button type="button" role="tab" data-admin-case-tab="uploads">Uploads</button>
+                    <button type="button" role="tab" data-admin-case-tab="vault_metadata">Vault Metadata</button>
+                    <button type="button" role="tab" data-admin-case-tab="billing">Billing</button>
+                    <button type="button" role="tab" data-admin-case-tab="mint">Mint</button>
+                    <button type="button" role="tab" data-admin-case-tab="audit_history">Audit History</button>
                   </div>
 
                   <div class="admin-case-tab-content" data-admin-case-workspace>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -6,6 +6,7 @@
 
   const INTERNAL_ROLE_KEYS = new Set([
     "super_admin",
+    "ceo_master_admin",
     "executive_tech_admin",
     "operations_admin",
     "finance_admin",
@@ -16,6 +17,9 @@
     superadmin: "super_admin",
     root_admin: "super_admin",
     platform_admin: "super_admin",
+    ceo_super_admin: "ceo_master_admin",
+    ceo_master_admin: "ceo_master_admin",
+    "ceo-master-admin": "ceo_master_admin",
     executive_technology: "executive_tech_admin",
     executive_tech_admin: "executive_tech_admin",
     "executive-tech-admin": "executive_tech_admin",
@@ -39,12 +43,14 @@
     isSuperAdmin: false,
     queue: "overview",
     selectedCaseId: "",
-    selectedTab: "identity",
+    selectedTab: "overview",
     cases: [],
     workspace: null,
     packageOptions: [],
     marketingSections: {},
     operationsSections: {},
+    activeImpersonation: null,
+    impersonationTicker: 0,
   };
   const DEFAULT_ROLE_KEY = "user";
 
@@ -81,14 +87,26 @@
   };
 
   const TAB_LABELS = {
-    identity: "Identity",
-    package_lane: "Package & Lane",
-    orders_billing: "Orders & Billing",
-    project: "Project",
-    entitlements: "Entitlements",
-    uploads_verification: "Uploads / Verification",
-    mint_readiness: "Mint Readiness",
-    audit_timeline: "Audit Timeline",
+    overview: "Overview",
+    package_services: "Package & Services",
+    family_household: "Family / Household",
+    production: "Production",
+    uploads: "Uploads",
+    vault_metadata: "Vault Metadata",
+    billing: "Billing",
+    mint: "Mint",
+    audit_history: "Audit History",
+  };
+  const TAB_BACKEND_KEY = {
+    overview: "identity",
+    package_services: "package_lane",
+    family_household: "project",
+    production: "project",
+    uploads: "uploads_verification",
+    vault_metadata: "entitlements",
+    billing: "orders_billing",
+    mint: "mint_readiness",
+    audit_history: "audit_timeline",
   };
 
   const ACTION_AVAILABILITY = {
@@ -190,7 +208,8 @@
 
   function isAllowedTab(tab) {
     const normalized = normalizeLower(tab);
-    return state.allowedTabs.includes(normalized);
+    const backendKey = normalizeLower(TAB_BACKEND_KEY[normalized] || normalized);
+    return state.allowedTabs.includes(backendKey);
   }
 
   function isAllowedCaseAction(action) {
@@ -226,7 +245,11 @@
       state.queue = state.allowedQueues[0] || "overview";
     }
     if (!isAllowedTab(state.selectedTab)) {
-      state.selectedTab = state.allowedTabs[0] || "identity";
+      const preferredTabs = Object.keys(TAB_BACKEND_KEY);
+      state.selectedTab =
+        preferredTabs.find(function (tab) {
+          return isAllowedTab(tab);
+        }) || "overview";
     }
   }
 
@@ -493,6 +516,66 @@
       method: "POST",
       body: JSON.stringify(body || {}),
     });
+  }
+
+  async function loadActiveImpersonation() {
+    if (!state.isSuperAdmin) {
+      state.activeImpersonation = null;
+      return;
+    }
+    try {
+      const payload = await fetchJson("/admin/control-center/super-admin/impersonation/active");
+      state.activeImpersonation = payload && payload.active ? payload : null;
+    } catch (_error) {
+      state.activeImpersonation = null;
+    }
+    renderImpersonationBanner();
+  }
+
+  function formatExpirationCountdown(value) {
+    if (!value) return "unknown expiry";
+    const expiresAt = new Date(value).getTime();
+    if (!Number.isFinite(expiresAt)) return "unknown expiry";
+    const diffMs = expiresAt - Date.now();
+    if (diffMs <= 0) return "expired";
+    const totalMinutes = Math.ceil(diffMs / 60000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return hours > 0 ? `${hours}h ${minutes}m remaining` : `${minutes}m remaining`;
+  }
+
+  function renderImpersonationBanner() {
+    const node = document.querySelector("[data-admin-impersonation-banner]");
+    if (!node) return;
+    const session = state.activeImpersonation;
+    if (!session || !session.active) {
+      node.innerHTML = "";
+      node.hidden = true;
+      return;
+    }
+    node.hidden = false;
+    const statusLabel = session.editing_enabled ? "editing enabled" : "read-only";
+    const project = session.project_id ? shortId(session.project_id) : "no linked project";
+    const expires = formatExpirationCountdown(session.expires_at);
+    node.innerHTML = `
+      <div class="admin-warning-strip" style="margin-top:0.75rem;">
+        <span>Impersonation Active</span>
+        <div>
+          <strong>${escapeHtml(session.banner || "Viewing Tomb of Light as Customer")}</strong>
+          <span class="admin-id-ref" style="margin-left:0.5rem;">project ${escapeHtml(project)}</span>
+          <span style="margin-left:0.5rem;">${escapeHtml(statusLabel)}</span>
+          <span style="margin-left:0.5rem;">${escapeHtml(expires)}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  function startImpersonationTicker() {
+    window.clearInterval(state.impersonationTicker);
+    state.impersonationTicker = window.setInterval(function () {
+      if (!state.activeImpersonation || !state.activeImpersonation.active) return;
+      renderImpersonationBanner();
+    }, 30000);
   }
 
   function renderTopSummary(summary, financeSections, marketingSections) {
@@ -837,10 +920,11 @@
     }
 
     const tab = state.selectedTab;
-    const tabData = workspace.tabs[tab];
+    const backendTab = TAB_BACKEND_KEY[tab] || tab;
+    const tabData = workspace.tabs[backendTab];
     const warningMarkup = renderWarningStrip((tabData && tabData.warnings) || workspace.warnings || []);
 
-    if (tab === "audit_timeline") {
+    if (backendTab === "audit_timeline") {
       const timeline = Array.isArray(tabData) ? tabData : Array.isArray(workspace.audit_timeline) ? workspace.audit_timeline : [];
       node.innerHTML = timeline.length
         ? timeline
@@ -865,7 +949,7 @@
       return;
     }
 
-    if (tab === "orders_billing") {
+    if (backendTab === "orders_billing") {
       const primaryOrder = tabData && tabData.primary_order ? tabData.primary_order : {};
       const related = Array.isArray(tabData && tabData.related_orders) ? tabData.related_orders : [];
       node.innerHTML = `
@@ -896,7 +980,7 @@
       return;
     }
 
-    if (tab === "uploads_verification") {
+    if (backendTab === "uploads_verification") {
       const uploads = tabData && Array.isArray(tabData.items) ? tabData.items : [];
       node.innerHTML = `
         ${warningMarkup}
@@ -916,7 +1000,7 @@
       return;
     }
 
-    if (tab === "identity") {
+    if (backendTab === "identity") {
       const userId =
         (tabData && tabData.user_id) ||
         (workspace.tabs && workspace.tabs.identity && workspace.tabs.identity.user_id) ||
@@ -973,7 +1057,7 @@
       return;
     }
 
-    if (tab === "mint_readiness") {
+    if (backendTab === "mint_readiness") {
       const guidance = getGuidanceItems(tabData && tabData.guidance);
       const history = Array.isArray(tabData && tabData.historical_attempts) ? tabData.historical_attempts : [];
       const currentState = tabData.current_state || tabData.eligibility || "blocked";
@@ -1039,7 +1123,7 @@
       return;
     }
 
-    if (tab === "package_lane") {
+    if (backendTab === "package_lane") {
       const projectId =
         (workspace.tabs && workspace.tabs.project && workspace.tabs.project.project_id) ||
         (workspace.project && workspace.project.id) ||
@@ -1082,10 +1166,38 @@
                 </label>
                 <label class="admin-field"><span>Target Lane</span><input type="text" data-super-admin-package-field="project_lane" value="${escapeHtml(tabData.project_lane || tabData.lane || "")}" /></label>
                 <label class="admin-field"><span>Order Status</span><input type="text" data-super-admin-package-field="order_status" value="${escapeHtml((workspace.tabs.orders_billing || {}).order_status || "")}" /></label>
+                <label class="admin-field"><span>Reason</span><input type="text" data-super-admin-package-field="reason" placeholder="Required for apply operations" /></label>
+                <label class="admin-field">
+                  <span>Service Operation</span>
+                  <select data-super-admin-service-field="operation">
+                    <option value="">None</option>
+                    <option value="assign">assign</option>
+                    <option value="upgrade">upgrade</option>
+                    <option value="downgrade">downgrade</option>
+                    <option value="complimentary_package">complimentary package</option>
+                    <option value="promotional_package">promotional package</option>
+                    <option value="internal_validation_account">internal validation account</option>
+                  </select>
+                </label>
+                <label class="admin-field"><span>Add Add-ons (comma separated)</span><input type="text" data-super-admin-service-field="add_addons" placeholder="extra_storage, tribute_narration" /></label>
+                <label class="admin-field"><span>Remove Add-ons (comma separated)</span><input type="text" data-super-admin-service-field="remove_addons" placeholder="extra_upload_pack" /></label>
+                <label class="admin-field"><span>Storage Adjustment (GB)</span><input type="number" step="0.1" data-super-admin-service-field="storage_adjustment_gb" value="0" /></label>
+                <label class="admin-field"><span>Upload Adjustment</span><input type="number" step="1" data-super-admin-service-field="upload_adjustment" value="0" /></label>
+                <label class="admin-field"><span>Member Allowance Adjustment</span><input type="number" step="1" data-super-admin-service-field="member_allowance_adjustment" value="0" /></label>
+                <label class="admin-field"><span>Maintenance State</span><input type="text" data-super-admin-service-field="maintenance_state" value="" placeholder="active, paused, not_started" /></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="narration_enabled" /><span>Narration</span></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="vault_enabled" /><span>Vault</span></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="scheduled_reveal_enabled" /><span>Scheduled Reveal</span></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="link_keys_enabled" /><span>Link Keys</span></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="certificate_access_enabled" /><span>Certificate Access</span></label>
+                <label class="admin-field" style="display: inline-flex; align-items: center; gap: 0.45rem;"><input type="checkbox" data-super-admin-service-field="viewer_access_enabled" /><span>Viewer Access</span></label>
               </div>
               <div class="inline-actions" style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
                 <button class="btn btn-secondary" type="button" data-super-admin-package-preview="${escapeHtml(projectId)}">Preview Change</button>
                 <button class="btn btn-primary" type="button" data-super-admin-package-apply="${escapeHtml(projectId)}">Apply Package Change</button>
+                <button class="btn btn-secondary" type="button" data-super-admin-service-preview="${escapeHtml(projectId)}">Preview Service Controls</button>
+                <button class="btn btn-primary" type="button" data-super-admin-service-apply="${escapeHtml(projectId)}">Apply Service Controls</button>
+                <button class="btn btn-secondary" type="button" data-super-admin-preview-cancel>Cancel Preview</button>
               </div>
               <div data-super-admin-package-preview-output class="helper" style="margin-top: 0.75rem;"></div>
             </article>
@@ -1096,7 +1208,7 @@
       return;
     }
 
-    if (tab === "project") {
+    if (backendTab === "project") {
       const caseId = workspace.case_id || state.selectedCaseId || "";
       const linked = (tabData && tabData.linked_family) || {};
       const showSuperAdminControls = Boolean(state.isSuperAdmin && caseId);
@@ -1240,8 +1352,17 @@
     }
 
     const context = getWorkspaceContext(selected);
+    const impersonation = state.activeImpersonation;
+    const isImpersonating = Boolean(impersonation && impersonation.active);
+    const canStartImpersonation = Boolean(state.isSuperAdmin && context.caseId && !isImpersonating);
+    const canStopImpersonation = Boolean(state.isSuperAdmin && isImpersonating);
     node.innerHTML = `
       <div class="admin-context-card">
+        ${
+          isImpersonating
+            ? `<div class="admin-warning-strip"><span>Impersonation Active</span><div><strong>${escapeHtml(impersonation.banner || "Viewing Tomb of Light as Customer")}</strong></div></div>`
+            : ""
+        }
         <h3>${escapeHtml(context.name || "Selected Case")}</h3>
         <p class="card-copy"><strong>Case:</strong> <span class="admin-id-ref">${escapeHtml(shortId(context.caseId))}</span></p>
         <p class="card-copy"><strong>Package:</strong> ${escapeHtml(context.packageName || "—")} ${context.packageCode ? `<span class="admin-id-ref">${escapeHtml(context.packageCode)}</span>` : ""}</p>
@@ -1255,6 +1376,17 @@
           <span>Mint Blocking Reasons</span>
           <div>${renderStatusStack(context.blocking, "none")}</div>
         </div>
+        ${
+          state.isSuperAdmin
+            ? `<div class="inline-actions" style="margin-top: 0.85rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                <label class="admin-field" style="min-width: 18rem;"><span>View reason</span><input type="text" data-admin-impersonation-start-reason placeholder="Required reason to start customer view" /></label>
+                <button class="btn btn-secondary" type="button" data-admin-impersonation-start="${escapeHtml(context.caseId)}" ${canStartImpersonation ? "" : "disabled"}>View as Customer</button>
+                <label class="admin-field" style="min-width: 18rem;"><span>Edit reason</span><input type="text" data-admin-impersonation-edit-reason placeholder="Required reason to enable editing" /></label>
+                <button class="btn btn-secondary" type="button" data-admin-impersonation-enable-editing ${isImpersonating ? "" : "disabled"}>Enable Admin Editing</button>
+                <button class="btn btn-primary" type="button" data-admin-impersonation-stop ${canStopImpersonation ? "" : "disabled"}>Exit Customer View</button>
+              </div>`
+            : ""
+        }
       </div>
     `;
   }
@@ -1483,6 +1615,73 @@
     }
   }
 
+  async function startImpersonation(caseId, reasonValue) {
+    if (!state.isSuperAdmin) {
+      setPageStatus("Super Admin access is required.", "error");
+      return;
+    }
+    const reason = normalizeValue(reasonValue);
+    if (!reason) {
+      setPageStatus("A reason is required to start customer view.", "error");
+      return;
+    }
+    setPageStatus("Starting View as Customer session...", "info");
+    try {
+      await postJson("/admin/control-center/super-admin/impersonation/start", {
+        case_id: caseId,
+        reason,
+      });
+      await loadActiveImpersonation();
+      renderCaseContext();
+      setPageStatus("Customer view started in read-only mode.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to start customer view.", "error");
+    }
+  }
+
+  async function enableImpersonationEditing(reasonValue) {
+    if (!state.isSuperAdmin || !state.activeImpersonation || !state.activeImpersonation.session_id) {
+      setPageStatus("No active customer-view session.", "error");
+      return;
+    }
+    const reason = normalizeValue(reasonValue);
+    if (!reason) {
+      setPageStatus("A reason is required to enable admin editing.", "error");
+      return;
+    }
+    setPageStatus("Enabling admin editing...", "info");
+    try {
+      await postJson(
+        `/admin/control-center/super-admin/impersonation/${encodeURIComponent(state.activeImpersonation.session_id)}/enable-editing`,
+        { reason },
+      );
+      await loadActiveImpersonation();
+      renderCaseContext();
+      setPageStatus("Admin editing enabled for the current customer-view session.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to enable admin editing.", "error");
+    }
+  }
+
+  async function stopImpersonation() {
+    if (!state.isSuperAdmin || !state.activeImpersonation || !state.activeImpersonation.session_id) {
+      setPageStatus("No active customer-view session.", "error");
+      return;
+    }
+    setPageStatus("Exiting customer view...", "info");
+    try {
+      await postJson(
+        `/admin/control-center/super-admin/impersonation/${encodeURIComponent(state.activeImpersonation.session_id)}/stop`,
+        {},
+      );
+      await loadActiveImpersonation();
+      renderCaseContext();
+      setPageStatus("Exited customer view.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to exit customer view.", "error");
+    }
+  }
+
   async function runCaseAction(action) {
     if (!isAllowedCaseAction(action)) {
       setPageStatus("Your role cannot run that case action.", "error");
@@ -1611,6 +1810,40 @@
     return payload;
   }
 
+  function collectSuperAdminServicePayload() {
+    const payload = {};
+    document.querySelectorAll("[data-super-admin-service-field]").forEach(function (node) {
+      const key = node.getAttribute("data-super-admin-service-field");
+      if (!key) return;
+      if (node instanceof HTMLInputElement && node.type === "checkbox") {
+        payload[key] = Boolean(node.checked);
+        return;
+      }
+      const value = normalizeValue(node.value);
+      if (key === "add_addons" || key === "remove_addons") {
+        payload[key] = value
+          ? value
+              .split(",")
+              .map(function (part) {
+                return normalizeValue(part);
+              })
+              .filter(Boolean)
+          : [];
+        return;
+      }
+      if (["storage_adjustment_gb", "upload_adjustment", "member_allowance_adjustment"].includes(key)) {
+        payload[key] = value === "" ? 0 : Number(value);
+        return;
+      }
+      payload[key] = value;
+    });
+    const packagePayload = collectSuperAdminPackagePayload();
+    payload.package_code = packagePayload.package_code || "";
+    payload.project_lane = packagePayload.project_lane || "";
+    payload.reason = packagePayload.reason || "";
+    return payload;
+  }
+
   function renderSuperAdminPackagePreview(payload) {
     const node = document.querySelector("[data-super-admin-package-preview-output]");
     if (!node) return;
@@ -1644,11 +1877,58 @@
     }
   }
 
+  function clearSuperAdminPreviewOutput() {
+    const node = document.querySelector("[data-super-admin-package-preview-output]");
+    if (!node) return;
+    node.textContent = "";
+  }
+
+  async function runSuperAdminServicePreview(projectId) {
+    if (!state.isSuperAdmin) {
+      setPageStatus("Super Admin access is required.", "error");
+      return;
+    }
+    setPageStatus("Generating service-control preview...", "info");
+    try {
+      const payload = await postJson(
+        `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/service-controls/preview`,
+        collectSuperAdminServicePayload(),
+      );
+      renderSuperAdminPackagePreview(payload || {});
+      setPageStatus("Service-control preview ready.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to preview service controls.", "error");
+    }
+  }
+
+  async function runSuperAdminServiceApply(projectId) {
+    if (!state.isSuperAdmin) {
+      setPageStatus("Super Admin access is required.", "error");
+      return;
+    }
+    if (!window.confirm("Apply service controls while preserving Stripe purchase history?")) return;
+    setPageStatus("Applying service controls...", "info");
+    try {
+      const payload = await postJson(
+        `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/service-controls/apply`,
+        collectSuperAdminServicePayload(),
+      );
+      renderSuperAdminPackagePreview(payload || {});
+      await loadOverview();
+      await loadCases();
+      if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
+      setPageStatus("Service controls applied.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to apply service controls.", "error");
+    }
+  }
+
   async function runSuperAdminPackageApply(projectId) {
     if (!state.isSuperAdmin) {
       setPageStatus("Super Admin access is required.", "error");
       return;
     }
+
     if (!window.confirm("Apply package change and repair consistency across project/order/entitlements?")) return;
     setPageStatus("Applying package change...", "info");
     try {
@@ -1804,6 +2084,27 @@
         return;
       }
 
+      const superAdminServicePreview = target.closest("[data-super-admin-service-preview]");
+      if (superAdminServicePreview) {
+        const projectId = superAdminServicePreview.getAttribute("data-super-admin-service-preview");
+        if (projectId) runSuperAdminServicePreview(projectId);
+        return;
+      }
+
+      const superAdminServiceApply = target.closest("[data-super-admin-service-apply]");
+      if (superAdminServiceApply) {
+        const projectId = superAdminServiceApply.getAttribute("data-super-admin-service-apply");
+        if (projectId) runSuperAdminServiceApply(projectId);
+        return;
+      }
+
+      const superAdminPreviewCancel = target.closest("[data-super-admin-preview-cancel]");
+      if (superAdminPreviewCancel) {
+        clearSuperAdminPreviewOutput();
+        setPageStatus("Preview canceled with no write.", "info");
+        return;
+      }
+
       const superAdminRepair = target.closest("[data-super-admin-repair-run]");
       if (superAdminRepair) {
         const caseId = superAdminRepair.getAttribute("data-super-admin-repair-run");
@@ -1818,6 +2119,29 @@
         state.selectedTab = tab;
         applyTabSelection();
         renderWorkspaceTab();
+        return;
+      }
+
+      const impersonationStart = target.closest("[data-admin-impersonation-start]");
+      if (impersonationStart) {
+        const caseId = impersonationStart.getAttribute("data-admin-impersonation-start");
+        const reasonInput = document.querySelector("[data-admin-impersonation-start-reason]");
+        const reason = reasonInput instanceof HTMLInputElement ? reasonInput.value : "";
+        if (caseId) startImpersonation(caseId, reason);
+        return;
+      }
+
+      const impersonationEnableEditing = target.closest("[data-admin-impersonation-enable-editing]");
+      if (impersonationEnableEditing) {
+        const reasonInput = document.querySelector("[data-admin-impersonation-edit-reason]");
+        const reason = reasonInput instanceof HTMLInputElement ? reasonInput.value : "";
+        enableImpersonationEditing(reason);
+        return;
+      }
+
+      const impersonationStop = target.closest("[data-admin-impersonation-stop]");
+      if (impersonationStop) {
+        stopImpersonation();
       }
     });
 
@@ -1899,6 +2223,8 @@
       if (state.isSuperAdmin) {
         await loadPackageOptions();
       }
+      await loadActiveImpersonation();
+      startImpersonationTicker();
     } catch (error) {
       setPageStatus(error.message || "Unable to load access profile.", "error");
     }

--- a/admin-family-manager.js
+++ b/admin-family-manager.js
@@ -116,20 +116,14 @@
 
     node.style.display = "block";
     node.textContent = message;
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
+    node.dataset.state = type || "info";
   }
 
   function clearStatus(node) {
     if (!node) return;
     node.style.display = "none";
     node.textContent = "";
+    node.dataset.state = "";
   }
 
   function getUserFacingErrorMessage(error, fallback) {

--- a/admin-intake.js
+++ b/admin-intake.js
@@ -163,14 +163,6 @@
     node.style.display = "block";
     node.textContent = message;
     node.dataset.state = type || "info";
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
   }
 
   function clearStatus(node) {

--- a/app.js
+++ b/app.js
@@ -17,6 +17,8 @@
   const TOKEN_KEY = "tol_access_token";
   const USER_KEY = "tol_user";
   const COOKIE_CHOICE_KEY = "tol_cookie_choice";
+  const ADMIN_APPEARANCE_DEFAULT_KEY = "tol_admin_appearance_default";
+  const ADMIN_APPEARANCE_BY_USER_KEY = "tol_admin_appearance_by_user";
   const PENDING_CHECKOUT_KEY = "tol_pending_checkout";
   const FOUNDER_MAINTENANCE_PENDING_KEY = "tol_founder_maintenance_pending";
   const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";
@@ -360,6 +362,7 @@
   // than maintaining its own copy of this set.
   const INTERNAL_ROLE_KEYS = new Set([
     "super_admin",
+    "ceo_master_admin",
     "executive_tech_admin",
     "operations_admin",
     "finance_admin",
@@ -370,6 +373,12 @@
     superadmin: "super_admin",
     root_admin: "super_admin",
     platform_admin: "super_admin",
+    ceo_super_admin: "ceo_master_admin",
+    "ceo-super-admin": "ceo_master_admin",
+    ceo_master_admin: "ceo_master_admin",
+    "ceo-master-admin": "ceo_master_admin",
+    ceo_admin: "ceo_master_admin",
+    ceo: "ceo_master_admin",
     executive_technology: "executive_tech_admin",
     executive_tech_admin: "executive_tech_admin",
     "executive-tech-admin": "executive_tech_admin",
@@ -1137,6 +1146,7 @@
   async function fetchCurrentUser() {
     const user = await apiRequest("/auth/me", { method: "GET" });
     saveUser(user);
+    setupAdminAppearance(user);
     return user;
   }
 
@@ -1188,14 +1198,6 @@
     node.style.display = "block";
     node.textContent = resolvedMessage;
     node.dataset.state = type || "info";
-
-    if (type === "error") {
-      node.style.color = "#ffb3b3";
-    } else if (type === "success") {
-      node.style.color = "#cfe8cf";
-    } else {
-      node.style.color = "#d6e6ff";
-    }
   }
 
   function clearStatus(node) {
@@ -1500,6 +1502,159 @@
     }
   }
 
+  function normalizeAdminAppearance(raw) {
+    const payload = raw && typeof raw === "object" ? raw : {};
+    const theme = String(payload.theme || "light").trim().toLowerCase();
+    const textScale = String(payload.textScale || "default").trim().toLowerCase();
+    return {
+      theme: ["light", "dark", "high-contrast"].includes(theme) ? theme : "light",
+      textScale: textScale === "large" ? "large" : "default",
+    };
+  }
+
+  function resolveAdminAppearancePrincipal(user) {
+    const source = user && typeof user === "object" ? user : getSavedUser() || {};
+    const directId = String(source.id || source._id || source.user_id || "").trim();
+    if (directId) return `id:${directId}`;
+    const email = String(source.email || "").trim().toLowerCase();
+    if (email) return `email:${email}`;
+    return "";
+  }
+
+  function readAdminAppearanceStore() {
+    try {
+      const raw = localStorage.getItem(ADMIN_APPEARANCE_BY_USER_KEY);
+      const parsed = raw ? JSON.parse(raw) : {};
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (_error) {
+      return {};
+    }
+  }
+
+  function writeAdminAppearanceStore(value) {
+    try {
+      localStorage.setItem(ADMIN_APPEARANCE_BY_USER_KEY, JSON.stringify(value || {}));
+    } catch (_error) {
+      // Ignore storage failures.
+    }
+  }
+
+  function getSavedAdminAppearance(user) {
+    const principal = resolveAdminAppearancePrincipal(user);
+    const store = readAdminAppearanceStore();
+    if (principal && store[principal]) {
+      return normalizeAdminAppearance(store[principal]);
+    }
+    try {
+      return normalizeAdminAppearance(JSON.parse(localStorage.getItem(ADMIN_APPEARANCE_DEFAULT_KEY) || "{}"));
+    } catch (_error) {
+      return normalizeAdminAppearance({});
+    }
+  }
+
+  function saveAdminAppearance(preference, user) {
+    const normalized = normalizeAdminAppearance(preference);
+    const principal = resolveAdminAppearancePrincipal(user);
+    if (principal) {
+      const store = readAdminAppearanceStore();
+      store[principal] = normalized;
+      writeAdminAppearanceStore(store);
+    }
+    try {
+      localStorage.setItem(ADMIN_APPEARANCE_DEFAULT_KEY, JSON.stringify(normalized));
+    } catch (_error) {
+      // Ignore storage failures.
+    }
+    return normalized;
+  }
+
+  function shouldEnableAdminAppearance(user) {
+    const pageHasAdminMarkers =
+      Boolean(document.querySelector("[data-admin-control-center-page]")) ||
+      Boolean(document.querySelector("[data-admin-queue-page]")) ||
+      Boolean(document.querySelector("[data-admin-family-manager-page]")) ||
+      Boolean(document.querySelector("[data-admin-review-page]"));
+    if (pageHasAdminMarkers) return true;
+    const isDashboardPage = Boolean(document.querySelector("[data-dashboard]"));
+    return isDashboardPage && isInternalRole(user || getSavedUser() || {});
+  }
+
+  function applyAdminAppearance(preference, user) {
+    if (!shouldEnableAdminAppearance(user)) {
+      document.body.classList.remove("admin-interface-mode");
+      delete document.body.dataset.adminTheme;
+      delete document.body.dataset.adminTextScale;
+      delete document.documentElement.dataset.adminTheme;
+      delete document.documentElement.dataset.adminTextScale;
+      return;
+    }
+    const normalized = normalizeAdminAppearance(preference);
+    document.body.classList.add("admin-interface-mode");
+    document.body.dataset.adminTheme = normalized.theme;
+    document.body.dataset.adminTextScale = normalized.textScale;
+    document.documentElement.dataset.adminTheme = normalized.theme;
+    document.documentElement.dataset.adminTextScale = normalized.textScale;
+  }
+
+  function injectAdminAppearanceControls(user) {
+    if (!shouldEnableAdminAppearance(user)) return;
+    const container = document.querySelector(".header-actions");
+    if (!container) return;
+    if (container.querySelector("[data-admin-appearance-toggle]")) return;
+    const appearance = getSavedAdminAppearance(user);
+    const wrapper = document.createElement("div");
+    wrapper.className = "admin-appearance-controls";
+    wrapper.innerHTML = `
+      <button class="btn btn-secondary" type="button" data-admin-appearance-toggle aria-expanded="false" aria-controls="admin-appearance-panel">Appearance</button>
+      <div class="admin-appearance-panel" id="admin-appearance-panel" data-admin-appearance-panel hidden>
+        <label>
+          Theme
+          <select data-admin-appearance-theme>
+            <option value="light"${appearance.theme === "light" ? ' selected="selected"' : ""}>Light</option>
+            <option value="dark"${appearance.theme === "dark" ? ' selected="selected"' : ""}>Dark</option>
+            <option value="high-contrast"${appearance.theme === "high-contrast" ? ' selected="selected"' : ""}>High Contrast</option>
+          </select>
+        </label>
+        <label class="admin-appearance-checkbox">
+          <input type="checkbox" data-admin-appearance-large-text ${appearance.textScale === "large" ? 'checked="checked"' : ""} />
+          <span>Larger Text</span>
+        </label>
+      </div>
+    `;
+    container.prepend(wrapper);
+    const toggle = wrapper.querySelector("[data-admin-appearance-toggle]");
+    const panel = wrapper.querySelector("[data-admin-appearance-panel]");
+    const themeSelect = wrapper.querySelector("[data-admin-appearance-theme]");
+    const largeTextInput = wrapper.querySelector("[data-admin-appearance-large-text]");
+    if (!toggle || !panel || !themeSelect || !largeTextInput) return;
+
+    toggle.addEventListener("click", function () {
+      const isOpen = !panel.hidden;
+      panel.hidden = isOpen;
+      toggle.setAttribute("aria-expanded", isOpen ? "false" : "true");
+    });
+
+    function saveAndApply() {
+      const updated = saveAdminAppearance(
+        {
+          theme: String(themeSelect.value || "light"),
+          textScale: largeTextInput.checked ? "large" : "default",
+        },
+        user || getSavedUser() || {},
+      );
+      applyAdminAppearance(updated, user);
+    }
+
+    themeSelect.addEventListener("change", saveAndApply);
+    largeTextInput.addEventListener("change", saveAndApply);
+  }
+
+  function setupAdminAppearance(user) {
+    const saved = getSavedAdminAppearance(user);
+    applyAdminAppearance(saved, user);
+    injectAdminAppearanceControls(user);
+  }
+
   function setupSelectPlaceholderState() {
     document.querySelectorAll("select").forEach(function (select) {
       function syncPlaceholderState() {
@@ -1525,6 +1680,10 @@
     applyPaymentLinks();
     syncPublicAuthCtas();
     setupSelectPlaceholderState();
+    setupAdminAppearance(getSavedUser());
+    window.addEventListener("tol:user-resolved", function (event) {
+      setupAdminAppearance(event && event.detail ? event.detail.user : null);
+    });
   });
 
   const sharedApi = {
@@ -1560,6 +1719,10 @@
     setFounderMaintenancePending,
     clearFounderMaintenancePending,
     getReadableErrorMessage,
+    getSavedAdminAppearance,
+    saveAdminAppearance,
+    applyAdminAppearance,
+    setupAdminAppearance,
   };
 
   window.TOLApp = sharedApi;

--- a/backend/app/core/admin_permission_registry.py
+++ b/backend/app/core/admin_permission_registry.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from app.core.role_catalog import normalize_role_code
 
+CEO_MASTER_ADMIN_EMAIL = "l.robinson@tomboflight.com"
+
 PERMISSION_REGISTRY: dict[str, dict[str, str]] = {
     "admin.access": {"name": "Admin Workspace Access", "description": "Access shared admin workspace data."},
     "admin.control.view": {"name": "Admin Control View", "description": "View admin control center case data."},
@@ -55,6 +57,7 @@ ROLE_CAPABILITIES: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit capability grants.
     "admin": set(),
     "super_admin": {"*"},
+    "ceo_master_admin": {"*"},
     "ceo_super_admin": {"*"},
     "executive_tech_admin": {
         "manage_roles",
@@ -95,6 +98,7 @@ ROLE_PERMISSION_MAP: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit permission grants.
     "admin": set(),
     "super_admin": {"*"},
+    "ceo_master_admin": {"*"},
     "ceo_super_admin": {"*"},
     "executive_tech_admin": {
         "admin.access",
@@ -154,6 +158,10 @@ ROLE_METADATA: dict[str, dict[str, str]] = {
         "name": "CEO Super Admin",
         "description": "CEO-level full platform controls with required audit logging.",
     },
+    "ceo_master_admin": {
+        "name": "CEO Master Administrator",
+        "description": "Canonical CEO-level master administrator role with full platform controls and audit logging.",
+    },
     "executive_tech_admin": {
         "name": "Executive Technical Admin",
         "description": "Executive technical operations and admin control center access.",
@@ -173,7 +181,7 @@ ROLE_METADATA: dict[str, dict[str, str]] = {
 }
 
 OFFICER_ROLE_MAPPING: dict[str, list[str]] = {
-    "l.robinson@tomboflight.com": ["CEO_SUPER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
+    "l.robinson@tomboflight.com": ["CEO_MASTER_ADMIN", "EXECUTIVE_TECH_ADMIN"],
     "marquis.l.floyd@tomboflight.com": ["CMO_ADMIN"],
     "jenn.wood@tomboflight.com": ["CFO_ADMIN"],
     "k.goffigan@tomboflight.com": ["COO_ADMIN"],
@@ -183,7 +191,7 @@ OFFICER_PROFILE_FIELDS: dict[str, dict[str, str]] = {
     "l.robinson@tomboflight.com": {
         "full_name": "Larry Robinson",
         "business_title": "CEO",
-        "access_tier": "super_admin",
+        "access_tier": "ceo_master_admin",
         "department_role": "executive_tech_admin",
     },
     "marquis.l.floyd@tomboflight.com": {

--- a/backend/app/core/role_catalog.py
+++ b/backend/app/core/role_catalog.py
@@ -8,6 +8,12 @@ ROLE_CODE_ALIASES: dict[str, str] = {
     "superadmin": "super_admin",
     "root_admin": "super_admin",
     "platform_admin": "super_admin",
+    "ceo_master_admin": "ceo_master_admin",
+    "ceo-master-admin": "ceo_master_admin",
+    "ceo_super_admin": "ceo_master_admin",
+    "ceo-super-admin": "ceo_master_admin",
+    "ceo_admin": "ceo_master_admin",
+    "ceo": "ceo_master_admin",
     "executive_tech_admin": "executive_tech_admin",
     "executive-tech-admin": "executive_tech_admin",
     "executive_technology": "executive_tech_admin",
@@ -29,6 +35,7 @@ ROLE_CODE_ALIASES: dict[str, str] = {
 
 OFFICER_ROLE_CODES: tuple[str, ...] = (
     "super_admin",
+    "ceo_master_admin",
     "executive_tech_admin",
     "operations_admin",
     "finance_admin",
@@ -40,6 +47,7 @@ INTERNAL_ADMIN_ROLE_CODES: frozenset[str] = frozenset(OFFICER_ROLE_CODES)
 SUPER_ADMIN_ROLE_CODES: frozenset[str] = frozenset(
     {
         "super_admin",
+        "ceo_master_admin",
     }
 )
 

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -754,6 +754,31 @@ def _resolve_workflow_state(project_id: str | None) -> dict[str, Any]:
     }
 
 
+def _collect_user_permission_overrides(user_id: str) -> set[str]:
+    normalized_user_id = _normalize_value(user_id)
+    if not normalized_user_id:
+        return set()
+    permissions: set[str] = set()
+    db = _db()
+    collection = db.get("user_permission_overrides") if hasattr(db, "get") else None
+    if collection is None:
+        try:
+            collection = db["user_permission_overrides"]
+        except KeyError:
+            return permissions
+    docs = collection.find(
+        {
+            "user_id": normalized_user_id,
+            "status": {"$in": ["active", "enabled", ""]},
+        }
+    )
+    for doc in docs:
+        permission_code = _normalize_value(doc.get("permission_code"))
+        if permission_code:
+            permissions.add(permission_code)
+    return permissions
+
+
 def resolve_access_context(
     user_id: str,
     project_id: str | None = None,
@@ -770,6 +795,7 @@ def resolve_access_context(
     role_codes = _collect_role_codes_for_user(user)
     capabilities = _collect_capabilities_for_roles(role_codes)
     permissions = _collect_permissions_for_roles(role_codes, capabilities)
+    permissions.update(_collect_user_permission_overrides(user_id))
 
     entitlements = list_user_project_entitlements(
         user_id,

--- a/backend/app/routes/admin_control_center.py
+++ b/backend/app/routes/admin_control_center.py
@@ -15,11 +15,13 @@ from app.services.admin_control_service import (
     admin_control_action_allowed,
     admin_control_bulk_action_allowed,
     admin_control_queue_allowed,
+    active_admin_impersonation,
     admin_console_overview,
     assign_lane,
     assign_missing_lanes,
     customer_case_workspace,
     execute_case_action,
+    enable_admin_impersonation_editing,
     export_operations_report,
     enable_mint_review,
     generate_entitlement,
@@ -33,12 +35,19 @@ from app.services.admin_control_service import (
     repair_all_safe_records,
     repair_record,
     repair_selected_records,
+    start_admin_impersonation,
     super_admin_apply_package_change,
+    super_admin_apply_officer_permissions,
+    super_admin_apply_service_controls,
     super_admin_apply_user_state_action,
+    super_admin_list_officers,
     super_admin_repair_case_action,
     super_admin_list_users,
+    super_admin_preview_officer_permissions,
     super_admin_preview_package_change,
+    super_admin_preview_service_controls,
     super_admin_update_user,
+    stop_admin_impersonation,
     resync_current_mint_receipt,
     project_workspace_snapshot,
     run_readiness_check,
@@ -136,6 +145,34 @@ class SuperAdminPackageChangePayload(BaseModel):
     reason: str = Field(default="", description="Required for apply operations to maintain audit traceability.")
 
 
+class SuperAdminServiceControlPayload(BaseModel):
+    operation: str = Field(default="", description="assign, upgrade, downgrade, complimentary_package, promotional_package, internal_validation_account")
+    package_code: str = Field(default="")
+    project_lane: str = Field(default="")
+    add_addons: list[str] = Field(default_factory=list)
+    remove_addons: list[str] = Field(default_factory=list)
+    storage_adjustment_gb: float | None = None
+    upload_adjustment: int | None = None
+    member_allowance_adjustment: int | None = None
+    narration_enabled: bool | None = None
+    vault_enabled: bool | None = None
+    scheduled_reveal_enabled: bool | None = None
+    link_keys_enabled: bool | None = None
+    certificate_access_enabled: bool | None = None
+    viewer_access_enabled: bool | None = None
+    maintenance_state: str = Field(default="")
+    account_flags: list[str] = Field(default_factory=list)
+    reason: str = Field(default="", description="Required for apply operations to maintain audit traceability.")
+
+
+class SuperAdminOfficerPermissionPayload(BaseModel):
+    officer_email: str = Field(min_length=1)
+    role_assignments: list[str] = Field(default_factory=list)
+    grant_permissions: list[str] = Field(default_factory=list)
+    revoke_permissions: list[str] = Field(default_factory=list)
+    reason: str = Field(default="", description="Required for apply operations to maintain audit traceability.")
+
+
 class SuperAdminRepairPayload(BaseModel):
     action: str = Field(min_length=1)
     reason: str = Field(min_length=1)
@@ -159,6 +196,19 @@ class SuperAdminRepairPayload(BaseModel):
     privacy_scope: str | None = None
     status: str | None = None
     confirm_destructive: bool = False
+
+
+class SuperAdminImpersonationStartPayload(BaseModel):
+    case_id: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+
+
+class SuperAdminImpersonationEditingPayload(BaseModel):
+    reason: str = Field(min_length=1)
+
+
+class SuperAdminImpersonationStopPayload(BaseModel):
+    reason: str = Field(default="")
 
 
 def _current_user_id(current_user: dict[str, Any]) -> str:
@@ -595,6 +645,90 @@ def super_admin_apply_project_package_change(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
+@router.post("/super-admin/projects/{project_id}/service-controls/preview")
+def super_admin_preview_project_service_controls(
+    project_id: str,
+    payload: SuperAdminServiceControlPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    del current_user
+    try:
+        return super_admin_preview_service_controls(
+            project_id=project_id,
+            payload=payload.model_dump(exclude_none=True),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/projects/{project_id}/service-controls/apply")
+def super_admin_apply_project_service_controls(
+    project_id: str,
+    payload: SuperAdminServiceControlPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    if not (payload.reason or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="A reason is required for service-control apply to maintain audit traceability.",
+        )
+    try:
+        return super_admin_apply_service_controls(
+            project_id=project_id,
+            payload=payload.model_dump(exclude_none=True),
+            actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/super-admin/officers")
+def super_admin_get_officers(
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    del current_user
+    return super_admin_list_officers()
+
+
+@router.post("/super-admin/officers/permissions/preview")
+def super_admin_preview_officer_permissions_route(
+    payload: SuperAdminOfficerPermissionPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    del current_user
+    try:
+        return super_admin_preview_officer_permissions(
+            officer_email=payload.officer_email,
+            role_assignments=payload.role_assignments,
+            grant_permissions=payload.grant_permissions,
+            revoke_permissions=payload.revoke_permissions,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/officers/permissions/apply")
+def super_admin_apply_officer_permissions_route(
+    payload: SuperAdminOfficerPermissionPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    if not (payload.reason or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="A reason is required for officer-permissions apply to maintain audit traceability.",
+        )
+    try:
+        return super_admin_apply_officer_permissions(
+            officer_email=payload.officer_email,
+            role_assignments=payload.role_assignments,
+            grant_permissions=payload.grant_permissions,
+            revoke_permissions=payload.revoke_permissions,
+            actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
 @router.post("/super-admin/cases/{case_id}/repair")
 def super_admin_case_repair(
     case_id: str,
@@ -606,6 +740,63 @@ def super_admin_case_repair(
             case_id=case_id,
             action=payload.action,
             payload=payload.model_dump(exclude_none=True),
+            actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/super-admin/impersonation/active")
+def super_admin_get_active_impersonation(
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    try:
+        return active_admin_impersonation(actor=current_user)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/impersonation/start")
+def super_admin_start_impersonation(
+    payload: SuperAdminImpersonationStartPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    try:
+        return start_admin_impersonation(
+            case_id=payload.case_id,
+            reason=payload.reason,
+            actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/impersonation/{session_id}/enable-editing")
+def super_admin_enable_impersonation_editing(
+    session_id: str,
+    payload: SuperAdminImpersonationEditingPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    try:
+        return enable_admin_impersonation_editing(
+            session_id=session_id,
+            reason=payload.reason,
+            actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/impersonation/{session_id}/stop")
+def super_admin_stop_impersonation(
+    session_id: str,
+    payload: SuperAdminImpersonationStopPayload | None = None,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    try:
+        return stop_admin_impersonation(
+            session_id=session_id,
+            reason=(payload.reason if payload else ""),
             actor=current_user,
         )
     except ValueError as exc:

--- a/backend/app/services/admin_access_bootstrap_service.py
+++ b/backend/app/services/admin_access_bootstrap_service.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from app.core.admin_permission_registry import (
+    CEO_MASTER_ADMIN_EMAIL,
     OFFICER_PROFILE_FIELDS,
     PERMISSION_REGISTRY,
     ROLE_METADATA,
@@ -108,6 +109,7 @@ def _sync_officer_assignments(db, now_iso: str) -> dict[str, Any]:
     assignments_updated = 0
     assignments_disabled = 0
 
+    ceo_master_admin_user_id = ""
     for email, expected_roles in mapping.items():
         user = users.find_one({"email": email})
         if user is None:
@@ -136,6 +138,8 @@ def _sync_officer_assignments(db, now_iso: str) -> dict[str, Any]:
         user_id = _normalize(user.get("_id"))
         if not user_id:
             continue
+        if email == CEO_MASTER_ADMIN_EMAIL:
+            ceo_master_admin_user_id = user_id
 
         for role_code in expected_roles:
             payload = {
@@ -167,12 +171,49 @@ def _sync_officer_assignments(db, now_iso: str) -> dict[str, Any]:
             )
             assignments_disabled += int(stale_result.modified_count)
 
+    if ceo_master_admin_user_id:
+        singleton_targets: list[str] = []
+        if hasattr(assignments, "find"):
+            for record in assignments.find(
+                {
+                    "role_code": {"$in": ["ceo_master_admin", "ceo_super_admin"]},
+                    "status": {"$in": ["active", "enabled", ""]},
+                }
+            ):
+                user_id = _normalize(record.get("user_id"))
+                if user_id and user_id != ceo_master_admin_user_id:
+                    singleton_targets.append(user_id)
+        else:
+            for record in (getattr(assignments, "documents", None) or []):
+                role_code = _normalize(record.get("role_code")).lower()
+                status = _normalize(record.get("status")).lower()
+                user_id = _normalize(record.get("user_id"))
+                if (
+                    role_code in {"ceo_master_admin", "ceo_super_admin"}
+                    and status in {"active", "enabled", ""}
+                    and user_id
+                    and user_id != ceo_master_admin_user_id
+                ):
+                    singleton_targets.append(user_id)
+        singleton_targets = sorted(set(singleton_targets))
+        if singleton_targets:
+            singleton_result = assignments.update_many(
+                {
+                    "role_code": {"$in": ["ceo_master_admin", "ceo_super_admin"]},
+                    "user_id": {"$in": singleton_targets},
+                    "status": {"$in": ["active", "enabled", ""]},
+                },
+                {"$set": {"status": "inactive", "updated_at": now_iso}},
+            )
+            assignments_disabled += int(singleton_result.modified_count)
+
     return {
         "updated_users": updated_users,
         "missing_users": missing_users,
         "assignments_created": assignments_created,
         "assignments_updated": assignments_updated,
         "assignments_disabled": assignments_disabled,
+        "ceo_master_admin_user_id": ceo_master_admin_user_id or None,
     }
 
 

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -8,8 +8,15 @@ from typing import Any, Callable
 from bson import ObjectId
 
 from app.config import settings
+from app.core.admin_permission_registry import (
+    CEO_MASTER_ADMIN_EMAIL,
+    OFFICER_PROFILE_FIELDS,
+    PERMISSION_REGISTRY,
+    ROLE_PERMISSION_MAP,
+)
 from app.core.package_catalog import (
     canonicalize_package_identifier,
+    get_addon,
     get_package,
     get_package_control_profile,
     normalize_package_code,
@@ -43,6 +50,20 @@ PAID_ORDER_STATUSES = {"paid", "succeeded", "complete", "completed"}
 OBJECT_ID_WRAPPER_PATTERN = re.compile(r"""^ObjectId\((["']?)([0-9a-fA-F]{24})\1\)$""")
 MAX_BULK_ACTION_LIMIT = 5000
 INTERNAL_ROLE_KEYS = set(INTERNAL_ADMIN_ROLE_CODES) | {"admin"}
+IMPERSONATION_SESSION_TTL_MINUTES = 30
+SERVICE_CONTROL_OPERATIONS = {
+    "assign",
+    "upgrade",
+    "downgrade",
+    "complimentary_package",
+    "promotional_package",
+    "internal_validation_account",
+}
+OFFICER_ADMIN_EMAILS = {
+    "jenn.wood@tomboflight.com",
+    "k.goffigan@tomboflight.com",
+    "marquis.l.floyd@tomboflight.com",
+}
 
 ADMIN_CONTROL_QUEUES = [
     "overview",
@@ -1916,7 +1937,353 @@ def super_admin_apply_package_change(
         "before": preview.get("before") or {},
         "after": after_snapshot,
         "changes": preview.get("changes") or [],
-        "repair_result": repaired,
+    }
+
+
+def _service_entitlement_view(*, package_code: str, entitlement: dict[str, Any] | None) -> dict[str, Any]:
+    package = get_package(package_code) or {}
+    resolved = dict((entitlement or {}).get("resolved_entitlements") or {})
+    active_addons = [
+        addon
+        for addon in ((entitlement or {}).get("active_addons") or [])
+        if _normalize(addon)
+    ]
+    package_addons = [_normalize(addon) for addon in (package.get("allowed_addons") or []) if _normalize(addon)]
+    addon_catalog: dict[str, dict[str, Any]] = {}
+    for addon_code in sorted(set(active_addons + package_addons)):
+        addon = get_addon(addon_code) or {}
+        addon_catalog[addon_code] = {
+            "display_name": _normalize(addon.get("display_name")) or addon_code,
+            "billing_type": _normalize(addon.get("billing_type")) or "unknown",
+            "price_usd": addon.get("price_usd"),
+            "active": addon_code in active_addons,
+        }
+    return {
+        "active_addons": active_addons,
+        "allowed_addons": package_addons,
+        "addon_catalog": addon_catalog,
+        "maintenance_state": _normalize((entitlement or {}).get("maintenance_status")) or "not_started",
+        "maintenance_plan": _normalize((entitlement or {}).get("maintenance_plan")) or "none",
+        "storage_gb": float(
+            resolved.get("max_storage_gb")
+            if resolved.get("max_storage_gb") is not None
+            else (package.get("max_storage_gb") or 0)
+        ),
+        "upload_allowance": int(
+            resolved.get("max_uploads")
+            if resolved.get("max_uploads") is not None
+            else (package.get("max_uploads") or 0)
+        ),
+        "member_allowance": int(
+            resolved.get("max_members")
+            if resolved.get("max_members") is not None
+            else (package.get("max_members") or 0)
+        ),
+        "narration_enabled": bool(
+            resolved.get("can_use_narration")
+            if resolved.get("can_use_narration") is not None
+            else package.get("can_use_narration")
+        ),
+        "vault_enabled": bool(
+            resolved.get("can_use_household_vault")
+            if resolved.get("can_use_household_vault") is not None
+            else package.get("can_use_household_vault")
+        ),
+        "scheduled_reveal_enabled": bool(
+            resolved.get("can_use_scheduled_reveal")
+            if resolved.get("can_use_scheduled_reveal") is not None
+            else package.get("can_use_scheduled_reveal")
+        ),
+        "link_keys_enabled": bool(
+            resolved.get("can_use_link_keys")
+            if resolved.get("can_use_link_keys") is not None
+            else package.get("can_use_link_keys")
+        ),
+        "certificate_access_enabled": bool(
+            resolved.get("can_use_lineage_certificate")
+            if resolved.get("can_use_lineage_certificate") is not None
+            else package.get("can_use_lineage_certificate")
+        ),
+        "viewer_access_enabled": bool(
+            resolved.get("can_use_viewer")
+            if resolved.get("can_use_viewer") is not None
+            else package.get("can_use_viewer")
+        ),
+        "service_operations_supported": sorted(
+            SERVICE_CONTROL_OPERATIONS
+            | {
+                "add_on_grant_removal",
+                "storage_adjustment",
+                "upload_adjustment",
+                "member_allowance_adjustment",
+                "narration",
+                "vault",
+                "scheduled_reveal",
+                "link_keys",
+                "certificate_access",
+                "viewer_access",
+                "maintenance_state",
+            }
+        ),
+    }
+
+
+def _apply_service_control_payload_to_preview(
+    *,
+    before: dict[str, Any],
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    proposed = {
+        "project": dict(before.get("project") or {}),
+        "order": dict(before.get("order") or {}),
+        "entitlement": dict(before.get("entitlement") or {}),
+        "service_controls": dict(before.get("service_controls") or {}),
+    }
+    operation = _normalize(payload.get("operation")).lower()
+    if operation and operation not in SERVICE_CONTROL_OPERATIONS:
+        raise ValueError("Unsupported service-control operation.")
+
+    target_package_code = normalize_package_code(_normalize(payload.get("package_code")))
+    if target_package_code:
+        target_package = get_package(target_package_code)
+        if not target_package:
+            raise ValueError("Unknown package code.")
+        target_lane = _normalize(payload.get("project_lane")).lower() or _normalize(target_package.get("package_lane")).lower()
+        if target_lane not in ALLOWED_LANES:
+            raise ValueError("Invalid project lane.")
+        proposed["project"]["package_code"] = target_package_code
+        proposed["project"]["package_slug"] = target_package_code
+        proposed["project"]["package_name"] = _normalize(target_package.get("display_name")) or target_package_code
+        proposed["project"]["project_lane"] = target_lane
+        proposed["order"]["package_code"] = target_package_code
+        proposed["order"]["package_slug"] = target_package_code
+        proposed["order"]["package_name"] = _normalize(target_package.get("display_name")) or target_package_code
+        proposed["order"]["lane"] = target_lane
+        proposed["order"]["package_lane"] = target_lane
+        proposed["entitlement"]["package_code"] = target_package_code
+        proposed["entitlement"]["package_lane"] = target_lane
+        proposed["service_controls"]["package_code"] = target_package_code
+        proposed["service_controls"]["operation"] = operation or "assign"
+    elif operation in SERVICE_CONTROL_OPERATIONS:
+        raise ValueError("package_code is required for package operation.")
+
+    active_addons = {
+        _normalize(addon)
+        for addon in (proposed["service_controls"].get("active_addons") or [])
+        if _normalize(addon)
+    }
+    add_addons = {
+        _normalize(addon)
+        for addon in (payload.get("add_addons") or [])
+        if _normalize(addon)
+    }
+    remove_addons = {
+        _normalize(addon)
+        for addon in (payload.get("remove_addons") or [])
+        if _normalize(addon)
+    }
+    for addon_code in add_addons:
+        if not get_addon(addon_code):
+            raise ValueError(f"Unknown add-on code: {addon_code}")
+        active_addons.add(addon_code)
+    for addon_code in remove_addons:
+        active_addons.discard(addon_code)
+    if add_addons or remove_addons:
+        proposed["service_controls"]["active_addons"] = sorted(active_addons)
+        proposed["entitlement"]["active_addons"] = sorted(active_addons)
+
+    maintenance_state = _normalize(payload.get("maintenance_state")).lower()
+    if maintenance_state:
+        proposed["service_controls"]["maintenance_state"] = maintenance_state
+        proposed["entitlement"]["maintenance_status"] = maintenance_state
+
+    storage_adjustment_gb = payload.get("storage_adjustment_gb")
+    upload_adjustment = payload.get("upload_adjustment")
+    member_allowance_adjustment = payload.get("member_allowance_adjustment")
+    controls = dict(proposed["service_controls"] or {})
+    if storage_adjustment_gb is not None:
+        controls["storage_gb"] = float(controls.get("storage_gb") or 0) + float(storage_adjustment_gb or 0)
+    if upload_adjustment is not None:
+        controls["upload_allowance"] = int(controls.get("upload_allowance") or 0) + int(upload_adjustment or 0)
+    if member_allowance_adjustment is not None:
+        controls["member_allowance"] = int(controls.get("member_allowance") or 0) + int(member_allowance_adjustment or 0)
+
+    for field_name in (
+        "narration_enabled",
+        "vault_enabled",
+        "scheduled_reveal_enabled",
+        "link_keys_enabled",
+        "certificate_access_enabled",
+        "viewer_access_enabled",
+    ):
+        if field_name not in payload:
+            continue
+        controls[field_name] = bool(payload.get(field_name))
+
+    if "account_flags" in payload:
+        flags = {_normalize(flag).lower() for flag in (payload.get("account_flags") or []) if _normalize(flag)}
+        controls["account_flags"] = sorted(flags)
+
+    proposed["service_controls"] = controls
+    return proposed
+
+
+def super_admin_preview_service_controls(
+    *,
+    project_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    normalized_project_id = _normalize(project_id)
+    if not normalized_project_id:
+        raise ValueError("Project id is required.")
+    project, order = _resolve_project_order_context(
+        normalized_project_id,
+        allow_owner_order_fallback=True,
+    )
+    entitlement = get_project_entitlement(_normalize(project.get("_id")))
+    package_fields = _package_fields_from_context(project, order, entitlement)
+    before = {
+        "project": {
+            "package_code": _normalize((project or {}).get("package_code")),
+            "package_slug": _normalize((project or {}).get("package_slug")),
+            "package_name": _normalize((project or {}).get("package_name")),
+            "project_lane": _normalize((project or {}).get("project_lane")),
+        },
+        "order": {
+            "package_code": _normalize((order or {}).get("package_code")),
+            "package_slug": _normalize((order or {}).get("package_slug")),
+            "package_name": _normalize((order or {}).get("package_name")),
+            "lane": _normalize((order or {}).get("lane")),
+            "package_lane": _normalize((order or {}).get("package_lane")),
+            "status": _normalize((order or {}).get("status")) if order else None,
+            "stripe_session_id": _normalize((order or {}).get("stripe_session_id")),
+            "payment_link_id": _normalize((order or {}).get("stripe_payment_link_id") or (order or {}).get("payment_link_id")),
+        },
+        "entitlement": {
+            "package_code": _normalize((entitlement or {}).get("package_code")),
+            "package_lane": _normalize((entitlement or {}).get("package_lane")),
+            "maintenance_plan": _normalize((entitlement or {}).get("maintenance_plan")),
+            "maintenance_status": _normalize((entitlement or {}).get("maintenance_status")),
+            "active_addons": list((entitlement or {}).get("active_addons") or []),
+            "resolved_entitlements": dict((entitlement or {}).get("resolved_entitlements") or {}),
+        },
+        "service_controls": _service_entitlement_view(
+            package_code=_normalize(package_fields.get("package_code")) or "legacy_snapshot",
+            entitlement=entitlement,
+        ),
+    }
+    proposed = _apply_service_control_payload_to_preview(before=before, payload=payload)
+    return {
+        "project_id": _normalize(project.get("_id")),
+        "order_id": _normalize((order or {}).get("_id")) or None,
+        "before": before,
+        "proposed_after": proposed,
+        "changes": _build_package_change_summary(before=before, proposed=proposed),
+        "validation": {
+            "project_exists": True,
+            "order_linked": bool(order),
+            "stripe_purchase_record_preserved": True,
+        },
+    }
+
+
+def super_admin_apply_service_controls(
+    *,
+    project_id: str,
+    payload: dict[str, Any],
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    preview = super_admin_preview_service_controls(project_id=project_id, payload=payload)
+    db = _db()
+    resolved_project_id = _normalize(preview.get("project_id"))
+    project_oid = _to_object_id(resolved_project_id)
+    if project_oid is None:
+        raise ValueError("Project id is invalid.")
+
+    project_after = dict((preview.get("proposed_after") or {}).get("project") or {})
+    if project_after:
+        project_after["updated_at"] = _now()
+        db["projects"].update_one({"_id": project_oid}, {"$set": project_after})
+
+    order_id = _normalize(preview.get("order_id"))
+    if order_id:
+        order_doc = _order_by_id(order_id)
+        if order_doc is not None:
+            order_updates = dict((preview.get("proposed_after") or {}).get("order") or {})
+            order_updates = {key: value for key, value in order_updates.items() if value is not None}
+            order_updates.pop("status", None)
+            order_updates.pop("stripe_session_id", None)
+            order_updates.pop("payment_link_id", None)
+            order_updates.pop("stripe_payment_intent_id", None)
+            if order_updates:
+                db["orders"].update_one({"_id": order_doc.get("_id")}, {"$set": order_updates})
+
+    entitlement_before = dict(((preview.get("before") or {}).get("entitlement") or {}))
+    entitlement_after = dict(((preview.get("proposed_after") or {}).get("entitlement") or {}))
+    entitlement_doc = get_project_entitlement(resolved_project_id) or {}
+    existing_resolved = dict((entitlement_doc or {}).get("resolved_entitlements") or {})
+    existing_resolved.update(
+        {
+            "max_storage_gb": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("storage_gb"),
+            "max_uploads": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("upload_allowance"),
+            "max_members": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("member_allowance"),
+            "can_use_narration": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("narration_enabled"),
+            "can_use_household_vault": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("vault_enabled"),
+            "can_use_scheduled_reveal": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("scheduled_reveal_enabled"),
+            "can_use_link_keys": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("link_keys_enabled"),
+            "can_use_lineage_certificate": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("certificate_access_enabled"),
+            "can_use_viewer": ((preview.get("proposed_after") or {}).get("service_controls") or {}).get("viewer_access_enabled"),
+        }
+    )
+    existing_resolved = {key: value for key, value in existing_resolved.items() if value is not None}
+
+    entitlement_updates = {
+        "package_code": entitlement_after.get("package_code") or entitlement_before.get("package_code"),
+        "package_lane": entitlement_after.get("package_lane") or entitlement_before.get("package_lane"),
+        "maintenance_status": entitlement_after.get("maintenance_status") or entitlement_before.get("maintenance_status"),
+        "active_addons": entitlement_after.get("active_addons") or entitlement_before.get("active_addons") or [],
+        "resolved_entitlements": existing_resolved,
+        "admin_service_controls": (preview.get("proposed_after") or {}).get("service_controls") or {},
+        "updated_at": _now(),
+    }
+    entitlement_filter = {"project_id": {"$in": _project_id_candidates(resolved_project_id)}}
+    existing_entitlement_doc = db["project_entitlements"].find_one(entitlement_filter)
+    if existing_entitlement_doc is not None:
+        db["project_entitlements"].update_one({"_id": existing_entitlement_doc.get("_id")}, {"$set": entitlement_updates})
+    else:
+        user_id = _normalize((project_after or {}).get("owner_user_id") or (_project_by_id(resolved_project_id) or {}).get("owner_user_id"))
+        entitlement_insert = dict(entitlement_updates)
+        entitlement_insert.update(
+            {
+                "project_id": _to_object_id(resolved_project_id) or resolved_project_id,
+                "user_id": _to_object_id(user_id) or user_id or None,
+                "status": "active",
+                "created_at": _now(),
+            }
+        )
+        db["project_entitlements"].insert_one(entitlement_insert)
+
+    _write_admin_action_audit(
+        actor=actor,
+        action="super_admin.service_controls",
+        target_type="project",
+        target_id=resolved_project_id,
+        before=preview.get("before") or {},
+        after=preview.get("proposed_after") or {},
+        context={
+            "surface": "admin_control_center.package_services",
+            "order_id": order_id or None,
+            "stripe_purchase_record_preserved": True,
+        },
+        details={"changes": preview.get("changes") or []},
+    )
+    return {
+        "project_id": resolved_project_id,
+        "order_id": order_id or None,
+        "before": preview.get("before") or {},
+        "after": preview.get("proposed_after") or {},
+        "changes": preview.get("changes") or [],
+        "stripe_purchase_record_preserved": True,
     }
 
 
@@ -3275,11 +3642,11 @@ def _flexible_name_regex(search: str) -> dict[str, Any] | None:
     return {"$regex": r"\s+".join(re.escape(part) for part in parts), "$options": "i"}
 
 
-def _search_seed_sets(search: str) -> tuple[set[str], set[str], set[str], set[str]]:
+def _search_seed_sets(search: str) -> tuple[set[str], set[str], set[str], set[str], set[str]]:
     db = _db()
     regex = _search_regex(search)
     if regex is None:
-        return set(), set(), set(), set()
+        return set(), set(), set(), set(), set()
     flexible_name_regex = _flexible_name_regex(search) or regex
     name_parts = [part for part in re.split(r"\s+", _normalize(search)) if part]
     first_last_filter: dict[str, Any] | None = None
@@ -3294,6 +3661,7 @@ def _search_seed_sets(search: str) -> tuple[set[str], set[str], set[str], set[st
     user_emails: set[str] = set()
     user_ids: set[str] = set()
     family_ids: set[str] = set()
+    household_ids: set[str] = set()
     project_ids_from_mint: set[str] = set()
 
     user_search_filters: list[dict[str, Any]] = [
@@ -3330,6 +3698,14 @@ def _search_seed_sets(search: str) -> tuple[set[str], set[str], set[str], set[st
         if family_id:
             family_ids.add(family_id)
 
+    for household in db["households"].find(
+        {"$or": [{"household_name": regex}, {"name": regex}]},
+        {"_id": 1},
+    ).limit(200):
+        household_id = _normalize(household.get("_id"))
+        if household_id:
+            household_ids.add(household_id)
+
     for mint_record in db["mint_records"].find(
         {
             "$or": [
@@ -3346,7 +3722,7 @@ def _search_seed_sets(search: str) -> tuple[set[str], set[str], set[str], set[st
         if project_id:
             project_ids_from_mint.add(project_id)
 
-    return user_emails, user_ids, family_ids, project_ids_from_mint
+    return user_emails, user_ids, family_ids, household_ids, project_ids_from_mint
 
 
 def _order_supports_search(order: dict[str, Any], search: str, user_emails: set[str]) -> bool:
@@ -3364,8 +3740,12 @@ def _order_supports_search(order: dict[str, Any], search: str, user_emails: set[
             _normalize(order.get("project_id")),
             _normalize(order.get("stripe_session_id")),
             _normalize(order.get("stripe_payment_link_id")),
+            _normalize(order.get("stripe_payment_intent_id")),
+            _normalize(order.get("stripe_customer_id")),
+            _normalize(order.get("stripe_subscription_id")),
             _normalize(order.get("session_id")),
             _normalize(order.get("order_id")),
+            _normalize(order.get("workflow_state")),
             _normalize(order.get("wallet_address")),
             _normalize(order.get("token_id")),
             _normalize(order.get("certificate_id")),
@@ -3381,10 +3761,12 @@ def _order_supports_search(order: dict[str, Any], search: str, user_emails: set[
 def _project_supports_search(
     project: dict[str, Any],
     *,
+    order: dict[str, Any] | None = None,
     search: str,
     user_emails: set[str],
     user_ids: set[str],
     family_ids: set[str],
+    household_ids: set[str],
     mint_project_ids: set[str],
 ) -> bool:
     normalized_search = _normalize(search).lower()
@@ -3407,11 +3789,21 @@ def _project_supports_search(
             _normalize(project.get("project_lane")),
             _normalize(project.get("status")),
             _normalize(project.get("phase")),
+            _normalize(project.get("workflow_state")),
             _normalize(project.get("wallet_address")),
             _normalize(project.get("token_id")),
             _normalize(project.get("certificate_id")),
             _normalize(project.get("id_last4")),
             _normalize(project.get("government_id_last4")),
+            _normalize((order or {}).get("_id")),
+            _normalize((order or {}).get("order_id")),
+            _normalize((order or {}).get("stripe_session_id")),
+            _normalize((order or {}).get("stripe_payment_link_id")),
+            _normalize((order or {}).get("payment_link_id")),
+            _normalize((order or {}).get("stripe_subscription_id")),
+            _normalize((order or {}).get("stripe_customer_id")),
+            _normalize((order or {}).get("stripe_payment_intent_id")),
+            _normalize((order or {}).get("status")),
         ]
     ).lower()
     if normalized_search in haystack:
@@ -3419,11 +3811,13 @@ def _project_supports_search(
     owner_email = _normalize_email(project.get("owner_email"))
     owner_user_id = _normalize(project.get("owner_user_id"))
     family_id = _normalize(project.get("family_id"))
+    household_id = _normalize(project.get("household_id"))
     return bool(
         project_id in mint_project_ids
         or owner_email in user_emails
         or owner_user_id in user_ids
         or family_id in family_ids
+        or household_id in household_ids
     )
 
 
@@ -3969,6 +4363,214 @@ def super_admin_list_users(*, search: str = "", limit: int = 100) -> dict[str, A
     return {"items": items, "total": len(items)}
 
 
+def _officer_role_assignments(user_id: str) -> list[str]:
+    db = _db()
+    roles: set[str] = set()
+    for assignment in db["user_role_assignments"].find(
+        {
+            "user_id": user_id,
+            "status": {"$in": ["active", "enabled", ""]},
+        }
+    ):
+        role_code = normalize_role_code(_normalize(assignment.get("role_code")))
+        if role_code:
+            roles.add(role_code)
+    return sorted(roles)
+
+
+def _officer_permission_overrides(user_id: str) -> list[str]:
+    db = _db()
+    permissions: set[str] = set()
+    for item in db["user_permission_overrides"].find(
+        {
+            "user_id": user_id,
+            "status": {"$in": ["active", "enabled", ""]},
+        }
+    ):
+        permission_code = _normalize(item.get("permission_code"))
+        if permission_code:
+            permissions.add(permission_code)
+    return sorted(permissions)
+
+
+def super_admin_list_officers() -> dict[str, Any]:
+    db = _db()
+    items: list[dict[str, Any]] = []
+    for email in sorted(OFFICER_ADMIN_EMAILS):
+        user = _find_case_user(email=email)
+        profile = OFFICER_PROFILE_FIELDS.get(email) or {}
+        if user is None:
+            items.append(
+                {
+                    "email": email,
+                    "full_name": profile.get("full_name"),
+                    "business_title": profile.get("business_title"),
+                    "expected_access_tier": profile.get("access_tier"),
+                    "expected_department_role": profile.get("department_role"),
+                    "status": "missing_user",
+                    "role_assignments": [],
+                    "permission_overrides": [],
+                }
+            )
+            continue
+        user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id")) or _normalize(user.get("user_id"))
+        items.append(
+            {
+                "user_id": user_id,
+                "email": _normalize_email(user.get("email")) or email,
+                "full_name": _user_display_name(user),
+                "business_title": _normalize(user.get("business_title")) or profile.get("business_title"),
+                "status": _normalize(user.get("status")) or "active",
+                "current_role": _user_role_value(user),
+                "access_tier": _normalize(user.get("access_tier")) or None,
+                "department_role": _normalize(user.get("department_role")) or None,
+                "expected_access_tier": profile.get("access_tier"),
+                "expected_department_role": profile.get("department_role"),
+                "role_assignments": _officer_role_assignments(user_id),
+                "permission_overrides": _officer_permission_overrides(user_id),
+            }
+        )
+    return {"items": items, "total": len(items)}
+
+
+def super_admin_preview_officer_permissions(
+    *,
+    officer_email: str,
+    role_assignments: list[str] | None = None,
+    grant_permissions: list[str] | None = None,
+    revoke_permissions: list[str] | None = None,
+) -> dict[str, Any]:
+    normalized_email = _normalize_email(officer_email)
+    if normalized_email not in OFFICER_ADMIN_EMAILS:
+        raise ValueError("Officer email is not managed by this workflow.")
+    user = _find_case_user(email=normalized_email)
+    if user is None:
+        raise ValueError("Officer user was not found.")
+    user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id")) or _normalize(user.get("user_id"))
+    before_roles = set(_officer_role_assignments(user_id))
+    before_permissions = set(_officer_permission_overrides(user_id))
+
+    target_roles = {
+        normalize_role_code(role_code)
+        for role_code in (role_assignments or [])
+        if normalize_role_code(role_code)
+    }
+    for role_code in target_roles:
+        if role_code == "ceo_master_admin":
+            raise ValueError("ceo_master_admin cannot be assigned through officer management.")
+
+    after_roles = set(before_roles)
+    if target_roles:
+        after_roles = target_roles
+
+    after_permissions = set(before_permissions)
+    for permission in grant_permissions or []:
+        permission_code = _normalize(permission)
+        if permission_code not in PERMISSION_REGISTRY:
+            raise ValueError(f"Unknown permission code: {permission_code}")
+        after_permissions.add(permission_code)
+    for permission in revoke_permissions or []:
+        after_permissions.discard(_normalize(permission))
+
+    expected_profile = OFFICER_PROFILE_FIELDS.get(normalized_email) or {}
+    return {
+        "officer_email": normalized_email,
+        "user_id": user_id,
+        "before": {
+            "role_assignments": sorted(before_roles),
+            "permission_overrides": sorted(before_permissions),
+            "access_tier": _normalize(user.get("access_tier")) or None,
+            "department_role": _normalize(user.get("department_role")) or None,
+        },
+        "proposed_after": {
+            "role_assignments": sorted(after_roles),
+            "permission_overrides": sorted(after_permissions),
+            "access_tier": _normalize(expected_profile.get("access_tier")) or _normalize(user.get("access_tier")) or None,
+            "department_role": _normalize(expected_profile.get("department_role")) or _normalize(user.get("department_role")) or None,
+        },
+        "changes": _build_package_change_summary(
+            before={
+                "officer": {
+                    "role_assignments": sorted(before_roles),
+                    "permission_overrides": sorted(before_permissions),
+                }
+            },
+            proposed={
+                "officer": {
+                    "role_assignments": sorted(after_roles),
+                    "permission_overrides": sorted(after_permissions),
+                }
+            },
+        ),
+    }
+
+
+def super_admin_apply_officer_permissions(
+    *,
+    officer_email: str,
+    role_assignments: list[str] | None = None,
+    grant_permissions: list[str] | None = None,
+    revoke_permissions: list[str] | None = None,
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    preview = super_admin_preview_officer_permissions(
+        officer_email=officer_email,
+        role_assignments=role_assignments,
+        grant_permissions=grant_permissions,
+        revoke_permissions=revoke_permissions,
+    )
+    db = _db()
+    user_id = _normalize(preview.get("user_id"))
+    if not user_id:
+        raise ValueError("Officer user is missing an id.")
+    now_value = _now()
+    for role_code in preview.get("proposed_after", {}).get("role_assignments", []):
+        db["user_role_assignments"].update_one(
+            {"user_id": user_id, "role_code": role_code},
+            {"$set": {"status": "active", "updated_at": now_value}, "$setOnInsert": {"created_at": now_value}},
+            upsert=True,
+        )
+    db["user_role_assignments"].update_many(
+        {
+            "user_id": user_id,
+            "role_code": {"$nin": preview.get("proposed_after", {}).get("role_assignments", [])},
+            "status": {"$in": ["active", "enabled", ""]},
+        },
+        {"$set": {"status": "inactive", "updated_at": now_value}},
+    )
+    for permission_code in preview.get("proposed_after", {}).get("permission_overrides", []):
+        db["user_permission_overrides"].update_one(
+            {"user_id": user_id, "permission_code": permission_code},
+            {"$set": {"status": "active", "updated_at": now_value}, "$setOnInsert": {"created_at": now_value}},
+            upsert=True,
+        )
+    db["user_permission_overrides"].update_many(
+        {
+            "user_id": user_id,
+            "permission_code": {"$nin": preview.get("proposed_after", {}).get("permission_overrides", [])},
+            "status": {"$in": ["active", "enabled", ""]},
+        },
+        {"$set": {"status": "inactive", "updated_at": now_value}},
+    )
+    _write_admin_action_audit(
+        actor=actor,
+        action="super_admin.officer_permissions",
+        target_type="user",
+        target_id=user_id,
+        before=preview.get("before") or {},
+        after=preview.get("proposed_after") or {},
+        context={"surface": "admin_control_center.officer_management", "officer_email": _normalize_email(officer_email)},
+        details={"changes": preview.get("changes") or []},
+    )
+    return {
+        "officer_email": _normalize_email(officer_email),
+        "user_id": user_id,
+        "before": preview.get("before") or {},
+        "after": preview.get("proposed_after") or {},
+        "changes": preview.get("changes") or [],
+    }
+
+
 def _validate_super_admin_email(email: str, *, user_id: str) -> str:
     normalized = _normalize_email(email)
     if not normalized or "@" not in normalized:
@@ -4001,6 +4603,17 @@ def _is_internal_admin_account(user: dict[str, Any]) -> bool:
     if _normalize(user.get("account_type")).lower() == "business_admin":
         return True
     return False
+
+
+def _is_canonical_ceo_master_admin_identity(user: dict[str, Any]) -> bool:
+    return _normalize_email(user.get("email")) == CEO_MASTER_ADMIN_EMAIL
+
+
+def _enforce_ceo_master_admin_singleton(*, target_user: dict[str, Any], new_role: str) -> None:
+    if new_role != "ceo_master_admin":
+        return
+    if not _is_canonical_ceo_master_admin_identity(target_user):
+        raise ValueError("ceo_master_admin role can only be assigned to Larry Robinson's canonical identity.")
 
 
 def super_admin_update_user(
@@ -4036,6 +4649,7 @@ def super_admin_update_user(
         updates["status"] = status_value
     if "role" in payload:
         new_role = _validated_role_value(_normalize(payload.get("role")))
+        _enforce_ceo_master_admin_singleton(target_user=user, new_role=new_role)
         # Granting super_admin role is high-impact.  Require that the target
         # user is already an internal admin account (not a customer account).
         # This prevents accidental or malicious escalation of customer accounts
@@ -4047,9 +4661,15 @@ def super_admin_update_user(
             )
         updates["role"] = new_role
     if "access_tier" in payload:
-        updates["access_tier"] = normalize_role_code(_normalize(payload.get("access_tier"))) or None
+        access_tier = normalize_role_code(_normalize(payload.get("access_tier"))) or None
+        if access_tier:
+            _enforce_ceo_master_admin_singleton(target_user=user, new_role=access_tier)
+        updates["access_tier"] = access_tier
     if "department_role" in payload:
-        updates["department_role"] = normalize_role_code(_normalize(payload.get("department_role"))) or None
+        department_role = normalize_role_code(_normalize(payload.get("department_role"))) or None
+        if department_role:
+            _enforce_ceo_master_admin_singleton(target_user=user, new_role=department_role)
+        updates["department_role"] = department_role
 
     if len(updates) == 1:
         raise ValueError("No valid updates were provided.")
@@ -4114,6 +4734,298 @@ def super_admin_apply_user_state_action(
         payload={"status": mapped_status},
         actor=actor,
     )
+
+
+def _impersonation_collection():
+    return _db()["admin_impersonation_sessions"]
+
+
+def _resolve_impersonation_target(case_id: str) -> dict[str, Any]:
+    normalized_case_id = _normalize(case_id)
+    if not normalized_case_id:
+        raise ValueError("case_id is required.")
+
+    project = None
+    order = None
+    user = None
+    project_id = ""
+    user_id = ""
+    display_name = ""
+
+    if normalized_case_id.startswith("user:"):
+        user_id = normalized_case_id.split(":", 1)[1]
+        user = _find_case_user(user_id=user_id)
+        if user is None:
+            raise ValueError("Target customer user was not found.")
+    elif normalized_case_id.startswith("order:"):
+        order_id = normalized_case_id.split(":", 1)[1]
+        order = _order_by_id(order_id)
+        if order is None:
+            raise ValueError("Target order was not found.")
+        project_id = _normalize(order.get("project_id"))
+        if project_id:
+            project = _project_by_id(project_id)
+            if project is not None:
+                user = _find_case_user(
+                    user_id=_normalize(project.get("owner_user_id")),
+                    email=_normalize_email(project.get("owner_email")),
+                )
+        if user is None:
+            user = _find_case_user(
+                user_id=_normalize(order.get("user_id")),
+                email=_normalize_email(order.get("email")),
+            )
+    else:
+        project_id = normalized_case_id
+        project = _project_by_id(project_id)
+        if project is None:
+            raise ValueError("Target project was not found.")
+        user = _find_case_user(
+            user_id=_normalize(project.get("owner_user_id")),
+            email=_normalize_email(project.get("owner_email")),
+        )
+
+    if user is None:
+        raise ValueError("Target customer user was not found.")
+    user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id") or user.get("user_id"))
+    if not user_id:
+        raise ValueError("Target customer user id is missing.")
+    if not project_id:
+        project_id = _normalize((project or {}).get("_id") or (order or {}).get("project_id"))
+    display_name = _user_display_name(user) or _normalize((project or {}).get("name")) or "Customer"
+
+    return {
+        "case_id": normalized_case_id,
+        "user_id": user_id,
+        "project_id": project_id or None,
+        "display_name": display_name,
+        "email": _normalize_email(user.get("email")) or None,
+    }
+
+
+def _impersonation_doc_to_payload(document: dict[str, Any] | None) -> dict[str, Any]:
+    if not document:
+        return {"active": False}
+    return {
+        "active": _normalize(document.get("status")).lower() == "active",
+        "session_id": _normalize(document.get("session_id")) or _normalize_object_id(document.get("_id")),
+        "status": _normalize(document.get("status")) or "inactive",
+        "case_id": _normalize(document.get("case_id")) or None,
+        "project_id": _normalize(document.get("project_id")) or None,
+        "impersonated_user_id": _normalize(document.get("impersonated_user_id")) or None,
+        "impersonated_customer_name": _normalize(document.get("impersonated_customer_name")) or None,
+        "started_at": _serialize_datetime(document.get("started_at")),
+        "expires_at": _serialize_datetime(document.get("expires_at")),
+        "ended_at": _serialize_datetime(document.get("ended_at")),
+        "reason": _normalize(document.get("reason")) or None,
+        "editing_enabled": bool(document.get("editing_enabled")),
+        "editing_enabled_at": _serialize_datetime(document.get("editing_enabled_at")),
+        "editing_reason": _normalize(document.get("editing_reason")) or None,
+        "banner": f"Viewing Tomb of Light as {_normalize(document.get('impersonated_customer_name')) or 'Customer'}",
+    }
+
+
+def _active_impersonation_for_actor(actor_user_id: str) -> dict[str, Any] | None:
+    sessions = _impersonation_collection().find(
+        {
+            "actor_user_id": actor_user_id,
+            "status": {"$in": ["active"]},
+        }
+    ).sort("started_at", -1).limit(5)
+    for session in sessions:
+        return session
+    return None
+
+
+def _expire_stale_impersonation_sessions(actor_user_id: str) -> None:
+    now = _now()
+    sessions = _impersonation_collection().find(
+        {"actor_user_id": actor_user_id, "status": {"$in": ["active"]}}
+    ).sort("started_at", -1).limit(20)
+    for session in sessions:
+        expires_at = _coerce_datetime(session.get("expires_at"))
+        if expires_at is None or expires_at > now:
+            continue
+        _impersonation_collection().update_one(
+            {"_id": session.get("_id")},
+            {"$set": {"status": "expired", "ended_at": now, "updated_at": now}},
+        )
+
+
+def start_admin_impersonation(
+    *,
+    case_id: str,
+    reason: str,
+    actor: dict[str, Any] | None,
+) -> dict[str, Any]:
+    actor_snapshot = _super_admin_actor_snapshot(actor)
+    actor_user_id = _normalize(actor_snapshot.get("actor_user_id"))
+    if not actor_user_id:
+        raise ValueError("Actor user id is required.")
+    normalized_reason = _normalize(reason)
+    if not normalized_reason:
+        raise ValueError("A reason is required to start impersonation.")
+
+    _expire_stale_impersonation_sessions(actor_user_id)
+    active_session = _active_impersonation_for_actor(actor_user_id)
+    if active_session is not None:
+        raise ValueError("An active impersonation session already exists. Exit it before starting another.")
+
+    target = _resolve_impersonation_target(case_id)
+    now = _now()
+    session_id = secrets.token_urlsafe(24)
+    payload = {
+        "session_id": session_id,
+        "status": "active",
+        "actor_user_id": actor_user_id,
+        "actor_email": actor_snapshot.get("actor_email"),
+        "actor_name": actor_snapshot.get("actor_name"),
+        "actor_role": actor_snapshot.get("actor_role"),
+        "impersonated_user_id": target["user_id"],
+        "impersonated_customer_name": target["display_name"],
+        "impersonated_email": target["email"],
+        "project_id": target["project_id"],
+        "case_id": target["case_id"],
+        "reason": normalized_reason,
+        "editing_enabled": False,
+        "started_at": now,
+        "expires_at": now + timedelta(minutes=IMPERSONATION_SESSION_TTL_MINUTES),
+        "created_at": now,
+        "updated_at": now,
+    }
+    _impersonation_collection().insert_one(payload)
+    _write_admin_action_audit(
+        actor=actor,
+        action="impersonation.start",
+        target_type="user",
+        target_id=target["user_id"],
+        after={
+            "session_id": session_id,
+            "project_id": target["project_id"],
+            "case_id": target["case_id"],
+            "editing_enabled": False,
+        },
+        context={"surface": "admin_control_center.impersonation", "read_only": True},
+        details={"reason": normalized_reason},
+    )
+    return _impersonation_doc_to_payload(payload)
+
+
+def enable_admin_impersonation_editing(
+    *,
+    session_id: str,
+    reason: str,
+    actor: dict[str, Any] | None,
+) -> dict[str, Any]:
+    actor_snapshot = _super_admin_actor_snapshot(actor)
+    actor_user_id = _normalize(actor_snapshot.get("actor_user_id"))
+    normalized_reason = _normalize(reason)
+    if not actor_user_id:
+        raise ValueError("Actor user id is required.")
+    if not normalized_reason:
+        raise ValueError("A reason is required to enable admin editing.")
+    normalized_session_id = _normalize(session_id)
+    if not normalized_session_id:
+        raise ValueError("session_id is required.")
+
+    _expire_stale_impersonation_sessions(actor_user_id)
+    session = _impersonation_collection().find_one(
+        {"session_id": normalized_session_id, "actor_user_id": actor_user_id, "status": "active"}
+    )
+    if session is None:
+        raise ValueError("Active impersonation session not found.")
+
+    now = _now()
+    expires_at = _coerce_datetime(session.get("expires_at"))
+    if expires_at is not None and expires_at <= now:
+        _impersonation_collection().update_one(
+            {"_id": session.get("_id")},
+            {"$set": {"status": "expired", "ended_at": now, "updated_at": now}},
+        )
+        raise ValueError("Impersonation session has expired.")
+
+    _impersonation_collection().update_one(
+        {"_id": session.get("_id")},
+        {
+            "$set": {
+                "editing_enabled": True,
+                "editing_enabled_at": now,
+                "editing_reason": normalized_reason,
+                "updated_at": now,
+            }
+        },
+    )
+    refreshed = _impersonation_collection().find_one({"_id": session.get("_id")}) or session
+    _write_admin_action_audit(
+        actor=actor,
+        action="impersonation.enable_editing",
+        target_type="impersonation_session",
+        target_id=normalized_session_id,
+        before={"editing_enabled": bool(session.get("editing_enabled"))},
+        after={"editing_enabled": True, "editing_reason": normalized_reason},
+        context={"surface": "admin_control_center.impersonation"},
+    )
+    return _impersonation_doc_to_payload(refreshed)
+
+
+def stop_admin_impersonation(
+    *,
+    session_id: str,
+    actor: dict[str, Any] | None,
+    reason: str = "",
+) -> dict[str, Any]:
+    actor_snapshot = _super_admin_actor_snapshot(actor)
+    actor_user_id = _normalize(actor_snapshot.get("actor_user_id"))
+    normalized_session_id = _normalize(session_id)
+    if not actor_user_id:
+        raise ValueError("Actor user id is required.")
+    if not normalized_session_id:
+        raise ValueError("session_id is required.")
+
+    session = _impersonation_collection().find_one(
+        {"session_id": normalized_session_id, "actor_user_id": actor_user_id, "status": "active"}
+    )
+    if session is None:
+        raise ValueError("Active impersonation session not found.")
+
+    now = _now()
+    normalized_reason = _normalize(reason)
+    _impersonation_collection().update_one(
+        {"_id": session.get("_id")},
+        {
+            "$set": {
+                "status": "stopped",
+                "ended_at": now,
+                "stop_reason": normalized_reason or "operator_exit",
+                "updated_at": now,
+            }
+        },
+    )
+    refreshed = _impersonation_collection().find_one({"_id": session.get("_id")}) or session
+    _write_admin_action_audit(
+        actor=actor,
+        action="impersonation.stop",
+        target_type="impersonation_session",
+        target_id=normalized_session_id,
+        before={"status": "active"},
+        after={"status": "stopped"},
+        context={"surface": "admin_control_center.impersonation"},
+        details={"reason": normalized_reason or None},
+    )
+    return _impersonation_doc_to_payload(refreshed)
+
+
+def active_admin_impersonation(
+    *,
+    actor: dict[str, Any] | None,
+) -> dict[str, Any]:
+    actor_snapshot = _super_admin_actor_snapshot(actor)
+    actor_user_id = _normalize(actor_snapshot.get("actor_user_id"))
+    if not actor_user_id:
+        raise ValueError("Actor user id is required.")
+    _expire_stale_impersonation_sessions(actor_user_id)
+    session = _active_impersonation_for_actor(actor_user_id)
+    return _impersonation_doc_to_payload(session)
 
 
 def _user_id_candidates(user: dict[str, Any]) -> list[Any]:
@@ -4434,6 +5346,125 @@ def _mint_record_snapshot(project_id: str) -> dict[str, Any]:
     }
 
 
+def _vault_metadata_snapshot(*, project_id: str, owner_user_id: str = "", owner_email: str = "") -> dict[str, Any]:
+    if not project_id:
+        return {
+            "vault_item_count": 0,
+            "scheduled_reveal_count": 0,
+            "collection_count": 0,
+            "access_grant_count": 0,
+            "release_rule_count": 0,
+            "audit_event_count": 0,
+            "latest_item_updated_at": None,
+        }
+    db = _db()
+    project_candidates = _project_id_candidates(project_id)
+    owner_candidates = [owner for owner in {_normalize(owner_user_id), _normalize(owner_email)} if owner]
+    item_filters = [{"project_id": {"$in": project_candidates}}]
+    if owner_candidates:
+        item_filters.append({"owner_user_id": {"$in": owner_candidates}})
+    item_query = {"$or": item_filters} if len(item_filters) > 1 else item_filters[0]
+    item_cursor = db["vault_items"].find(item_query).sort("updated_at", -1).limit(200)
+    items = list(item_cursor)
+    item_ids = [_normalize_object_id(item.get("_id")) for item in items if _normalize_object_id(item.get("_id"))]
+    scheduled_reveal_count = sum(
+        1
+        for item in items
+        if _normalize(item.get("release_state")).lower() == "scheduled" or bool(item.get("reveal_at"))
+    )
+    grant_count = db["vault_access_grants"].count_documents({"vault_item_id": {"$in": item_ids}}) if item_ids else 0
+    release_rule_count = db["vault_release_rules"].count_documents({"vault_item_id": {"$in": item_ids}}) if item_ids else 0
+    audit_event_count = db["vault_audit_events"].count_documents({"vault_item_id": {"$in": item_ids}}) if item_ids else 0
+    collection_count = db["vault_collections"].count_documents({"project_id": {"$in": project_candidates}})
+    return {
+        "vault_item_count": len(items),
+        "scheduled_reveal_count": scheduled_reveal_count,
+        "collection_count": collection_count,
+        "access_grant_count": grant_count,
+        "release_rule_count": release_rule_count,
+        "audit_event_count": audit_event_count,
+        "latest_item_updated_at": _serialize_datetime((items[0] or {}).get("updated_at")) if items else None,
+    }
+
+
+def _decorate_account_360_workspace(workspace: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(workspace or {})
+    tabs = dict(payload.get("tabs") or {})
+    identity = dict(tabs.get("identity") or {})
+    package_services = dict(tabs.get("package_lane") or {})
+    family_household = dict(tabs.get("project") or {})
+    uploads = dict(tabs.get("uploads_verification") or {})
+    billing = dict(tabs.get("orders_billing") or {})
+    mint = dict(tabs.get("mint_readiness") or {})
+    audit_history = tabs.get("audit_timeline") or []
+    entitlement = dict(tabs.get("entitlements") or {})
+    project_snapshot = dict(payload.get("project") or {})
+    order_snapshot = dict(payload.get("order") or {})
+    project_id = _normalize((family_household or {}).get("project_id") or project_snapshot.get("id"))
+    owner_user_id = _normalize(identity.get("user_id") or project_snapshot.get("owner_user_id"))
+    owner_email = _normalize_email(identity.get("email") or project_snapshot.get("owner_email"))
+    vault_metadata = _vault_metadata_snapshot(
+        project_id=project_id,
+        owner_user_id=owner_user_id,
+        owner_email=owner_email,
+    )
+
+    tabs["overview"] = {
+        "case_id": payload.get("case_id"),
+        "user_id": identity.get("user_id"),
+        "name": identity.get("full_name"),
+        "email": identity.get("email"),
+        "project_id": project_id or None,
+        "order_id": _normalize(order_snapshot.get("id") or order_snapshot.get("_id")) or None,
+        "family_id": ((family_household.get("linked_family") or {}).get("family_id")),
+        "household_id": ((family_household.get("linked_family") or {}).get("household_id")),
+        "package_code": package_services.get("package_code"),
+        "package_name": package_services.get("package_name"),
+        "workflow_state": family_household.get("build_status") or project_snapshot.get("status"),
+        "workflow_phase": family_household.get("phase") or project_snapshot.get("phase"),
+        "alerts": list(payload.get("alerts") or []),
+    }
+    tabs["package_services"] = {
+        **package_services,
+        "service_controls": entitlement.get("admin_service_controls")
+        or _service_entitlement_view(
+            package_code=_normalize(package_services.get("package_code")) or "legacy_snapshot",
+            entitlement={
+                "resolved_entitlements": entitlement.get("resolved_entitlements") or {},
+                "active_addons": entitlement.get("active_addons") or [],
+                "maintenance_status": entitlement.get("maintenance_status"),
+                "maintenance_plan": entitlement.get("maintenance_plan"),
+            },
+        ),
+    }
+    tabs["family_household"] = {
+        **family_household,
+        "family_id": ((family_household.get("linked_family") or {}).get("family_id")),
+        "household_id": ((family_household.get("linked_family") or {}).get("household_id")),
+        "family_name": ((family_household.get("linked_family") or {}).get("family_name")),
+        "household_name": ((family_household.get("linked_family") or {}).get("household_name")),
+    }
+    tabs["production"] = {
+        "project_id": project_id or None,
+        "build_status": family_household.get("build_status") or project_snapshot.get("status"),
+        "phase": family_household.get("phase") or project_snapshot.get("phase"),
+        "source": family_household.get("source") or project_snapshot.get("source"),
+        "readiness_summary": dict(payload.get("readiness") or {}),
+    }
+    tabs["uploads"] = uploads
+    tabs["vault_metadata"] = {
+        **entitlement,
+        **vault_metadata,
+        "can_use_household_vault": bool((entitlement.get("resolved_entitlements") or {}).get("can_use_household_vault")),
+        "can_use_scheduled_reveal": bool((entitlement.get("resolved_entitlements") or {}).get("can_use_scheduled_reveal")),
+    }
+    tabs["billing"] = billing
+    tabs["mint"] = mint
+    tabs["audit_history"] = audit_history
+    payload["tabs"] = tabs
+    return payload
+
+
 def _workspace_related_orders(
     *,
     project_id: str,
@@ -4661,22 +5692,23 @@ def list_customer_cases(
         )
         return {"items": [_filter_case_item_for_access(item, current_user) for item in items]}
 
-    user_emails, user_ids, family_ids, mint_project_ids = _search_seed_sets(search)
+    user_emails, user_ids, family_ids, household_ids, mint_project_ids = _search_seed_sets(search)
 
     cases: list[dict[str, Any]] = []
     for project in db["projects"].find({}).sort("updated_at", -1).limit(max(400, safe_limit * 10)):
+        project_id = _normalize(project.get("_id") or project.get("id"))
+        order = _latest_linked_order(project_id) or _latest_user_order_for_project(project)
         if not _project_supports_search(
             project,
+            order=order,
             search=search,
             user_emails=user_emails,
             user_ids=user_ids,
             family_ids=family_ids,
+            household_ids=household_ids,
             mint_project_ids=mint_project_ids,
         ):
             continue
-
-        project_id = _normalize(project.get("_id") or project.get("id"))
-        order = _latest_linked_order(project_id) or _latest_user_order_for_project(project)
         entitlement = get_project_entitlement(project_id)
         package_fields = _package_fields_from_context(project, order, entitlement)
         readiness_order_id = (
@@ -5120,18 +6152,25 @@ def customer_case_workspace(
         if order is None:
             raise ValueError("Order case not found.")
         project = _project_by_id(_normalize(order.get("project_id")))
-        workspace_payload = _filter_workspace_for_access(_build_case_workspace_payload(
-            case_id=normalized_case_id,
-            project=project,
-            order=order,
-        ), current_user)
+        workspace_payload = _filter_workspace_for_access(
+            _build_case_workspace_payload(
+                case_id=normalized_case_id,
+                project=project,
+                order=order,
+            ),
+            current_user,
+        )
     else:
         project, order = _resolve_project_order_context(normalized_case_id)
-        workspace_payload = _filter_workspace_for_access(_build_case_workspace_payload(
-            case_id=normalized_case_id,
-            project=project,
-            order=order,
-        ), current_user)
+        workspace_payload = _filter_workspace_for_access(
+            _build_case_workspace_payload(
+                case_id=normalized_case_id,
+                project=project,
+                order=order,
+            ),
+            current_user,
+        )
+    workspace_payload = _decorate_account_360_workspace(workspace_payload)
     _write_admin_action_audit(
         actor=current_user,
         action="operations.sensitive_record_access",

--- a/backend/tests/test_admin_access_bootstrap.py
+++ b/backend/tests/test_admin_access_bootstrap.py
@@ -100,7 +100,7 @@ class AdminAccessBootstrapTests(unittest.TestCase):
         mapping = normalized_officer_role_mapping()
         self.assertEqual(
             mapping["l.robinson@tomboflight.com"],
-            ["ceo_super_admin", "executive_tech_admin"],
+            ["ceo_master_admin", "executive_tech_admin"],
         )
         self.assertNotIn("l.robinson@tomboflight", mapping)
         self.assertEqual(mapping["jenn.wood@tomboflight.com"], ["finance_admin"])
@@ -133,7 +133,11 @@ class AdminAccessBootstrapTests(unittest.TestCase):
             for doc in user_role_assignments
             if doc["user_id"] == "u-larry" and doc.get("status") == "active"
         )
-        self.assertEqual(larry_roles, ["ceo_super_admin", "executive_tech_admin"])
+        self.assertEqual(larry_roles, ["ceo_master_admin", "executive_tech_admin"])
+        self.assertNotIn(
+            ("u-jenn", "ceo_master_admin"),
+            assignment_keys,
+        )
 
         jenn_roles = [
             doc["role_code"]

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from unittest.mock import patch
 
@@ -44,15 +45,41 @@ class FakeCollection:
         query = query or {}
         return len([document for document in self.documents if self._matches(document, query)])
 
-    def update_one(self, query, update):
+    def update_one(self, query, update, upsert=False):
         updated = 0
         for document in self.documents:
             if self._matches(document, query):
                 for key, value in (update.get("$set") or {}).items():
                     document[key] = value
+                for key, value in (update.get("$setOnInsert") or {}).items():
+                    document.setdefault(key, value)
                 updated = 1
                 break
-        return type("Result", (), {"matched_count": updated, "modified_count": updated})()
+        upserted_id = None
+        if not updated and upsert:
+            inserted = dict(query)
+            for key, value in (update.get("$setOnInsert") or {}).items():
+                inserted[key] = value
+            for key, value in (update.get("$set") or {}).items():
+                inserted[key] = value
+            inserted.setdefault("_id", ObjectId())
+            self.documents.append(inserted)
+            updated = 1
+            upserted_id = inserted["_id"]
+        return type(
+            "Result",
+            (),
+            {"matched_count": 0 if upserted_id else updated, "modified_count": updated if not upserted_id else 0, "upserted_id": upserted_id},
+        )()
+
+    def update_many(self, query, update):
+        modified = 0
+        for document in self.documents:
+            if self._matches(document, query):
+                for key, value in (update.get("$set") or {}).items():
+                    document[key] = value
+                modified += 1
+        return type("Result", (), {"modified_count": modified})()
 
     def insert_one(self, payload):
         document = dict(payload)
@@ -74,6 +101,10 @@ class FakeCollection:
                 if not any(self._matches(document, option) for option in expected):
                     return False
                 continue
+            if key == "$and":
+                if not all(self._matches(document, option) for option in expected):
+                    return False
+                continue
 
             actual = self._get_nested(document, key)
             if isinstance(expected, dict):
@@ -83,6 +114,18 @@ class FakeCollection:
                         if not any(item in values for item in actual):
                             return False
                     elif actual not in values:
+                        return False
+                elif "$nin" in expected:
+                    values = expected["$nin"]
+                    if isinstance(actual, list):
+                        if any(item in values for item in actual):
+                            return False
+                    elif actual in values:
+                        return False
+                elif "$regex" in expected:
+                    pattern = expected.get("$regex")
+                    flags = re.IGNORECASE if "i" in str(expected.get("$options") or "") else 0
+                    if not re.search(str(pattern), str(actual or ""), flags):
                         return False
                 else:
                     return False
@@ -797,6 +840,87 @@ class SuperAdminControlsTests(unittest.TestCase):
                     actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
                 )
 
+    def test_ceo_master_admin_role_is_singleton_to_larry_identity(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "someone.else@tomboflight.com",
+                        "full_name": "Someone Else",
+                        "role": "operations_admin",
+                        "status": "active",
+                    }
+                ]
+            }
+        )
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            with self.assertRaisesRegex(
+                ValueError,
+                "ceo_master_admin role can only be assigned to Larry Robinson's canonical identity",
+            ):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(user_id),
+                    payload={"role": "ceo_master_admin"},
+                    actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
+                )
+
+    def test_impersonation_session_lifecycle_readonly_to_editing_to_stop(self):
+        actor_id = ObjectId()
+        customer_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": customer_id,
+                        "email": "rakim@example.com",
+                        "full_name": "Rakim Robinson",
+                        "role": "user",
+                        "status": "active",
+                    }
+                ],
+                "admin_impersonation_sessions": [],
+            }
+        )
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            started = admin_control_service.start_admin_impersonation(
+                case_id=f"user:{customer_id}",
+                reason="Support walkthrough",
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            self.assertTrue(started["active"])
+            self.assertFalse(started["editing_enabled"])
+
+            with self.assertRaisesRegex(ValueError, "active impersonation session already exists"):
+                admin_control_service.start_admin_impersonation(
+                    case_id=f"user:{customer_id}",
+                    reason="Second session should fail",
+                    actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+                )
+
+            enabled = admin_control_service.enable_admin_impersonation_editing(
+                session_id=started["session_id"],
+                reason="Need to correct customer profile field",
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            self.assertTrue(enabled["editing_enabled"])
+
+            active = admin_control_service.active_admin_impersonation(
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            self.assertTrue(active["active"])
+            self.assertEqual(active["impersonated_customer_name"], "Rakim Robinson")
+
+            stopped = admin_control_service.stop_admin_impersonation(
+                session_id=started["session_id"],
+                reason="Finished assistance",
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            self.assertFalse(stopped["active"])
+            self.assertEqual(stopped["status"], "stopped")
+
     def test_super_admin_package_change_preview_and_apply(self):
         project_id = ObjectId()
         order_id = ObjectId()
@@ -989,6 +1113,18 @@ class AdminConsoleOverviewTests(unittest.TestCase):
         )
         with (
             patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service,
+                "get_project_entitlement",
+                return_value={
+                    "package_code": "legacy_plus",
+                    "package_lane": "household",
+                    "maintenance_plan": "monthly",
+                    "maintenance_status": "active",
+                    "resolved_entitlements": {"can_use_household_vault": True, "can_use_viewer": True},
+                    "active_addons": ["extra_storage"],
+                },
+            ),
             patch.object(
                 admin_control_service,
                 "run_readiness_check",
@@ -1329,6 +1465,28 @@ class CfoScopeAndFinanceHistoryTests(unittest.TestCase):
             patch.object(admin_control_service, "get_database", return_value=db),
             patch.object(
                 admin_control_service,
+                "get_project_entitlement",
+                return_value={
+                    "package_code": "legacy_plus",
+                    "package_lane": "household",
+                    "maintenance_plan": "monthly",
+                    "maintenance_status": "active",
+                    "resolved_entitlements": {"can_use_household_vault": True, "can_use_viewer": True},
+                    "active_addons": ["extra_storage"],
+                },
+            ),
+            patch.object(
+                admin_control_service,
+                "resolve_canonical_mint_status",
+                return_value={
+                    "project_id": str(project_id),
+                    "current_status": "not_started",
+                    "minted": False,
+                    "records": [],
+                },
+            ),
+            patch.object(
+                admin_control_service,
                 "run_readiness_check",
                 return_value={
                     "mint_review_ready": False,
@@ -1475,6 +1633,404 @@ class CfoScopeAndFinanceHistoryTests(unittest.TestCase):
         self.assertEqual(stored_order.get("package_slug"), "legacy_plus")
         self.assertEqual(stored_order.get("lane"), "household")
         self.assertEqual(stored_order.get("package_lane"), "household")
+
+
+class MasterAdminCompletionTests(unittest.TestCase):
+    def test_account_360_workspace_exposes_required_tabs(self):
+        project_id = ObjectId()
+        order_id = ObjectId()
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [{"_id": user_id, "email": "rakim@example.com", "full_name": "Rakim Robinson", "role": "user", "status": "active"}],
+                "projects": [
+                    {
+                        "_id": project_id,
+                        "owner_email": "rakim@example.com",
+                        "owner_user_id": str(user_id),
+                        "name": "Rakim Legacy Project",
+                        "project_lane": "household",
+                        "package_code": "legacy_plus",
+                        "package_slug": "legacy_plus",
+                        "package_name": "Legacy Plus",
+                        "status": "in_production",
+                        "phase": "build_started",
+                        "family_id": str(ObjectId()),
+                        "household_id": str(ObjectId()),
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "email": "rakim@example.com",
+                        "project_id": project_id,
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_plus",
+                        "package_slug": "legacy_plus",
+                        "stripe_session_id": "cs_test_123",
+                    }
+                ],
+                "project_entitlements": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": project_id,
+                        "user_id": user_id,
+                        "package_code": "legacy_plus",
+                        "package_lane": "household",
+                        "maintenance_plan": "monthly",
+                        "maintenance_status": "active",
+                        "resolved_entitlements": {"can_use_household_vault": True, "can_use_viewer": True},
+                        "active_addons": ["extra_storage"],
+                    }
+                ],
+                "uploaded_files": [],
+                "audit_logs": [],
+                "families": [],
+                "households": [],
+                "vault_items": [],
+                "vault_collections": [],
+                "vault_access_grants": [],
+                "vault_release_rules": [],
+                "vault_audit_events": [],
+                "mint_records": [],
+                "finance_events": [],
+            }
+        )
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service,
+                "get_project_entitlement",
+                return_value={
+                    "package_code": "legacy_plus",
+                    "package_lane": "household",
+                    "maintenance_plan": "monthly",
+                    "maintenance_status": "active",
+                    "resolved_entitlements": {"can_use_household_vault": True, "can_use_viewer": True},
+                    "active_addons": ["extra_storage"],
+                },
+            ),
+            patch.object(
+                admin_control_service,
+                "resolve_canonical_mint_status",
+                return_value={
+                    "project_id": str(project_id),
+                    "current_status": "not_started",
+                    "minted": False,
+                    "records": [],
+                },
+            ),
+            patch.object(
+                admin_control_service,
+                "run_readiness_check",
+                return_value={
+                    "mint_review_ready": True,
+                    "mint_eligible": False,
+                    "mint_already_completed": False,
+                    "package_synced": True,
+                    "lane_assigned": True,
+                    "order_linked": True,
+                    "entitlement_exists": True,
+                    "blocking_reasons": ["upload_review_pending"],
+                    "summary": "Ready for review",
+                },
+            ),
+        ):
+            workspace = admin_control_service.customer_case_workspace(str(project_id))
+        tabs = workspace.get("tabs") or {}
+        for key in (
+            "overview",
+            "package_services",
+            "family_household",
+            "production",
+            "uploads",
+            "vault_metadata",
+            "billing",
+            "mint",
+            "audit_history",
+        ):
+            self.assertIn(key, tabs)
+
+    def test_master_search_supports_order_stripe_and_workflow_identifiers(self):
+        project_id = ObjectId()
+        order_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "projects": [
+                    {
+                        "_id": project_id,
+                        "owner_email": "rakim@example.com",
+                        "owner_user_id": str(ObjectId()),
+                        "name": "Rakim Search Project",
+                        "family_id": str(ObjectId()),
+                        "household_id": str(ObjectId()),
+                        "package_code": "legacy_plus",
+                        "project_lane": "household",
+                        "status": "client_review",
+                        "phase": "client_review",
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "project_id": project_id,
+                        "email": "rakim@example.com",
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_plus",
+                        "stripe_session_id": "cs_test_search",
+                        "stripe_payment_intent_id": "pi_test_search",
+                        "stripe_customer_id": "cus_test_search",
+                    }
+                ],
+                "project_entitlements": [],
+                "uploaded_files": [],
+                "audit_logs": [],
+                "users": [],
+                "families": [],
+                "households": [],
+                "mint_records": [],
+            }
+        )
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=None),
+            patch.object(
+                admin_control_service,
+                "run_readiness_check",
+                return_value={"mint_review_ready": False, "mint_eligible": False, "mint_already_completed": False, "blocking_reasons": []},
+            ),
+            patch.object(admin_control_service, "count_workspace_uploads", return_value=1),
+        ):
+            by_order_id = admin_control_service.list_customer_cases(search=str(order_id), limit=10)
+            by_stripe = admin_control_service.list_customer_cases(search="cs_test_search", limit=10)
+            by_workflow = admin_control_service.list_customer_cases(search="client_review", limit=10)
+        self.assertTrue(by_order_id["items"])
+        self.assertTrue(by_stripe["items"])
+        self.assertTrue(by_workflow["items"])
+
+    def test_service_controls_preview_and_apply_preserve_stripe_purchase_record(self):
+        project_id = ObjectId()
+        order_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "projects": [
+                    {
+                        "_id": project_id,
+                        "owner_email": "rakim@example.com",
+                        "owner_user_id": str(ObjectId()),
+                        "package_code": "legacy_snapshot",
+                        "package_slug": "legacy_snapshot",
+                        "package_name": "Legacy Snapshot",
+                        "project_lane": "portrait",
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "email": "rakim@example.com",
+                        "project_id": project_id,
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                        "package_slug": "legacy_snapshot",
+                        "package_name": "Legacy Snapshot",
+                        "stripe_session_id": "cs_test_preserve",
+                    }
+                ],
+                "project_entitlements": [],
+                "finance_events": [],
+            }
+        )
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=None),
+        ):
+            before_order = dict(db["orders"].find_one({"_id": order_id}) or {})
+            preview = admin_control_service.super_admin_preview_service_controls(
+                project_id=str(project_id),
+                payload={
+                    "operation": "upgrade",
+                    "package_code": "legacy_plus",
+                    "add_addons": ["extra_storage"],
+                    "storage_adjustment_gb": 1.0,
+                    "maintenance_state": "active",
+                },
+            )
+            after_preview_order = dict(db["orders"].find_one({"_id": order_id}) or {})
+            applied = admin_control_service.super_admin_apply_service_controls(
+                project_id=str(project_id),
+                payload={
+                    "operation": "upgrade",
+                    "package_code": "legacy_plus",
+                    "add_addons": ["extra_storage"],
+                    "storage_adjustment_gb": 1.0,
+                    "maintenance_state": "active",
+                },
+                actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+        self.assertEqual(before_order.get("status"), after_preview_order.get("status"))
+        self.assertEqual(before_order.get("stripe_session_id"), after_preview_order.get("stripe_session_id"))
+        self.assertTrue(preview["validation"]["stripe_purchase_record_preserved"])
+        self.assertTrue(applied["stripe_purchase_record_preserved"])
+        stored_order = db["orders"].find_one({"_id": order_id}) or {}
+        self.assertEqual(stored_order.get("status"), "paid")
+        self.assertEqual(stored_order.get("stripe_session_id"), "cs_test_preserve")
+
+    def test_officer_permission_management_targets_only_named_officers(self):
+        jenn_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": jenn_id,
+                        "email": "jenn.wood@tomboflight.com",
+                        "full_name": "Jennifer Wood",
+                        "role": "admin",
+                        "access_tier": "finance_admin",
+                        "department_role": "finance_admin",
+                        "status": "active",
+                    }
+                ],
+                "user_role_assignments": [],
+                "user_permission_overrides": [],
+            }
+        )
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            officers = admin_control_service.super_admin_list_officers()
+            preview = admin_control_service.super_admin_preview_officer_permissions(
+                officer_email="jenn.wood@tomboflight.com",
+                role_assignments=["finance_admin"],
+                grant_permissions=["admin.audit.read"],
+            )
+            applied = admin_control_service.super_admin_apply_officer_permissions(
+                officer_email="jenn.wood@tomboflight.com",
+                role_assignments=["finance_admin"],
+                grant_permissions=["admin.audit.read"],
+                actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+        self.assertTrue(officers["items"])
+        self.assertIn("admin.audit.read", preview["proposed_after"]["permission_overrides"])
+        self.assertIn("admin.audit.read", applied["after"]["permission_overrides"])
+        self.assertTrue(db["user_permission_overrides"].documents)
+
+    def test_rakim_read_only_acceptance_path_no_production_writes(self):
+        actor_id = ObjectId()
+        customer_id = ObjectId()
+        project_id = ObjectId()
+        order_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": customer_id,
+                        "email": "rakim@example.com",
+                        "full_name": "Rakim Robinson",
+                        "role": "user",
+                        "status": "active",
+                    }
+                ],
+                "projects": [
+                    {
+                        "_id": project_id,
+                        "owner_email": "rakim@example.com",
+                        "owner_user_id": str(customer_id),
+                        "name": "Rakim Household",
+                        "package_code": "legacy_snapshot",
+                        "package_slug": "legacy_snapshot",
+                        "project_lane": "household",
+                        "status": "in_production",
+                    }
+                ],
+                "orders": [
+                    {
+                        "_id": order_id,
+                        "project_id": project_id,
+                        "email": "rakim@example.com",
+                        "status": "paid",
+                        "item_type": "package",
+                        "package_code": "legacy_snapshot",
+                        "package_slug": "legacy_snapshot",
+                        "stripe_session_id": "cs_test_rakim",
+                    }
+                ],
+                "project_entitlements": [],
+                "admin_impersonation_sessions": [],
+                "audit_logs": [],
+                "uploaded_files": [],
+                "families": [],
+                "households": [],
+                "mint_records": [],
+                "vault_items": [],
+                "vault_collections": [],
+                "vault_access_grants": [],
+                "vault_release_rules": [],
+                "vault_audit_events": [],
+                "finance_events": [],
+            }
+        )
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service,
+                "run_readiness_check",
+                return_value={
+                    "mint_review_ready": False,
+                    "mint_eligible": False,
+                    "mint_already_completed": False,
+                    "package_synced": True,
+                    "lane_assigned": True,
+                    "order_linked": True,
+                    "entitlement_exists": False,
+                    "summary": "ready",
+                    "blocking_reasons": [],
+                },
+            ),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=None),
+            patch.object(
+                admin_control_service,
+                "resolve_canonical_mint_status",
+                return_value={
+                    "project_id": str(project_id),
+                    "current_status": "not_started",
+                    "minted": False,
+                    "records": [],
+                },
+            ),
+        ):
+            cases = admin_control_service.list_customer_cases(search="Rakim", queue="users", limit=10)
+            workspace = admin_control_service.customer_case_workspace(str(project_id))
+            project_before = dict(db["projects"].find_one({"_id": project_id}) or {})
+            order_before = dict(db["orders"].find_one({"_id": order_id}) or {})
+            preview = admin_control_service.super_admin_preview_service_controls(
+                project_id=str(project_id),
+                payload={"operation": "upgrade", "package_code": "legacy_plus"},
+            )
+            project_after_preview = dict(db["projects"].find_one({"_id": project_id}) or {})
+            order_after_preview = dict(db["orders"].find_one({"_id": order_id}) or {})
+            started = admin_control_service.start_admin_impersonation(
+                case_id=str(project_id),
+                reason="Read-only acceptance verification",
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            active = admin_control_service.active_admin_impersonation(
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+            stopped = admin_control_service.stop_admin_impersonation(
+                session_id=started["session_id"],
+                reason="Acceptance complete",
+                actor={"_id": actor_id, "email": "l.robinson@tomboflight.com", "role": "ceo_master_admin"},
+            )
+        self.assertTrue(cases["items"])
+        self.assertIn("overview", workspace.get("tabs") or {})
+        self.assertTrue(preview["changes"])
+        self.assertEqual(project_before.get("package_code"), project_after_preview.get("package_code"))
+        self.assertEqual(order_before.get("package_code"), order_after_preview.get("package_code"))
+        self.assertEqual(order_before.get("stripe_session_id"), order_after_preview.get("stripe_session_id"))
+        self.assertTrue(active["active"])
+        self.assertFalse(stopped["active"])
+        self.assertEqual(stopped["status"], "stopped")
 
 
 if __name__ == "__main__":

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -1,0 +1,747 @@
+import { expect, test } from "@playwright/test";
+
+const OFFICER_A = { _id: "officer-a", id: "officer-a", email: "officer.a@tomboflight.test", role: "admin", access_tier: "ceo_master_admin", department_role: "executive_tech_admin", role_codes: ["ceo_master_admin", "executive_tech_admin"] };
+const OFFICER_B = { _id: "officer-b", id: "officer-b", email: "officer.b@tomboflight.test", role: "admin", access_tier: "operations_admin", department_role: "operations_admin", role_codes: ["operations_admin"] };
+const TABS = ["overview", "package_services", "family_household", "production", "uploads", "vault_metadata", "billing", "mint", "audit_history"];
+
+function normalize(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function makeCase(seed) {
+  return {
+    case_id: seed.case_id,
+    project_id: seed.project_id,
+    order_id: seed.order_id,
+    name: seed.name,
+    email: seed.email,
+    role: seed.role,
+    project: seed.project,
+    package: seed.package,
+    package_name: seed.package_name,
+    package_code: seed.package_code,
+    lane: seed.lane,
+    status: seed.status,
+    alerts: seed.alerts || [],
+    operator_guidance: seed.operator_guidance || [],
+    tags: seed.tags || [],
+    quick_actions: ["sync_package", "repair_record", "run_readiness_check"],
+    search_index: seed.search_index || [],
+  };
+}
+
+function workspacePayload(seed) {
+  const now = new Date().toISOString();
+  return {
+    case_id: seed.case_id,
+    project: { id: seed.project_id, project_id: seed.project_id, name: seed.project, status: seed.status },
+    package: { package_code: seed.package_code, package_name: seed.package_name, package_lane: seed.lane },
+    readiness: { mint_review_ready: false, mint_eligible: false, blocking_reasons: ["upload_review_pending"] },
+    alerts: seed.alerts || [],
+    tabs: {
+      overview: { customer_type: seed.role, workflow_state: seed.status, warnings: [] },
+      package_services: { package_name: seed.package_name, package_code: seed.package_code, project_lane: seed.lane, maintenance_state: "active" },
+      family_household: { family_id: `fam-${seed.case_id}`, household_id: `house-${seed.case_id}` },
+      production: { build_status: seed.status, phase: "client_review", delivery_state: "in_progress" },
+      uploads: { uploaded_files: 2, review_status: "pending", verification_readiness: "waiting_for_uploads", items: [{ id: "upload-1", filename: "lineage.pdf", category: "verification", status: "pending", created_at: now }] },
+      vault_metadata: { collection_count: 2, release_rule_count: 1, warnings: ["private vault contents hidden by default"] },
+      billing: { order_status: "paid", stripe_session_id: "cs_test_fixture_only", payment_link_id: "plink_fixture", billing_history_impact: "no historical mutation" },
+      mint: { eligibility: "blocked", approvals: { mint_review_ready: false }, blocking_reasons: ["upload_review_pending"] },
+      audit_history: [{ action: "workspace_opened", target_type: "project", target_id: seed.project_id, actor_email: OFFICER_A.email, result: "success", timestamp: now }],
+      identity: {
+        user_id: seed.case_id.replace("case-", "user-"),
+        full_name: seed.name,
+        email: seed.email,
+        role: seed.role,
+        status: seed.status,
+        admin_user_relationship: seed.role,
+      },
+      package_lane: { package_name: seed.package_name, package_code: seed.package_code, project_lane: seed.lane, package_normalization_status: "normalized", source: "fixture", raw_value: seed.package_code },
+      project: {
+        project_name: seed.project,
+        project_id: seed.project_id,
+        build_status: seed.status,
+        phase: "client_review",
+        intake_readiness: "ready",
+        linked_family: { family_id: `fam-${seed.case_id}`, family_name: `${seed.name} Family`, household_id: `house-${seed.case_id}`, household_name: `${seed.name} Household` },
+      },
+      uploads_verification: { uploaded_files: 2, review_status: "pending", verification_readiness: "waiting_for_uploads", file_categories: ["verification"], items: [{ id: "upload-1", filename: "lineage.pdf", category: "verification", status: "pending", created_at: now }] },
+      entitlements: { maintenance_status: "active", access_scope: "standard", private_vault_contents: "hidden" },
+      orders_billing: { order_status: "paid", package_name: seed.package_name, package_code: seed.package_code, lane: seed.lane, paid: true, stripe_session_id: "cs_test_fixture_only", payment_link_id: "plink_fixture", project_link_status: "linked", maintenance_state: "active", next_charge_date: now, primary_order: { id: seed.order_id, status: "paid", package_name: seed.package_name }, related_orders: [] },
+      mint_readiness: { current_state: "blocked", eligibility: "blocked", approvals: { mint_review_ready: false }, queue_status: "pending", blocking_reasons: ["upload_review_pending"], guidance: [{ severity: "warning", title: "Uploads pending", next_action: "Review uploads" }] },
+      audit_timeline: [{ action: "workspace_opened", target_type: "project", target_id: seed.project_id, actor_email: OFFICER_A.email, result: "success", timestamp: now }],
+    },
+  };
+}
+
+function createMockEnvironment() {
+  const cases = [
+    makeCase({
+      case_id: "case-customer",
+      project_id: "proj-customer",
+      order_id: "order-customer",
+      name: "Customer Fixture",
+      email: "customer.fixture@tomboflight.test",
+      role: "customer",
+      project: "Customer Legacy Project",
+      package: "legacy_plus",
+      package_name: "Legacy Plus",
+      package_code: "legacy_plus",
+      lane: "household",
+      status: "client_review",
+      tags: ["customer"],
+      search_index: ["customer fixture", "customer.fixture@tomboflight.test", "user-customer", "proj-customer", "fam-customer", "house-customer", "order-customer", "cs_fixture_customer", "legacy_plus", "client_review"],
+    }),
+    makeCase({
+      case_id: "case-officer",
+      project_id: "proj-officer",
+      order_id: "order-officer",
+      name: "Officer Fixture",
+      email: "officer.fixture@tomboflight.test",
+      role: "officer",
+      project: "Officer Oversight",
+      package: "legacy_snapshot",
+      package_name: "Legacy Snapshot",
+      package_code: "legacy_snapshot",
+      lane: "portrait",
+      status: "active",
+      tags: ["officer"],
+      search_index: ["officer fixture", "officer.fixture@tomboflight.test"],
+    }),
+    makeCase({
+      case_id: "case-internal-validation",
+      project_id: "proj-internal-validation",
+      order_id: "order-internal-validation",
+      name: "Internal Validation Account",
+      email: "validation.fixture@tomboflight.test",
+      role: "internal_validation_account",
+      project: "Validation Sandbox",
+      package: "legacy_snapshot",
+      package_name: "Legacy Snapshot",
+      package_code: "legacy_snapshot",
+      lane: "portrait",
+      status: "active",
+      tags: ["internal validation account"],
+      search_index: ["internal validation account"],
+    }),
+    makeCase({
+      case_id: "case-prototype-genesis",
+      project_id: "proj-genesis",
+      order_id: "order-genesis",
+      name: "Genesis Prototype",
+      email: "genesis.prototype@tomboflight.test",
+      role: "prototype",
+      project: "Genesis Prototype",
+      package: "heirloom_legacy_tree",
+      package_name: "Heirloom Legacy Tree",
+      package_code: "heirloom_legacy_tree",
+      lane: "household",
+      status: "prototype",
+      tags: ["prototype"],
+      search_index: ["genesis prototype", "prototype"],
+    }),
+    makeCase({
+      case_id: "case-larry-personal",
+      project_id: "proj-larry-personal",
+      order_id: "order-larry-personal",
+      name: "Larry Personal Project",
+      email: "larry.personal.fixture@tomboflight.test",
+      role: "customer",
+      project: "Larry Personal Project",
+      package: "legacy_plus",
+      package_name: "Legacy Plus",
+      package_code: "legacy_plus",
+      lane: "household",
+      status: "delivered_project",
+      tags: ["delivered project"],
+      search_index: ["larry personal project", "delivered project"],
+    }),
+    makeCase({
+      case_id: "case-suspended",
+      project_id: "proj-suspended",
+      order_id: "order-suspended",
+      name: "Suspended Fixture",
+      email: "suspended.fixture@tomboflight.test",
+      role: "customer",
+      project: "Suspended Account Project",
+      package: "legacy_snapshot",
+      package_name: "Legacy Snapshot",
+      package_code: "legacy_snapshot",
+      lane: "portrait",
+      status: "suspended_account",
+      tags: ["suspended account"],
+      search_index: ["suspended account", "suspended.fixture@tomboflight.test"],
+    }),
+  ];
+
+  const stats = {
+    packageApplyWrites: 0,
+    serviceApplyWrites: 0,
+    officerApplyWrites: 0,
+    previewWrites: 0,
+    stripeMutations: 0,
+    blockchainOps: 0,
+    productionWrites: 0,
+    impersonationAuditEvents: 0,
+  };
+
+  const state = {
+    activeImpersonation: null,
+    officerPermissions: {
+      "jenn.wood@tomboflight.com": { role_assignments: ["finance_admin"], permission_overrides: [] },
+      "k.goffigan@tomboflight.com": { role_assignments: ["operations_admin"], permission_overrides: [] },
+      "marquis.l.floyd@tomboflight.com": { role_assignments: ["marketing_admin"], permission_overrides: [] },
+    },
+  };
+
+  return { cases, stats, state };
+}
+
+async function installApiRoutes(page, env) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+
+    if (!path.startsWith("/auth/") && !path.startsWith("/admin/") && !path.startsWith("/packages/")) {
+      return route.continue();
+    }
+
+    const json = (payload, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(payload) });
+
+    if (method === "GET" && path === "/auth/me") {
+      return json(OFFICER_A);
+    }
+    if (method === "POST" && path === "/auth/logout") {
+      return json({ ok: true });
+    }
+    if (method === "GET" && path === "/packages/catalog") {
+      return json({ packages: { legacy_snapshot: { display_name: "Legacy Snapshot" }, legacy_plus: { display_name: "Legacy Plus" }, heirloom_legacy_tree: { display_name: "Heirloom Legacy Tree" } } });
+    }
+    if (method === "GET" && path === "/admin/control-center/access-profile") {
+      return json({
+        role_key: "ceo_master_admin",
+        is_super_admin: true,
+        allowed_queues: ["overview", "customer_cases", "users", "orders", "projects", "entitlements", "mint_queue", "upload_review", "billing_maintenance", "audit", "system_health"],
+        allowed_tabs: ["identity", "package_lane", "project", "uploads_verification", "entitlements", "orders_billing", "mint_readiness", "audit_timeline", "overview", "package_services", "family_household", "production", "uploads", "vault_metadata", "billing", "mint", "audit_history"],
+        allowed_actions: ["sync_package", "repair_record", "run_readiness_check", "refresh_case_data"],
+        allowed_bulk_actions: ["repair-selected-records", "repair-all-safe-records", "repair-missing-entitlements"],
+      });
+    }
+    if (method === "GET" && path === "/admin/control-center/overview") {
+      return json({
+        summary: { total_users: 6, total_active_projects: 6, paid_orders: 6, missing_entitlements: 0, mint_ready_projects: 0, projects_with_data_mismatch: 0 },
+        priority_repairs: { paid_order_without_project_link: [], project_without_entitlement: [], package_without_lane: [], mint_eligible_blocked: [] },
+      });
+    }
+    if (method === "GET" && path === "/admin/control-center/cases") {
+      const search = normalize(url.searchParams.get("search"));
+      const queue = normalize(url.searchParams.get("queue") || "overview");
+      if (queue === "users" && search === "permission-denied") return json({ detail: "Permission denied." }, 403);
+      if (queue === "users" && search === "backend-error") return json({ detail: "Backend error." }, 500);
+      const items = env.cases.filter((item) => {
+        if (!search) return true;
+        return item.search_index.some((entry) => normalize(entry).includes(search));
+      });
+      return json({ items });
+    }
+    if (method === "GET" && path.startsWith("/admin/control-center/cases/")) {
+      const caseId = decodeURIComponent(path.split("/").pop() || "");
+      if (caseId === "case-permission-denied") return json({ detail: "Permission denied." }, 403);
+      if (caseId === "case-backend-error") return json({ detail: "Workspace retrieval failed." }, 500);
+      const found = env.cases.find((item) => item.case_id === caseId) || env.cases[0];
+      const payload = workspacePayload(found);
+      if (caseId === "case-empty") {
+        payload.tabs.uploads = { uploaded_files: 0, review_status: "empty", verification_readiness: "no_files", items: [] };
+        payload.tabs.audit_history = [];
+      }
+      return json(payload);
+    }
+    if (method === "GET" && path === "/admin/control-center/super-admin/impersonation/active") {
+      if (!env.state.activeImpersonation) return json({ active: false });
+      return json({ ...env.state.activeImpersonation, active: true });
+    }
+    if (method === "POST" && path === "/admin/control-center/super-admin/impersonation/start") {
+      const body = JSON.parse(request.postData() || "{}");
+      if (!normalize(body.reason)) return json({ detail: "A reason is required." }, 422);
+      if (env.state.activeImpersonation) return json({ detail: "active impersonation session already exists" }, 400);
+      env.state.activeImpersonation = {
+        session_id: "imp-session-1",
+        banner: "Viewing Tomb of Light as Customer",
+        project_id: "proj-customer",
+        editing_enabled: false,
+        expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+      };
+      env.stats.impersonationAuditEvents += 1;
+      return json({ ...env.state.activeImpersonation, active: true });
+    }
+    if (method === "POST" && path.endsWith("/enable-editing")) {
+      const body = JSON.parse(request.postData() || "{}");
+      if (!normalize(body.reason)) return json({ detail: "A reason is required to enable editing." }, 422);
+      if (!env.state.activeImpersonation) return json({ detail: "No active session." }, 400);
+      env.state.activeImpersonation.editing_enabled = true;
+      env.stats.impersonationAuditEvents += 1;
+      return json({ ...env.state.activeImpersonation, active: true });
+    }
+    if (method === "POST" && path.endsWith("/stop")) {
+      env.state.activeImpersonation = null;
+      env.stats.impersonationAuditEvents += 1;
+      return json({ active: false, status: "stopped" });
+    }
+    if (method === "POST" && path.includes("/package-change/preview")) {
+      env.stats.previewWrites += 0;
+      return json({
+        changes: [{ scope: "project", field: "package_code", before: "legacy_snapshot", after: "legacy_plus" }],
+        before: { order: { package_code: "legacy_snapshot", stripe_session_id: "cs_checkout_history" }, project: { package_code: "legacy_snapshot" } },
+        proposed_after: { project: { package_code: "legacy_plus" } },
+        validation: { stripe_purchase_record_preserved: true },
+        summary: {
+          original_purchase: "Legacy Snapshot",
+          current_package: "Legacy Snapshot",
+          proposed_package: "Legacy Plus",
+          services_added: ["narration"],
+          services_removed: [],
+          entitlement_changes: ["viewer_access_enabled: true"],
+          access_impact: "Expanded",
+          billing_history_impact: "No Stripe mutation",
+          reason: "Fixture reason",
+          authorization_source: "ceo_master_admin",
+          effective_date: new Date().toISOString(),
+        },
+      });
+    }
+    if (method === "POST" && path.includes("/package-change/apply")) {
+      env.stats.packageApplyWrites += 1;
+      return json({ changed: true, stripe_purchase_record_preserved: true, changes: [{ scope: "project", field: "package_code", before: "legacy_snapshot", after: "legacy_plus" }] });
+    }
+    if (method === "POST" && path.includes("/service-controls/preview")) {
+      return json({
+        changes: [{ scope: "service_controls", field: "vault_enabled", before: false, after: true }],
+        validation: { stripe_purchase_record_preserved: true },
+        summary: {
+          original_purchase: "Legacy Snapshot",
+          current_package: "Legacy Snapshot",
+          proposed_package: "Legacy Plus",
+          services_added: ["vault", "scheduled_reveal"],
+          services_removed: ["none"],
+          entitlement_changes: ["max_storage_gb: +10"],
+          access_impact: "Expanded",
+          billing_history_impact: "No Stripe mutation",
+          reason: "Fixture reason",
+          authorization_source: "ceo_master_admin",
+          effective_date: new Date().toISOString(),
+        },
+      });
+    }
+    if (method === "POST" && path.includes("/service-controls/apply")) {
+      env.stats.serviceApplyWrites += 1;
+      return json({ changed: true, stripe_purchase_record_preserved: true, idempotent: true, changes: [{ scope: "service_controls", field: "vault_enabled", before: false, after: true }] });
+    }
+    if (method === "GET" && path === "/admin/control-center/super-admin/officers") {
+      return json({
+        items: [
+          { full_name: "Jennifer Wood", officer_email: "jenn.wood@tomboflight.com", role_assignments: env.state.officerPermissions["jenn.wood@tomboflight.com"].role_assignments, permission_overrides: env.state.officerPermissions["jenn.wood@tomboflight.com"].permission_overrides },
+          { full_name: "Keith Goffigan", officer_email: "k.goffigan@tomboflight.com", role_assignments: env.state.officerPermissions["k.goffigan@tomboflight.com"].role_assignments, permission_overrides: env.state.officerPermissions["k.goffigan@tomboflight.com"].permission_overrides },
+          { full_name: "Marquis Floyd", officer_email: "marquis.l.floyd@tomboflight.com", role_assignments: env.state.officerPermissions["marquis.l.floyd@tomboflight.com"].role_assignments, permission_overrides: env.state.officerPermissions["marquis.l.floyd@tomboflight.com"].permission_overrides },
+        ],
+      });
+    }
+    if (method === "POST" && path === "/admin/control-center/super-admin/officers/permissions/preview") {
+      const body = JSON.parse(request.postData() || "{}");
+      if ((body.role_assignments || []).some((role) => normalize(role) === "ceo_master_admin")) return json({ detail: "ceo_master_admin cannot be assigned through officer management." }, 400);
+      return json({
+        officer_email: body.officer_email,
+        before: env.state.officerPermissions[body.officer_email] || { role_assignments: [], permission_overrides: [] },
+        proposed_after: { role_assignments: body.role_assignments || [], permission_overrides: body.grant_permissions || [] },
+        changes: [{ scope: "officer", field: "permission_overrides", before: [], after: body.grant_permissions || [] }],
+      });
+    }
+    if (method === "POST" && path === "/admin/control-center/super-admin/officers/permissions/apply") {
+      const body = JSON.parse(request.postData() || "{}");
+      if (!normalize(body.reason)) return json({ detail: "A reason is required for officer-permissions apply to maintain audit traceability." }, 422);
+      if ((body.role_assignments || []).some((role) => normalize(role) === "ceo_master_admin")) return json({ detail: "ceo_master_admin cannot be assigned through officer management." }, 400);
+      env.stats.officerApplyWrites += 1;
+      env.state.officerPermissions[body.officer_email] = {
+        role_assignments: body.role_assignments || [],
+        permission_overrides: body.grant_permissions || [],
+      };
+      return json({ applied: true, after: env.state.officerPermissions[body.officer_email], audit_event_created: true });
+    }
+
+    return json({ detail: `Unhandled fixture route: ${method} ${path}` }, 404);
+  });
+}
+
+async function bootstrap(page, user = OFFICER_A) {
+  await page.addInitScript(({ userPayload }) => {
+    localStorage.setItem("tol_access_token", "fixture-token");
+    localStorage.setItem("tol_user", JSON.stringify(userPayload));
+    localStorage.setItem("tol_api_base_url", window.location.origin);
+  }, { userPayload: user });
+}
+
+async function openAppearancePanel(page) {
+  await page.getByRole("button", { name: "Appearance" }).click();
+  await expect(page.locator("[data-admin-appearance-panel]")).toBeVisible();
+}
+
+async function setAppearance(page, { theme, large }) {
+  await openAppearancePanel(page);
+  if (theme) await page.locator("[data-admin-appearance-theme]").selectOption(theme);
+  await page.locator("[data-admin-appearance-large-text]").setChecked(Boolean(large));
+}
+
+test.beforeEach(async ({ page }) => {
+  const env = createMockEnvironment();
+  test.info().annotations.push({ type: "mock-env", description: JSON.stringify(env.stats) });
+  await installApiRoutes(page, env);
+  await bootstrap(page);
+  await page.goto("/admin-control-center.html");
+  await expect(page.locator("[data-admin-control-title]")).toContainText("Customer Operations Workspace");
+  await expect(page.locator("[data-open-case]").first()).toBeVisible();
+  page.__env = env;
+});
+
+test("[appearance] validates readability + screenshots for all appearance modes", async ({ page }) => {
+  const modes = [
+    { name: "light", theme: "light", large: false },
+    { name: "dark", theme: "dark", large: false },
+    { name: "high-contrast", theme: "high-contrast", large: false },
+    { name: "larger-text", theme: "light", large: true },
+    { name: "high-contrast-larger-text", theme: "high-contrast", large: true },
+  ];
+
+  for (const mode of modes) {
+    await setAppearance(page, { theme: mode.theme, large: mode.large });
+    await page.getByRole("tab", { name: "Package & Services" }).click();
+    await expect(page.locator("[data-admin-impersonation-banner]")).toBeAttached();
+    await page.screenshot({ path: `browser-screenshots/${mode.name}.png`, fullPage: true });
+    const checks = await page.evaluate(() => {
+      const body = document.body;
+      const bodyStyle = getComputedStyle(body);
+      const baseFont = parseFloat(bodyStyle.fontSize || "0");
+      const lineHeight = parseFloat(bodyStyle.lineHeight || "0");
+      const labels = [...document.querySelectorAll("label")].slice(0, 10).map((el) => parseFloat(getComputedStyle(el).fontSize || "0"));
+      const lowOpacityImportantText = [...document.querySelectorAll("h1, h2, h3, p, label, th, td, button")]
+        .filter((el) => {
+          const style = getComputedStyle(el);
+          return parseFloat(style.opacity || "1") < 0.75 && (el.textContent || "").trim().length > 0;
+        })
+        .length;
+      const focusBefore = document.activeElement;
+      const firstFocusable = document.querySelector("button, a, input, select, textarea");
+      if (firstFocusable instanceof HTMLElement) firstFocusable.focus();
+      const focusStyle = firstFocusable ? getComputedStyle(firstFocusable) : null;
+      const outlineWidth = focusStyle ? parseFloat(focusStyle.outlineWidth || "0") : 0;
+      return {
+        baseFont,
+        lineHeight,
+        minLabelFont: labels.length ? Math.min(...labels) : 99,
+        lowOpacityImportantText,
+        outlineWidth,
+        hasImpersonationBanner: !!document.querySelector("[data-admin-impersonation-banner]"),
+        _focusBeforeTag: focusBefore ? focusBefore.tagName : "",
+      };
+    });
+    expect(checks.baseFont).toBeGreaterThanOrEqual(16);
+    expect(checks.lineHeight).toBeGreaterThanOrEqual(1.45);
+    expect(checks.minLabelFont).toBeGreaterThanOrEqual(15);
+    expect(checks.lowOpacityImportantText).toBe(0);
+    expect(checks.outlineWidth).toBeGreaterThan(0);
+    expect(checks.hasImpersonationBanner).toBeTruthy();
+  }
+});
+
+test("[theme] validates persistence across reload/navigation/login and impersonation lifecycle", async ({ page }) => {
+  await setAppearance(page, { theme: "high-contrast", large: true });
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-admin-theme", "high-contrast");
+  await expect(page.locator("body")).toHaveAttribute("data-admin-text-scale", "large");
+
+  await page.goto("/admin-family-manager.html");
+  await expect(page.locator("body")).toHaveAttribute("data-admin-theme", "high-contrast");
+  await page.goto("/admin-control-center.html");
+  await expect(page.locator("body")).toHaveAttribute("data-admin-theme", "high-contrast");
+
+  await page.evaluate(() => {
+    localStorage.removeItem("tol_access_token");
+    localStorage.setItem("tol_access_token", "fixture-token");
+  });
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-admin-theme", "high-contrast");
+
+  await page.locator("[data-admin-impersonation-start-reason]").fill("Read-only customer review");
+  await page.locator("[data-admin-impersonation-start]").click();
+  await expect(page.locator("[data-admin-impersonation-banner]")).toContainText("Impersonation Active");
+  await page.locator("[data-admin-impersonation-stop]").click();
+  await expect(page.locator("[data-admin-impersonation-banner]")).toBeHidden();
+
+  const preferenceStore = await page.evaluate(() => {
+    const map = JSON.parse(localStorage.getItem("tol_admin_appearance_by_user") || "{}");
+    map["email:officer.a@tomboflight.test"] = { theme: "high-contrast", textScale: "large" };
+    map["email:officer.b@tomboflight.test"] = { theme: "dark", textScale: "default" };
+    localStorage.setItem("tol_admin_appearance_by_user", JSON.stringify(map));
+    return map;
+  });
+  expect(preferenceStore["email:officer.a@tomboflight.test"].theme).toBe("high-contrast");
+  expect(preferenceStore["email:officer.b@tomboflight.test"].theme).toBe("dark");
+});
+
+test("[keyboard] validates keyboard-only navigation reachability and no trap", async ({ page }) => {
+  await page.keyboard.press("Tab");
+  await expect(page.locator(":focus")).toBeVisible();
+  await page.getByPlaceholder("Name, email, birthday, package, project, family, last4, order, session, wallet, token, certificate").focus();
+  await expect(page.locator(":focus")).toHaveAttribute("data-admin-case-search", "");
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Tab");
+  await page.getByRole("tab", { name: "Package & Services" }).focus();
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-admin-case-workspace]")).toContainText("Package");
+  await expect(page.locator("[data-super-admin-package-preview]")).toBeVisible();
+  await page.locator("[data-super-admin-package-preview]").focus();
+  await page.keyboard.press("Enter");
+  await page.locator("[data-super-admin-preview-cancel]").focus();
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-admin-control-action-status]")).toContainText("Preview canceled with no write");
+  await page.locator("[data-admin-impersonation-start]").focus();
+  await expect(page.locator(":focus")).toHaveAttribute("data-admin-impersonation-start", /case-/);
+  const activeElementTag = await page.evaluate(() => document.activeElement?.tagName || "");
+  expect(activeElementTag.length).toBeGreaterThan(0);
+});
+
+test("[contrast] validates WCAG AA contrast thresholds for key selectors", async ({ page }) => {
+  const failures = await page.evaluate(() => {
+    function parseRgb(value) {
+      const m = String(value || "").match(/rgba?\(([^)]+)\)/i);
+      if (!m) return null;
+      const parts = m[1].split(",").map((p) => Number.parseFloat(p.trim()));
+      if (parts.length < 3 || parts.some((n) => !Number.isFinite(n))) return null;
+      return { r: parts[0], g: parts[1], b: parts[2], a: Number.isFinite(parts[3]) ? parts[3] : 1 };
+    }
+    function srgb(v) {
+      const n = v / 255;
+      return n <= 0.03928 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+    }
+    function luminance(rgb) {
+      return 0.2126 * srgb(rgb.r) + 0.7152 * srgb(rgb.g) + 0.0722 * srgb(rgb.b);
+    }
+    function ratio(fg, bg) {
+      const l1 = luminance(fg);
+      const l2 = luminance(bg);
+      const light = Math.max(l1, l2);
+      const dark = Math.min(l1, l2);
+      return (light + 0.05) / (dark + 0.05);
+    }
+    function effectiveBg(node) {
+      let cur = node;
+      while (cur) {
+        const color = parseRgb(getComputedStyle(cur).backgroundColor);
+        if (color && color.a > 0.95) return color;
+        cur = cur.parentElement;
+      }
+      return { r: 255, g: 255, b: 255, a: 1 };
+    }
+    const targets = [
+      { selector: "body", required: 4.5 },
+      { selector: ".card-copy", required: 4.5 },
+      { selector: ".site-nav a", required: 4.5 },
+      { selector: ".btn", required: 4.5 },
+      { selector: ".admin-status-chip", required: 3.0 },
+      { selector: "label", required: 4.5 },
+      { selector: "input", required: 4.5 },
+      { selector: "[data-state='error']", required: 4.5 },
+      { selector: "[data-state='warning']", required: 4.5 },
+      { selector: "[data-state='success']", required: 4.5 },
+      { selector: "[data-admin-impersonation-banner]", required: 4.5 },
+      { selector: ".site-nav a[aria-current='page']", required: 4.5 },
+      { selector: ":focus-visible", required: 3.0 },
+    ];
+    const problems = [];
+    for (const target of targets) {
+      const el = document.querySelector(target.selector);
+      if (!el) continue;
+      const style = getComputedStyle(el);
+      const fg = parseRgb(style.color);
+      const bg = effectiveBg(el);
+      if (!fg || !bg) continue;
+      const value = ratio(fg, bg);
+      if (value + 1e-6 < target.required) {
+        problems.push({
+          selector: target.selector,
+          ratio: Number(value.toFixed(2)),
+          required: target.required,
+          foreground: style.color,
+          background: getComputedStyle(el).backgroundColor,
+        });
+      }
+    }
+    return problems;
+  });
+  expect(failures).toEqual([]);
+  await page.screenshot({ path: "browser-screenshots/wcag-contrast.png", fullPage: true });
+});
+
+test("[account360] validates all tabs + loading/empty/denied/error states and sensitive-data guards", async ({ page }) => {
+  for (const tabLabel of ["Overview", "Package & Services", "Family / Household", "Production", "Uploads", "Vault Metadata", "Billing", "Mint", "Audit History"]) {
+    await page.getByRole("tab", { name: tabLabel }).click();
+  }
+  await expect(page.locator("[data-admin-case-workspace]")).toContainText("workspace_opened");
+
+  const deniedStatus = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/cases?queue=users&limit=80&search=permission-denied`);
+    return res.status;
+  });
+  expect(deniedStatus).toBe(403);
+
+  const backendErrorStatus = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/cases?queue=users&limit=80&search=backend-error`);
+    return res.status;
+  });
+  expect(backendErrorStatus).toBe(500);
+
+  await page.getByPlaceholder("Name, email, birthday, package, project, family, last4, order, session, wallet, token, certificate").fill("case-empty");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-admin-case-list]")).toContainText("No case results");
+
+  await expect(page.locator("body")).not.toContainText("sk_live_");
+  await expect(page.locator("body")).not.toContainText("private_key");
+  await expect(page.locator("body")).not.toContainText("token=");
+  await expect(page.locator("body")).not.toContainText("password");
+});
+
+test("[search] validates multi-identifier search and badge distinctions", async ({ page }) => {
+  const terms = [
+    "customer fixture",
+    "customer.fixture@tomboflight.test",
+    "proj-customer",
+    "order-customer",
+    "fam-customer",
+    "house-customer",
+    "cs_fixture_customer",
+    "legacy_plus",
+    "client_review",
+  ];
+  for (const term of terms) {
+    await page.getByPlaceholder("Name, email, birthday, package, project, family, last4, order, session, wallet, token, certificate").fill(term);
+    await page.keyboard.press("Enter");
+    await expect(page.locator("[data-admin-case-list]")).toContainText("Customer Fixture");
+  }
+  await page.getByPlaceholder("Name, email, birthday, package, project, family, last4, order, session, wallet, token, certificate").fill("genesis prototype");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-admin-case-list]")).toContainText("Genesis Prototype");
+  await expect(page.locator("[data-admin-case-list]")).not.toContainText("Larry Personal Project");
+});
+
+test("[package-service] validates preview/cancel/apply/idempotent and no Stripe or blockchain mutation", async ({ page }) => {
+  const env = page.__env;
+  page.on("dialog", async (dialog) => dialog.accept());
+  await page.getByRole("tab", { name: "Package & Services" }).click();
+  await expect(page.locator("[data-super-admin-package-field='reason']")).toBeVisible();
+  await page.locator("[data-super-admin-package-field='reason']").fill("Fixture package update");
+  await page.locator("[data-super-admin-service-field='operation']").selectOption("upgrade");
+  await page.locator("[data-super-admin-service-field='add_addons']").fill("extra_storage");
+  await page.locator("[data-super-admin-package-preview]").click();
+  await expect(page.locator("[data-super-admin-package-preview-output]")).toContainText("Project");
+  const beforeCancelWrites = env.stats.packageApplyWrites + env.stats.serviceApplyWrites;
+  await page.locator("[data-super-admin-preview-cancel]").click();
+  expect(env.stats.packageApplyWrites + env.stats.serviceApplyWrites).toBe(beforeCancelWrites);
+  await page.locator("[data-super-admin-service-preview]").click();
+  await page.locator("[data-super-admin-service-apply]").click();
+  await page.locator("[data-super-admin-service-apply]").click();
+  await page.locator("[data-super-admin-package-apply]").click();
+  expect(env.stats.serviceApplyWrites).toBeGreaterThanOrEqual(2);
+  expect(env.stats.packageApplyWrites).toBeGreaterThanOrEqual(1);
+  expect(env.stats.stripeMutations).toBe(0);
+  expect(env.stats.blockchainOps).toBe(0);
+});
+
+test("[officer] validates officer permission templates/preview/apply/guardrails via browser API flow", async ({ page }) => {
+  const env = page.__env;
+  const preview = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/super-admin/officers/permissions/preview`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        officer_email: "jenn.wood@tomboflight.com",
+        role_assignments: ["finance_admin"],
+        grant_permissions: ["admin.audit.read"],
+      }),
+    });
+    return { status: res.status, body: await res.json() };
+  });
+  expect(preview.status).toBe(200);
+  expect(preview.body.proposed_after.permission_overrides).toContain("admin.audit.read");
+
+  const noReason = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/super-admin/officers/permissions/apply`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        officer_email: "jenn.wood@tomboflight.com",
+        role_assignments: ["finance_admin"],
+        grant_permissions: ["admin.audit.read"],
+      }),
+    });
+    return res.status;
+  });
+  expect(noReason).toBe(422);
+
+  const applied = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/super-admin/officers/permissions/apply`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        officer_email: "k.goffigan@tomboflight.com",
+        role_assignments: ["operations_admin"],
+        grant_permissions: ["admin.control.view"],
+        reason: "Fixture approval",
+      }),
+    });
+    return { status: res.status, body: await res.json() };
+  });
+  expect(applied.status).toBe(200);
+  expect(applied.body.audit_event_created).toBeTruthy();
+  expect(env.stats.officerApplyWrites).toBeGreaterThanOrEqual(1);
+
+  const ceoReject = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/super-admin/officers/permissions/preview`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        officer_email: "marquis.l.floyd@tomboflight.com",
+        role_assignments: ["ceo_master_admin"],
+      }),
+    });
+    return res.status;
+  });
+  expect(ceoReject).toBe(400);
+});
+
+test("[impersonation] validates read-only start, reason requirements, banner, escalation, stop, and nested rejection", async ({ page }) => {
+  const env = page.__env;
+  await expect(page.locator("[data-admin-impersonation-start]")).toBeVisible();
+  await page.locator("[data-admin-impersonation-start]").click();
+  await expect(page.locator("[data-admin-control-action-status]")).toContainText("reason is required");
+  await page.locator("[data-admin-impersonation-start-reason]").fill("Read-only customer verification");
+  await page.locator("[data-admin-impersonation-start]").click();
+  await expect(page.locator("[data-admin-impersonation-banner]")).toContainText("read-only");
+  const nested = await page.evaluate(async () => {
+    const res = await fetch(`${window.location.origin}/admin/control-center/super-admin/impersonation/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ case_id: "case-customer", reason: "Second start should fail" }),
+    });
+    return res.status;
+  });
+  expect(nested).toBe(400);
+  await page.locator("[data-admin-impersonation-enable-editing]").click();
+  await expect(page.locator("[data-admin-control-action-status]")).toContainText("reason is required");
+  await page.locator("[data-admin-impersonation-edit-reason]").fill("Escalated correction review");
+  await page.locator("[data-admin-impersonation-enable-editing]").click();
+  await expect(page.locator("[data-admin-impersonation-banner]")).toContainText("editing enabled");
+  await page.locator("[data-admin-impersonation-stop]").click();
+  await expect(page.locator("[data-admin-impersonation-banner]")).toBeHidden();
+  expect(env.stats.impersonationAuditEvents).toBeGreaterThanOrEqual(3);
+});

--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -8,6 +8,7 @@
 
   const INTERNAL_ROLE_KEYS = new Set([
     "super_admin",
+    "ceo_master_admin",
     "executive_tech_admin",
     "operations_admin",
     "finance_admin",
@@ -18,6 +19,10 @@
     superadmin: "super_admin",
     root_admin: "super_admin",
     platform_admin: "super_admin",
+    ceo_super_admin: "ceo_master_admin",
+    "ceo-super-admin": "ceo_master_admin",
+    ceo_master_admin: "ceo_master_admin",
+    "ceo-master-admin": "ceo_master_admin",
     executive_technology: "executive_tech_admin",
     executive_tech_admin: "executive_tech_admin",
     "executive-tech-admin": "executive_tech_admin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "tomboflight-browser-tests",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tomboflight-browser-tests",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.54.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tomboflight-browser-tests",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test:browser": "playwright test",
+    "test:browser:headed": "playwright test --headed",
+    "test:browser:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.1"
+  }
+}
+

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./browser-tests",
+  timeout: 60_000,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"], ["json", { outputFile: "browser-test-results.json" }]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+    viewport: { width: 1600, height: 1100 },
+  },
+  webServer: {
+    command: "python3 -m http.server 4173 --bind 127.0.0.1",
+    url: "http://127.0.0.1:4173/admin-control-center.html",
+    timeout: 120_000,
+    reuseExistingServer: true,
+  },
+});
+

--- a/styles.css
+++ b/styles.css
@@ -7836,7 +7836,7 @@ main [id] {
 .admin-ops-page .btn:disabled,
 .admin-ops-page .btn.is-disabled {
   cursor: not-allowed;
-  opacity: 0.42;
+  opacity: 0.78;
   transform: none;
   box-shadow: none;
 }
@@ -8891,5 +8891,176 @@ main [id] {
 
   .pricing-accordion > :not(summary) {
     padding: 0 18px 18px;
+  }
+}
+
+/* ============================================================
+   Admin accessibility appearance modes
+   ============================================================ */
+
+body.admin-interface-mode {
+  --admin-bg: #f5f8fc;
+  --admin-panel: #ffffff;
+  --admin-border: #cfdbea;
+  --admin-text: #0f1723;
+  --admin-muted: #415367;
+  --admin-focus: #0f5ea8;
+  --admin-focus-glow: rgba(15, 94, 168, 0.28);
+  --admin-status-info: #0f5ea8;
+  --admin-status-success: #13603a;
+  --admin-status-error: #922922;
+  --admin-status-warning: #7a4a06;
+  --admin-helper-bg: rgba(255, 255, 255, 0.86);
+  color: var(--admin-text);
+  line-height: 1.6;
+}
+
+body.admin-interface-mode[data-admin-theme="dark"] {
+  --admin-bg: #08101d;
+  --admin-panel: #0f192a;
+  --admin-border: #2b3d53;
+  --admin-text: #e9f1ff;
+  --admin-muted: #c5d3e5;
+  --admin-focus: #73b7ff;
+  --admin-focus-glow: rgba(115, 183, 255, 0.4);
+  --admin-status-info: #9ccfff;
+  --admin-status-success: #9be8bc;
+  --admin-status-error: #ffb8b4;
+  --admin-status-warning: #ffd886;
+  --admin-helper-bg: rgba(11, 20, 33, 0.82);
+  color-scheme: dark;
+}
+
+body.admin-interface-mode[data-admin-theme="high-contrast"] {
+  --admin-bg: #000000;
+  --admin-panel: #000000;
+  --admin-border: #ffffff;
+  --admin-text: #ffffff;
+  --admin-muted: #ffffff;
+  --admin-focus: #ffd400;
+  --admin-focus-glow: rgba(255, 212, 0, 0.55);
+  --admin-status-info: #ffffff;
+  --admin-status-success: #7cffad;
+  --admin-status-error: #ff9d9d;
+  --admin-status-warning: #ffe48a;
+  --admin-helper-bg: #000000;
+  color-scheme: dark;
+}
+
+body.admin-interface-mode[data-admin-text-scale="large"] {
+  font-size: 18px;
+}
+
+body.admin-interface-mode :focus-visible {
+  outline: 3px solid var(--admin-focus) !important;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--admin-focus-glow);
+}
+
+body.admin-interface-mode .admin-ops-page,
+body.admin-interface-mode [data-admin-family-manager-page],
+body.admin-interface-mode [data-admin-queue-page],
+body.admin-interface-mode [data-admin-review-page] {
+  color: var(--admin-text);
+}
+
+body.admin-interface-mode .admin-command-bar,
+body.admin-interface-mode .admin-case-rail,
+body.admin-interface-mode .admin-case-list-panel,
+body.admin-interface-mode .admin-case-workspace-panel,
+body.admin-interface-mode .admin-case-context-panel,
+body.admin-interface-mode .portal-intake-layout section,
+body.admin-interface-mode .admin-review-layout section,
+body.admin-interface-mode .family-manager-pane,
+body.admin-interface-mode .family-manager-pane .family-record-card {
+  background: var(--admin-panel);
+  border-color: var(--admin-border);
+  color: var(--admin-text);
+  box-shadow: 0 16px 38px rgba(7, 13, 25, 0.12);
+}
+
+body.admin-interface-mode .card-copy,
+body.admin-interface-mode .helper,
+body.admin-interface-mode .notice,
+body.admin-interface-mode label,
+body.admin-interface-mode .admin-command-copy p,
+body.admin-interface-mode .admin-command-search label {
+  color: var(--admin-muted);
+  opacity: 1;
+}
+
+body.admin-interface-mode input,
+body.admin-interface-mode select,
+body.admin-interface-mode textarea,
+body.admin-interface-mode button,
+body.admin-interface-mode .btn,
+body.admin-interface-mode table,
+body.admin-interface-mode [role="tab"] {
+  color: var(--admin-text);
+  border-color: var(--admin-border);
+}
+
+body.admin-interface-mode .helper[data-state] {
+  color: var(--admin-status-info);
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--admin-border);
+  background: var(--admin-helper-bg);
+}
+
+body.admin-interface-mode [data-state="success"] {
+  color: var(--admin-status-success) !important;
+}
+
+body.admin-interface-mode [data-state="error"] {
+  color: var(--admin-status-error) !important;
+}
+
+body.admin-interface-mode [data-state="warning"] {
+  color: var(--admin-status-warning) !important;
+}
+
+body.admin-interface-mode [data-state="info"] {
+  color: var(--admin-status-info) !important;
+}
+
+.admin-appearance-controls {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.admin-appearance-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 210px;
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--admin-border, rgba(154, 173, 196, 0.4));
+  background: var(--admin-panel, #ffffff);
+  box-shadow: 0 12px 28px rgba(8, 17, 30, 0.22);
+  z-index: 30;
+}
+
+.admin-appearance-panel label {
+  display: grid;
+  gap: 8px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--admin-muted, #32465c);
+}
+
+.admin-appearance-checkbox {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+}
+
+@media (max-width: 760px) {
+  .admin-appearance-panel {
+    right: auto;
+    left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- complete Master Admin backend and frontend control-center capability wiring
- add focused Playwright browser/accessibility validation suite for Master Admin surfaces
- validate appearance modes, theme persistence, keyboard navigation, contrast, Account 360 tabs, search, package/service controls, officer-management API paths, and impersonation flow

## Validation
- pytest: admin console, admin repair guardrails, admin access bootstrap, authorization/logout, account separation, mint policy, link integrity
- playwright: browser-tests/master-admin.spec.mjs
