### PR TITLE
Sales-open Master Admin completion: manual fulfillment, Stripe operations, account classification, diagnostics

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -8,7 +8,7 @@
       name="description"
       content="Internal premium operations console for Tomb of Light customer cases, repairs, entitlements, mint readiness, and audit review."
     />
-    <link rel="stylesheet" href="styles.css?v=20260713-livefix3" />
+    <link rel="stylesheet" href="styles.css?v=20260727-masterops1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -50,6 +50,7 @@
               <span class="eyebrow">Internal Premium Operations</span>
               <h1 data-admin-control-title>Customer Operations Workspace</h1>
               <p data-admin-control-status>Loading internal case operations...</p>
+              <div class="admin-status-summary" data-admin-status-summary aria-live="polite"></div>
             </div>
 
             <div class="admin-command-search">
@@ -84,17 +85,12 @@
             <div data-admin-impersonation-banner aria-live="polite"></div>
           </div>
 
-          <section class="admin-case-context-panel" data-admin-diagnostics-panel hidden aria-label="Master Admin diagnostics">
-            <h3>System Diagnostics — read-only</h3>
-            <p class="card-copy">This section displays system and release metadata only. Your CEO Master Administrator controls remain fully operational.</p>
-            <dl class="admin-diagnostics-grid" data-admin-diagnostics-output></dl>
-          </section>
-
           <div class="admin-case-console-shell">
               <aside class="admin-case-rail">
                 <h3>Operations Rail</h3>
                 <nav class="admin-case-nav" aria-label="Admin operations navigation">
                    <button type="button" data-case-queue="overview" class="is-active">Overview</button>
+                   <button type="button" data-case-queue="manual_fulfillment">Paid — Manual Fulfillment</button>
                    <button type="button" data-case-queue="intake_onboarding">Intake &amp; Onboarding</button>
                    <button type="button" data-case-queue="verification_upload_review">Verification &amp; Upload Review</button>
                    <button type="button" data-case-queue="workspace_access_invites">Workspace Access &amp; Invites</button>
@@ -208,6 +204,22 @@
                 <div class="admin-case-context" data-admin-case-context></div>
               </aside>
           </div>
+
+          <section class="admin-diagnostics-section" data-admin-diagnostics-section hidden aria-label="Master Admin diagnostics">
+            <button
+              class="btn btn-secondary admin-diagnostics-toggle"
+              type="button"
+              data-admin-diagnostics-toggle
+              aria-expanded="false"
+            >
+              Show System Diagnostics
+            </button>
+            <div class="admin-diagnostics-panel" data-admin-diagnostics-panel hidden>
+              <h3>System Diagnostics — read-only</h3>
+              <p class="card-copy">This section displays system and release metadata only. Your CEO Master Administrator controls remain fully operational.</p>
+              <dl class="admin-diagnostics-grid" data-admin-diagnostics-output></dl>
+            </div>
+          </section>
         </section>
       </main>
 
@@ -222,8 +234,8 @@
     </div>
 
     <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260713-livefix3"></script>
-    <script src="auth.js?v=20260713-livefix3"></script>
-    <script src="admin-control-center.js?v=20260713-livefix3"></script>
+    <script src="app.js?v=20260727-masterops1"></script>
+    <script src="auth.js?v=20260727-masterops1"></script>
+    <script src="admin-control-center.js?v=20260727-masterops1"></script>
   </body>
 </html>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -57,6 +57,8 @@
     overviewLoadFailed: false,
     casesLoadFailed: false,
     lastStatusMessage: "",
+    diagnostics: null,
+    fulfillmentItems: [],
   };
   const DEFAULT_ROLE_KEY = "user";
 
@@ -109,6 +111,10 @@
 
   const QUEUE_META = {
     overview: ["Overview", "Executive repair posture across active customer operations."],
+    manual_fulfillment: [
+      "Paid — Manual Fulfillment Required",
+      "Stripe-verified purchases awaiting manual review and provisioning by an authorized operator.",
+    ],
     intake_onboarding: ["Intake & Onboarding", "New accounts/projects, intake progression, and stalled intake visibility."],
     verification_upload_review: ["Verification & Upload Review", "Upload review, verification pending states, and aging verification queues."],
     workspace_access_invites: ["Workspace Access & Invites", "Invite delivery health, expiration risk, and member access mismatches."],
@@ -613,11 +619,15 @@
   }
 
   function renderDiagnostics(payload) {
-    const panel = document.querySelector("[data-admin-diagnostics-panel]");
+    const section = document.querySelector("[data-admin-diagnostics-section]");
     const output = document.querySelector("[data-admin-diagnostics-output]");
-    if (!panel || !output) return;
-    panel.hidden = false;
+    if (!section || !output) return;
+    // The diagnostics section becomes available but stays collapsed by
+    // default; it sits in normal document flow and never overlays cases.
+    section.hidden = false;
     const data = payload || {};
+    state.diagnostics = data;
+    renderStatusSummary();
     const rows = [
       ["Authenticated user ID", data.user_id],
       ["Normalized role", data.role_key],
@@ -648,6 +658,235 @@
         bootstrap_endpoint_status: "unavailable",
         search_endpoint_status: "unavailable",
       });
