### PR TITLE
Bump dashboard and admin stylesheet cache-busting revision

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -8,7 +8,7 @@
       name="description"
       content="Internal premium operations console for Tomb of Light customer cases, repairs, entitlements, mint readiness, and audit review."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260713-livefix1" />
   </head>
   <body>
     <div class="page-wrap">

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -188,6 +188,10 @@ test("[asset-versioning] dashboard and control center include cache-busting live
   const dashboardScripts = await page.locator("script[src]").evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute("src") || ""),
   );
+  const dashboardStyles = await page.locator("link[rel='stylesheet']").evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("href") || ""),
+  );
+  expect(dashboardStyles.some((href) => href.includes("styles.css?v=20260713-livefix1"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("app.js?v=20260713-livefix1"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-admin.js?v=20260713-livefix1"))).toBeTruthy();
 
@@ -195,6 +199,10 @@ test("[asset-versioning] dashboard and control center include cache-busting live
   const controlCenterScripts = await page.locator("script[src]").evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute("src") || ""),
   );
+  const controlCenterStyles = await page.locator("link[rel='stylesheet']").evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("href") || ""),
+  );
+  expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260713-livefix1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260713-livefix1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260713-livefix1"))).toBeTruthy();
 });

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,7 +8,7 @@
       name="description"
       content="Your private Tomb of Light customer or internal operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260713-livefix1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- update `dashboard.html` and `admin-control-center.html` to load `styles.css?v=20260713-livefix1`
- extend dashboard browser regression to assert stylesheet versioning in both pages, catching mixed static asset revisions

## Validation
- `npm run test:browser -- --reporter=list`
- `npx playwright test browser-tests/dashboard-admin.spec.mjs --browser=webkit --reporter=list`