### PR TITLE
Fix live Safari admin workspace bootstrap and appearance modes

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -197,8 +197,8 @@
     </div>
 
     <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260507-434"></script>
-    <script src="auth.js?v=20260410-2"></script>
-    <script src="admin-control-center.js?v=20260411-4"></script>
+    <script src="app.js?v=20260713-livefix1"></script>
+    <script src="auth.js?v=20260713-livefix1"></script>
+    <script src="admin-control-center.js?v=20260713-livefix1"></script>
   </body>
 </html>

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -1,0 +1,200 @@
+import { expect, test } from "@playwright/test";
+
+const LARRY = {
+  _id: "larry-ceo-1",
+  id: "larry-ceo-1",
+  email: "larry@tomboflight.com",
+  role: "admin",
+  access_tier: "ceo_master_admin",
+  department_role: "executive_tech_admin",
+  role_codes: ["ceo_master_admin", "executive_tech_admin"],
+};
+
+async function installDashboardRoutes(page, options = {}) {
+  const state = {
+    authMeCalls: 0,
+    controlCenterWrites: 0,
+    stripeMutations: 0,
+    blockchainOps: 0,
+  };
+  const failFirstAuthMe = Boolean(options.failFirstAuthMe);
+  const failAllAuthMe = Boolean(options.failAllAuthMe);
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+
+    if (!path.startsWith("/auth/") && !path.startsWith("/admin/") && !path.startsWith("/api/") && !path.startsWith("/packages/")) {
+      return route.continue();
+    }
+
+    const json = (payload, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(payload) });
+
+    if (method === "GET" && path === "/auth/me") {
+      state.authMeCalls += 1;
+      if (failAllAuthMe) {
+        return json({ detail: "Session bootstrap failed." }, 500);
+      }
+      if (failFirstAuthMe && state.authMeCalls === 1) {
+        return json({ detail: "Session bootstrap failed." }, 500);
+      }
+      return json(LARRY);
+    }
+    if (method === "POST" && path === "/auth/logout") {
+      return json({ ok: true });
+    }
+    if (path.startsWith("/admin/control-center/") && method !== "GET") {
+      state.controlCenterWrites += 1;
+    }
+    if (path.includes("stripe")) {
+      state.stripeMutations += 1;
+    }
+    if (path.includes("mint") && method !== "GET") {
+      state.blockchainOps += 1;
+    }
+    if (method === "GET" && path === "/admin/control-center/access-profile") {
+      return json({
+        role_key: "ceo_master_admin",
+        is_super_admin: true,
+        allowed_queues: ["overview", "customer_cases", "users", "orders", "projects", "entitlements", "mint_queue", "upload_review", "billing_maintenance", "audit", "system_health"],
+      });
+    }
+    if (method === "GET" && path === "/admin/control-center/overview") {
+      return json({ summary: { total_users: 1, total_active_projects: 1, paid_orders: 1 } });
+    }
+    if (method === "GET" && path === "/admin/control-center/cases") {
+      return json({ items: [] });
+    }
+    return json({ ok: true });
+  });
+  return state;
+}
+
+async function openAppearancePanel(page) {
+  const toggle = page.locator("[data-admin-appearance-toggle]");
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  await expect(page.locator("[data-admin-appearance-panel]")).toBeVisible();
+}
+
+async function seedInternalSession(page) {
+  await page.addInitScript((user) => {
+    localStorage.setItem("tol_access_token", "fixture-token");
+    localStorage.setItem("tol_user", JSON.stringify(user));
+  }, LARRY);
+}
+
+async function seedTokenOnlySession(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("tol_access_token", "fixture-token");
+  });
+}
+
+test("[dashboard-theme] light/dark/high-contrast + larger text change computed styles and persist", async ({ page }, testInfo) => {
+  await seedInternalSession(page);
+  await installDashboardRoutes(page);
+  await page.goto("/dashboard.html", { waitUntil: "networkidle" });
+  await expect(page.locator("[data-admin-tools-panel]")).toBeVisible();
+
+  await openAppearancePanel(page);
+  const themeSelect = page.locator("[data-admin-appearance-theme]");
+  const largeText = page.locator("[data-admin-appearance-large-text]");
+
+  const readStyles = async () =>
+    page.evaluate(() => {
+      const bodyStyles = window.getComputedStyle(document.body);
+      const panel = document.querySelector("[data-admin-tools-panel]") || document.querySelector(".portal-core-panel");
+      const panelStyles = panel ? window.getComputedStyle(panel) : bodyStyles;
+      const title = document.querySelector(".portal-core-title") || document.body;
+      const titleStyles = window.getComputedStyle(title);
+      return {
+        bodyBg: bodyStyles.backgroundColor,
+        bodyFg: bodyStyles.color,
+        bodyFont: bodyStyles.fontSize,
+        panelBg: panelStyles.backgroundColor,
+        panelFg: panelStyles.color,
+        fontSize: titleStyles.fontSize,
+        lineHeight: titleStyles.lineHeight,
+        htmlTheme: document.documentElement.dataset.adminTheme || "",
+      };
+    });
+
+  await themeSelect.selectOption("light");
+  await page.waitForTimeout(120);
+  const light = await readStyles();
+  await page.screenshot({ path: testInfo.outputPath("dashboard-light.png"), fullPage: true });
+
+  await themeSelect.selectOption("dark");
+  await page.waitForTimeout(120);
+  const dark = await readStyles();
+  await page.screenshot({ path: testInfo.outputPath("dashboard-dark.png"), fullPage: true });
+
+  await themeSelect.selectOption("high-contrast");
+  await page.waitForTimeout(120);
+  const highContrast = await readStyles();
+  await page.screenshot({ path: testInfo.outputPath("dashboard-high-contrast.png"), fullPage: true });
+
+  await largeText.check();
+  await page.waitForTimeout(120);
+  const largerText = await readStyles();
+  await page.screenshot({ path: testInfo.outputPath("dashboard-high-contrast-large.png"), fullPage: true });
+
+  expect(light.bodyBg).not.toBe(dark.bodyBg);
+  expect(light.panelBg).not.toBe(dark.panelBg);
+  expect(highContrast.htmlTheme).toBe("high-contrast");
+  expect(parseFloat(largerText.bodyFont)).toBeGreaterThan(parseFloat(highContrast.bodyFont));
+  expect(parseFloat(largerText.lineHeight) || 0).toBeGreaterThan(0);
+
+  await page.reload({ waitUntil: "networkidle" });
+  const persisted = await readStyles();
+  expect(persisted.htmlTheme).toBe("high-contrast");
+  expect(parseFloat(persisted.bodyFont)).toBeGreaterThan(parseFloat(light.bodyFont));
+});
+
+test("[dashboard-bootstrap] ceo role resolves tools and workspace nodes", async ({ page }) => {
+  await seedInternalSession(page);
+  const state = await installDashboardRoutes(page);
+  await page.goto("/dashboard.html", { waitUntil: "networkidle" });
+
+  await expect(page.locator("[data-dashboard-next-focus]")).toContainText("Control Center");
+  await expect(page.locator("[data-admin-tools-panel]")).toBeVisible();
+  await expect(page.locator("a[href$='admin-control-center.html']")).toBeVisible();
+  await expect(page.locator("[data-dashboard-identity-node]")).toContainText("Ready");
+  await expect(page.locator("[data-dashboard-package-node]")).toContainText("Ready");
+  await expect(page.locator("[data-dashboard-records-node]")).toContainText("Ready");
+
+  expect(state.controlCenterWrites).toBe(0);
+  expect(state.stripeMutations).toBe(0);
+  expect(state.blockchainOps).toBe(0);
+});
+
+test("[dashboard-bootstrap-error] failed bootstrap shows actionable error with retry", async ({ page }) => {
+  await seedTokenOnlySession(page);
+  await installDashboardRoutes(page, { failAllAuthMe: true });
+  await page.goto("/dashboard.html", { waitUntil: "networkidle" });
+
+  await page.waitForTimeout(7300);
+  await expect(page.locator("[data-dashboard-status]")).toContainText("failed");
+  await expect(page.locator("[data-admin-tools-panel]")).toContainText("Admin Workspace Error");
+  await expect(page.locator("[data-admin-tools-panel]")).toContainText("Retry");
+});
+
+test("[asset-versioning] dashboard and control center include cache-busting livefix revision", async ({ page }) => {
+  await seedInternalSession(page);
+  await installDashboardRoutes(page);
+  await page.goto("/dashboard.html", { waitUntil: "domcontentloaded" });
+  const dashboardScripts = await page.locator("script[src]").evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("src") || ""),
+  );
+  expect(dashboardScripts.some((src) => src.includes("app.js?v=20260713-livefix1"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("dashboard-admin.js?v=20260713-livefix1"))).toBeTruthy();
+
+  await page.goto("/admin-control-center.html", { waitUntil: "domcontentloaded" });
+  const controlCenterScripts = await page.locator("script[src]").evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("src") || ""),
+  );
+  expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260713-livefix1"))).toBeTruthy();
+  expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260713-livefix1"))).toBeTruthy();
+});

