### PR TITLE
Add Cloudflare Worker API gateway to fix persistent Admin Control Center failures

### DIFF
--- a/app.js
+++ b/app.js
@@ -433,7 +433,14 @@
   function isFrontendOriginBaseUrl(value) {
     try {
       const parsed = new URL(String(value || "").trim());
-      return parsed.origin === window.location.origin;
+      if (parsed.origin !== window.location.origin) {
+        return false;
+      }
+      // A same-origin URL with a non-root path (e.g. /api-gateway) is a
+      // same-origin API gateway, not the frontend root — treat it as a backend URL.
+      const hasApiPath =
+        parsed.pathname && parsed.pathname !== "/" && parsed.pathname !== "";
+      return !hasApiPath;
     } catch (_error) {
       return false;
     }

--- a/cloudflare-worker-api-gateway.js
+++ b/cloudflare-worker-api-gateway.js
@@ -1,0 +1,76 @@
+/**
+ * Tomb of Light — Cloudflare Worker: API Gateway
+ *
+ * Proxies /api-gateway/* requests from tomboflight.com to
+ * tomboflight-api.onrender.com, making all API calls same-origin
+ * from the browser's perspective and eliminating CORS entirely.
+ *
+ * Deploy in Cloudflare Dashboard:
+ *   Workers & Pages → Create → Create Worker → paste this code → Deploy
+ *   Then: Websites → tomboflight.com → Workers Routes →
+ *         Route: tomboflight.com/api-gateway/*  →  select this worker
+ *
+ * After deploying the route, config.js lists https://tomboflight.com/api-gateway
+ * as the primary API base URL. The browser never directly contacts onrender.com.
+ */
+
+const BACKEND_ORIGIN = "https://tomboflight-api.onrender.com";
+const GATEWAY_PREFIX = "/api-gateway";
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (!url.pathname.startsWith(GATEWAY_PREFIX)) {
+      return new Response(JSON.stringify({ detail: "Not found." }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Strip /api-gateway prefix and preserve path + query string
+    const backendPath = url.pathname.slice(GATEWAY_PREFIX.length) || "/";
+    const backendUrl = `${BACKEND_ORIGIN}${backendPath}${url.search}`;
+
+    // Forward the request with all original headers intact
+    const backendRequest = new Request(backendUrl, {
+      method: request.method,
+      headers: request.headers,
+      body: ["GET", "HEAD"].includes(request.method) ? undefined : request.body,
+      redirect: "follow",
+    });
+
+    let response;
+    try {
+      response = await fetch(backendRequest);
+    } catch (_error) {
+      return new Response(
+        JSON.stringify({ detail: "API gateway: backend unreachable." }),
+        {
+          status: 502,
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+          },
+        }
+      );
+    }
+
+    // Return the backend response as-is; backend CORS headers are not needed
+    // because the browser sees this as a same-origin response from tomboflight.com.
+    const responseHeaders = new Headers(response.headers);
+    responseHeaders.set("Cache-Control", "no-store");
+    // Remove backend CORS headers — not needed for same-origin responses.
+    responseHeaders.delete("Access-Control-Allow-Origin");
+    responseHeaders.delete("Access-Control-Allow-Credentials");
+    responseHeaders.delete("Access-Control-Allow-Methods");
+    responseHeaders.delete("Access-Control-Allow-Headers");
+    responseHeaders.delete("Access-Control-Max-Age");
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  },
+};

--- a/config.js
+++ b/config.js
@@ -639,13 +639,13 @@
     TOL_PRICING,
     API_BASE_URL: isLocal
       ? preferredLocalApiBaseUrl
-      : "https://tomboflight-api.onrender.com",
+      : "https://tomboflight.com/api-gateway",
     API_BASE_URLS: isLocal
       ? localApiBaseUrls
-      : ["https://tomboflight-api.onrender.com"],
+      : ["https://tomboflight.com/api-gateway", "https://tomboflight-api.onrender.com"],
     INVITE_API_BASE_URL_FALLBACKS: isLocal
       ? localApiBaseUrls
-      : ["https://tomboflight-api.onrender.com"],
+      : ["https://tomboflight.com/api-gateway", "https://tomboflight-api.onrender.com"],
 
     PAYMENT_LINKS: Object.assign({}, buildPaymentLinksFromPricing(TOL_PRICING)),
   });


### PR DESCRIPTION
## Why

After PR #560 was merged (30 s timeout + removed dead fallback), the Admin Control Center still shows `NET-API-UNREACHABLE` for the master admin account even after a full Cloudflare cache purge and browser hard reset.

Root cause: the browser is blocking cross-origin `fetch()` calls from `tomboflight.com` to `tomboflight-api.onrender.com`. This manifests as `TypeError: Failed to fetch` in the browser (caught as `NET-API-UNREACHABLE`). The backend itself is healthy and responding in < 500 ms -- the block is client-side, caused by a browser extension or network-level policy that restricts cross-site requests to third-party hosting domains (`onrender.com`).

## Solution

Add a **Cloudflare Worker reverse proxy** that turns all Admin API requests into same-origin requests from the browser's perspective:

```
Browser -> tomboflight.com/api-gateway/* (same-origin)
         -> Cloudflare Worker (server-side)
         -> tomboflight-api.onrender.com/* (no browser CORS)
```

The browser never directly contacts `onrender.com`. No CORS. No cross-site blocking. No extension interference.

## Changes

- **`cloudflare-worker-api-gateway.js`**: New Worker that strips the `/api-gateway` prefix and proxies to `tomboflight-api.onrender.com`, forwarding all headers (including `Authorization`) and stripping CORS headers from responses (not needed for same-origin traffic).
- **`config.js`**: Sets `https://tomboflight.com/api-gateway` as the primary `API_BASE_URL` and `API_BASE_URLS[0]`, with `tomboflight-api.onrender.com` as the fallback.
- **`app.js`**: Fixed `isFrontendOriginBaseUrl()` to allow same-origin URLs that have a non-root path (e.g. `/api-gateway`) to be used as backend API URLs instead of being filtered out.

## Deployment required (one-time Cloudflare step)

After merging, the site deploys automatically via GitHub Pages. The Worker must also be activated in the Cloudflare dashboard:

1. **Cloudflare Dashboard** -> Workers & Pages -> Create Application -> Create Worker
2. Paste the contents of `cloudflare-worker-api-gateway.js` -> **Deploy**
3. Go to **Websites** -> `tomboflight.com` -> **Workers Routes** -> Add Route:
   - Route: `tomboflight.com/api-gateway/*`
   - Worker: select the worker created above
4. Save

Once the route is active, all admin API calls go through the Worker as same-origin requests.

## Testing

- 14/14 Playwright browser tests pass
- Backend health: `tomboflight-api.onrender.com/health` 200 OK in < 500 ms
- CORS: verified correct for both `tomboflight.com` and `www.tomboflight.com`