+    }
+  }
+
+  function roleDisplayLabel(roleKey) {
+    const labels = {
+      ceo_master_admin: "CEO Master Administrator",
+      finance_admin: "Finance Administrator (CFO)",
+      operations_admin: "Operations Administrator (COO)",
+      marketing_admin: "Marketing Administrator (CMO)",
+    };
+    return labels[roleKey] || "Administrator";
+  }
+
+  function renderStatusSummary() {
+    const summary = document.querySelector("[data-admin-status-summary]");
+    if (!summary) return;
+    const data = state.diagnostics || {};
+    const bootstrapOk = (data.bootstrap_endpoint_status || "") === "ok";
+    const searchOk = (data.search_endpoint_status || "") === "ok";
+    const chips = [
+      ["System Ready", bootstrapOk],
+      ["CEO Role Verified", Boolean(data.is_ceo_master_admin)],
+      ["Search Ready", searchOk],
+      ["Metrics Ready", !state.overviewLoadFailed],
+      [
+        state.bootstrapFailed ? "Payments Attention Required" : "Payments Ready",
+        !state.bootstrapFailed,
+      ],
+    ];
+    summary.innerHTML = chips
+      .map(function (chip) {
+        return `<span class="admin-status-chip" data-state="${chip[1] ? "ok" : "attention"}">${escapeHtml(chip[0])}</span>`;
+      })
+      .join("");
+  }
+
+  function toggleDiagnosticsPanel() {
+    const panel = document.querySelector("[data-admin-diagnostics-panel]");
+    const toggle = document.querySelector("[data-admin-diagnostics-toggle]");
+    if (!panel || !toggle) return;
+    const expanded = panel.hidden;
+    panel.hidden = !expanded;
+    toggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+    toggle.textContent = expanded ? "Hide System Diagnostics" : "Show System Diagnostics";
+  }
+
+  const FULFILLMENT_ACTION_LABELS = {
+    verify_payment: "Verify Payment",
+    start_fulfillment: "Mark Fulfillment In Progress",
+    assign_package: "Assign Purchased Package",
+    complete_fulfillment: "Mark Fulfillment Complete",
+    escalate_mismatch: "Escalate Payment Mismatch",
+  };
+
+  function renderFulfillmentQueue() {
+    const list = document.querySelector("[data-admin-case-list]");
+    if (!list) return;
+    const items = state.fulfillmentItems || [];
+    if (!items.length) {
+      list.innerHTML = `<div class="family-record-card admin-card"><h3>No paid orders waiting</h3><p class="card-copy">Verified purchases requiring manual fulfillment will appear here.</p></div>`;
+      return;
+    }
+    list.innerHTML = items
+      .map(function (item) {
+        const actionButtons = Object.keys(FULFILLMENT_ACTION_LABELS)
+          .map(function (action) {
+            return `<button class="btn btn-secondary" type="button" data-fulfillment-action="${action}" data-fulfillment-order="${escapeHtml(item.order_id)}">${escapeHtml(FULFILLMENT_ACTION_LABELS[action])}</button>`;
+          })
+          .join("");
+        return `
+          <div class="family-record-card admin-card admin-fulfillment-card">
+            <h3>${escapeHtml(item.customer_name || item.email || "Unknown customer")}</h3>
+            <p class="card-copy">${escapeHtml(item.email || "no email")} · ${escapeHtml(item.package_name || item.package_code || "unknown package")} · ${escapeHtml(item.amount_label || "amount unknown")} ${escapeHtml((item.currency || "usd").toUpperCase())}</p>
+            <dl class="admin-diagnostics-grid">
+              <div><dt>Order</dt><dd>${escapeHtml(item.order_id)}</dd></div>
+              <div><dt>Stripe session</dt><dd>${escapeHtml(item.stripe_session_id || "none")}</dd></div>
+              <div><dt>Payment intent</dt><dd>${escapeHtml(item.stripe_payment_intent_id || "none")}</dd></div>
+              <div><dt>Payment status</dt><dd>${escapeHtml(item.payment_status || "unknown")}${item.payment_verified ? " (verified)" : " (not verified)"}</dd></div>
+              <div><dt>Billing plan</dt><dd>${escapeHtml(item.billing_plan || "one_time")}</dd></div>
+              <div><dt>Coupon</dt><dd>${escapeHtml(item.coupon || "none")}</dd></div>
+              <div><dt>Payment date</dt><dd>${escapeHtml(item.payment_date || "unknown")}</dd></div>
+              <div><dt>Fulfillment status</dt><dd>${escapeHtml(item.fulfillment_status || "pending_manual_fulfillment")}</dd></div>
+              <div><dt>Linked project</dt><dd>${escapeHtml(item.linked_project_id || "none")}</dd></div>
+              <div><dt>Entitlement</dt><dd>${escapeHtml(item.entitlement_status || "unknown")}</dd></div>
+              <div><dt>Assigned operator</dt><dd>${escapeHtml(item.assigned_operator || "unassigned")}</dd></div>
+              <div><dt>Next required action</dt><dd>${escapeHtml(item.next_required_action || "verify_payment")}</dd></div>
+            </dl>
+            <div class="admin-bulk-action-grid">${actionButtons}</div>
+          </div>`;
+      })
+      .join("");
+  }
+
+  async function loadFulfillmentQueue() {
+    setPageStatus("Loading paid manual fulfillment queue...", "info");
+    try {
+      const payload = await fetchJson("/admin/control-center/fulfillment/queue");
+      state.fulfillmentItems = Array.isArray(payload.items) ? payload.items : [];
+      renderFulfillmentQueue();
+      clearPageStatus();
+    } catch (error) {
+      setPageStatus(error.message || "Unable to load fulfillment queue.", "error");
+    }
+  }
+
+  async function runFulfillmentAction(orderId, action) {
+    const label = FULFILLMENT_ACTION_LABELS[action] || action;
+    const reason = window.prompt(`${label}: enter a reason for the audit record.`);
+    if (reason === null) return;
+    if (!reason || reason.trim().length < 3) {
+      setPageStatus("A reason of at least 3 characters is required.", "error");
+      return;
+    }
+    const idempotencyKey =
+      window.crypto && window.crypto.randomUUID
+        ? window.crypto.randomUUID()
+        : `mf-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setPageStatus(`Running ${label.toLowerCase()}...`, "info");
+    try {
+      await postJson(
+        `/admin/control-center/fulfillment/orders/${encodeURIComponent(orderId)}/actions/${encodeURIComponent(action)}`,
+        { reason: reason.trim(), idempotency_key: idempotencyKey },
+      );
+      await loadFulfillmentQueue();
+      setPageStatus(`${label} completed.`, "success");
+    } catch (error) {
+      setPageStatus(error.message || `${label} failed.`, "error");
+    }
+  }
+
+  function renderStripeOpsCard(workspace, tabData) {
+    const identity = (workspace && workspace.tabs && workspace.tabs.identity) || {};
+    const email = identity.email || "";
+    const subscriptionId = (tabData && (tabData.subscription || (tabData.primary_order || {}).subscription_id)) || "";
+    return `
+      <article class="admin-dossier-card admin-dossier-card--wide" data-stripe-ops-card>
+        <div class="admin-card-header"><span class="admin-card-badge">$</span><h3 class="admin-card-title">Stripe Operations</h3></div>
+        <p class="card-copy">Server-side Stripe actions for this customer. Every action requires a reason and is audit logged.</p>
+        <div class="admin-field-grid">
+          <label class="admin-field"><span>Customer Email</span><input type="email" data-stripe-ops-field="customer_email" value="${escapeHtml(email)}" /></label>
+          <label class="admin-field"><span>Reason (required)</span><input type="text" data-stripe-ops-field="reason" placeholder="Why are you doing this?" /></label>
+          <label class="admin-field"><span>Stripe Price ID (links / subscriptions)</span><input type="text" data-stripe-ops-field="price_id" placeholder="price_..." /></label>
+          <label class="admin-field"><span>Subscription ID</span><input type="text" data-stripe-ops-field="subscription_id" value="${escapeHtml(subscriptionId)}" placeholder="sub_..." /></label>
+          <label class="admin-field"><span>Invoice ID (retry)</span><input type="text" data-stripe-ops-field="invoice_id" placeholder="in_..." /></label>
+          <label class="admin-field"><span>Invoice Amount (cents)</span><input type="number" min="1" data-stripe-ops-field="amount_cents" placeholder="e.g. 250000" /></label>
+          <label class="admin-field"><span>Invoice Description</span><input type="text" data-stripe-ops-field="description" placeholder="What is being invoiced" /></label>
+        </div>
+        <div class="inline-actions" style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="ensure_customer">Ensure Stripe Customer</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="open_customer">Open in Stripe</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="payment_link">Create Payment Link</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="invoice">Create + Send Invoice</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="invoice_retry">Retry Invoice</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="subscription_create">Create Subscription</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="subscription_change">Change Subscription Price</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="subscription_pause">Pause Subscription</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="subscription_resume">Resume Subscription</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="subscription_cancel">Cancel Subscription</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="payment_method_link">Send Payment-Method Update Link</button>
+          <button class="btn btn-secondary" type="button" data-stripe-ops-action="history">Payment History</button>
+        </div>
+        <div class="admin-record-list" data-stripe-ops-result style="margin-top: 0.75rem;"></div>
+      </article>
+    `;
+  }
+
+  function stripeOpsField(card, name) {
+    const input = card.querySelector(`[data-stripe-ops-field="${name}"]`);
+    return input ? String(input.value || "").trim() : "";
+  }
+
+  function renderStripeOpsResult(card, payload) {
+    const node = card.querySelector("[data-stripe-ops-result]");
+    if (!node) return;
+    node.innerHTML = `<pre style="white-space: pre-wrap; word-break: break-word; margin: 0;">${escapeHtml(JSON.stringify(payload, null, 2))}</pre>`;
+  }
+
+  async function runStripeOpsAction(card, action) {
+    const email = stripeOpsField(card, "customer_email");
+    const reason = stripeOpsField(card, "reason");
+    const needsReason = action !== "open_customer" && action !== "history";
+    if (needsReason && reason.length < 3) {
+      setPageStatus("A reason of at least 3 characters is required for Stripe operations.", "error");
+      return;
+    }
+    setPageStatus("Running Stripe operation...", "info");
+    try {
+      let result;
+      if (action === "ensure_customer") {
+        result = await postJson("/admin/stripe-ops/customers/ensure", { customer_email: email, reason });
+      } else if (action === "open_customer") {
+        result = await fetchJson(`/admin/stripe-ops/customers/open?customer_email=${encodeURIComponent(email)}`);
+        if (result && result.dashboard_url) window.open(result.dashboard_url, "_blank", "noopener");
+      } else if (action === "payment_link") {
+        result = await postJson("/admin/stripe-ops/payment-links", { price_id: stripeOpsField(card, "price_id"), reason });
+      } else if (action === "invoice") {
+        result = await postJson("/admin/stripe-ops/invoices", {
+          customer_email: email,
+          amount_cents: Number(stripeOpsField(card, "amount_cents")) || 0,
+          description: stripeOpsField(card, "description"),
+          reason,
+        });
+      } else if (action === "invoice_retry") {
+        result = await postJson("/admin/stripe-ops/invoices/retry", { invoice_id: stripeOpsField(card, "invoice_id"), reason });
+      } else if (action === "subscription_create") {
+        result = await postJson("/admin/stripe-ops/subscriptions", { customer_email: email, price_id: stripeOpsField(card, "price_id"), reason });
+      } else if (action === "subscription_change") {
+        result = await postJson("/admin/stripe-ops/subscriptions/change-price", { subscription_id: stripeOpsField(card, "subscription_id"), price_id: stripeOpsField(card, "price_id"), reason });
+      } else if (action === "subscription_pause") {
+        result = await postJson("/admin/stripe-ops/subscriptions/pause", { subscription_id: stripeOpsField(card, "subscription_id"), reason });
+      } else if (action === "subscription_resume") {
+        result = await postJson("/admin/stripe-ops/subscriptions/resume", { subscription_id: stripeOpsField(card, "subscription_id"), reason });
+      } else if (action === "subscription_cancel") {
+        if (!window.confirm("Cancel this subscription? This is a destructive action.")) {
+          setPageStatus("Subscription cancel aborted.", "info");
+          return;
+        }
+        result = await postJson("/admin/stripe-ops/subscriptions/cancel", { subscription_id: stripeOpsField(card, "subscription_id"), reason, at_period_end: true, confirm: true });
+      } else if (action === "payment_method_link") {
+        result = await postJson("/admin/stripe-ops/payment-method-update-link", { customer_email: email, reason });
+      } else if (action === "history") {
+        result = await fetchJson(`/admin/stripe-ops/customers/history?customer_email=${encodeURIComponent(email)}`);
+      } else {
+        return;
+      }
+      renderStripeOpsResult(card, result);
+      setPageStatus("Stripe operation completed.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Stripe operation failed.", "error");
     }
   }
 
@@ -995,6 +1234,7 @@
             <div class="admin-case-primary">
               <h3>${escapeHtml(item.name || "Customer Case")}</h3>
               <p>${escapeHtml(item.email || "No email")} · ${escapeHtml(item.role || "customer")}</p>
+              ${item.account_type ? `<p class="card-copy">Account Type: ${escapeHtml(item.account_type)}</p>` : ""}
             </div>
             <div class="admin-case-detail">
               <span>Project</span>
@@ -1126,6 +1366,7 @@
             ${related.length ? related.map(function (order) { return `<p><strong>${escapeHtml(shortId(order.id))}</strong><span>${escapeHtml(order.status || "unknown")} · ${escapeHtml(order.package_name || order.package_code || "—")} · ${escapeHtml(formatDate(order.created_at))}</span></p>`; }).join("") : '<p>No related orders.</p>'}
           </div>
         </article>
+        ${state.isSuperAdmin ? renderStripeOpsCard(workspace, tabData) : ""}
       `;
       return;
     }
@@ -1678,6 +1919,17 @@
   }
 
   async function loadCases() {
+    if (state.queue === "manual_fulfillment") {
+      state.cases = [];
+      state.selectedCaseId = "";
+      state.workspace = null;
+      renderCaseHeader();
+      renderCaseContext();
+      updateActionAvailability();
+      updateBulkActionAvailability();
+      await loadFulfillmentQueue();
+      return;
+    }
     if (isMarketingRole()) {
       state.cases = [];
       state.selectedCaseId = "";
@@ -2264,6 +2516,28 @@
         return;
       }
 
+      const diagnosticsToggle = target.closest("[data-admin-diagnostics-toggle]");
+      if (diagnosticsToggle) {
+        toggleDiagnosticsPanel();
+        return;
+      }
+
+      const fulfillmentActionButton = target.closest("[data-fulfillment-action]");
+      if (fulfillmentActionButton) {
+        const action = fulfillmentActionButton.getAttribute("data-fulfillment-action") || "";
+        const orderId = fulfillmentActionButton.getAttribute("data-fulfillment-order") || "";
+        if (action && orderId) runFulfillmentAction(orderId, action);
+        return;
+      }
+
+      const stripeOpsButton = target.closest("[data-stripe-ops-action]");
+      if (stripeOpsButton) {
+        const card = stripeOpsButton.closest("[data-stripe-ops-card]");
+        const action = stripeOpsButton.getAttribute("data-stripe-ops-action") || "";
+        if (card && action) runStripeOpsAction(card, action);
+        return;
+      }
+
       const openCaseButton = target.closest("[data-open-case]");
       if (openCaseButton) {
         const caseId = openCaseButton.getAttribute("data-open-case");
@@ -2477,8 +2751,8 @@
         ? "All permitted operational queues"
         : `${queueCount} permitted ${isMarketingRole() ? "section" : "queue"}${queueCount === 1 ? "" : "s"}`;
       statusNode.textContent = isMarketingRole()
-        ? `Marketing command center is active for role: ${state.roleKey || DEFAULT_ROLE_KEY} across ${scopeLabel}.`
-        : `Search-first case operations are active for role: ${state.roleKey || DEFAULT_ROLE_KEY} across ${scopeLabel}.`;
+        ? `Marketing command center is active for ${roleDisplayLabel(state.roleKey)} across ${scopeLabel}.`
+        : `Search-first case operations are active for ${roleDisplayLabel(state.roleKey)} across ${scopeLabel}.`;
     }
   }
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -140,6 +140,10 @@ class Settings(BaseSettings):
         default=3,
         validation_alias=AliasChoices("STRIPE_PAYMENT_METHOD_MAX_CARDS"),
     )