--- a/dashboard-admin.js
+++ b/dashboard-admin.js
@@ -34,6 +34,34 @@
     finance: "finance_admin",
     marketing: "marketing_admin",
   };
+  const ROLE_PERMISSION_FALLBACK = {
+    ceo_master_admin: [
+      "*",
+    ],
+    super_admin: [
+      "*",
+    ],
+    executive_tech_admin: [
+      "admin.access",
+      "admin.control.view",
+      "admin.intake.review",
+      "admin.intake.write",
+    ],
+    operations_admin: [
+      "admin.access",
+      "admin.control.view",
+      "admin.intake.review",
+      "admin.intake.write",
+    ],
+    finance_admin: [
+      "admin.access",
+      "admin.control.view",
+    ],
+    marketing_admin: [
+      "admin.access",
+      "admin.control.view",
+    ],
+  };
 
   function normalizeValue(value) {
     return String(value || "")
@@ -105,6 +133,7 @@
 
     const roleKey = getInternalRoleKey(me);
 
+    if (roleKey === "ceo_master_admin") return "CEO Master Administrator";
     if (roleKey === "super_admin") return "CEO / Super Admin";
     if (roleKey === "executive_tech_admin") return "Executive Technical Admin";
     if (roleKey === "operations_admin") {
@@ -121,8 +150,12 @@
 
   function getPermissionSet(me) {
     const values = Array.isArray(me && me.permissions) ? me.permissions : [];
+    const roleSignals = getRoleSignals(me);
+    const inferred = roleSignals.flatMap(function (roleCode) {
+      return ROLE_PERMISSION_FALLBACK[roleCode] || [];
+    });
     return new Set(
-      values.map(function (value) {
+      [...values, ...inferred].map(function (value) {
         return normalizeValue(value);
       }),
     );
@@ -179,7 +212,12 @@
     const dashboard = document.querySelector("[data-dashboard]");
     const roleTitle = getRoleTitle(me);
     const cards = getRoleCards(me);
-    const nextFocus = cards.length ? "Intake Queue" : "Awaiting published tools";
+    const canUseControlCenter = hasPermission(me, ["admin.control.view"]);
+    const nextFocus = canUseControlCenter
+      ? "Control Center"
+      : cards.length
+        ? "Intake Queue"
+        : "Awaiting published tools";
 
     if (body) {
       body.classList.add("portal-dashboard-body", "portal-admin-mode");
@@ -205,6 +243,9 @@
       ],
       ["[data-dashboard-package-display]", roleTitle],
       ["[data-dashboard-next-focus]", nextFocus],
+      ["[data-dashboard-identity-node]", "Identity Ready"],
+      ["[data-dashboard-package-node]", "Package Scope Ready"],
+      ["[data-dashboard-records-node]", "Records Ready"],
     ];
 
     updates.forEach(function (item) {
@@ -388,20 +429,88 @@
     enableAdminWorkspaceLinks(me);
   }
 
+  function renderAdminWorkspaceError(operation, message) {
+    const statusNode = document.querySelector("[data-dashboard-status]");
+    if (statusNode) {
+      statusNode.textContent = `${operation} failed. ${message}`;
+    }
+    const anchor = document.querySelector("[data-admin-portal-anchor]");
+    if (!anchor) return;
+    const existing = document.querySelector("[data-admin-tools-panel]");
+    if (existing) existing.remove();
+    const panel = document.createElement("div");
+    panel.className = "form-panel portal-admin-panel";
+    panel.setAttribute("data-admin-tools-panel", "true");
+    panel.innerHTML = `
+      <span class="eyebrow">Admin Workspace Error</span>
+      <p class="card-copy" style="margin-bottom: 0.85rem;"><strong>Operation:</strong> ${escapeHtml(operation)}</p>
+      <p class="card-copy" style="margin-bottom: 1rem;">${escapeHtml(message)}</p>
+      <div class="inline-actions"><button class="btn btn-primary" type="button" data-admin-bootstrap-retry>Retry</button></div>
+    `;
+    anchor.prepend(panel);
+    const retryButton = panel.querySelector("[data-admin-bootstrap-retry]");
+    if (retryButton instanceof HTMLButtonElement) {
+      retryButton.addEventListener("click", async function () {
+        retryButton.disabled = true;
+        retryButton.textContent = "Retrying...";
+        try {
+          const me = await app.fetchCurrentUser();
+          window.TOLResolvedUser = me;
+          applyAdminDashboardLayer(me);
+        } catch (error) {
+          const safeMessage = String((error && error.message) || "Unable to refresh workspace context.");
+          renderAdminWorkspaceError("workspace bootstrap", safeMessage);
+        }
+      });
+    }
+  }
+
   document.addEventListener("DOMContentLoaded", function () {
     // auth.js fetches /auth/me in setupDashboard() and publishes
     // tol:user-resolved with the result.  We subscribe here instead of
     // making a duplicate network request.
     if (window.TOLResolvedUser) {
       // auth.js resolved before this DOMContentLoaded handler ran.
-      applyAdminDashboardLayer(window.TOLResolvedUser);
+      try {
+        applyAdminDashboardLayer(window.TOLResolvedUser);
+      } catch (error) {
+        renderAdminWorkspaceError(
+          "workspace bootstrap",
+          String((error && error.message) || "Unable to initialize internal workspace."),
+        );
+      }
       return;
     }
+
+    const bootstrapTimeout = window.setTimeout(function () {
+      if (!window.TOLResolvedUser) {
+        renderAdminWorkspaceError(
+          "session resolution",
+          "No resolved internal session was detected. Use Retry to reload authorized tools.",
+        );
+      }
+    }, 7000);
 
     window.addEventListener(
       "tol:user-resolved",
       function (event) {
-        applyAdminDashboardLayer(event.detail.user);
+        window.clearTimeout(bootstrapTimeout);
+        try {
+          const user = event && event.detail ? event.detail.user : null;
+          if (!user) {
+            renderAdminWorkspaceError(
+              "session resolution",
+              "Resolved session payload is missing required user context.",
+            );
+            return;
+          }
+          applyAdminDashboardLayer(user);
+        } catch (error) {
+          renderAdminWorkspaceError(
+            "workspace bootstrap",
+            String((error && error.message) || "Unable to initialize internal workspace."),
+          );
+        }
       },
       { once: true },
     );

--- a/dashboard.html
+++ b/dashboard.html
@@ -764,9 +764,9 @@
     </div>
 
     <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260508-451"></script>
-    <script src="auth.js?v=20260509-audit"></script>
-    <script src="dashboard-intake.js?v=20260509-audit"></script>
-    <script src="dashboard-admin.js?v=20260508-451"></script>
+    <script src="app.js?v=20260713-livefix1"></script>
+    <script src="auth.js?v=20260713-livefix1"></script>
+    <script src="dashboard-intake.js?v=20260713-livefix1"></script>
+    <script src="dashboard-admin.js?v=20260713-livefix1"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -9024,6 +9024,48 @@ body.admin-interface-mode [data-state="info"] {
   color: var(--admin-status-info) !important;
 }
 
+body.portal-dashboard-body.admin-interface-mode {
+  background: var(--admin-bg);
+  color: var(--admin-text);
+}
+
+body.portal-dashboard-body.admin-interface-mode .site-header,
+body.portal-dashboard-body.admin-interface-mode .portal-core-panel,
+body.portal-dashboard-body.admin-interface-mode .portal-metric-card,
+body.portal-dashboard-body.admin-interface-mode .portal-command-center-panel,
+body.portal-dashboard-body.admin-interface-mode .portal-admin-panel,
+body.portal-dashboard-body.admin-interface-mode .family-record-card,
+body.portal-dashboard-body.admin-interface-mode [data-admin-tools-panel] {
+  background: var(--admin-panel) !important;
+  color: var(--admin-text) !important;
+  border-color: var(--admin-border) !important;
+}
+
+body.portal-dashboard-body.admin-interface-mode .portal-metric-card p,
+body.portal-dashboard-body.admin-interface-mode .portal-core-guidance,
+body.portal-dashboard-body.admin-interface-mode .card-copy,
+body.portal-dashboard-body.admin-interface-mode .portal-command-label,
+body.portal-dashboard-body.admin-interface-mode .portal-metric-label {
+  color: var(--admin-muted) !important;
+  opacity: 1;
+}
+
+body.portal-dashboard-body.admin-interface-mode .portal-chip,
+body.portal-dashboard-body.admin-interface-mode .presence-badge,
+body.portal-dashboard-body.admin-interface-mode .portal-node {
+  color: var(--admin-text) !important;
+  border-color: var(--admin-border) !important;
+  background: var(--admin-helper-bg) !important;
+}
+
+body.portal-dashboard-body.admin-interface-mode a,
+body.portal-dashboard-body.admin-interface-mode .portal-metric-card strong,
+body.portal-dashboard-body.admin-interface-mode .portal-core-title,
+body.portal-dashboard-body.admin-interface-mode .portal-core-status,
+body.portal-dashboard-body.admin-interface-mode .portal-core-label {
+  color: var(--admin-text) !important;
+}
+
 .admin-appearance-controls {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- fix Admin Workspace bootstrap so CEO sessions retain Master Admin tool visibility even when `/auth/me` omits explicit permission arrays
- add explicit bootstrap error panel with safe messaging and retry action instead of blank cards
- wire dashboard-specific admin appearance selectors so Light, Dark, High Contrast, and Larger Text immediately affect dashboard surfaces in Safari/WebKit
- bump admin dashboard and control-center script cache-busting query parameters to force coherent static asset revisions
- add focused Playwright dashboard regression coverage for appearance computed-style changes, bootstrap success/error handling, and asset-version detection

## Validation
- `npm run test:browser -- --reporter=list`
- `npx playwright test browser-tests/dashboard-admin.spec.mjs --browser=webkit --reporter=list`
- `python3 -m pytest backend/tests/test_admin_console.py -q`