### PR TITLE
Advance Bridge campaign to Sip & Paint Event 2

### DIFF
--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -1,3 +1,4 @@
+import html
 import re
 import unittest
 from pathlib import Path
@@ -103,7 +104,8 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         config_source = (REPO_ROOT / "config.js").read_text(encoding="utf-8")
         homepage = (REPO_ROOT / "index.html").read_text(encoding="utf-8")
         pricing_page = (REPO_ROOT / "pricing.html").read_text(encoding="utf-8")
-        bridge_page = (REPO_ROOT / "bridge-taste.html").read_text(encoding="utf-8")
+        bridge_page = (REPO_ROOT / "bridge-paint.html").read_text(encoding="utf-8")
+        archived_bridge_page = (REPO_ROOT / "bridge-taste.html").read_text(encoding="utf-8")
         app_source = (REPO_ROOT / "app.js").read_text(encoding="utf-8")
         deploy_workflow = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text(
             encoding="utf-8"
@@ -169,7 +171,7 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertIn("Required Legacy Care &amp; Maintenance", pricing_page)
         self.assertIn("Add-ons &amp; Legacy Services", pricing_page)
         self.assertIn("Private Bridge Event Access", pricing_page)
-        self.assertIn("View Private Bridge Access", pricing_page)
+        self.assertIn("View Private Sip &amp; Paint Access", pricing_page)
         self.assertIn("Storage &amp; Vault Upgrades", pricing_page)
         self.assertIn("Rush Delivery", pricing_page)
         self.assertIn('href="portal-help.html">Need help choosing?</a>', pricing_page)
@@ -215,6 +217,53 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertGreaterEqual(homepage.count('rel="noopener noreferrer"'), 3)
         self.assertGreaterEqual(pricing_page.count('rel="noopener noreferrer"'), 20)
 
+        bridge_page_text = html.unescape(bridge_page)
+        pricing_page_text = html.unescape(pricing_page)
+        bridge_paint_codes = [
+            "BRIDGE-PAINT-SNAPSHOT",
+            "BRIDGE-PAINT-PORTRAIT",
+            "BRIDGE-PAINT-DIGITAL",
+            "BRIDGE-PAINT-HOUSEHOLD",
+            "BRIDGE-PAINT-HEIRLOOM",
+            "BRIDGE-PAINT-PLUS",
+            "BRIDGE-PAINT-ESTATE",
+            "BRIDGE-PAINT-COMMAND",
+        ]
+
+        for package_code in bridge_paint_codes:
+            self.assertIn(package_code, bridge_page)
+            self.assertNotIn(package_code, homepage)
+
+        for expected_content in [
+            "Sip & Paint",
+            "Event 2 of 4",
+            "August 29, 2026",
+            "6:00 PM",
+            "9:00 PM",
+            "Norfolk, VA",
+            "Private Event",
+            "Invite Only",
+            "BRIDGE-PAINT",
+        ]:
+            self.assertIn(expected_content, bridge_page_text)
+
+        self.assertIn("Private Bridge Event Access", bridge_page)
+        self.assertIn(
+            "Use the standard Tomb of Light package checkout and enter your private Bridge Event code directly at",
+            bridge_page,
+        )
+        self.assertNotIn("Important: do not modify Stripe URLs", bridge_page)
+        self.assertNotIn("Private Bridge Event Access", homepage)
+        self.assertNotIn("BRIDGE-TASTE", homepage)
+        self.assertNotIn("BRIDGE-PAINT", homepage)
+        self.assertNotRegex(homepage, r"BRIDGE-(?:TASTE|PAINT)-")
+        self.assertIn("bridge-paint.html", pricing_page)
+        self.assertIn("BRIDGE-PAINT", pricing_page)
+        self.assertIn("Sip & Paint — Event 2 of 4", pricing_page_text)
+        self.assertNotIn("BRIDGE-TASTE", pricing_page)
+
+        self.assertIn("Bridge Event 1 Has Concluded", archived_bridge_page)
+        self.assertIn('href="bridge-paint.html"', archived_bridge_page)
         for package_code in [
             "BRIDGE-TASTE-SNAPSHOT",
             "BRIDGE-TASTE-PORTRAIT",
@@ -225,26 +274,13 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
             "BRIDGE-TASTE-ESTATE",
             "BRIDGE-TASTE-COMMAND",
         ]:
-            self.assertIn(package_code, bridge_page)
+            self.assertNotIn(package_code, archived_bridge_page)
 
-        self.assertIn("Private Bridge Event Access", bridge_page)
-        self.assertIn("Do not look for a special checkout link.", bridge_page)
-        self.assertIn(
-            "Use the standard package checkout and enter your private Bridge Event code directly at Stripe checkout",
-            bridge_page,
-        )
-        self.assertNotIn("Important: do not modify Stripe URLs", bridge_page)
-        self.assertNotIn("Private Bridge Event Access", homepage)
-        self.assertNotIn("BRIDGE-TASTE", homepage)
-        self.assertNotIn("BRIDGE-PAINT", homepage)
-        self.assertNotIn("BRIDGE-PAINT", pricing_page)
-        self.assertNotIn("BRIDGE-PAINT", bridge_page)
-        self.assertNotIn("BRIDGE-LINEAGE", homepage)
-        self.assertNotIn("BRIDGE-LINEAGE", pricing_page)
-        self.assertNotIn("BRIDGE-LINEAGE", bridge_page)
-        self.assertNotIn("GRANDOPENING", homepage)
-        self.assertNotIn("GRANDOPENING", pricing_page)
-        self.assertNotIn("GRANDOPENING", bridge_page)
+        for inactive_campaign in ["BRIDGE-LINEAGE", "GRANDOPENING"]:
+            self.assertNotIn(inactive_campaign, homepage)
+            self.assertNotIn(inactive_campaign, pricing_page)
+            self.assertNotIn(inactive_campaign, bridge_page)
+            self.assertNotIn(inactive_campaign, archived_bridge_page)
         self.assertIn('const checkoutFrozen = link.getAttribute("aria-disabled") === "true";', app_source)
         self.assertIn("prefilled_promo_code", app_source)
         self.assertIn("function configureDirectStripeCheckout(link, href) {", app_source)
@@ -259,7 +295,8 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
         self.assertIn("https://tomboflight.com/pricing.html", sitemap)
         self.assertIn("https://tomboflight.com/platform.html", sitemap)
         self.assertIn("https://tomboflight.com/refunds-delivery.html", sitemap)
-        self.assertIn("https://tomboflight.com/bridge-taste.html", sitemap)
+        self.assertIn("https://tomboflight.com/bridge-paint.html", sitemap)
+        self.assertNotIn("https://tomboflight.com/bridge-taste.html", sitemap)
 
     def test_founder_access_redirects_to_pricing(self):
         founder_page = (REPO_ROOT / "founder-access.html").read_text(encoding="utf-8")

--- a/bridge-paint.html
+++ b/bridge-paint.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tomb of Light | Sip &amp; Paint — Private Bridge Event</title>
+    <meta
+      name="description"
+      content="Tomb of Light Sip &amp; Paint is Event 2 of 4: a private invite-only Bridge to Grand Opening event in Norfolk, VA."
+    />
+    <link rel="canonical" href="https://tomboflight.com/bridge-paint.html" />
+    <meta property="og:title" content="Tomb of Light | Sip &amp; Paint — Private Bridge Event" />
+    <meta
+      property="og:description"
+      content="Tomb of Light Sip &amp; Paint is Event 2 of 4: a private invite-only Bridge to Grand Opening event in Norfolk, VA."
+    />
+    <meta property="og:url" content="https://tomboflight.com/bridge-paint.html" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tomb of Light | Sip &amp; Paint — Private Bridge Event" />
+    <meta
+      name="twitter:description"
+      content="Tomb of Light Sip &amp; Paint is Event 2 of 4: a private invite-only Bridge to Grand Opening event in Norfolk, VA."
+    />
+    <link rel="icon" href="favicon.ico?v=20260508-1" sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=20260508-1" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=20260508-1" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
+    <link rel="manifest" href="site.webmanifest?v=20260508-1" />
+    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+  </head>
+  <body class="homepage-body pricing-page-body">
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+    <div class="site-watermark" aria-hidden="true"></div>
+    <div class="page-wrap">
+      <header class="site-header" role="banner">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="platform.html">Platform</a>
+            <a href="how-it-works.html">How It Works</a>
+            <a href="security.html">Security</a>
+            <a href="compliance.html">Compliance</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="pricing.html">Back to Pricing</a>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" role="main">
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">BRIDGE TO GRAND OPENING</span>
+              <h1>Sip &amp; Paint</h1>
+              <p class="section-lead">Event 2 of 4</p>
+              <div class="hero-meta" aria-label="Sip and Paint event details">
+                <span class="meta-pill">August 29, 2026</span>
+                <span class="meta-pill">6:00 PM – 9:00 PM</span>
+                <span class="meta-pill">Norfolk, VA</span>
+                <span class="meta-pill">Private Event — Invite Only</span>
+                <span class="meta-pill">Contact for private address</span>
+              </div>
+              <p>
+                Join Tomb of Light for the second stop on the Bridge to Grand Opening — an invite-only Sip &amp; Paint
+                experience centered on connection, creativity, legacy, and the growing Tomb of Light community.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section section-tight" aria-labelledby="bridge-access-title">
+          <div class="container">
+            <div class="section-head section-head-wide">
+              <span class="eyebrow">PRIVATE BRIDGE EVENT ACCESS</span>
+              <h2 id="bridge-access-title">Private Bridge Event Access</h2>
+              <p class="section-lead">
+                Invited Sip &amp; Paint guests may use their private BRIDGE-PAINT code for 50% off an eligible Tomb of
+                Light package purchase.
+              </p>
+            </div>
+
+            <article class="cta-panel cta-panel-premium offer-panel offer-panel-private">
+              <div class="hero-meta" aria-label="Bridge offer details">
+                <span class="meta-pill">BRIDGE-PAINT</span>
+                <span class="meta-pill">50% off eligible package purchases</span>
+                <span class="meta-pill">Expires August 29, 2026 at 11:59 PM</span>
+                <span class="meta-pill">Limited to 25 redemptions per package code</span>
+              </div>
+              <div class="offer-code-list bridge-access-grid">
+                <div class="offer-code-item">
+                  <strong>Legacy Snapshot</strong>
+                  <code class="offer-code">BRIDGE-PAINT-SNAPSHOT</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Legacy Portrait Intro</strong>
+                  <code class="offer-code">BRIDGE-PAINT-PORTRAIT</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Digital Legacy Portrait</strong>
+                  <code class="offer-code">BRIDGE-PAINT-DIGITAL</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Household Foundation</strong>
+                  <code class="offer-code">BRIDGE-PAINT-HOUSEHOLD</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Heirloom Legacy Tree</strong>
+                  <code class="offer-code">BRIDGE-PAINT-HEIRLOOM</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Legacy Plus</strong>
+                  <code class="offer-code">BRIDGE-PAINT-PLUS</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Family Estate Concierge</strong>
+                  <code class="offer-code">BRIDGE-PAINT-ESTATE</code>
+                </div>
+                <div class="offer-code-item">
+                  <strong>Command Structure Network</strong>
+                  <code class="offer-code">BRIDGE-PAINT-COMMAND</code>
+                </div>
+              </div>
+              <p class="section-note">
+                Use the standard Tomb of Light package checkout and enter your private Bridge Event code directly at
+                Stripe checkout when prompted.
+              </p>
+              <p class="section-note">
+                Bridge Event codes apply to eligible package purchases only. They do not apply to maintenance,
+                subscriptions, add-ons, services, rush delivery, NFT services, white-glove support, taxes, or future
+                balances.
+              </p>
+              <div class="pricing-actions pricing-actions-inline">
+                <a class="btn btn-primary" href="pricing.html">View Full Pricing</a>
+                <a class="btn btn-secondary" href="portal-help.html">Need Help Choosing?</a>
+              </div>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer" role="contentinfo">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-top">
+              <div>
+                <div class="footer-brand">
+                  Tomb of Light<span class="brand-symbol">™</span>
+                </div>
+                <p class="footer-copy">
+                  A private, guided, premium digital lineage platform for protecting memory, lineage, and identity
+                  across generations.
+                </p>
+              </div>
+
+              <div class="footer-links">
+                <a href="platform.html">Platform</a>
+                <a href="reviews/">Reviews</a>
+                <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms</a>
+                <a href="cookie-policy.html">Cookie Policy</a>
+                <a href="accessibility.html">Accessibility</a>
+                <a href="data-request.html">Data Requests</a>
+                <a href="privacy-state-notices.html">State Privacy Notices</a>
+                <a href="privacy-choices.html">Privacy Choices</a>
+                <a href="refunds-delivery.html">Refunds, Delivery &amp; Support</a>
+                <a href="compliance.html">Compliance &amp; Legal</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script src="config.js?v=20260331-2"></script>
+    <script src="app.js?v=20260508-451"></script>
+  </body>
+</html>

--- a/bridge-taste.html
+++ b/bridge-taste.html
@@ -3,24 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tomb of Light | Private Bridge Event Access</title>
+    <title>Tomb of Light | Bridge Event 1 Has Concluded</title>
     <meta
       name="description"
-      content="Private BRIDGE-TASTE invite details for eligible Tomb of Light package purchases, including code entry instructions and offer guardrails."
+      content="Bridge Event 1 has concluded. Continue with Tomb of Light's current private Sip &amp; Paint event."
     />
     <link rel="canonical" href="https://tomboflight.com/bridge-taste.html" />
-    <meta property="og:title" content="Tomb of Light | Private Bridge Event Access" />
+    <meta property="og:title" content="Tomb of Light | Bridge Event 1 Has Concluded" />
     <meta
       property="og:description"
-      content="Private BRIDGE-TASTE invite details for eligible Tomb of Light package purchases and code entry at secure Stripe checkout."
+      content="Bridge Event 1 has concluded. Continue with Tomb of Light's current private Sip &amp; Paint event."
     />
     <meta property="og:url" content="https://tomboflight.com/bridge-taste.html" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Tomb of Light | Private Bridge Event Access" />
+    <meta name="twitter:title" content="Tomb of Light | Bridge Event 1 Has Concluded" />
     <meta
       name="twitter:description"
-      content="Private BRIDGE-TASTE invite details for eligible Tomb of Light package purchases and code entry at secure Stripe checkout."
+      content="Bridge Event 1 has concluded. Continue with Tomb of Light's current private Sip &amp; Paint event."
     />
     <link rel="icon" href="favicon.ico?v=20260508-1" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=20260508-1" />
@@ -64,81 +64,20 @@
         <section class="page-hero">
           <div class="container">
             <div class="page-hero-panel">
-              <span class="eyebrow">Private Bridge Event Access</span>
-              <h1>Private Bridge Event Access</h1>
+              <span class="eyebrow">BRIDGE TO GRAND OPENING</span>
+              <h1>Bridge Event 1 Has Concluded</h1>
               <p>
-                Invited Bridge Event guests may use their private event code for 50% off eligible Tomb of Light
-                package purchases.
+                The first stop on the Bridge to Grand Opening has concluded. Thank you to everyone who supported
+                the beginning of the Tomb of Light event series.
               </p>
-              <div class="hero-meta" aria-label="Bridge offer details">
-                <span class="meta-pill">BRIDGE-TASTE</span>
-                <span class="meta-pill">50% off eligible package purchases</span>
-                <span class="meta-pill">Expires August 1, 2026 at 11:59 PM</span>
-                <span class="meta-pill">Limited to 25 redemptions per package code</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="section section-tight" aria-labelledby="bridge-codes-title">
-          <div class="container">
-            <div class="section-head section-head-wide">
-              <span class="eyebrow">Eligible package codes</span>
-              <h2 id="bridge-codes-title">Enter your private code directly at Stripe checkout.</h2>
               <p class="section-lead">
-                Do not look for a special checkout link. Use the standard secure package checkout and enter the code
-                during Stripe checkout when prompted.
-              </p>
-            </div>
-
-            <article class="cta-panel cta-panel-premium offer-panel offer-panel-private">
-              <div class="offer-code-list bridge-access-grid">
-                <div class="offer-code-item">
-                  <strong>Legacy Snapshot</strong>
-                  <code class="offer-code">BRIDGE-TASTE-SNAPSHOT</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Legacy Portrait Intro</strong>
-                  <code class="offer-code">BRIDGE-TASTE-PORTRAIT</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Digital Legacy Portrait</strong>
-                  <code class="offer-code">BRIDGE-TASTE-DIGITAL</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Household Foundation</strong>
-                  <code class="offer-code">BRIDGE-TASTE-HOUSEHOLD</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Heirloom Legacy Tree</strong>
-                  <code class="offer-code">BRIDGE-TASTE-HEIRLOOM</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Legacy Plus</strong>
-                  <code class="offer-code">BRIDGE-TASTE-PLUS</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Family Estate Concierge</strong>
-                  <code class="offer-code">BRIDGE-TASTE-ESTATE</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Command Structure Network</strong>
-                  <code class="offer-code">BRIDGE-TASTE-COMMAND</code>
-                </div>
-              </div>
-              <p class="section-note">
-                Bridge Event codes apply to package purchases only. They do not apply to maintenance, subscriptions,
-                add-ons, services, rush delivery, NFT services, white-glove support, taxes, or future balances.
-              </p>
-              <p class="section-note">
-                Use the standard package checkout and enter your private Bridge Event code directly at Stripe checkout
-                when prompted.
+                The Bridge to Grand Opening continues with Event 2: Sip &amp; Paint.
               </p>
               <div class="pricing-actions pricing-actions-inline">
-                <a class="btn btn-primary" href="pricing.html">Return to Pricing</a>
-                <a class="btn btn-secondary" href="portal-help.html">Need help choosing?</a>
+                <a class="btn btn-primary" href="bridge-paint.html">View Current Private Event</a>
+                <a class="btn btn-secondary" href="pricing.html">View Full Pricing</a>
               </div>
-            </article>
+            </div>
           </div>
         </section>
       </main>

--- a/pricing.html
+++ b/pricing.html
@@ -709,19 +709,20 @@
 
               <article class="cta-panel cta-panel-premium pricing-cta-panel bridge-invite-panel">
                 <span class="eyebrow">Private Bridge Event Access</span>
-                <h3>BRIDGE-TASTE remains invite-only and separate from the main catalog.</h3>
+                <h3>Sip &amp; Paint — Event 2 of 4</h3>
                 <p class="section-lead">
-                  Invited Bridge Event guests may review the private BRIDGE-TASTE details separately and enter
-                  their event code directly during Stripe checkout.
+                  BRIDGE-PAINT remains invite-only and separate from the main catalog. Invited Sip &amp; Paint guests
+                  may review their private event access and enter their BRIDGE-PAINT code during standard Stripe
+                  checkout.
                 </p>
                 <div class="hero-meta" aria-label="Bridge offer details">
-                  <span class="meta-pill">BRIDGE-TASTE</span>
+                  <span class="meta-pill">BRIDGE-PAINT</span>
                   <span class="meta-pill">50% off eligible package purchases</span>
-                  <span class="meta-pill">Expires August 1, 2026 at 11:59 PM</span>
+                  <span class="meta-pill">Expires August 29, 2026 at 11:59 PM</span>
                   <span class="meta-pill">Limited to 25 redemptions per package code</span>
                 </div>
                 <div class="pricing-actions pricing-actions-inline">
-                  <a class="btn btn-primary" href="bridge-taste.html">View Private Bridge Access</a>
+                  <a class="btn btn-primary" href="bridge-paint.html">View Private Sip &amp; Paint Access</a>
                   <a class="btn btn-secondary" href="portal-help.html">Need help choosing?</a>
                 </div>
                 <p class="section-note">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -63,7 +63,7 @@
 </url>
 
 <url>
-<loc>https://tomboflight.com/bridge-taste.html</loc>
+<loc>https://tomboflight.com/bridge-paint.html</loc>
 <priority>0.7</priority>
 </url>
 


### PR DESCRIPTION
## Summary

The public Bridge campaign still presented concluded Event 1. This updates customer-facing event access to the invite-only Sip & Paint Event 2 while preserving prior Event 1 links as a concluded archive.

- Add the private Sip & Paint event page with Event 2 details and all eight BRIDGE-PAINT codes.
- Archive Bridge Event 1 and direct visitors to the current private event.
- Update the pricing event panel, sitemap, and frontend integrity contract.

## Safety

Stripe checkout URLs, package pricing, maintenance pricing, and checkout routing are unchanged. The Stripe URL set remains 59 unique URLs across 124 occurrences.

## Testing

- `python3 -m pytest -q backend/tests/test_frontend_link_integrity.py` (11 passed)
- Verified responsive layout and mobile navigation across 320px through desktop widths.