+    manual_fulfillment_mode: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("MANUAL_FULFILLMENT_MODE"),
+    )
     password_reset_token_expire_minutes: int = Field(
         default=30,
         validation_alias=AliasChoices("PASSWORD_RESET_TOKEN_EXPIRE_MINUTES"),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.routes.admin_intake_submissions import (
 from app.routes.admin_continuity_preview import router as admin_continuity_preview_router
 from app.routes.asset_delivery import router as asset_delivery_router
 from app.routes.admin_control_center import router as admin_control_center_router
+from app.routes.admin_stripe_operations import router as admin_stripe_operations_router
 from app.routes.admin_maintenance import router as admin_maintenance_router
 from app.routes.audit_logs import router as audit_logs_router
 from app.routes.auth import router as auth_router
@@ -233,6 +234,7 @@ app.include_router(intake_submissions_router)
 app.include_router(admin_intake_submissions_router)
 app.include_router(admin_continuity_preview_router)
 app.include_router(admin_control_center_router)
+app.include_router(admin_stripe_operations_router)
 app.include_router(projects_router)
 app.include_router(project_entitlements_router)
 app.include_router(project_workflow_router)

--- a/backend/app/routes/admin_control_center.py
+++ b/backend/app/routes/admin_control_center.py
@@ -10,6 +10,10 @@ from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
 from app.dependencies.auth import require_any_permission, require_permission, require_super_admin
 from app.services.auth_service import admin_issue_password_reset
 from app.services.audit_log_service import write_audit_log
+from app.services.manual_fulfillment_service import (
+    execute_fulfillment_action,
+    list_manual_fulfillment_queue,
+)
 from app.services.admin_control_service import (
     MAX_BULK_ACTION_LIMIT,
     admin_control_access_profile,
@@ -413,6 +417,43 @@ def link_project_to_order(
             order_id=order_id,
             project_id=(payload.project_id if payload else ""),
             actor=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+class FulfillmentActionPayload(BaseModel):
+    reason: str = Field(..., min_length=3)
+    idempotency_key: str = Field(..., min_length=8)
+
+
+@router.get("/fulfillment/queue")
+def get_manual_fulfillment_queue(
+    limit: int = Query(default=100, ge=1, le=500),
+    current_user: dict[str, Any] = Depends(
+        require_any_permission(["admin.control.billing", "admin.orders.read"])
+    ),
+):
+    del current_user
+    return list_manual_fulfillment_queue(limit=limit)
+
+
+@router.post("/fulfillment/orders/{order_id}/actions/{action}")
+def run_manual_fulfillment_action(
+    order_id: str,
+    action: str,
+    payload: FulfillmentActionPayload,
+    current_user: dict[str, Any] = Depends(
+        require_any_permission(["admin.control.billing", "admin.orders.repair"])
+    ),
+):
+    try:
+        return execute_fulfillment_action(
+            current_user,
+            order_id=order_id,
+            action=action,
+            reason=payload.reason,
+            idempotency_key=payload.idempotency_key,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/backend/app/routes/admin_stripe_operations.py
+++ b/backend/app/routes/admin_stripe_operations.py
@@ -1,0 +1,250 @@
+"""Protected Stripe operations routes for the Master Admin console.
+
+Card entry always happens on Stripe-hosted surfaces. These routes never
+accept or return raw card numbers or CVC values.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.dependencies.auth import require_permission
+from app.services import stripe_admin_operations_service as stripe_ops
+
+router = APIRouter(prefix="/admin/stripe-ops", tags=["Admin Stripe Operations"])
+
+_BILLING_PERMISSION = "admin.control.billing"
+
+
+def _run(fn, /, **kwargs) -> Any:
+    try:
+        return fn(**kwargs)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+
+class CustomerPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    customer_email: str = Field(..., min_length=3)
+    reason: str = Field(..., min_length=3)
+
+
+class PaymentLinkPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    price_id: str = Field(..., min_length=6)
+    quantity: int = Field(default=1, ge=1, le=10)
+    reason: str = Field(..., min_length=3)
+
+
+class InvoicePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    customer_email: str = Field(..., min_length=3)
+    amount_cents: int = Field(..., gt=0)
+    description: str = Field(..., min_length=3)
+    days_until_due: int = Field(default=7, ge=1, le=90)
+    reason: str = Field(..., min_length=3)
+
+
+class SubscriptionCreatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    customer_email: str = Field(..., min_length=3)
+    price_id: str = Field(..., min_length=6)
+    reason: str = Field(..., min_length=3)
+
+
+class SubscriptionChangePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subscription_id: str = Field(..., min_length=4)
+    price_id: str = Field(..., min_length=6)
+    reason: str = Field(..., min_length=3)
+
+
+class SubscriptionActionPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subscription_id: str = Field(..., min_length=4)
+    reason: str = Field(..., min_length=3)
+
+
+class SubscriptionCancelPayload(SubscriptionActionPayload):
+    at_period_end: bool = True
+    confirm: bool = False
+
+
+class InvoiceRetryPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    invoice_id: str = Field(..., min_length=4)
+    reason: str = Field(..., min_length=3)
+
+
+@router.post("/customers/ensure")
+def ensure_customer(
+    payload: CustomerPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.ensure_customer,
+        admin_user=current_user,
+        customer_email=payload.customer_email,
+        reason=payload.reason,
+    )
+
+
+@router.get("/customers/open")
+def open_customer(
+    customer_email: str = Query(..., min_length=3),
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.open_customer_in_stripe,
+        admin_user=current_user,
+        customer_email=customer_email,
+    )
+
+
+@router.post("/payment-links")
+def create_payment_link(
+    payload: PaymentLinkPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.create_payment_link,
+        admin_user=current_user,
+        price_id=payload.price_id,
+        quantity=payload.quantity,
+        reason=payload.reason,
+    )
+
+
+@router.post("/invoices")
+def create_and_send_invoice(
+    payload: InvoicePayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.create_and_send_invoice,
+        admin_user=current_user,
+        customer_email=payload.customer_email,
+        amount_cents=payload.amount_cents,
+        description=payload.description,
+        days_until_due=payload.days_until_due,
+        reason=payload.reason,
+    )
+
+
+@router.post("/invoices/retry")
+def retry_invoice(
+    payload: InvoiceRetryPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.retry_invoice_payment,
+        admin_user=current_user,
+        invoice_id=payload.invoice_id,
+        reason=payload.reason,
+    )
+
+
+@router.post("/subscriptions")
+def create_subscription(
+    payload: SubscriptionCreatePayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.create_subscription,
+        admin_user=current_user,
+        customer_email=payload.customer_email,
+        price_id=payload.price_id,
+        reason=payload.reason,
+    )
+
+
+@router.post("/subscriptions/change-price")
+def change_subscription_price(
+    payload: SubscriptionChangePayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.change_subscription_price,
+        admin_user=current_user,
+        subscription_id=payload.subscription_id,
+        price_id=payload.price_id,
+        reason=payload.reason,
+    )
+
+
+@router.post("/subscriptions/pause")
+def pause_subscription(
+    payload: SubscriptionActionPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.pause_subscription,
+        admin_user=current_user,
+        subscription_id=payload.subscription_id,
+        reason=payload.reason,
+    )
+
+
+@router.post("/subscriptions/resume")
+def resume_subscription(
+    payload: SubscriptionActionPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.resume_subscription,
+        admin_user=current_user,
+        subscription_id=payload.subscription_id,
+        reason=payload.reason,
+    )
+
+
+@router.post("/subscriptions/cancel")
+def cancel_subscription(
+    payload: SubscriptionCancelPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.cancel_subscription,
+        admin_user=current_user,
+        subscription_id=payload.subscription_id,
+        at_period_end=payload.at_period_end,
+        confirm=payload.confirm,
+        reason=payload.reason,
+    )
+
+
+@router.post("/payment-method-update-link")
+def send_payment_method_update_link(
+    payload: CustomerPayload,
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.send_payment_method_update_link,
+        admin_user=current_user,
+        customer_email=payload.customer_email,
+        reason=payload.reason,
+    )
+
+
+@router.get("/customers/history")
+def customer_history(
+    customer_email: str = Query(..., min_length=3),
+    current_user: dict[str, Any] = Depends(require_permission(_BILLING_PERMISSION)),
+):
+    return _run(
+        stripe_ops.customer_payment_history,
+        admin_user=current_user,
+        customer_email=customer_email,
+    )

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -51,6 +51,7 @@ class OrderResponse(BaseModel):
     project_id: Optional[str] = None
     stripe_session_id: Optional[str] = None
     stripe_payment_link_id: Optional[str] = None
+    fulfillment_status: Optional[str] = None
     created_at: datetime
 
 

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -68,6 +68,7 @@ OFFICER_ADMIN_EMAILS = {
 
 ADMIN_CONTROL_QUEUES = [
     "overview",
+    "manual_fulfillment",
     "intake_onboarding",
     "verification_upload_review",
     "workspace_access_invites",
@@ -138,6 +139,7 @@ BULK_ACTION_PERMISSIONS: dict[str, set[str]] = {
 }
 QUEUE_PERMISSIONS: dict[str, set[str]] = {
     "overview": {"admin.control.view"},
+    "manual_fulfillment": {"admin.control.billing", "admin.orders.read"},
     "intake_onboarding": {"admin.intake.review", "admin.control.view"},
     "verification_upload_review": {"uploads.admin.review", "verification.review"},
     "workspace_access_invites": {"admin.control.view"},
@@ -239,6 +241,7 @@ MARKETING_TAB_ALLOWLIST = [
     "marketing_dashboard",
 ]
 OPERATIONS_QUEUE_ALLOWLIST = [
+    "manual_fulfillment",
     "intake_onboarding",
     "verification_upload_review",
     "workspace_access_invites",
@@ -597,7 +600,7 @@ def admin_control_bulk_action_allowed(
 # Bumped alongside the static frontend cache-busting query string
 # (see admin-control-center.html / dashboard.html `?v=` suffix) whenever a
 # hotfix ships to the admin control center or dashboard assets.
-FRONTEND_ASSET_REVISION = "20260713-livefix2"
+FRONTEND_ASSET_REVISION = "20260727-masterops1"
 
 
 def _backend_release_identifier() -> str:
@@ -4391,6 +4394,72 @@ def _user_supports_search(user: dict[str, Any], search: str) -> bool:
     return normalized_search in haystack
 
 
+def _classify_user_account_type(
+    user: dict[str, Any],
+    *,
+    is_internal: bool,
+    has_project: bool,
+    has_pending_verified_purchase: bool,
+) -> str:
+    status_value = _normalize(user.get("status")).lower()
+    if status_value in {"archived"}:
+        return "Archived Account"
+    if status_value in {"suspended", "disabled", "locked"}:
+        return "Suspended Account"
+    email = _normalize_email(user.get("email")) or ""
+    name = _normalize(user.get("full_name") or user.get("name")).lower()
+    if "genesis prototype" in name or "genesis-prototype" in email:
+        return "Prototype"
+    if _normalize(user.get("account_class")).lower() == "internal_validation" or "internal validation" in name:
+        return "Internal Validation Account"
+    haystack = f"{name} {email}"
+    if any(marker in haystack for marker in ("smoke user", "smoke-user", "cors test", "test fixture", "smoketest")):
+        return "Test/Smoke Account"
+    if is_internal:
+        if email in OFFICER_ADMIN_EMAILS:
+            return "Officer Administrative Identity"
+        if email == _normalize(CEO_MASTER_ADMIN_EMAIL).lower():
+            return "Internal Administrative Identity"
+        return "Unexplained Privileged Account"
+    if has_project:
+        return "Customer with Active Project"
+    if has_pending_verified_purchase:
+        return "Customer With Verified Purchase Pending Fulfillment"
+    return "Customer Identity"
+
+
+def _user_owns_project(user_id: str) -> bool:
+    db = _db()
+    user_oid = _to_object_id(user_id)
+    owner_values: list[Any] = [user_id]
+    if user_oid is not None:
+        owner_values.append(user_oid)
+    return db["projects"].find_one({"$or": [
+        {"user_id": {"$in": owner_values}},
+        {"owner_id": {"$in": owner_values}},
+        {"created_by": {"$in": owner_values}},
+    ]}) is not None
+
+
+def _user_has_pending_verified_purchase(user_id: str, email: str | None) -> bool:
+    db = _db()
+    user_oid = _to_object_id(user_id)
+    or_clauses: list[dict[str, Any]] = [{"user_id": user_id}]
+    if user_oid is not None:
+        or_clauses.append({"user_id": user_oid})
+    if email:
+        or_clauses.append({"email": email})
+    order = db["orders"].find_one(
+        {
+            "$or": or_clauses,
+            "status": {"$in": sorted(PAID_ORDER_STATUSES)},
+            "source": {"$in": ["stripe_webhook", "stripe_verified", "admin_manual"]},
+            "project_id": None,
+        }
+    )
+    return order is not None
+
+
 def _serialize_user_case(user: dict[str, Any]) -> dict[str, Any]:
     user_id = _normalize_object_id(user.get("_id")) or _normalize(user.get("id"))
     if not user_id:
@@ -4398,24 +4467,43 @@ def _serialize_user_case(user: dict[str, Any]) -> dict[str, Any]:
     role = _user_role_value(user)
     is_internal = _is_internal_user_document(user)
     status_value = _normalize(user.get("status")) or "active"
+    email = _normalize_email(user.get("email")) or None
+    has_project = _user_owns_project(user_id)
+    has_pending_purchase = False if has_project else _user_has_pending_verified_purchase(user_id, email)
+    account_type = _classify_user_account_type(
+        user,
+        is_internal=is_internal,
+        has_project=has_project,
+        has_pending_verified_purchase=has_pending_purchase,
+    )
     alerts: list[str] = []
     if status_value not in {"active", "enabled", ""}:
         alerts.append("user_inactive")
     if is_internal:
         alerts.append("internal_admin_identity")
+    if account_type == "Customer With Verified Purchase Pending Fulfillment":
+        alerts.append("verified_purchase_pending_fulfillment")
+
+    quick_actions = ["refresh_case_data"]
 
     return {
         "case_id": f"user:{user_id}",
         "project_id": None,
         "order_id": None,
         "name": _user_display_name(user),
-        "email": _normalize_email(user.get("email")) or None,
+        "email": email,
         "role": role,
-        "project": "User account",
-        "package": "Account",
-        "package_name": "Account",
-        "package_slug": "account",
-        "package_code": "account",
+        "account_type": account_type,
+        "project": "Active Project" if has_project else "No Project",
+        "package": "No Package Assigned",
+        "package_name": "No Package Assigned",
+        "package_slug": "",
+        "package_code": "",
+        "purchase": (
+            "Verified Purchase Pending Fulfillment"
+            if has_pending_purchase
+            else "No Verified Purchase Linked"
+        ),
         "package_normalization_status": "not_applicable",
         "lane": "admin" if is_internal else "customer",
         "project_lane": "admin" if is_internal else "customer",
@@ -4424,7 +4512,7 @@ def _serialize_user_case(user: dict[str, Any]) -> dict[str, Any]:
         "status": status_value,
         "alerts": alerts,
         "operator_guidance": _operator_guidance_items(alerts=alerts),
-        "quick_actions": ["refresh_case_data"],
+        "quick_actions": quick_actions,
         "mint_blocking_reasons": [],
         "updated_at": _serialize_datetime(user.get("updated_at") or user.get("last_login_at") or user.get("created_at")),
     }

--- a/backend/app/services/manual_fulfillment_service.py
+++ b/backend/app/services/manual_fulfillment_service.py
@@ -1,0 +1,402 @@
+"""Manual fulfillment queue for Stripe-verified paid orders.
+
+Sales stay open: customers pay through Stripe-hosted checkout and payment is
+verified by webhook or server-side session retrieval. Package provisioning is
+then completed manually by an authorized administrator from this queue.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Optional, cast
+
+from bson import ObjectId
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from app.database import get_database
+from app.services.audit_log_service import write_audit_log
+from app.services import order_service
+from app.services.order_service import (
+    AUTHORITATIVE_ORDER_SOURCES,
+    FULFILLMENT_COMPLETE,
+    FULFILLMENT_ESCALATED,
+    FULFILLMENT_IN_PROGRESS,
+    FULFILLMENT_PENDING,
+    OPEN_FULFILLMENT_STATUSES,
+    PAID_ORDER_STATUSES,
+)
+
+logger = logging.getLogger(__name__)
+
+FULFILLMENT_ACTIONS = {
+    "verify_payment",
+    "start_fulfillment",
+    "assign_package",
+    "complete_fulfillment",
+    "escalate_mismatch",
+}
+
+
+def _db() -> Database:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    return cast(Database, db)
+
+
+def _orders() -> Collection:
+    return _db()["orders"]
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _to_object_id(value: Any) -> Optional[ObjectId]:
+    raw = _normalize(value)
+    if not raw or not ObjectId.is_valid(raw):
+        return None
+    return ObjectId(raw)
+
+
+def _actor_fields(admin_user: dict[str, Any]) -> dict[str, str]:
+    return {
+        "actor_user_id": _normalize(admin_user.get("_id") or admin_user.get("id")),
+        "actor_email": _normalize(admin_user.get("email")).lower(),
+        "actor_name": _normalize(admin_user.get("full_name") or admin_user.get("name")),
+    }
+
+
+def _next_required_action(order: dict[str, Any]) -> str:
+    fulfillment_status = _normalize(order.get("fulfillment_status"))
+    if fulfillment_status == FULFILLMENT_COMPLETE:
+        return "none"
+    if fulfillment_status == FULFILLMENT_ESCALATED:
+        return "resolve_payment_mismatch"
+    if not order.get("payment_verified_at"):
+        return "verify_payment"
+    if not order.get("project_id"):
+        return "assign_purchased_package"
+    return "complete_fulfillment"
+
+
+def _entitlement_status_for_project(project_id: Any) -> str:
+    oid = _to_object_id(project_id)
+    if oid is None:
+        return "no_project"
+    entitlement = _db()["project_entitlements"].find_one(
+        {"project_id": oid}, sort=[("created_at", -1)]
+    ) or _db()["project_entitlements"].find_one({"project_id": str(oid)})
+    if not entitlement:
+        return "missing"
+    return _normalize(entitlement.get("status")) or "active"
+
+
+def _serialize_queue_item(order: dict[str, Any]) -> dict[str, Any]:
+    user = None
+    user_oid = _to_object_id(order.get("user_id"))
+    if user_oid is not None:
+        user = _db()["users"].find_one({"_id": user_oid})
+    project_id = order.get("project_id")
+    created_at = order.get("created_at")
+    return {
+        "order_id": str(order.get("_id")),
+        "customer_name": _normalize((user or {}).get("full_name") or (user or {}).get("name")),
+        "email": _normalize(order.get("email")),
+        "stripe_session_id": _normalize(order.get("stripe_session_id")) or None,
+        "stripe_payment_intent_id": _normalize(order.get("stripe_payment_intent_id")) or None,
+        "payment_status": _normalize(order.get("status")),
+        "payment_verified": bool(order.get("payment_verified_at")),
+        "payment_verified_at": order.get("payment_verified_at"),
+        "amount_label": _normalize(order.get("price_label")),
+        "currency": _normalize(order.get("currency")) or "usd",
+        "package_code": _normalize(order.get("package_code") or order.get("package_slug")),
+        "package_name": _normalize(order.get("package_name")),
+        "billing_plan": _normalize(order.get("billing_plan")) or "one_time",
+        "item_type": _normalize(order.get("item_type")) or "package",
+        "coupon": _normalize(order.get("coupon") or order.get("campaign")) or None,
+        "payment_date": created_at.isoformat() if isinstance(created_at, datetime) else created_at,
+        "fulfillment_status": _normalize(order.get("fulfillment_status")) or FULFILLMENT_PENDING,
+        "linked_user_id": str(user_oid) if user_oid is not None else None,
+        "linked_project_id": str(project_id) if project_id else None,
+        "entitlement_status": _entitlement_status_for_project(project_id),
+        "assigned_operator": _normalize(order.get("fulfillment_operator_email")) or None,
+        "next_required_action": _next_required_action(order),
+        "source": _normalize(order.get("source")),
+    }
+
+
+def list_manual_fulfillment_queue(*, limit: int = 100) -> dict[str, Any]:
+    query = {
+        "status": {"$in": sorted(PAID_ORDER_STATUSES)},
+        "source": {"$in": sorted(AUTHORITATIVE_ORDER_SOURCES)},
+        "fulfillment_status": {"$in": sorted(OPEN_FULFILLMENT_STATUSES)},
+    }
+    cursor = _orders().find(query).sort("created_at", -1).limit(max(1, min(limit, 500)))
+    items = [_serialize_queue_item(order) for order in cursor]
+    return {
+        "queue": "paid_manual_fulfillment_required",
+        "count": len(items),
+        "items": items,
+    }
+
+
+def _require_open_order(order_id: str) -> dict[str, Any]:
+    oid = _to_object_id(order_id)
+    if oid is None:
+        raise ValueError("Invalid order id.")
+    order = _orders().find_one({"_id": oid})
+    if not order:
+        raise ValueError("Order not found.")
+    if _normalize(order.get("status")).lower() not in PAID_ORDER_STATUSES:
+        raise ValueError("Order is not a verified paid order.")
+    if _normalize(order.get("source")).lower() not in AUTHORITATIVE_ORDER_SOURCES:
+        raise ValueError("Order payment source is not authoritative.")
+    return order
+
+
+def _write_fulfillment_audit(
+    admin_user: dict[str, Any],
+    *,
+    action: str,
+    order: dict[str, Any],
+    before: dict[str, Any],
+    after: dict[str, Any],
+    reason: str,
+    idempotency_key: str,
+) -> None:
+    write_audit_log(
+        **_actor_fields(admin_user),
+        action=f"manual_fulfillment.{action}",
+        target_type="order",
+        target_id=str(order.get("_id")),
+        before=before,
+        after=after,
+        context={
+            "queue": "paid_manual_fulfillment_required",
+            "reason": reason,
+            "idempotency_key": idempotency_key,
+            "stripe_session_id": _normalize(order.get("stripe_session_id")) or None,
+            "package_code": _normalize(order.get("package_code")),
+            "email": _normalize(order.get("email")),
+        },
+    )
+
+
+def _verify_payment(admin_user: dict[str, Any], order: dict[str, Any], reason: str, idempotency_key: str) -> dict[str, Any]:
+    if order.get("payment_verified_at"):
+        return {"order_id": str(order["_id"]), "already_verified": True, "verified": True}
+
+    session_id = _normalize(order.get("stripe_session_id"))
+    verification: dict[str, Any] = {"method": None, "verified": False}
+    if _normalize(order.get("source")).lower() == "admin_manual":
+        verification = {
+            "method": "protected_manual_finance_workflow",
+            "verified": True,
+            "authorization_source": _normalize(order.get("manual_authorization_source")) or None,
+        }
+    elif session_id:
+        session = order_service._retrieve_checkout_session(session_id)
+        payment_status = _normalize(session.get("payment_status")).lower()
+        if payment_status != "paid":
+            raise ValueError(f"Stripe reports payment_status '{payment_status or 'unknown'}' for this session.")
+        verification = {
+            "method": "stripe_session_retrieval",
+            "verified": True,
+            "stripe_payment_status": payment_status,
+            "amount_total": session.get("amount_total"),
+            "currency": _normalize(session.get("currency")) or None,
+            "payment_intent": _normalize(session.get("payment_intent")) or None,
+        }
+    else:
+        raise ValueError("Order has no Stripe session and no protected manual authorization; cannot verify payment.")
+
+    now = datetime.now(UTC)
+    update: dict[str, Any] = {
+        "payment_verified_at": now,
+        "payment_verified_by": _normalize(admin_user.get("email")).lower(),
+        "payment_verification": verification,
+    }
+    if verification.get("amount_total") is not None:
+        update["amount_total_cents"] = verification["amount_total"]
+    if verification.get("currency"):
+        update["currency"] = verification["currency"]
+    if verification.get("payment_intent"):
+        update["stripe_payment_intent_id"] = verification["payment_intent"]
+    _orders().update_one({"_id": order["_id"]}, {"$set": update})
+    _write_fulfillment_audit(
+        admin_user,
+        action="verify_payment",
+        order=order,
+        before={"payment_verified": False},
+        after={"payment_verified": True, "verification": verification},
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
+    return {"order_id": str(order["_id"]), "verified": True, "verification": verification}
+
+
+def _start_fulfillment(admin_user: dict[str, Any], order: dict[str, Any], reason: str, idempotency_key: str) -> dict[str, Any]:
+    current = _normalize(order.get("fulfillment_status"))
+    operator = _normalize(admin_user.get("email")).lower()
+    if current == FULFILLMENT_IN_PROGRESS and _normalize(order.get("fulfillment_operator_email")) == operator:
+        return {"order_id": str(order["_id"]), "fulfillment_status": current, "already_in_progress": True}
+    if current == FULFILLMENT_COMPLETE:
+        raise ValueError("Order fulfillment is already complete.")
+    update = {
+        "fulfillment_status": FULFILLMENT_IN_PROGRESS,
+        "fulfillment_operator_email": operator,
+        "fulfillment_started_at": datetime.now(UTC),
+    }
+    _orders().update_one({"_id": order["_id"]}, {"$set": update})
+    _write_fulfillment_audit(
+        admin_user,
+        action="start_fulfillment",
+        order=order,
+        before={"fulfillment_status": current or FULFILLMENT_PENDING},
+        after={"fulfillment_status": FULFILLMENT_IN_PROGRESS, "operator": operator},
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
+    return {"order_id": str(order["_id"]), "fulfillment_status": FULFILLMENT_IN_PROGRESS}
+
+
+def _assign_package(admin_user: dict[str, Any], order: dict[str, Any], reason: str, idempotency_key: str) -> dict[str, Any]:
+    if not order.get("payment_verified_at"):
+        raise ValueError("Verify payment before provisioning the purchased package.")
+    if order.get("project_id"):
+        return {
+            "order_id": str(order["_id"]),
+            "already_provisioned": True,
+            "project_id": str(order["project_id"]),
+        }
+    user_oid = _to_object_id(order.get("user_id"))
+    user = _db()["users"].find_one({"_id": user_oid}) if user_oid is not None else None
+    if not user:
+        raise ValueError("Order is not linked to a customer account. Link or create the customer first.")
+
+    package_code = _normalize(order.get("package_code") or order.get("package_slug"))
+    order_doc = order_service._attach_project_to_paid_package_order(
+        order_id=order["_id"],
+        order_doc=dict(order),
+        user=user,
+        package_code=package_code,
+        package_name=_normalize(order.get("package_name")),
+        stripe_session_id=_normalize(order.get("stripe_session_id")) or None,
+        stripe_payment_link_id=_normalize(order.get("stripe_payment_link_id")) or None,
+    )
+    order_service._trigger_package_provisioning()
+    project_id = str(order_doc.get("project_id")) if order_doc.get("project_id") else None
+    _orders().update_one(
+        {"_id": order["_id"]},
+        {
+            "$set": {
+                "fulfillment_status": FULFILLMENT_IN_PROGRESS,
+                "fulfillment_operator_email": _normalize(admin_user.get("email")).lower(),
+                "package_provisioned_at": datetime.now(UTC),
+                "package_provisioned_by": _normalize(admin_user.get("email")).lower(),
+            }
+        },
+    )
+    _write_fulfillment_audit(
+        admin_user,
+        action="assign_package",
+        order=order,
+        before={"project_id": None},
+        after={"project_id": project_id, "package_code": package_code},
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
+    return {
+        "order_id": str(order["_id"]),
+        "provisioned": True,
+        "project_id": project_id,
+        "package_code": package_code,
+        "entitlement_status": _entitlement_status_for_project(project_id),
+    }
+
+
+def _complete_fulfillment(admin_user: dict[str, Any], order: dict[str, Any], reason: str, idempotency_key: str) -> dict[str, Any]:
+    current = _normalize(order.get("fulfillment_status"))
+    if current == FULFILLMENT_COMPLETE:
+        return {"order_id": str(order["_id"]), "fulfillment_status": current, "already_complete": True}
+    if not order.get("payment_verified_at"):
+        raise ValueError("Verify payment before completing fulfillment.")
+    if not order.get("project_id"):
+        raise ValueError("Assign the purchased package before completing fulfillment.")
+    operator = _normalize(admin_user.get("email")).lower()
+    update = {
+        "fulfillment_status": FULFILLMENT_COMPLETE,
+        "fulfillment_completed_at": datetime.now(UTC),
+        "fulfillment_completed_by": operator,
+        "fulfillment_operator_email": operator,
+    }
+    _orders().update_one({"_id": order["_id"]}, {"$set": update})
+    _write_fulfillment_audit(
+        admin_user,
+        action="complete_fulfillment",
+        order=order,
+        before={"fulfillment_status": current or FULFILLMENT_PENDING},
+        after={"fulfillment_status": FULFILLMENT_COMPLETE, "operator": operator},
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
+    return {"order_id": str(order["_id"]), "fulfillment_status": FULFILLMENT_COMPLETE}
+
+
+def _escalate_mismatch(admin_user: dict[str, Any], order: dict[str, Any], reason: str, idempotency_key: str) -> dict[str, Any]:
+    current = _normalize(order.get("fulfillment_status"))
+    if current == FULFILLMENT_ESCALATED:
+        return {"order_id": str(order["_id"]), "fulfillment_status": current, "already_escalated": True}
+    update = {
+        "fulfillment_status": FULFILLMENT_ESCALATED,
+        "fulfillment_escalated_at": datetime.now(UTC),
+        "fulfillment_escalated_by": _normalize(admin_user.get("email")).lower(),
+        "fulfillment_escalation_reason": reason,
+    }
+    _orders().update_one({"_id": order["_id"]}, {"$set": update})
+    _write_fulfillment_audit(
+        admin_user,
+        action="escalate_mismatch",
+        order=order,
+        before={"fulfillment_status": current or FULFILLMENT_PENDING},
+        after={"fulfillment_status": FULFILLMENT_ESCALATED},
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
+    return {"order_id": str(order["_id"]), "fulfillment_status": FULFILLMENT_ESCALATED}
+
+
+def execute_fulfillment_action(
+    admin_user: dict[str, Any],
+    *,
+    order_id: str,
+    action: str,
+    reason: str = "",
+    idempotency_key: str = "",
+) -> dict[str, Any]:
+    normalized_action = _normalize(action).lower().replace("-", "_")
+    if normalized_action not in FULFILLMENT_ACTIONS:
+        raise ValueError(f"Unsupported fulfillment action '{action}'.")
+    reason = _normalize(reason)
+    idempotency_key = _normalize(idempotency_key)
+    if not reason:
+        raise ValueError("A reason is required for fulfillment actions.")
+    if len(idempotency_key) < 8:
+        raise ValueError("An idempotency_key of at least 8 characters is required.")
+
+    order = _require_open_order(order_id)
+
+    handlers = {
+        "verify_payment": _verify_payment,
+        "start_fulfillment": _start_fulfillment,
+        "assign_package": _assign_package,
+        "complete_fulfillment": _complete_fulfillment,
+        "escalate_mismatch": _escalate_mismatch,
+    }
+    result = handlers[normalized_action](admin_user, order, reason, idempotency_key)
+    refreshed = _orders().find_one({"_id": order["_id"]}) or order
+    result["item"] = _serialize_queue_item(refreshed)
+    return result

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -10,6 +10,7 @@ from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.errors import OperationFailure
 
+from app.config import settings
 from app.core.package_catalog import get_package
 from app.core.package_mapping import normalize_package_code as normalize_mapped_package_code
 from app.database import get_database
@@ -33,6 +34,16 @@ AUTHORITATIVE_ORDER_SOURCES = {
 
 PAID_ORDER_STATUSES = {"paid", "complete", "completed", "succeeded"}
 PENDING_PUBLIC_ORDER_STATUS = "pending_confirmation"
+FULFILLMENT_PENDING = "pending_manual_fulfillment"
+FULFILLMENT_IN_PROGRESS = "fulfillment_in_progress"
+FULFILLMENT_COMPLETE = "fulfillment_complete"
+FULFILLMENT_ESCALATED = "payment_mismatch_escalated"
+FULFILLMENT_AUTO = "auto_provisioned"
+OPEN_FULFILLMENT_STATUSES = {FULFILLMENT_PENDING, FULFILLMENT_IN_PROGRESS, FULFILLMENT_ESCALATED}
+
+
+def manual_fulfillment_mode_enabled() -> bool:
+    return bool(getattr(settings, "manual_fulfillment_mode", True))
 logger = logging.getLogger(__name__)
 
 
@@ -350,6 +361,7 @@ def _serialize_order(order: dict[str, Any]) -> dict[str, Any]:
         "project_id": str(order["project_id"]) if order.get("project_id") else None,
         "stripe_session_id": order.get("stripe_session_id"),
         "stripe_payment_link_id": order.get("stripe_payment_link_id"),
+        "fulfillment_status": order.get("fulfillment_status"),
         "created_at": order["created_at"],
     }
 
@@ -453,9 +465,18 @@ def _create_verified_paid_package_order(
         "stripe_session_id": session_id,
         "created_at": datetime.now(UTC),
     }
+    manual_mode = manual_fulfillment_mode_enabled()
+    if manual_mode:
+        order_doc["fulfillment_status"] = FULFILLMENT_PENDING
     _set_if_present(order_doc, "stripe_payment_link_id", purchase.get("stripe_payment_link_id"))
+    _set_if_present(order_doc, "stripe_payment_intent_id", _normalize(session.get("payment_intent")) or None)
     result = orders.insert_one(order_doc)
     order_doc["_id"] = result.inserted_id
+
+    if manual_mode:
+        # Payment is verified and recorded, but package provisioning stays
+        # manually controlled through the admin fulfillment queue.
+        return _serialize_order(order_doc)
 
     order_doc = _attach_project_to_paid_package_order(
         order_id=result.inserted_id,
@@ -1424,13 +1445,22 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         }
         _set_if_present(update_fields, "stripe_payment_link_id", stripe_payment_link_id)
         _set_if_present(update_fields, "campaign", campaign)
+        _set_if_present(update_fields, "stripe_payment_intent_id", _normalize(session.get("payment_intent")) or None)
+        manual_mode = manual_fulfillment_mode_enabled()
+        if (
+            manual_mode
+            and item_type == "package"
+            and not existing.get("fulfillment_status")
+            and not existing.get("project_id")
+        ):
+            update_fields["fulfillment_status"] = FULFILLMENT_PENDING
         orders.update_one({"_id": existing["_id"]}, {"$set": update_fields})
 
         order_doc = orders.find_one({"_id": existing["_id"]}) or {
             **existing,
             **update_fields,
         }
-        if item_type == "package" and not order_doc.get("project_id"):
+        if item_type == "package" and not manual_mode and not order_doc.get("project_id"):
             order_doc = _attach_project_to_paid_package_order(
                 order_id=existing["_id"],
                 order_doc=order_doc,
@@ -1441,7 +1471,7 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
                 stripe_session_id=session_id,
                 stripe_payment_link_id=stripe_payment_link_id,
             )
-        if item_type == "package":
+        if item_type == "package" and not manual_mode:
             _trigger_package_provisioning()
 
         return {
@@ -1472,13 +1502,17 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         "stripe_session_id": session_id,
         "created_at": datetime.now(UTC),
     }
+    manual_mode = manual_fulfillment_mode_enabled()
+    if manual_mode and item_type == "package":
+        order_doc["fulfillment_status"] = FULFILLMENT_PENDING
     _set_if_present(order_doc, "stripe_payment_link_id", stripe_payment_link_id)
     _set_if_present(order_doc, "campaign", campaign)
+    _set_if_present(order_doc, "stripe_payment_intent_id", _normalize(session.get("payment_intent")) or None)
 
     result = orders.insert_one(order_doc)
     order_doc["_id"] = result.inserted_id
 
-    if item_type == "package":
+    if item_type == "package" and not manual_mode:
         target_project_id = _extract_target_project_id(session)
         order_doc = _attach_project_to_paid_package_order(
             order_id=result.inserted_id,
@@ -1506,7 +1540,7 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
                     stripe_subscription_id=_normalize(session.get("subscription")) or None,
                     stripe_customer_id=_normalize(session.get("customer")) or None,
                 )
-    if item_type == "package":
+    if item_type == "package" and not manual_mode:
         _trigger_package_provisioning()
 
     return {

--- a/backend/app/services/stripe_admin_operations_service.py
+++ b/backend/app/services/stripe_admin_operations_service.py
@@ -1,0 +1,401 @@
+"""Protected Stripe operations for the Master Admin console.
+
+All card entry happens on Stripe-hosted surfaces (Checkout, Payment Links,
+Hosted Invoice Page, Billing Portal). No raw card numbers or CVC values ever
+pass through or are stored in Tomb of Light. Only safe Stripe references
+(customer, session, invoice, subscription, payment intent, price IDs) and
+safe card metadata (brand, last4) are handled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, cast
+
+import stripe
+from pymongo.database import Database
+
+from app.config import settings
+from app.database import get_database
+from app.services.audit_log_service import write_audit_log
+from app.services.billing_service import (
+    _ensure_stripe_customer_for_user,
+    _require_stripe_secret_key,
+    _stripe_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+STRIPE_DASHBOARD_BASE = "https://dashboard.stripe.com"
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _db() -> Database:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    return cast(Database, db)
+
+
+def _require_reason(reason: str) -> str:
+    normalized = _normalize(reason)
+    if len(normalized) < 3:
+        raise ValueError("A reason is required for Stripe operations.")
+    return normalized
+
+
+def _find_customer_user(customer_email: str) -> dict[str, Any]:
+    email = _normalize(customer_email).lower()
+    if not email:
+        raise ValueError("customer_email is required.")
+    user = _db()["users"].find_one({"email": email})
+    if not user:
+        raise ValueError("No Tomb of Light account exists for that email.")
+    return user
+
+
+def _audit(
+    admin_user: dict[str, Any],
+    *,
+    action: str,
+    target_id: str,
+    reason: str,
+    details: Optional[dict[str, Any]] = None,
+) -> None:
+    write_audit_log(
+        actor_user_id=_normalize(admin_user.get("_id") or admin_user.get("id")) or None,
+        actor_email=_normalize(admin_user.get("email")).lower() or None,
+        actor_name=_normalize(admin_user.get("full_name") or admin_user.get("name")) or None,
+        action=f"stripe_ops.{action}",
+        target_type="stripe",
+        target_id=target_id,
+        context={"reason": reason, "surface": "master_admin_stripe_operations"},
+        details=details or {},
+    )
+
+
+def _safe_card_metadata(payment_method: dict[str, Any]) -> dict[str, Any]:
+    card = payment_method.get("card") or {}
+    return {
+        "id": _normalize(payment_method.get("id")),
+        "brand": _normalize(card.get("brand")),
+        "last4": _normalize(card.get("last4")),
+        "exp_month": card.get("exp_month"),
+        "exp_year": card.get("exp_year"),
+    }
+
+
+def ensure_customer(admin_user: dict[str, Any], *, customer_email: str, reason: str) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    user = _find_customer_user(customer_email)
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize(customer.get("id"))
+    _audit(admin_user, action="ensure_customer", target_id=customer_id, reason=reason,
+           details={"customer_email": _normalize(customer_email).lower()})
+    return {
+        "customer_id": customer_id,
+        "email": _normalize(customer.get("email")) or _normalize(customer_email).lower(),
+        "dashboard_url": f"{STRIPE_DASHBOARD_BASE}/customers/{customer_id}",
+    }
+
+
+def open_customer_in_stripe(admin_user: dict[str, Any], *, customer_email: str) -> dict[str, Any]:
+    user = _find_customer_user(customer_email)
+    customer_id = _normalize(user.get("stripe_customer_id"))
+    if not customer_id:
+        raise ValueError("Customer has no Stripe customer record yet. Create one first.")
+    return {
+        "customer_id": customer_id,
+        "dashboard_url": f"{STRIPE_DASHBOARD_BASE}/customers/{customer_id}",
+    }
+
+
+def create_payment_link(
+    admin_user: dict[str, Any],
+    *,
+    price_id: str,
+    quantity: int = 1,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    price_id = _normalize(price_id)
+    if not price_id.startswith("price_"):
+        raise ValueError("A valid Stripe price id (price_...) is required.")
+    _require_stripe_secret_key()
+    price = _stripe_to_dict(stripe.Price.retrieve(price_id))
+    link = _stripe_to_dict(
+        stripe.PaymentLink.create(
+            line_items=[{"price": price_id, "quantity": max(1, int(quantity))}],
+        )
+    )
+    link_id = _normalize(link.get("id"))
+    mode = "subscription" if _normalize(price.get("type")) == "recurring" else "one_time"
+    _audit(admin_user, action="create_payment_link", target_id=link_id, reason=reason,
+           details={"price_id": price_id, "mode": mode})
+    return {
+        "payment_link_id": link_id,
+        "url": _normalize(link.get("url")),
+        "mode": mode,
+        "price_id": price_id,
+    }
+
+
+def create_and_send_invoice(
+    admin_user: dict[str, Any],
+    *,
+    customer_email: str,
+    amount_cents: int,
+    description: str,
+    days_until_due: int = 7,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    if int(amount_cents) <= 0:
+        raise ValueError("amount_cents must be a positive integer.")
+    description = _normalize(description)
+    if not description:
+        raise ValueError("An invoice line description is required.")
+    user = _find_customer_user(customer_email)
+    _require_stripe_secret_key()
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize(customer.get("id"))
+    invoice = _stripe_to_dict(
+        stripe.Invoice.create(
+            customer=customer_id,
+            collection_method="send_invoice",
+            days_until_due=max(1, int(days_until_due)),
+            auto_advance=False,
+        )
+    )
+    stripe.InvoiceItem.create(
+        customer=customer_id,
+        amount=int(amount_cents),
+        currency="usd",
+        description=description,
+        invoice=invoice["id"],
+    )
+    finalized = _stripe_to_dict(stripe.Invoice.finalize_invoice(invoice["id"]))
+    sent = _stripe_to_dict(stripe.Invoice.send_invoice(finalized["id"]))
+    _audit(admin_user, action="create_and_send_invoice", target_id=_normalize(sent.get("id")), reason=reason,
+           details={"customer_id": customer_id, "amount_cents": int(amount_cents)})
+    return {
+        "invoice_id": _normalize(sent.get("id")),
+        "status": _normalize(sent.get("status")),
+        "hosted_invoice_url": _normalize(sent.get("hosted_invoice_url")) or None,
+        "customer_id": customer_id,
+    }
+
+
+def create_subscription(
+    admin_user: dict[str, Any],
+    *,
+    customer_email: str,
+    price_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    price_id = _normalize(price_id)
+    if not price_id.startswith("price_"):
+        raise ValueError("A valid Stripe price id (price_...) is required.")
+    user = _find_customer_user(customer_email)
+    _require_stripe_secret_key()
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize(customer.get("id"))
+    subscription = _stripe_to_dict(
+        stripe.Subscription.create(
+            customer=customer_id,
+            items=[{"price": price_id}],
+            collection_method="send_invoice",
+            days_until_due=7,
+        )
+    )
+    _audit(admin_user, action="create_subscription", target_id=_normalize(subscription.get("id")), reason=reason,
+           details={"customer_id": customer_id, "price_id": price_id})
+    return {
+        "subscription_id": _normalize(subscription.get("id")),
+        "status": _normalize(subscription.get("status")),
+        "customer_id": customer_id,
+    }
+
+
+def _retrieve_subscription(subscription_id: str) -> dict[str, Any]:
+    subscription_id = _normalize(subscription_id)
+    if not subscription_id.startswith("sub_"):
+        raise ValueError("A valid Stripe subscription id (sub_...) is required.")
+    _require_stripe_secret_key()
+    return _stripe_to_dict(stripe.Subscription.retrieve(subscription_id))
+
+
+def change_subscription_price(
+    admin_user: dict[str, Any],
+    *,
+    subscription_id: str,
+    price_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    price_id = _normalize(price_id)
+    if not price_id.startswith("price_"):
+        raise ValueError("A valid Stripe price id (price_...) is required.")
+    subscription = _retrieve_subscription(subscription_id)
+    items = ((subscription.get("items") or {}).get("data")) or []
+    if not items:
+        raise ValueError("Subscription has no line items to change.")
+    updated = _stripe_to_dict(
+        stripe.Subscription.modify(
+            subscription["id"],
+            items=[{"id": items[0]["id"], "price": price_id}],
+            proration_behavior="create_prorations",
+        )
+    )
+    _audit(admin_user, action="change_subscription_price", target_id=subscription["id"], reason=reason,
+           details={"new_price_id": price_id})
+    return {"subscription_id": subscription["id"], "status": _normalize(updated.get("status")), "price_id": price_id}
+
+
+def pause_subscription(admin_user: dict[str, Any], *, subscription_id: str, reason: str) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    subscription = _retrieve_subscription(subscription_id)
+    updated = _stripe_to_dict(
+        stripe.Subscription.modify(
+            subscription["id"],
+            pause_collection={"behavior": "keep_as_draft"},
+        )
+    )
+    _audit(admin_user, action="pause_subscription", target_id=subscription["id"], reason=reason)
+    return {"subscription_id": subscription["id"], "paused": True, "status": _normalize(updated.get("status"))}
+
+
+def resume_subscription(admin_user: dict[str, Any], *, subscription_id: str, reason: str) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    subscription = _retrieve_subscription(subscription_id)
+    updated = _stripe_to_dict(
+        stripe.Subscription.modify(subscription["id"], pause_collection="")
+    )
+    _audit(admin_user, action="resume_subscription", target_id=subscription["id"], reason=reason)
+    return {"subscription_id": subscription["id"], "paused": False, "status": _normalize(updated.get("status"))}
+
+
+def cancel_subscription(
+    admin_user: dict[str, Any],
+    *,
+    subscription_id: str,
+    at_period_end: bool = True,
+    confirm: bool = False,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    subscription = _retrieve_subscription(subscription_id)
+    if at_period_end:
+        updated = _stripe_to_dict(
+            stripe.Subscription.modify(subscription["id"], cancel_at_period_end=True)
+        )
+    else:
+        if not confirm:
+            raise ValueError("Immediate cancellation requires explicit confirmation.")
+        updated = _stripe_to_dict(stripe.Subscription.cancel(subscription["id"]))
+    _audit(admin_user, action="cancel_subscription", target_id=subscription["id"], reason=reason,
+           details={"at_period_end": bool(at_period_end)})
+    return {
+        "subscription_id": subscription["id"],
+        "status": _normalize(updated.get("status")),
+        "cancel_at_period_end": bool(updated.get("cancel_at_period_end")),
+    }
+
+
+def send_payment_method_update_link(
+    admin_user: dict[str, Any],
+    *,
+    customer_email: str,
+    reason: str,
+) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    user = _find_customer_user(customer_email)
+    _require_stripe_secret_key()
+    customer = _ensure_stripe_customer_for_user(user)
+    customer_id = _normalize(customer.get("id"))
+    session = _stripe_to_dict(
+        stripe.billing_portal.Session.create(
+            customer=customer_id,
+            return_url=settings.stripe_billing_portal_return_url_clean
+            or "https://tomboflight.com/billing.html",
+        )
+    )
+    _audit(admin_user, action="send_payment_method_update_link", target_id=customer_id, reason=reason)
+    return {"customer_id": customer_id, "portal_url": _normalize(session.get("url"))}
+
+
+def retry_invoice_payment(admin_user: dict[str, Any], *, invoice_id: str, reason: str) -> dict[str, Any]:
+    reason = _require_reason(reason)
+    invoice_id = _normalize(invoice_id)
+    if not invoice_id.startswith("in_"):
+        raise ValueError("A valid Stripe invoice id (in_...) is required.")
+    _require_stripe_secret_key()
+    invoice = _stripe_to_dict(stripe.Invoice.retrieve(invoice_id))
+    if _normalize(invoice.get("status")) not in {"open", "uncollectible"}:
+        raise ValueError(f"Invoice status '{invoice.get('status')}' is not retryable.")
+    paid = _stripe_to_dict(stripe.Invoice.pay(invoice_id))
+    _audit(admin_user, action="retry_invoice_payment", target_id=invoice_id, reason=reason)
+    return {"invoice_id": invoice_id, "status": _normalize(paid.get("status")), "paid": bool(paid.get("paid"))}
+
+
+def customer_payment_history(admin_user: dict[str, Any], *, customer_email: str) -> dict[str, Any]:
+    user = _find_customer_user(customer_email)
+    customer_id = _normalize(user.get("stripe_customer_id"))
+    if not customer_id:
+        return {
+            "customer_id": None,
+            "payments": [],
+            "invoices": [],
+            "subscriptions": [],
+            "failed_payments": [],
+        }
+    _require_stripe_secret_key()
+    payments = _stripe_to_dict(stripe.PaymentIntent.list(customer=customer_id, limit=25))
+    invoices = _stripe_to_dict(stripe.Invoice.list(customer=customer_id, limit=25))
+    subscriptions = _stripe_to_dict(
+        stripe.Subscription.list(customer=customer_id, status="all", limit=25)
+    )
+
+    def _payment(p: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "payment_intent_id": _normalize(p.get("id")),
+            "amount": p.get("amount"),
+            "currency": _normalize(p.get("currency")),
+            "status": _normalize(p.get("status")),
+            "created": p.get("created"),
+        }
+
+    def _invoice(i: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "invoice_id": _normalize(i.get("id")),
+            "status": _normalize(i.get("status")),
+            "amount_due": i.get("amount_due"),
+            "amount_paid": i.get("amount_paid"),
+            "currency": _normalize(i.get("currency")),
+            "hosted_invoice_url": _normalize(i.get("hosted_invoice_url")) or None,
+            "created": i.get("created"),
+        }
+
+    def _subscription(s: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "subscription_id": _normalize(s.get("id")),
+            "status": _normalize(s.get("status")),
+            "cancel_at_period_end": bool(s.get("cancel_at_period_end")),
+            "paused": bool(s.get("pause_collection")),
+            "created": s.get("created"),
+        }
+
+    payment_items = [_payment(p) for p in (payments.get("data") or [])]
+    invoice_items = [_invoice(i) for i in (invoices.get("data") or [])]
+    return {
+        "customer_id": customer_id,
+        "payments": payment_items,
+        "invoices": invoice_items,
+        "subscriptions": [_subscription(s) for s in (subscriptions.get("data") or [])],
+        "failed_payments": [p for p in payment_items if p["status"] in {"requires_payment_method", "canceled"}]
+        + [i for i in invoice_items if i["status"] == "open" and (i.get("amount_paid") or 0) == 0],
+    }

--- a/backend/tests/test_manual_fulfillment_queue.py
+++ b/backend/tests/test_manual_fulfillment_queue.py
@@ -1,0 +1,291 @@
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from contextlib import contextmanager
+
+from app.services import audit_log_service
+from app.services import manual_fulfillment_service as mfs
+from app.services import order_service
+
+
+@contextmanager
+def use_db(db):
+    with (
+        patch.object(mfs, "get_database", return_value=db),
+        patch.object(audit_log_service, "get_database", return_value=db),
+    ):
+        yield
+
+
+class _Cursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def sort(self, *args, **kwargs):  # noqa: ARG002
+        return self
+
+    def limit(self, n):
+        self._docs = self._docs[:n]
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class FakeCollection:
+    def __init__(self, seed=None):
+        self.docs = [dict(d) for d in (seed or [])]
+
+    def _match(self, query, item):
+        for key, expected in (query or {}).items():
+            if isinstance(expected, dict) and "$in" in expected:
+                if item.get(key) not in expected["$in"]:
+                    return False
+            elif item.get(key) != expected:
+                return False
+        return True
+
+    def find_one(self, query, sort=None):  # noqa: ARG002
+        for item in self.docs:
+            if self._match(query, item):
+                return dict(item)
+        return None
+
+    def find(self, query):
+        return _Cursor(dict(i) for i in self.docs if self._match(query, i))
+
+    def update_one(self, query, update):
+        for index, item in enumerate(self.docs):
+            if self._match(query, item):
+                updated = dict(item)
+                updated.update((update or {}).get("$set") or {})
+                self.docs[index] = updated
+                return
+
+    def insert_one(self, document):
+        payload = dict(document)
+        payload.setdefault("_id", ObjectId())
+        self.docs.append(payload)
+
+        class _Result:
+            inserted_id = payload["_id"]
+
+        return _Result()
+
+
+class FakeDb:
+    def __init__(self, collections):
+        self._collections = collections
+
+    def __getitem__(self, name):
+        return self._collections.setdefault(name, FakeCollection())
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return self[name]
+
+
+USER_ID = ObjectId()
+ORDER_ID = ObjectId()
+
+ADMIN = {"_id": "admin-1", "email": "l.robinson@tomboflight.com", "full_name": "Larry Robinson"}
+
+
+def _paid_order(**overrides):
+    order = {
+        "_id": ORDER_ID,
+        "user_id": USER_ID,
+        "email": "customer@example.com",
+        "package_code": "legacy_plus",
+        "package_slug": "legacy_plus",
+        "package_name": "Legacy Plus",
+        "price_label": "$3,200",
+        "item_type": "package",
+        "billing_plan": "one_time",
+        "source": "stripe_webhook",
+        "status": "paid",
+        "stripe_session_id": "cs_test_1",
+        "fulfillment_status": mfs.FULFILLMENT_PENDING,
+        "created_at": datetime.now(UTC),
+    }
+    order.update(overrides)
+    return order
+
+
+class ManualFulfillmentQueueTests(unittest.TestCase):
+    def _fake_db(self, orders=None, users=None, entitlements=None):
+        return FakeDb(
+            {
+                "orders": FakeCollection(orders or []),
+                "users": FakeCollection(
+                    users
+                    if users is not None
+                    else [{"_id": USER_ID, "email": "customer@example.com", "full_name": "Customer One"}]
+                ),
+                "project_entitlements": FakeCollection(entitlements or []),
+                "audit_logs": FakeCollection(),
+            }
+        )
+
+    def test_queue_lists_open_verified_orders_only(self):
+        db = self._fake_db(
+            orders=[
+                _paid_order(),
+                _paid_order(
+                    _id=ObjectId(),
+                    stripe_session_id="cs_done",
+                    fulfillment_status=mfs.FULFILLMENT_COMPLETE,
+                ),
+                _paid_order(
+                    _id=ObjectId(),
+                    stripe_session_id=None,
+                    source="customer_checkout_pending",
+                    status="pending_confirmation",
+                    fulfillment_status=None,
+                ),
+            ]
+        )
+        with use_db(db):
+            result = mfs.list_manual_fulfillment_queue()
+        self.assertEqual(result["count"], 1)
+        item = result["items"][0]
+        self.assertEqual(item["order_id"], str(ORDER_ID))
+        self.assertEqual(item["customer_name"], "Customer One")
+        self.assertEqual(item["next_required_action"], "verify_payment")
+        self.assertEqual(item["entitlement_status"], "no_project")
+
+    def test_action_requires_reason_and_idempotency_key(self):
+        db = self._fake_db(orders=[_paid_order()])
+        with use_db(db):
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="start_fulfillment", reason="", idempotency_key="k" * 8
+                )
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="start_fulfillment", reason="valid reason", idempotency_key="short"
+                )
+
+    def test_verify_payment_uses_server_side_stripe_session(self):
+        db = self._fake_db(orders=[_paid_order()])
+        session = {"payment_status": "paid", "amount_total": 320000, "currency": "usd", "payment_intent": "pi_1"}
+        with (
+            use_db(db),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+        ):
+            result = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="verify_payment", reason="CEO review", idempotency_key="verify-key-1"
+            )
+        self.assertTrue(result["verified"])
+        stored = db["orders"].find_one({"_id": ORDER_ID})
+        self.assertTrue(stored.get("payment_verified_at"))
+        self.assertEqual(stored.get("stripe_payment_intent_id"), "pi_1")
+        audit_actions = [d["action"] for d in db["audit_logs"].docs]
+        self.assertEqual(audit_actions, ["manual_fulfillment.verify_payment"])
+
+    def test_verify_payment_rejects_unpaid_stripe_session(self):
+        db = self._fake_db(orders=[_paid_order()])
+        session = {"payment_status": "unpaid"}
+        with (
+            use_db(db),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+        ):
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="verify_payment", reason="CEO review", idempotency_key="verify-key-2"
+                )
+        stored = db["orders"].find_one({"_id": ORDER_ID})
+        self.assertFalse(stored.get("payment_verified_at"))
+
+    def test_assign_package_requires_verified_payment(self):
+        db = self._fake_db(orders=[_paid_order()])
+        with use_db(db):
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="assign_package", reason="provision", idempotency_key="assign-key-1"
+                )
+
+    def test_assign_package_provisions_once_and_is_idempotent(self):
+        project_id = ObjectId()
+        db = self._fake_db(orders=[_paid_order(payment_verified_at=datetime.now(UTC))])
+
+        def fake_attach(**kwargs):
+            doc = dict(kwargs["order_doc"])
+            doc["project_id"] = project_id
+            db["orders"].update_one({"_id": doc["_id"]}, {"$set": {"project_id": project_id}})
+            return doc
+
+        with (
+            use_db(db),
+            patch.object(order_service, "_attach_project_to_paid_package_order", side_effect=fake_attach) as attach_mock,
+            patch.object(order_service, "_trigger_package_provisioning") as provision_mock,
+        ):
+            first = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="assign_package", reason="provision", idempotency_key="assign-key-2"
+            )
+            second = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="assign_package", reason="provision", idempotency_key="assign-key-2"
+            )
+        self.assertTrue(first["provisioned"])
+        self.assertEqual(first["project_id"], str(project_id))
+        self.assertTrue(second.get("already_provisioned"))
+        self.assertEqual(attach_mock.call_count, 1)
+        self.assertEqual(provision_mock.call_count, 1)
+
+    def test_complete_fulfillment_requires_provisioned_project(self):
+        db = self._fake_db(orders=[_paid_order(payment_verified_at=datetime.now(UTC))])
+        with use_db(db):
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="complete_fulfillment", reason="done", idempotency_key="complete-1"
+                )
+
+    def test_complete_fulfillment_records_actor_and_is_idempotent(self):
+        db = self._fake_db(
+            orders=[
+                _paid_order(
+                    payment_verified_at=datetime.now(UTC),
+                    project_id=ObjectId(),
+                    fulfillment_status=mfs.FULFILLMENT_IN_PROGRESS,
+                )
+            ]
+        )
+        with use_db(db):
+            first = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="complete_fulfillment", reason="fulfilled", idempotency_key="complete-2"
+            )
+            second = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="complete_fulfillment", reason="fulfilled", idempotency_key="complete-2"
+            )
+        self.assertEqual(first["fulfillment_status"], mfs.FULFILLMENT_COMPLETE)
+        self.assertTrue(second.get("already_complete"))
+        stored = db["orders"].find_one({"_id": ORDER_ID})
+        self.assertEqual(stored["fulfillment_completed_by"], "l.robinson@tomboflight.com")
+        audit_actions = [d["action"] for d in db["audit_logs"].docs]
+        self.assertEqual(audit_actions.count("manual_fulfillment.complete_fulfillment"), 1)
+
+    def test_escalate_mismatch_marks_order(self):
+        db = self._fake_db(orders=[_paid_order()])
+        with use_db(db):
+            result = mfs.execute_fulfillment_action(
+                ADMIN, order_id=str(ORDER_ID), action="escalate_mismatch", reason="amount mismatch", idempotency_key="escalate-1"
+            )
+        self.assertEqual(result["fulfillment_status"], mfs.FULFILLMENT_ESCALATED)
+        stored = db["orders"].find_one({"_id": ORDER_ID})
+        self.assertEqual(stored["fulfillment_escalation_reason"], "amount mismatch")
+
+    def test_rejects_action_on_non_authoritative_order(self):
+        db = self._fake_db(orders=[_paid_order(source="customer_checkout_pending")])
+        with use_db(db):
+            with self.assertRaises(ValueError):
+                mfs.execute_fulfillment_action(
+                    ADMIN, order_id=str(ORDER_ID), action="verify_payment", reason="check", idempotency_key="reject-1"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_order_authority_security_patch.py
+++ b/backend/tests/test_order_authority_security_patch.py
@@ -248,6 +248,7 @@ class OrderAuthoritySecurityTests(unittest.TestCase):
         with (
             patch.object(order_service, "_get_orders_collection", return_value=orders),
             patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(order_service, "manual_fulfillment_mode_enabled", return_value=False),
             patch.object(
                 order_service,
                 "_attach_project_to_paid_package_order",
@@ -262,6 +263,52 @@ class OrderAuthoritySecurityTests(unittest.TestCase):
         self.assertEqual(attach_mock.call_count, 1)
         self.assertEqual(provisioning_mock.call_count, 1)
         self.assertEqual(len([d for d in orders.docs if d.get("stripe_session_id") == "cs_test_paid_one"]), 1)
+
+    def test_manual_fulfillment_mode_records_paid_order_without_auto_provisioning(self):
+        orders = FakeOrdersCollection()
+        payload = SimpleNamespace(package_code="legacy_plus", stripe_session_id="cs_test_manual_one")
+        session = _paid_checkout_session(session_id="cs_test_manual_one")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(order_service, "manual_fulfillment_mode_enabled", return_value=True),
+            patch.object(order_service, "_attach_project_to_paid_package_order") as attach_mock,
+            patch.object(order_service, "_trigger_package_provisioning") as provisioning_mock,
+        ):
+            first = order_service.create_order_for_user(self.user, payload)
+            second = order_service.create_order_for_user(self.user, payload)
+        self.assertEqual(first["status"], "paid")
+        self.assertEqual(first["source"], "stripe_verified")
+        self.assertEqual(first["fulfillment_status"], order_service.FULFILLMENT_PENDING)
+        self.assertIsNone(first["project_id"])
+        self.assertEqual(second["id"], first["id"])
+        attach_mock.assert_not_called()
+        provisioning_mock.assert_not_called()
+
+    def test_manual_fulfillment_mode_webhook_records_pending_fulfillment(self):
+        orders = FakeOrdersCollection()
+        event = {
+            "type": "checkout.session.completed",
+            "data": {"object": {"id": "cs_test_manual_evt"}},
+        }
+        session = _paid_checkout_session(session_id="cs_test_manual_evt")
+        with (
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(order_service, "_get_user_by_email", return_value=self.user),
+            patch.object(order_service, "store_stripe_customer_reference"),
+            patch.object(order_service, "manual_fulfillment_mode_enabled", return_value=True),
+            patch.object(order_service, "_attach_project_to_paid_package_order") as attach_mock,
+            patch.object(order_service, "_trigger_package_provisioning") as provisioning_mock,
+        ):
+            result = order_service.upsert_order_from_stripe_event(event)
+        attach_mock.assert_not_called()
+        provisioning_mock.assert_not_called()
+        stored = orders.find_one({"stripe_session_id": "cs_test_manual_evt"})
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored["status"], "paid")
+        self.assertEqual(stored["fulfillment_status"], order_service.FULFILLMENT_PENDING)
+        self.assertIsNone(result.get("project_id"))
 
     def test_repeated_webhook_delivery_is_idempotent(self):
         orders = FakeOrdersCollection()

--- a/styles.css
+++ b/styles.css
@@ -9227,3 +9227,66 @@ body.portal-dashboard-body.admin-interface-mode .portal-core-label {
     left: 0;
   }
 }
+
+/* Master Admin: compact status summary, collapsed diagnostics, fulfillment queue */
+.admin-status-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.admin-status-summary:empty {
+  display: none;
+}
+
+.admin-status-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 124, 175, 0.35);
+  padding: 0.2rem 0.65rem;
+  font-size: 0.74rem;
+  color: #a8cbff;
+  background: rgba(22, 34, 55, 0.6);
+}
+
+.admin-status-chip[data-state="ok"] {
+  border-color: rgba(94, 200, 140, 0.5);
+  color: #8fe0b0;
+}
+
+.admin-status-chip[data-state="attention"] {
+  border-color: rgba(230, 160, 90, 0.55);
+  color: #f0c08a;
+}
+
+/* Diagnostics stays in normal document flow: never fixed, never sticky,
+   never overlaying cases or Account 360. Collapsed by default. */
+.admin-diagnostics-section {
+  position: static;
+  margin-top: 1rem;
+}
+
+.admin-diagnostics-toggle {
+  font-size: 0.8rem;
+}
+
+.admin-diagnostics-panel {
+  position: static;
+  margin-top: 0.75rem;
+  border: 1px solid rgba(120, 160, 220, 0.19);
+  border-radius: 14px;
+  padding: 0.9rem;
+  background: linear-gradient(155deg, rgba(8, 15, 27, 0.96), rgba(6, 11, 20, 0.98));
+}
+
+body.admin-interface-mode .admin-diagnostics-panel {
+  background: var(--admin-panel);
+  border-color: var(--admin-border);
+  color: var(--admin-text);
+}
+
+.admin-fulfillment-card .admin-bulk-action-grid {
+  margin-top: 0.75rem;
+}


### PR DESCRIPTION
## Summary

Completes the CEO Master Admin sales-open workflow on top of PRs #560–#564. Sales stay open through Stripe-hosted checkout; every verified purchase now lands in a manual fulfillment queue instead of auto-provisioning.

### Manual fulfillment (backend)
- New `MANUAL_FULFILLMENT_MODE` setting (default **ON**). Verified paid orders get `fulfillment_status: pending_manual_fulfillment` and auto-provisioning is skipped in all three verified paths (verified-session order creation, webhook update, webhook insert).
- New service + routes: `GET /admin/control-center/fulfillment/queue`, `POST /admin/control-center/fulfillment/orders/{id}/actions/{action}` with actions `verify_payment`, `start_fulfillment`, `assign_package` (provisions via the existing authoritative helpers), `complete_fulfillment`, `escalate_mismatch`. Every action requires a reason + idempotency key and is audit-logged; repeats are no-ops.
- `stripe_payment_intent_id` captured on verified orders; `fulfillment_status` exposed on order serialization.

### Stripe operations (Master Admin)
- New `/admin/stripe-ops` routes + service (permission `admin.control.billing`): ensure/open customer, one-time & subscription payment links, invoice create+send and retry, subscription create/change-price/pause/resume/cancel (cancel requires confirm), payment-method update link (billing portal), payment/invoice history. Server-side keys only; IDs only in responses; all actions audited with reasons.

### Master Admin console (frontend)
- **Paid — Manual Fulfillment** queue rail section with per-order action buttons.
- **Stripe Operations** card in the case Billing tab (super admin only).
- Honest account classification: identity-only users show *Customer Identity / No Project / No Package Assigned*; officer, internal validation, prototype, test/smoke, archived, suspended, and unexplained-privileged types classified; account type shown in the Users rail.
- Diagnostics panel: no longer sticky/overlapping — collapsed by default, normal document flow at the bottom of the workspace; compact status chips in the command bar.
- Role labels humanized (`ceo_master_admin` → “CEO Master Administrator”); raw codes remain in diagnostics only.
- Cache revision bumped to `20260727-masterops1`.

### Tests
- New `tests/test_manual_fulfillment_queue.py` (10 tests) and manual-mode coverage in `test_order_authority_security_patch.py` (23 total).
- Full backend suite: **no new failures** — the 6 remaining failures (repair-guardrails package-change reason, dashboard cache-version subtests, PR465 package parity subtests, contracts/continuity-kernel suites) were verified pre-existing on unmodified `main` (b9db56a).

### Not in this PR (requires production access)
- Production investigation of `admin@tomboflight.com`, live test-account classification, controlled live execution, Render deployment, and live acceptance in Larry's session.