### PR TITLE
Make Stripe sole authority for paid orders and provisioning

### DIFF
--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.dependencies.auth import get_current_user, require_permission
-from app.schemas.order import OrderCreate, OrderResponse
+from app.dependencies.auth import get_current_user, require_any_permission, require_permission
+from app.schemas.order import AdminManualOrderCreate, OrderResponse, PublicCheckoutOrderCreate
 from app.services.order_service import (
+    create_manual_order_for_admin,
     create_order_for_user,
     ensure_order_indexes,
     get_orders_for_user,
@@ -23,11 +24,28 @@ def initialize_order_indexes() -> None:
     status_code=status.HTTP_201_CREATED,
 )
 def record_checkout_order(
-    payload: OrderCreate,
+    payload: PublicCheckoutOrderCreate,
     current_user: dict = Depends(get_current_user),
 ):
     try:
         return create_order_for_user(current_user, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/admin/manual-order",
+    response_model=OrderResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_manual_order_admin(
+    payload: AdminManualOrderCreate,
+    current_user: dict = Depends(
+        require_any_permission(["admin.control.billing", "admin.orders.repair"])
+    ),
+):
+    try:
+        return create_manual_order_for_admin(current_user, payload)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,21 +1,33 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class OrderCreate(BaseModel):
+class PublicCheckoutOrderCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     package_code: str | None = Field(default=None)
     package_slug: str | None = Field(default=None)
-    package_name: str = Field(..., min_length=1)
-    price_label: str = Field(..., min_length=1)
-    item_type: str = Field(default="package")
-    billing_plan: str = Field(default="one_time")
-    source: str = Field(default="stripe_payment_link")
-    order_status: str = Field(default="paid")
-    project_id: Optional[str] = None
     stripe_session_id: Optional[str] = None
-    stripe_payment_link_id: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_package_identity(self):
+        if not (self.package_code or self.package_slug or self.stripe_session_id):
+            raise ValueError("package_code or package_slug is required.")
+        return self
+
+
+class AdminManualOrderCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    customer_email: str = Field(..., min_length=3)
+    package_code: str | None = Field(default=None)
+    package_slug: str | None = Field(default=None)
+    project_id: Optional[str] = None
+    reason: str = Field(..., min_length=3)
+    authorization_source: str = Field(..., min_length=3)
+    idempotency_key: str = Field(..., min_length=8)
 
     @model_validator(mode="after")
     def validate_package_identity(self):

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -32,6 +32,7 @@ AUTHORITATIVE_ORDER_SOURCES = {
 }
 
 PAID_ORDER_STATUSES = {"paid", "complete", "completed", "succeeded"}
+PENDING_PUBLIC_ORDER_STATUS = "pending_confirmation"
 logger = logging.getLogger(__name__)
 
 
@@ -353,15 +354,80 @@ def _serialize_order(order: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def create_order_for_user(user: dict[str, Any], payload: Any) -> dict[str, Any]:
-    orders = _get_orders_collection()
+def _validated_user_object_id(user: dict[str, Any]) -> ObjectId:
+    user_id = _normalize(str(user.get("_id") or user.get("id") or user.get("user_id") or ""))
+    if not ObjectId.is_valid(user_id):
+        raise ValueError("Authenticated user id is invalid.")
+    return ObjectId(user_id)
 
-    package_code = _normalize_package_code(
-        getattr(payload, "package_code", None) or getattr(payload, "package_slug", None)
+
+def _create_pending_public_checkout_order(
+    *,
+    user: dict[str, Any],
+    package_code: str,
+) -> dict[str, Any]:
+    if package_code == "unknown" or not get_package(package_code):
+        raise ValueError("Unknown package.")
+
+    orders = _get_orders_collection()
+    user_oid = _validated_user_object_id(user)
+    existing = orders.find_one(
+        {
+            "user_id": user_oid,
+            "package_code": package_code,
+            "status": PENDING_PUBLIC_ORDER_STATUS,
+            "source": "customer_checkout_pending",
+        },
+        sort=[("created_at", -1)],
     )
-    item_type = _normalize(getattr(payload, "item_type", "package")).lower() or "package"
-    target_project_id = _normalize(getattr(payload, "project_id", None))
-    if item_type == "package" and target_project_id:
+    if existing:
+        return _serialize_order(existing)
+
+    package = get_package(package_code) or {}
+    order_doc = {
+        "user_id": user_oid,
+        "email": _normalize_email(user.get("email")),
+        "package_code": package_code,
+        "package_slug": package_code,
+        "lane": _package_lane_for_code(package_code),
+        "package_lane": _package_lane_for_code(package_code),
+        "package_name": _normalize(package.get("display_name")) or package_code.replace("_", " ").title(),
+        "price_label": _format_price_label(_base_package_price_cents(package_code), "one_time"),
+        "item_type": "package",
+        "billing_plan": "one_time",
+        "source": "customer_checkout_pending",
+        "status": PENDING_PUBLIC_ORDER_STATUS,
+        "created_at": datetime.now(UTC),
+    }
+    result = orders.insert_one(order_doc)
+    order_doc["_id"] = result.inserted_id
+    return _serialize_order(order_doc)
+
+
+def _create_verified_paid_package_order(
+    *,
+    user: dict[str, Any],
+    session_id: str,
+    requested_package_code: str = "",
+) -> dict[str, Any]:
+    orders = _get_orders_collection()
+    existing = _find_order_by_session_id_for_customer(
+        orders=orders,
+        session_id=session_id,
+        user=user,
+    )
+    if existing:
+        return _serialize_order(existing)
+
+    session = _retrieve_checkout_session(session_id)
+    _ensure_session_belongs_to_user(user=user, session=session)
+    purchase = _extract_verified_package_purchase_from_session(session)
+    package_code = purchase["package_code"]
+    if requested_package_code and requested_package_code != package_code:
+        raise ValueError("Checkout session product and requested package do not match.")
+
+    target_project_id = _extract_target_project_id(session)
+    if target_project_id:
         entitlement = get_project_entitlement(target_project_id) or {}
         entitlement_status = _normalize(entitlement.get("status")).lower() or "active"
         entitlement_package = _normalize_package_code(entitlement.get("package_code"))
@@ -370,81 +436,149 @@ def create_order_for_user(user: dict[str, Any], payload: Any) -> dict[str, Any]:
                 "This workspace already has an active package entitlement. Invite members instead of purchasing again."
             )
 
-    order_status = _public_checkout_status(
-        getattr(payload, "source", ""),
-        getattr(payload, "order_status", ""),
-    )
-    stripe_session_id = _normalize(getattr(payload, "stripe_session_id", None))
-
-    existing = None
-    if stripe_session_id:
-        existing = orders.find_one({"stripe_session_id": stripe_session_id})
-
-    if existing is None:
-        existing = orders.find_one(
-            {
-                "user_id": ObjectId(str(user["_id"])),
-                "package_code": package_code,
-                "status": order_status,
-            },
-            sort=[("created_at", -1)],
-        )
-
-    if existing:
-        return _serialize_order(existing)
-
+    user_oid = _validated_user_object_id(user)
     order_doc = {
-        "user_id": ObjectId(str(user["_id"])),
-        "email": user["email"],
+        "user_id": user_oid,
+        "email": _normalize_email(user.get("email")),
         "package_code": package_code,
         "package_slug": package_code,
         "lane": _package_lane_for_code(package_code),
         "package_lane": _package_lane_for_code(package_code),
-        "package_name": payload.package_name,
-        "price_label": payload.price_label,
-        "item_type": getattr(payload, "item_type", "package"),
-        "billing_plan": getattr(payload, "billing_plan", "one_time"),
-        "source": payload.source,
-        "status": order_status,
+        "package_name": purchase["package_name"],
+        "price_label": purchase["price_label"],
+        "item_type": "package",
+        "billing_plan": purchase["billing_plan"],
+        "source": "stripe_verified",
+        "status": "paid",
+        "stripe_session_id": session_id,
         "created_at": datetime.now(UTC),
     }
-    _set_if_present(order_doc, "stripe_session_id", payload.stripe_session_id)
-    _set_if_present(order_doc, "stripe_payment_link_id", payload.stripe_payment_link_id)
-
+    _set_if_present(order_doc, "stripe_payment_link_id", purchase.get("stripe_payment_link_id"))
     result = orders.insert_one(order_doc)
     order_doc["_id"] = result.inserted_id
 
-    if (
-        order_doc["item_type"] == "package"
-        and order_doc["status"] in PAID_ORDER_STATUSES
-        and _is_authoritative_order_source(order_doc.get("source"))
-    ):
-        order_doc = _attach_project_to_paid_package_order(
-            order_id=result.inserted_id,
-            order_doc=order_doc,
-            user=user,
-            package_code=package_code,
-            package_name=payload.package_name,
-            target_project_id=target_project_id,
-            stripe_session_id=payload.stripe_session_id,
-            stripe_payment_link_id=payload.stripe_payment_link_id,
-        )
-    elif order_doc["item_type"] == "maintenance":
-        if target_project_id:
-            project_oid = _to_object_id(target_project_id)
-            if project_oid is not None:
-                orders.update_one(
-                    {"_id": result.inserted_id},
-                    {"$set": {"project_id": project_oid}},
-                )
-                order_doc["project_id"] = project_oid
-                _schedule_maintenance_start(
-                    project_id=str(project_oid),
-                    billing_plan=order_doc.get("billing_plan", "monthly"),
-                )
+    order_doc = _attach_project_to_paid_package_order(
+        order_id=result.inserted_id,
+        order_doc=order_doc,
+        user=user,
+        package_code=package_code,
+        package_name=purchase["package_name"],
+        target_project_id=target_project_id,
+        stripe_session_id=session_id,
+        stripe_payment_link_id=purchase.get("stripe_payment_link_id"),
+    )
+    _trigger_package_provisioning()
+    return _serialize_order(order_doc)
 
-    if order_doc["item_type"] == "package":
-        _trigger_package_provisioning()
+
+def create_order_for_user(user: dict[str, Any], payload: Any) -> dict[str, Any]:
+    requested_package_code = _normalize_package_code(
+        getattr(payload, "package_code", None) or getattr(payload, "package_slug", None)
+    )
+    target_project_id = _normalize(getattr(payload, "project_id", None))
+    if target_project_id and requested_package_code != "unknown":
+        entitlement = get_project_entitlement(target_project_id) or {}
+        entitlement_status = _normalize(entitlement.get("status")).lower() or "active"
+        entitlement_package = _normalize_package_code(entitlement.get("package_code"))
+        if entitlement_status == "active" and entitlement_package == requested_package_code:
+            raise ValueError(
+                "This workspace already has an active package entitlement. Invite members instead of purchasing again."
+            )
+
+    stripe_session_id = _normalize(getattr(payload, "stripe_session_id", None))
+
+    if stripe_session_id:
+        return _create_verified_paid_package_order(
+            user=user,
+            session_id=stripe_session_id,
+            requested_package_code=requested_package_code if requested_package_code != "unknown" else "",
+        )
+
+    return _create_pending_public_checkout_order(
+        user=user,
+        package_code=requested_package_code,
+    )
+
+
+def create_manual_order_for_admin(admin_user: dict[str, Any], payload: Any) -> dict[str, Any]:
+    customer_email = _normalize_email(getattr(payload, "customer_email", ""))
+    if not customer_email:
+        raise ValueError("customer_email is required.")
+    reason = _normalize(getattr(payload, "reason", ""))
+    authorization_source = _normalize(getattr(payload, "authorization_source", ""))
+    idempotency_key = _normalize(getattr(payload, "idempotency_key", ""))
+    if not reason:
+        raise ValueError("reason is required.")
+    if not authorization_source:
+        raise ValueError("authorization_source is required.")
+    if not idempotency_key:
+        raise ValueError("idempotency_key is required.")
+
+    package_code = _normalize_package_code(
+        getattr(payload, "package_code", None) or getattr(payload, "package_slug", None)
+    )
+    if package_code == "unknown" or not get_package(package_code):
+        raise ValueError("Unknown package.")
+
+    customer_user = _get_user_by_email(customer_email) or create_pending_checkout_user(customer_email)
+    if not customer_user:
+        raise ValueError("Customer account could not be resolved.")
+
+    orders = _get_orders_collection()
+    existing = orders.find_one({"manual_idempotency_key": idempotency_key})
+    if existing:
+        return _serialize_order(existing)
+
+    package = get_package(package_code) or {}
+    package_name = _normalize(package.get("display_name")) or package_code.replace("_", " ").title()
+    order_doc = {
+        "user_id": _validated_user_object_id(customer_user),
+        "email": customer_email,
+        "package_code": package_code,
+        "package_slug": package_code,
+        "lane": _package_lane_for_code(package_code),
+        "package_lane": _package_lane_for_code(package_code),
+        "package_name": package_name,
+        "price_label": _format_price_label(_base_package_price_cents(package_code), "one_time"),
+        "item_type": "package",
+        "billing_plan": "one_time",
+        "source": "admin_manual",
+        "status": "paid",
+        "manual_reason": reason,
+        "manual_authorization_source": authorization_source,
+        "manual_idempotency_key": idempotency_key,
+        "created_at": datetime.now(UTC),
+    }
+    result = orders.insert_one(order_doc)
+    order_doc["_id"] = result.inserted_id
+
+    order_doc = _attach_project_to_paid_package_order(
+        order_id=result.inserted_id,
+        order_doc=order_doc,
+        user=customer_user,
+        package_code=package_code,
+        package_name=package_name,
+        target_project_id=_normalize(getattr(payload, "project_id", "")),
+    )
+    _trigger_package_provisioning()
+
+    from app.services.audit_log_service import write_audit_log
+
+    write_audit_log(
+        actor_user_id=_normalize(str(admin_user.get("_id") or admin_user.get("id") or admin_user.get("user_id") or "")) or None,
+        actor_email=_normalize_email(admin_user.get("email")),
+        actor_name=_normalize(admin_user.get("full_name") or admin_user.get("name")),
+        action="admin_manual_order_recorded",
+        target_type="order",
+        target_id=str(result.inserted_id),
+        details={
+            "customer_email": customer_email,
+            "package_code": package_code,
+            "reason": reason,
+            "authorization_source": authorization_source,
+            "idempotency_key": idempotency_key,
+        },
+    )
 
     return _serialize_order(order_doc)
 
@@ -667,6 +801,12 @@ def ensure_order_indexes() -> None:
         unique=False,
         sparse=True,
     )
+    _ensure_index(
+        [("manual_idempotency_key", 1)],
+        name="manual_idempotency_key_1",
+        unique=True,
+        sparse=True,
+    )
 
 
 def _get_user_by_email(email: str) -> Optional[dict[str, Any]]:
@@ -809,6 +949,157 @@ def _format_price_label(amount_subtotal: Any, billing_plan: str) -> str:
 
     return f"${amount:,.2f}"
 
+
+def _normalize_currency(value: Any) -> str:
+    return _normalize(str(value or "")).lower()
+
+
+def _base_package_price_cents(package_code: str) -> int:
+    package = get_package(package_code) or {}
+    base_price = package.get("base_price_usd")
+    try:
+        return int(round(float(base_price) * 100))
+    except Exception:
+        return 0
+
+
+def _match_package_code_from_product(
+    *,
+    raw_code: str,
+    product_name: str,
+) -> str:
+    if raw_code:
+        normalized = _normalize_package_code(raw_code)
+        if normalized != "unknown" and get_package(normalized):
+            return normalized
+    normalized_from_name = _normalize_package_code(product_name)
+    if normalized_from_name != "unknown" and get_package(normalized_from_name):
+        return normalized_from_name
+    return "unknown"
+
+
+def _extract_verified_package_purchase_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    session_status = _normalize(session.get("status")).lower()
+    if session_status == "expired":
+        raise ValueError("Checkout session has expired.")
+
+    if _normalize(session.get("payment_status")).lower() != "paid":
+        raise ValueError("Checkout session is not paid.")
+
+    line_items = ((session.get("line_items") or {}).get("data")) or []
+    if not line_items:
+        raise ValueError("Checkout session has no line items.")
+
+    first_item = line_items[0] or {}
+    price_obj = first_item.get("price") or {}
+    if not price_obj:
+        raise ValueError("Checkout session line item is missing price data.")
+
+    price_id = _normalize(price_obj.get("id"))
+    if not price_id:
+        raise ValueError("Checkout session line item has unknown price.")
+
+    product_obj = price_obj.get("product") or {}
+    product_id = _normalize(product_obj.get("id"))
+    if not product_id:
+        raise ValueError("Checkout session line item has unknown product.")
+
+    raw_package_code = _normalize(
+        ((session.get("metadata") or {}).get("package_code"))
+        or ((session.get("metadata") or {}).get("package_slug"))
+        or ((product_obj.get("metadata") or {}).get("package_code"))
+        or ((product_obj.get("metadata") or {}).get("package_slug"))
+    )
+    product_name = _normalize(
+        product_obj.get("name")
+        or first_item.get("description")
+        or ((session.get("metadata") or {}).get("package_name"))
+    )
+    package_code = _match_package_code_from_product(
+        raw_code=raw_package_code,
+        product_name=product_name,
+    )
+    if package_code == "unknown":
+        raise ValueError("Checkout session product is not an approved Tomb of Light package.")
+
+    package = get_package(package_code) or {}
+    amount_cents = price_obj.get("unit_amount")
+    if not isinstance(amount_cents, int):
+        raise ValueError("Checkout session line item has unknown price amount.")
+
+    currency = _normalize_currency(price_obj.get("currency") or session.get("currency"))
+    if not currency:
+        raise ValueError("Checkout session line item currency is missing.")
+
+    expected_cents = _base_package_price_cents(package_code)
+    if expected_cents <= 0:
+        raise ValueError("Package catalog price is not configured.")
+    if currency != "usd" or amount_cents != expected_cents:
+        raise ValueError("Checkout session product and price do not match the approved package catalog.")
+
+    amount_total = session.get("amount_total")
+    if isinstance(amount_total, int) and amount_total != expected_cents:
+        raise ValueError("Checkout session amount does not match expected package total.")
+
+    billing_plan = "one_time"
+    package_name = _normalize(package.get("display_name")) or package_code.replace("_", " ").title()
+
+    return {
+        "package_code": package_code,
+        "package_name": package_name,
+        "price_label": _format_price_label(expected_cents, billing_plan),
+        "item_type": "package",
+        "billing_plan": billing_plan,
+        "currency": currency,
+        "amount_cents": expected_cents,
+        "stripe_payment_link_id": _normalize(session.get("payment_link")) or None,
+        "price_id": price_id,
+        "product_id": product_id,
+    }
+
+
+def _ensure_session_belongs_to_user(
+    *,
+    user: dict[str, Any],
+    session: dict[str, Any],
+) -> None:
+    session_email = _extract_email_from_session(session)
+    user_email = _normalize_email(user.get("email"))
+    if not session_email or not user_email or session_email != user_email:
+        raise ValueError("Checkout session email does not match authenticated customer.")
+
+    metadata = session.get("metadata") or {}
+    metadata_user_id = _normalize(metadata.get("user_id"))
+    current_user_id = _normalize(str(user.get("_id") or user.get("id") or user.get("user_id") or ""))
+    if metadata_user_id and current_user_id and metadata_user_id != current_user_id:
+        raise ValueError("Checkout session user association mismatch.")
+
+    session_customer_id = _normalize(session.get("customer"))
+    user_customer_id = _normalize(user.get("stripe_customer_id"))
+    if session_customer_id and user_customer_id and session_customer_id != user_customer_id:
+        raise ValueError("Checkout session customer does not match authenticated customer.")
+
+
+def _find_order_by_session_id_for_customer(
+    *,
+    orders: Collection,
+    session_id: str,
+    user: dict[str, Any],
+) -> dict[str, Any] | None:
+    existing = orders.find_one({"stripe_session_id": session_id})
+    if not existing:
+        return None
+
+    existing_user_id = _normalize(str(existing.get("user_id") or ""))
+    current_user_id = _normalize(str(user.get("_id") or user.get("id") or user.get("user_id") or ""))
+    existing_email = _normalize_email(existing.get("email"))
+    current_email = _normalize_email(user.get("email"))
+    if (
+        (existing_user_id and current_user_id and existing_user_id != current_user_id)
+        or (existing_email and current_email and existing_email != current_email)
+    ):
+        raise ValueError("Checkout session is already associated with another customer.")
+    return existing
 
 def _schedule_maintenance_start(
     *,
@@ -1034,10 +1325,18 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "error": str(e),
         }
 
-    email = _extract_email_from_session(session)
-    if not email:
-        email = _get_email_from_event(event)
+    try:
+        purchase = _extract_verified_package_purchase_from_session(session)
+    except ValueError as exc:
+        return {
+            "order_id": None,
+            "reason": "invalid_checkout_session",
+            "error": str(exc),
+            "type": event_type,
+            "session_id": session_id,
+        }
 
+    email = _extract_email_from_session(session) or _get_email_from_event(event)
     if not email:
         return {
             "order_id": None,
@@ -1046,20 +1345,30 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "session_id": session_id,
         }
 
-    user = _get_user_by_email(email)
+    user = _get_user_by_email(email) or create_pending_checkout_user(
+        email,
+        full_name=_extract_customer_name_from_session(session),
+    )
     if not user:
-        user = create_pending_checkout_user(
-            email,
-            full_name=_extract_customer_name_from_session(session),
-        )
-        if not user:
-            return {
-                "order_id": None,
-                "reason": "no_matching_user",
-                "type": event_type,
-                "session_id": session_id,
-                "email": email,
-            }
+        return {
+            "order_id": None,
+            "reason": "no_matching_user",
+            "type": event_type,
+            "session_id": session_id,
+            "email": email,
+        }
+
+    try:
+        _ensure_session_belongs_to_user(user=user, session=session)
+    except ValueError as exc:
+        return {
+            "order_id": None,
+            "reason": "customer_association_mismatch",
+            "error": str(exc),
+            "type": event_type,
+            "session_id": session_id,
+            "email": email,
+        }
 
     customer_id = _normalize(session.get("customer"))
     if customer_id:
@@ -1076,11 +1385,29 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
     checkout_context = _extract_checkout_context(session)
     campaign = _normalize((session.get("metadata") or {}).get("campaign") or checkout_context.get("campaign")).upper()
 
-    item_type, package_code, package_name, price_label, billing_plan = _infer_purchase_fields(session)
-    stripe_payment_link_id = session.get("payment_link")
+    item_type = purchase["item_type"]
+    package_code = purchase["package_code"]
+    package_name = purchase["package_name"]
+    price_label = purchase["price_label"]
+    billing_plan = purchase["billing_plan"]
+    stripe_payment_link_id = purchase["stripe_payment_link_id"]
 
     existing = orders.find_one({"stripe_session_id": session_id})
     if existing:
+        existing_user_id = _normalize(str(existing.get("user_id") or ""))
+        incoming_user_id = _normalize(str(user.get("_id") or user.get("id") or user.get("user_id") or ""))
+        existing_email = _normalize_email(existing.get("email"))
+        if (
+            (existing_user_id and incoming_user_id and existing_user_id != incoming_user_id)
+            or (existing_email and existing_email != email)
+        ):
+            return {
+                "order_id": None,
+                "reason": "session_already_associated_with_another_customer",
+                "type": event_type,
+                "session_id": session_id,
+                "email": email,
+            }
         update_fields: dict[str, Any] = {
             "email": email,
             "package_code": package_code,

--- a/backend/tests/test_order_authority_security_patch.py
+++ b/backend/tests/test_order_authority_security_patch.py
@@ -1,0 +1,443 @@
+import copy
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.dependencies import auth as auth_dependencies
+from app.dependencies.auth import require_any_permission
+from app.schemas.order import AdminManualOrderCreate, PublicCheckoutOrderCreate
+from app.services import order_service
+
+
+class _InsertResult:
+    def __init__(self, inserted_id):
+        self.inserted_id = inserted_id
+
+
+class FakeOrdersCollection:
+    def __init__(self, seed=None):
+        self.docs = [dict(item) for item in (seed or [])]
+        self._next = 1
+
+    def _match(self, query, item):
+        for key, expected in (query or {}).items():
+            if item.get(key) != expected:
+                return False
+        return True
+
+    def find_one(self, query, sort=None):  # noqa: ARG002
+        for item in self.docs:
+            if self._match(query, item):
+                return dict(item)
+        return None
+
+    def insert_one(self, document):
+        payload = dict(document)
+        payload.setdefault("_id", f"order-{self._next}")
+        self._next += 1
+        self.docs.append(payload)
+        return _InsertResult(payload["_id"])
+
+    def update_one(self, query, update):
+        for index, item in enumerate(self.docs):
+            if self._match(query, item):
+                updated = dict(item)
+                updated.update((update or {}).get("$set") or {})
+                self.docs[index] = updated
+                return
+
+    def index_information(self):
+        return {}
+
+    def create_index(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
+def _paid_checkout_session(
+    *,
+    session_id="cs_test_paid_1",
+    email="customer@example.com",
+    package_code="legacy_plus",
+    product_name="Legacy Plus",
+    unit_amount=320000,
+    currency="usd",
+    payment_status="paid",
+    status="complete",
+):
+    return {
+        "id": session_id,
+        "object": "checkout.session",
+        "status": status,
+        "payment_status": payment_status,
+        "amount_total": unit_amount,
+        "currency": currency,
+        "customer_email": email,
+        "customer_details": {"email": email, "name": "Customer One"},
+        "metadata": {"package_code": package_code, "user_id": "507f1f77bcf86cd799439012"},
+        "line_items": {
+            "data": [
+                {
+                    "description": product_name,
+                    "price": {
+                        "id": "price_tol_legacy_plus",
+                        "currency": currency,
+                        "unit_amount": unit_amount,
+                        "product": {
+                            "id": "prod_tol_legacy_plus",
+                            "name": product_name,
+                            "metadata": {"package_code": package_code},
+                        },
+                    },
+                }
+            ]
+        },
+    }
+
+
+class OrderAuthoritySecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.user = {
+            "_id": "507f1f77bcf86cd799439012",
+            "email": "customer@example.com",
+            "stripe_customer_id": "cus_123",
+        }
+
+    def test_public_schema_rejects_source_admin_manual(self):
+        with self.assertRaises(ValidationError):
+            PublicCheckoutOrderCreate(package_code="legacy_plus", source="admin_manual")
+
+    def test_public_schema_rejects_paid_order_status(self):
+        with self.assertRaises(ValidationError):
+            PublicCheckoutOrderCreate(package_code="legacy_plus", order_status="paid")
+
+    def test_public_schema_rejects_browser_package_name_and_price(self):
+        with self.assertRaises(ValidationError):
+            PublicCheckoutOrderCreate(
+                package_code="legacy_plus",
+                package_name="Forged Name",
+                price_label="$1.00",
+            )
+
+    def test_invalid_unpaid_session_creates_no_paid_order_project_entitlement_or_maintenance(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_unpaid")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+            patch.object(order_service, "_attach_project_to_paid_package_order") as attach_mock,
+            patch.object(order_service, "apply_package_purchase_to_project") as apply_mock,
+            patch.object(order_service, "_schedule_maintenance_start") as maintenance_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        self.assertEqual(len([d for d in orders.docs if d.get("status") == "paid"]), 0)
+        attach_mock.assert_not_called()
+        apply_mock.assert_not_called()
+        maintenance_mock.assert_not_called()
+
+    def test_unpaid_stripe_session_cannot_provision(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_unpaid")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+            patch.object(order_service, "_attach_project_to_paid_package_order") as attach_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        attach_mock.assert_not_called()
+
+    def test_invalid_request_creates_no_project(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_no_project")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid", session_id="cs_test_no_project")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+            patch.object(order_service, "create_project_from_paid_order") as create_project_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        create_project_mock.assert_not_called()
+
+    def test_invalid_request_creates_no_entitlement(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_no_entitlement")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid", session_id="cs_test_no_entitlement")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+            patch.object(order_service, "apply_package_purchase_to_project") as apply_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        apply_mock.assert_not_called()
+
+    def test_invalid_request_creates_no_maintenance_record(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_no_maintenance")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid", session_id="cs_test_no_maintenance")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+            patch.object(order_service, "_schedule_maintenance_start") as maintenance_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        maintenance_mock.assert_not_called()
+
+    def test_expired_stripe_session_cannot_provision(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_expired")
+        expired_session = _paid_checkout_session(status="expired")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=expired_session),
+            patch.object(order_service, "_attach_project_to_paid_package_order") as attach_mock,
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        attach_mock.assert_not_called()
+
+    def test_unknown_product_or_price_cannot_provision(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_unknown")
+        unknown_product_session = _paid_checkout_session(
+            package_code="unknown_package",
+            product_name="Unknown Product",
+            unit_amount=None,
+        )
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unknown_product_session),
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+
+    def test_product_price_mismatch_cannot_provision(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_mismatch")
+        mismatch_session = _paid_checkout_session(unit_amount=100)
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=mismatch_session),
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+
+    def test_customer_email_mismatch_cannot_provision(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_email_mismatch")
+        mismatch_email_session = _paid_checkout_session(email="another@example.com")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=mismatch_email_session),
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+
+    def test_verified_paid_session_provisions_correct_package_exactly_once(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_paid_one")
+        session = _paid_checkout_session(session_id="cs_test_paid_one")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(
+                order_service,
+                "_attach_project_to_paid_package_order",
+                side_effect=lambda **kwargs: kwargs["order_doc"],
+            ) as attach_mock,
+            patch.object(order_service, "_trigger_package_provisioning") as provisioning_mock,
+        ):
+            first = order_service.create_order_for_user(self.user, payload)
+            second = order_service.create_order_for_user(self.user, payload)
+        self.assertEqual(first["package_code"], "legacy_plus")
+        self.assertEqual(second["id"], first["id"])
+        self.assertEqual(attach_mock.call_count, 1)
+        self.assertEqual(provisioning_mock.call_count, 1)
+        self.assertEqual(len([d for d in orders.docs if d.get("stripe_session_id") == "cs_test_paid_one"]), 1)
+
+    def test_repeated_webhook_delivery_is_idempotent(self):
+        orders = FakeOrdersCollection()
+        event = {
+            "type": "checkout.session.completed",
+            "data": {"object": {"id": "cs_test_evt"}},
+        }
+        session = _paid_checkout_session(session_id="cs_test_evt")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(order_service, "_get_user_by_email", return_value=self.user),
+            patch.object(order_service, "store_stripe_customer_reference"),
+            patch.object(
+                order_service,
+                "_attach_project_to_paid_package_order",
+                side_effect=lambda **kwargs: kwargs["order_doc"],
+            ),
+            patch.object(order_service, "_trigger_package_provisioning"),
+        ):
+            first = order_service.upsert_order_from_stripe_event(event)
+            second = order_service.upsert_order_from_stripe_event(event)
+        self.assertFalse(first.get("existing"))
+        self.assertTrue(second.get("existing"))
+        self.assertEqual(len([d for d in orders.docs if d.get("stripe_session_id") == "cs_test_evt"]), 1)
+
+    def test_existing_historical_orders_remain_unchanged(self):
+        keith_order = {
+            "_id": "order-keith-1",
+            "user_id": "507f1f77bcf86cd799439099",
+            "email": "keith.goffigan@example.com",
+            "package_code": "legacy_snapshot",
+            "status": "paid",
+            "source": "stripe_webhook",
+        }
+        keith_upgrade = {
+            "_id": "order-keith-upgrade-1",
+            "user_id": "507f1f77bcf86cd799439099",
+            "email": "keith.goffigan@example.com",
+            "package_code": "legacy_plus",
+            "status": "paid",
+            "source": "admin_manual",
+        }
+        larry_order = {
+            "_id": "order-larry-1",
+            "user_id": "507f1f77bcf86cd799439199",
+            "email": "larry.robinson@example.com",
+            "package_code": "digital_legacy_portrait",
+            "status": "paid",
+            "source": "stripe_webhook",
+        }
+        orders = FakeOrdersCollection(seed=[keith_order, keith_upgrade, larry_order])
+        baseline = copy.deepcopy(orders.docs)
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_unpaid_hist")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid", session_id="cs_test_unpaid_hist")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        self.assertEqual(orders.docs[:3], baseline[:3])
+        self.assertEqual(orders.docs[0]["email"], "keith.goffigan@example.com")
+        self.assertEqual(orders.docs[1]["package_code"], "legacy_plus")
+
+    def test_larry_mint_record_remains_unchanged(self):
+        mint_record = {
+            "_id": "mint-larry-1",
+            "owner_email": "larry.robinson@example.com",
+            "project_id": "project-larry-1",
+            "token_status": "canonical_minted",
+        }
+        baseline = copy.deepcopy(mint_record)
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_unpaid_larry")
+        unpaid_session = _paid_checkout_session(payment_status="unpaid", session_id="cs_test_unpaid_larry")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=unpaid_session),
+        ):
+            with self.assertRaises(ValueError):
+                order_service.create_order_for_user(self.user, payload)
+        self.assertEqual(mint_record, baseline)
+
+    def test_customer_cannot_access_admin_manual_order_route(self):
+        dependency = require_any_permission(["admin.control.billing", "admin.orders.repair"])
+        request = SimpleNamespace(path_params={}, query_params={})
+        with patch.object(
+            auth_dependencies,
+            "_get_or_resolve_access_context",
+            return_value={"permissions": {"user.read"}},
+        ):
+            with self.assertRaises(HTTPException) as exc:
+                dependency(
+                    request=request,
+                    current_user={
+                        "_id": "507f1f77bcf86cd799439012",
+                        "email": "customer@example.com",
+                    },
+                )
+        self.assertEqual(exc.exception.status_code, 403)
+
+    def test_manual_order_requires_permission_reason_idempotency_and_audit_event(self):
+        dependency = require_any_permission(["admin.control.billing", "admin.orders.repair"])
+        request = SimpleNamespace(path_params={}, query_params={})
+        with patch.object(
+            auth_dependencies,
+            "_get_or_resolve_access_context",
+            return_value={"permissions": {"admin.control.billing"}},
+        ):
+            resolved = dependency(
+                request=request,
+                current_user={
+                    "_id": "507f1f77bcf86cd799439001",
+                    "email": "finance@example.com",
+                },
+            )
+        self.assertEqual(resolved["email"], "finance@example.com")
+
+        with self.assertRaises(ValidationError):
+            AdminManualOrderCreate(
+                customer_email="customer@example.com",
+                package_code="legacy_plus",
+                authorization_source="finance_ticket",
+                idempotency_key="idem-key-99999",
+            )
+        with self.assertRaises(ValidationError):
+            AdminManualOrderCreate(
+                customer_email="customer@example.com",
+                package_code="legacy_plus",
+                reason="manual reconciliation",
+                authorization_source="finance_ticket",
+            )
+
+        orders = FakeOrdersCollection()
+        payload = AdminManualOrderCreate(
+            customer_email="customer@example.com",
+            package_code="legacy_plus",
+            reason="approved finance correction",
+            authorization_source="finance_ticket_123",
+            idempotency_key="idem-key-12345678",
+        )
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_get_user_by_email", return_value=self.user),
+            patch.object(
+                order_service,
+                "_attach_project_to_paid_package_order",
+                side_effect=lambda **kwargs: kwargs["order_doc"],
+            ),
+            patch.object(order_service, "_trigger_package_provisioning"),
+            patch("app.services.audit_log_service.write_audit_log") as audit_mock,
+        ):
+            result = order_service.create_manual_order_for_admin(
+                {
+                    "_id": "507f1f77bcf86cd799439001",
+                    "email": "finance@example.com",
+                    "full_name": "Finance Admin",
+                },
+                payload,
+            )
+        self.assertEqual(result["status"], "paid")
+        self.assertEqual(audit_mock.call_count, 1)
+        self.assertEqual(len(orders.docs), 1)
+
+    def test_admin_manual_schema_forbids_administrative_metadata_outside_contract(self):
+        with self.assertRaises(ValidationError):
+            AdminManualOrderCreate(
+                customer_email="customer@example.com",
+                package_code="legacy_plus",
+                reason="manual fix",
+                authorization_source="finance_ticket",
+                idempotency_key="idem-key-12345678",
+                order_status="paid",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
`POST /orders/record-checkout` accepted client-controlled paid authority fields, which allowed an authenticated customer to forge `source=admin_manual` and `order_status=paid` and reach paid-order provisioning logic without trusted payment proof.

This patch moves paid authority to server-trusted sources only and closes the forged paid-order path.

## What changed
- Replaced the public checkout payload with a strict schema that forbids administrative and paid-authority fields.
- Updated `/orders/record-checkout` flow so browser requests are non-authoritative by default (`pending_confirmation`) and can only become paid via server-side Stripe checkout-session verification.
- Added Stripe verification checks for:
  - paid status
  - expired session rejection
  - customer/email association
  - approved package mapping
  - product/price/amount/currency consistency against Tomb of Light catalog
  - session ownership conflict and duplicate-session handling
- Added a dedicated admin manual-order route with required:
  - admin/finance permission gate
  - reason
  - authorization source
  - idempotency key
  - audit event
- Added manual-order idempotency index support.

## Security and behavior notes
- Public customer requests can no longer create paid orders or trigger paid provisioning side effects from claimed client values.
- Repeated verified session/webhook processing is idempotent for order creation.
- Historical safety tests were added to prove existing historical records are not rewritten.

## Tests
Added targeted tests in `backend/tests/test_order_authority_security_patch.py` covering:
- spoofed `admin_manual` and `paid` inputs rejected at public boundary
- browser-provided package/price authority rejected
- invalid sessions do not create paid orders, projects, entitlements, or maintenance effects
- unpaid/expired/unknown/mismatched/mismatched-customer Stripe sessions rejected
- verified paid session provisions correct package exactly once
- repeated webhook/session delivery idempotent
- historical orders and named historical records unchanged
- admin manual-order gate and required fields/audit behavior

Also ran:
- `pytest -q tests/test_order_authority_security_patch.py tests/test_household_invites_and_orders.py tests/test_order_service_checkout_context.py tests/test_stripe_webhooks.py` (pass)
- `pytest -q` once per request (existing unrelated contract-suite failures remain in baseline)