### PR TITLE
Operationalize Continuity Kernel execution (Phase 8)

### DIFF
--- a/.github/workflows/continuity-kernel-guardrails.yml
+++ b/.github/workflows/continuity-kernel-guardrails.yml
@@ -53,3 +53,12 @@ jobs:
 
       - name: Run Phase 6L runtime no-skip enforcement test
         run: python -m unittest backend.tests.contracts.test_continuity_kernel_phase6l_runtime_no_skip_enforcement -v
+
+      - name: Run Phase 8 operational runtime tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          python -m unittest
+          backend.tests.test_continuity_runtime_service
+          backend.tests.test_continuity_runtime_route
+          -v

--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -70,6 +70,13 @@
               </button>
             </div>
             <div class="helper" data-admin-control-action-status aria-live="polite"></div>
+            <div class="admin-warning-strip" data-admin-kernel-status aria-live="polite">
+              <span>Continuity Kernel</span>
+              <div>
+                <strong data-admin-kernel-status-label>Checking operational runtime...</strong>
+                <span data-admin-kernel-status-meta></span>
+              </div>
+            </div>
             <div
               class="notice"
               data-state="error"
@@ -199,6 +206,18 @@
                     <button class="btn btn-primary" type="button" data-admin-bulk-action="repair-all-safe-records">Repair All Safe Records</button>
                   </div>
                   <div class="admin-priority-repair-list" data-admin-priority-repairs></div>
+                </div>
+                <div class="admin-console-priority" data-admin-kernel-operations-panel>
+                  <div class="admin-card-header">
+                    <h3>Governed Operations</h3>
+                    <button class="btn btn-secondary" type="button" data-admin-kernel-refresh>
+                      Refresh
+                    </button>
+                  </div>
+                  <p class="card-copy">
+                    Execution requests, approvals, results, and audit closure from the operational Kernel.
+                  </p>
+                  <div class="admin-priority-repair-list" data-admin-kernel-operations></div>
                 </div>
                 <div class="helper" data-admin-priority-feed-status aria-live="polite"></div>
                 <div class="admin-case-context" data-admin-case-context></div>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -59,6 +59,9 @@
     lastStatusMessage: "",
     diagnostics: null,
     fulfillmentItems: [],
+    kernelStatus: null,
+    kernelOperations: [],
+    kernelPendingIdempotency: {},
   };
   const DEFAULT_ROLE_KEY = "user";
 
@@ -602,6 +605,217 @@
       method: "POST",
       body: JSON.stringify(body || {}),
     });
+  }
+
+  function kernelIdempotencyKey(action, target) {
+    const suffix =
+      window.crypto && typeof window.crypto.randomUUID === "function"
+        ? window.crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const targetId = normalizeValue(
+      target && (target.project_id || target.case_id || target.user_id || target.officer_email || target.target_id),
+    );
+    return `kernel-${normalizeLower(action).replaceAll("-", "_")}-${targetId || "bulk"}-${suffix}`;
+  }
+
+  function promptExecutionReason(label, defaultReason) {
+    const reason = window.prompt(
+      `${label}: enter the operational reason that will be attached to the evidence packet.`,
+      defaultReason || "",
+    );
+    if (reason === null) return null;
+    const normalized = normalizeValue(reason);
+    if (normalized.length < 3) {
+      setPageStatus("A reason of at least 3 characters is required for governed execution.", "error");
+      return null;
+    }
+    return normalized;
+  }
+
+  async function submitGovernedOperation(action, target, parameters, reason) {
+    if (!state.kernelStatus || !state.kernelStatus.execution_enabled) {
+      throw new Error("Continuity Kernel execution is unavailable or disabled by the emergency kill switch.");
+    }
+    const normalizedAction = normalizeLower(action).replaceAll("-", "_");
+    const fingerprint = JSON.stringify({
+      action: normalizedAction,
+      target: target || {},
+      parameters: parameters || {},
+      reason,
+    });
+    const idempotencyKey =
+      state.kernelPendingIdempotency[fingerprint] || kernelIdempotencyKey(normalizedAction, target || {});
+    state.kernelPendingIdempotency[fingerprint] = idempotencyKey;
+    const payload = {
+      action: normalizedAction,
+      target: target || {},
+      parameters: parameters || {},
+      reason,
+      idempotency_key: idempotencyKey,
+    };
+    let operation;
+    if (state.kernelStatus.one_step_execution_allowed) {
+      operation = await postJson("/admin/control-center/kernel/execute", {
+        ...payload,
+        confirmed: true,
+        solo_founder_override_acknowledged: true,
+      });
+    } else {
+      operation = await postJson("/admin/control-center/kernel/operations", payload);
+    }
+    delete state.kernelPendingIdempotency[fingerprint];
+    return operation;
+  }
+
+  function kernelOperationMessage(operation, completedLabel) {
+    const payload = operation || {};
+    if (Array.isArray(payload.blocked_reasons) && payload.blocked_reasons.length) {
+      return `Operation ${shortId(payload.operation_id)} was blocked by preflight; no business write executed.`;
+    }
+    if (payload.state === "review_requested") {
+      return `Governed operation ${shortId(payload.operation_id)} submitted for officer approval.`;
+    }
+    if (payload.execution_outcome === "partial_failure") {
+      return `Operation ${shortId(payload.operation_id)} executed with ${payload.execution_failure_count || 0} recorded failure(s).`;
+    }
+    if (payload.evidence_recording_status === "incomplete") {
+      return `Operation ${shortId(payload.operation_id)} executed, but secondary audit evidence is incomplete and requires review.`;
+    }
+    return `${completedLabel} Kernel operation ${shortId(payload.operation_id)} captured the execution evidence.`;
+  }
+
+  function kernelOperationStatusType(operation) {
+    return operation &&
+      ((Array.isArray(operation.blocked_reasons) && operation.blocked_reasons.length > 0) ||
+        operation.execution_outcome === "partial_failure" ||
+        operation.evidence_recording_status === "incomplete")
+      ? "error"
+      : "success";
+  }
+
+  function renderKernelStatus() {
+    const node = document.querySelector("[data-admin-kernel-status]");
+    const label = document.querySelector("[data-admin-kernel-status-label]");
+    const meta = document.querySelector("[data-admin-kernel-status-meta]");
+    if (!node || !label || !meta) return;
+    const payload = state.kernelStatus;
+    if (!payload) {
+      node.dataset.state = "error";
+      label.textContent = "Operational runtime unavailable";
+      meta.textContent = " Governed writes are fail-closed.";
+      return;
+    }
+    const enabled = Boolean(payload.execution_enabled);
+    node.dataset.state = enabled ? "success" : "error";
+    label.textContent = enabled ? "Operational execution enabled" : "Emergency kill switch active";
+    const mode = payload.one_step_execution_allowed ? "CEO one-step execution" : "officer request workflow";
+    meta.textContent = ` v${payload.runtime_version || "—"} · ${payload.action_count || 0} actions · ${mode}`;
+  }
+
+  function renderKernelOperations() {
+    const node = document.querySelector("[data-admin-kernel-operations]");
+    if (!node) return;
+    const items = Array.isArray(state.kernelOperations) ? state.kernelOperations : [];
+    if (!items.length) {
+      node.innerHTML = '<p class="card-copy">No governed operations have been recorded yet.</p>';
+      return;
+    }
+    node.innerHTML = items
+      .map(function (operation) {
+        const canApprove = Boolean(
+            state.kernelStatus &&
+            state.kernelStatus.one_step_execution_allowed &&
+            operation.state === "review_requested" &&
+            (!Array.isArray(operation.blocked_reasons) || operation.blocked_reasons.length === 0),
+        );
+        const canClose = Boolean(
+          state.kernelStatus &&
+            state.kernelStatus.one_step_execution_allowed &&
+            operation.state === "apply_executed" &&
+            operation.execution_outcome !== "partial_failure" &&
+            operation.evidence_recording_status !== "incomplete",
+        );
+        return `
+          <div class="admin-priority-repair-item">
+            <span>
+              ${escapeHtml(titleize(operation.action))}
+              <small class="admin-id-ref">${escapeHtml(shortId(operation.target_id))}</small>
+            </span>
+            <strong>${escapeHtml(titleize(operation.state))}</strong>
+            ${
+              canApprove
+                ? `<button class="btn btn-primary" type="button" data-admin-kernel-approve-execute="${escapeHtml(operation.operation_id)}">Approve + Execute</button>`
+                : ""
+            }
+            ${
+              canClose
+                ? `<button class="btn btn-secondary" type="button" data-admin-kernel-close="${escapeHtml(operation.operation_id)}">Close Audit</button>`
+                : ""
+            }
+          </div>
+        `;
+      })
+      .join("");
+  }
+
+  async function loadKernelOperations() {
+    if (!state.kernelStatus) {
+      state.kernelOperations = [];
+      renderKernelOperations();
+      return;
+    }
+    try {
+      const payload = await fetchJson("/admin/control-center/kernel/operations?limit=12");
+      state.kernelOperations = Array.isArray(payload && payload.items) ? payload.items : [];
+    } catch (_error) {
+      state.kernelOperations = [];
+    }
+    renderKernelOperations();
+  }
+
+  async function loadKernelStatus() {
+    try {
+      state.kernelStatus = await fetchJson("/admin/control-center/kernel/status");
+    } catch (_error) {
+      state.kernelStatus = null;
+    }
+    renderKernelStatus();
+    await loadKernelOperations();
+  }
+
+  async function approveAndExecuteKernelOperation(operationId) {
+    const reason = promptExecutionReason("Approve and execute this governed operation");
+    if (reason === null) return;
+    if (!window.confirm("Approve and execute this operation against live business records?")) return;
+    setPageStatus("Approving and executing governed operation...", "info");
+    try {
+      await postJson(`/admin/control-center/kernel/operations/${encodeURIComponent(operationId)}/approve`, {
+        approval_reason: reason,
+        solo_founder_override_acknowledged: true,
+      });
+      const operation = await postJson(
+        `/admin/control-center/kernel/operations/${encodeURIComponent(operationId)}/execute`,
+        {},
+      );
+      await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
+      setPageStatus(
+        kernelOperationMessage(operation, "Execution completed."),
+        kernelOperationStatusType(operation),
+      );
+    } catch (error) {
+      setPageStatus(error.message || "Unable to approve and execute the governed operation.", "error");
+    }
+  }
+
+  async function closeKernelOperation(operationId) {
+    if (!window.confirm("Close the audit record for this completed operation?")) return;
+    try {
+      await postJson(`/admin/control-center/kernel/operations/${encodeURIComponent(operationId)}/close`, {});
+      await loadKernelStatus();
+      setPageStatus("Continuity operation audit closed.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to close the Continuity audit record.", "error");
+    }
   }
 
   async function loadActiveImpersonation() {
@@ -2015,18 +2229,6 @@
       setPageStatus("Your role cannot run that bulk action.", "error");
       return;
     }
-    const endpointMap = {
-      "repair-missing-entitlements": "/admin/control-center/bulk/repair-missing-entitlements",
-      "assign-missing-lanes": "/admin/control-center/bulk/assign-missing-lanes",
-      "link-unlinked-paid-orders": "/admin/control-center/bulk/link-unlinked-paid-orders",
-      "normalize-broken-package-records": "/admin/control-center/bulk/normalize-broken-package-records",
-      "refresh-mint-readiness": "/admin/control-center/bulk/refresh-mint-readiness",
-      "repair-selected-records": "/admin/control-center/bulk/repair-selected-records",
-      "repair-all-safe-records": "/admin/control-center/bulk/repair-all-safe-records",
-    };
-    const endpoint = endpointMap[action];
-    if (!endpoint) return;
-
     const body = action === "repair-selected-records" ? selectedRepairIds() : { limit: 500 };
     if (
       action === "repair-selected-records" &&
@@ -2036,13 +2238,17 @@
       return;
     }
 
-    setPageStatus("Running bulk action...", "info");
+    const reason = promptExecutionReason(`Run ${titleize(action)}`);
+    if (reason === null) return;
+    if (!window.confirm("Submit this bulk operation to the Continuity Kernel for live execution?")) return;
+
+    setPageStatus("Submitting governed bulk operation...", "info");
     try {
-      await postJson(endpoint, body);
-      await Promise.allSettled([loadOverview(), loadCases()]);
-      setPageStatus("Bulk action completed.", "success");
+      const operation = await submitGovernedOperation(action, {}, body, reason);
+      await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
+      setPageStatus(kernelOperationMessage(operation, "Bulk action completed."), kernelOperationStatusType(operation));
     } catch (error) {
-      setPageStatus(error.message || "Bulk action failed.", "error");
+      setPageStatus(error.message || "Governed bulk action failed.", "error");
     }
   }
 
@@ -2123,18 +2329,33 @@
       return;
     }
     const caseId = state.selectedCaseId;
+    const isReadOnlyAction = action === "run_readiness_check" || action === "refresh_case_data";
+    let reason = "";
+    if (!isReadOnlyAction) {
+      reason = promptExecutionReason(`Run ${titleize(action)} for the selected case`);
+      if (reason === null) return;
+      if (!window.confirm("Submit this case operation to the Continuity Kernel for live execution?")) return;
+    }
     setPageStatus("Running case action...", "info");
     try {
-      await postJson(
-        `/admin/control-center/cases/${encodeURIComponent(caseId)}/actions/${encodeURIComponent(action)}`,
-        {},
-      );
+      const operation = isReadOnlyAction
+        ? await postJson(
+            `/admin/control-center/cases/${encodeURIComponent(caseId)}/actions/${encodeURIComponent(action)}`,
+            {},
+          )
+        : await submitGovernedOperation(action, { case_id: caseId }, {}, reason);
       await loadOverview();
       await loadCases();
+      if (!isReadOnlyAction) await loadKernelStatus();
       if (state.selectedCaseId === caseId) {
         await loadCaseWorkspace(caseId);
       }
-      setPageStatus("Case action completed.", "success");
+      setPageStatus(
+        isReadOnlyAction
+          ? "Case check completed."
+          : kernelOperationMessage(operation, "Case action completed."),
+        isReadOnlyAction ? "success" : kernelOperationStatusType(operation),
+      );
     } catch (error) {
       setPageStatus(error.message || "Case action failed.", "error");
     }
@@ -2173,43 +2394,44 @@
     return payload;
   }
 
+  async function runSuperAdminCreateAccount() {
+    if (!state.isSuperAdmin) return;
+    const fullName = normalizeValue(window.prompt("Customer full name:") || "");
+    const email = normalizeValue(window.prompt("Customer email:") || "");
+    if (!fullName || !email || !window.confirm(`Create customer account for ${email}?`)) return;
+    try {
+      await postJson("/admin/control-center/super-admin/users", { full_name: fullName, email });
+      await loadCases();
+      setPageStatus("Customer account created pending activation.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to create account.", "error");
+    }
+  }
+
+  async function runSuperAdminTransferOwnership(projectId) {
+    const ownerNode = document.querySelector("[data-super-admin-new-owner-id]");
+    const newOwnerUserId = normalizeValue(ownerNode && ownerNode.value);
+    const reason = normalizeValue(window.prompt("Reason for ownership transfer:") || "");
+    if (!newOwnerUserId || !reason || !window.confirm("Confirm project ownership transfer?")) return;
+    try {
+      await postJson(`/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/transfer-ownership`, {
+        new_owner_user_id: newOwnerUserId,
+        reason,
+        confirmed: true,
+      });
+      await loadCaseWorkspace(state.selectedCaseId);
+      setPageStatus("Project ownership transferred.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to transfer ownership.", "error");
+    }
+  }
+
   async function runSuperAdminUserUpdate(userId) {
     if (!state.isSuperAdmin) {
       setPageStatus("Super Admin access is required.", "error");
       return;
     }
 
-    async function runSuperAdminCreateAccount() {
-      if (!state.isSuperAdmin) return;
-      const fullName = normalizeValue(window.prompt("Customer full name:") || "");
-      const email = normalizeValue(window.prompt("Customer email:") || "");
-      if (!fullName || !email || !window.confirm(`Create customer account for ${email}?`)) return;
-      try {
-        await postJson("/admin/control-center/super-admin/users", { full_name: fullName, email });
-        await loadCases();
-        setPageStatus("Customer account created pending activation.", "success");
-      } catch (error) {
-        setPageStatus(error.message || "Unable to create account.", "error");
-      }
-    }
-
-    async function runSuperAdminTransferOwnership(projectId) {
-      const ownerNode = document.querySelector("[data-super-admin-new-owner-id]");
-      const newOwnerUserId = normalizeValue(ownerNode && ownerNode.value);
-      const reason = normalizeValue(window.prompt("Reason for ownership transfer:") || "");
-      if (!newOwnerUserId || !reason || !window.confirm("Confirm project ownership transfer?")) return;
-      try {
-        await postJson(`/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/transfer-ownership`, {
-          new_owner_user_id: newOwnerUserId,
-          reason,
-          confirmed: true,
-        });
-        await loadCaseWorkspace(state.selectedCaseId);
-        setPageStatus("Project ownership transferred.", "success");
-      } catch (error) {
-        setPageStatus(error.message || "Unable to transfer ownership.", "error");
-      }
-    }
     if (!window.confirm("Apply user profile and account updates?")) return;
     setPageStatus("Saving user updates...", "info");
     try {
@@ -2230,17 +2452,19 @@
       setPageStatus("Super Admin access is required.", "error");
       return;
     }
-    const reason = normalizeValue(window.prompt(`Reason for ${action}:`) || "");
-    if (!reason || !window.confirm(`Confirm ${action} for this account?`)) return;
+    const reason = promptExecutionReason(`${titleize(action)} this account`);
+    if (reason === null || !window.confirm(`Confirm ${action} for this account?`)) return;
     setPageStatus("Updating account status...", "info");
     try {
-      await postJson(
-        `/admin/control-center/super-admin/users/${encodeURIComponent(userId)}/status-action`,
-        { action, reason, confirmed: true },
+      const operation = await submitGovernedOperation(
+        "account_lifecycle",
+        { user_id: userId },
+        { lifecycle_action: action },
+        reason,
       );
-      await loadCases();
+      await Promise.allSettled([loadKernelStatus(), loadCases()]);
       if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
-      setPageStatus("Account status updated.", "success");
+      setPageStatus(kernelOperationMessage(operation, "Account status updated."), kernelOperationStatusType(operation));
     } catch (error) {
       setPageStatus(error.message || "Unable to update account status.", "error");
     }
@@ -2370,18 +2594,29 @@
       setPageStatus("Super Admin access is required.", "error");
       return;
     }
-    if (!window.confirm("Apply service controls while preserving Stripe purchase history?")) return;
+    const parameters = collectSuperAdminServicePayload();
+    const reason = normalizeValue(parameters.reason);
+    if (reason.length < 3) {
+      setPageStatus("A reason of at least 3 characters is required for service-control execution.", "error");
+      return;
+    }
+    if (!window.confirm("Apply service controls through the Continuity Kernel while preserving Stripe purchase history?")) return;
     setPageStatus("Applying service controls...", "info");
     try {
-      const payload = await postJson(
-        `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/service-controls/apply`,
-        { ...collectSuperAdminServicePayload(), confirmed: true },
+      const operation = await submitGovernedOperation(
+        "service_controls",
+        { project_id: projectId },
+        parameters,
+        reason,
       );
-      renderSuperAdminPackagePreview(payload || {});
+      renderSuperAdminPackagePreview(
+        operation.execution_result || operation.proposed_after_snapshot || operation || {},
+      );
       await loadOverview();
       await loadCases();
+      await loadKernelStatus();
       if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
-      setPageStatus("Service controls applied.", "success");
+      setPageStatus(kernelOperationMessage(operation, "Service controls applied."), kernelOperationStatusType(operation));
     } catch (error) {
       setPageStatus(error.message || "Unable to apply service controls.", "error");
     }
@@ -2393,42 +2628,73 @@
       return;
     }
 
-    if (!window.confirm("Apply package change and repair consistency across project/order/entitlements?")) return;
+    const parameters = collectSuperAdminPackagePayload();
+    const reason = normalizeValue(parameters.reason);
+    if (reason.length < 3) {
+      setPageStatus("A reason of at least 3 characters is required for package execution.", "error");
+      return;
+    }
+    if (!window.confirm("Apply the package change through the Continuity Kernel and repair consistency across project/order/entitlements?")) return;
     setPageStatus("Applying package change...", "info");
     try {
-      const payload = await postJson(
-        `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/package-change/apply`,
-        { ...collectSuperAdminPackagePayload(), confirmed: true },
+      const operation = await submitGovernedOperation(
+        "package_change",
+        { project_id: projectId },
+        parameters,
+        reason,
       );
-      renderSuperAdminPackagePreview(payload || {});
+      renderSuperAdminPackagePreview(
+        operation.execution_result || operation.proposed_after_snapshot || operation || {},
+      );
       await loadOverview();
       await loadCases();
+      await loadKernelStatus();
       if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
-      setPageStatus("Package change applied and synchronized.", "success");
+      setPageStatus(
+        kernelOperationMessage(operation, "Package change applied and synchronized."),
+        kernelOperationStatusType(operation),
+      );
     } catch (error) {
       setPageStatus(error.message || "Unable to apply package change.", "error");
     }
+  }
 
-    async function runSuperAdminPackageLifecycle(projectId, action, previewOnly) {
-      if (!state.isSuperAdmin) return;
-      const reason = previewOnly ? "" : normalizeValue(window.prompt(`Reason to ${action} this package:`) || "");
-      if (!previewOnly && (!reason || !window.confirm(`Confirm package ${action}?`))) return;
-      const endpoint = previewOnly
-        ? `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/package-revoke/preview`
-        : action === "restore"
-          ? `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/package-restore`
-          : `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/package-revoke/apply`;
+  async function runSuperAdminPackageLifecycle(projectId, action, previewOnly) {
+    if (!state.isSuperAdmin) return;
+    if (previewOnly) {
       try {
-        const payload = await postJson(endpoint, previewOnly ? {} : { reason, confirmed: true });
+        const payload = await postJson(
+          `/admin/control-center/super-admin/projects/${encodeURIComponent(projectId)}/package-revoke/preview`,
+          {},
+        );
         renderSuperAdminPackagePreview(payload || {});
-        if (!previewOnly) {
-          await Promise.allSettled([loadOverview(), loadCases()]);
-          if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
-        }
-        setPageStatus(previewOnly ? "Package revocation preview ready." : `Package ${action} completed.`, "success");
+        setPageStatus("Package revocation preview ready.", "success");
       } catch (error) {
-        setPageStatus(error.message || `Unable to ${action} package.`, "error");
+        setPageStatus(error.message || "Unable to preview package revocation.", "error");
       }
+      return;
+    }
+
+    const reason = promptExecutionReason(`${titleize(action)} this package`);
+    if (reason === null || !window.confirm(`Confirm package ${action} through the Continuity Kernel?`)) return;
+    try {
+      const operation = await submitGovernedOperation(
+        action === "restore" ? "package_restore" : "package_revoke",
+        { project_id: projectId },
+        {},
+        reason,
+      );
+      renderSuperAdminPackagePreview(
+        operation.execution_result || operation.proposed_after_snapshot || operation || {},
+      );
+      await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
+      if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
+      setPageStatus(
+        kernelOperationMessage(operation, `Package ${action} completed.`),
+        kernelOperationStatusType(operation),
+      );
+    } catch (error) {
+      setPageStatus(error.message || `Unable to ${action} package.`, "error");
     }
   }
 
@@ -2470,14 +2736,18 @@
     }
     setPageStatus("Applying super admin repair...", "info");
     try {
-      await postJson(
-        `/admin/control-center/super-admin/cases/${encodeURIComponent(caseId)}/repair`,
-        payload,
+      const operation = await submitGovernedOperation(
+        "case_repair",
+        { case_id: caseId },
+        { repair_action: payload.action, repair_payload: payload },
+        payload.reason,
       );
-      await loadOverview();
-      await loadCases();
+      await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
       if (state.selectedCaseId) await loadCaseWorkspace(state.selectedCaseId);
-      setPageStatus("Super admin repair completed and logged.", "success");
+      setPageStatus(
+        kernelOperationMessage(operation, "Super admin repair completed and logged."),
+        kernelOperationStatusType(operation),
+      );
     } catch (error) {
       setPageStatus(error.message || "Unable to complete super admin repair.", "error");
     }
@@ -2499,10 +2769,32 @@
           bootstrapAccessAndData();
         }
 
-        if (target.closest("[data-super-admin-create-account]")) {
-          runSuperAdminCreateAccount();
-          return;
-        }
+        return;
+      }
+
+      const superAdminCreateAccount = target.closest("[data-super-admin-create-account]");
+      if (superAdminCreateAccount) {
+        runSuperAdminCreateAccount();
+        return;
+      }
+
+      const kernelRefresh = target.closest("[data-admin-kernel-refresh]");
+      if (kernelRefresh) {
+        loadKernelStatus();
+        return;
+      }
+
+      const kernelApproveExecute = target.closest("[data-admin-kernel-approve-execute]");
+      if (kernelApproveExecute) {
+        const operationId = kernelApproveExecute.getAttribute("data-admin-kernel-approve-execute");
+        if (operationId) approveAndExecuteKernelOperation(operationId);
+        return;
+      }
+
+      const kernelClose = target.closest("[data-admin-kernel-close]");
+      if (kernelClose) {
+        const operationId = kernelClose.getAttribute("data-admin-kernel-close");
+        if (operationId) closeKernelOperation(operationId);
         return;
       }
 
@@ -2722,7 +3014,7 @@
     if (refreshButton) {
       refreshButton.addEventListener("click", async function () {
         setPageStatus("Refreshing customer case console...", "info");
-        await Promise.allSettled([loadOverview(), loadCases()]);
+        await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
         setPageStatus("Customer case console refreshed.", "success");
       });
     }
@@ -2774,6 +3066,7 @@
       if (state.isSuperAdmin) {
         await loadPackageOptions();
       }
+      await loadKernelStatus();
       await loadActiveImpersonation();
       startImpersonationTicker();
       clearBootstrapError();

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.routes.admin_intake_submissions import (
     router as admin_intake_submissions_router,
 )
 from app.routes.admin_continuity_preview import router as admin_continuity_preview_router
+from app.routes.admin_continuity_runtime import router as admin_continuity_runtime_router
 from app.routes.asset_delivery import router as asset_delivery_router
 from app.routes.admin_control_center import router as admin_control_center_router
 from app.routes.admin_stripe_operations import router as admin_stripe_operations_router
@@ -74,6 +75,7 @@ from app.routes.organizations import router as organizations_router
 from app.services.project_entitlement_service import ensure_project_entitlement_indexes
 from app.services.admin_access_bootstrap_service import bootstrap_admin_access_controls
 from app.services.admin_control_service import ensure_finance_event_indexes
+from app.services.continuity_runtime_service import ensure_continuity_runtime_indexes
 from app.services.organization_service import ensure_organization_indexes
 from app.routes.package_catalog import router as package_catalog_router
 from app.routes.package_catalog_public import router as package_catalog_public_router
@@ -157,6 +159,7 @@ async def lifespan(app: FastAPI):
         initialize_mint_job_indexes()
         ensure_stripe_event_indexes()
         ensure_finance_event_indexes()
+        ensure_continuity_runtime_indexes()
         ensure_organization_indexes()
         try:
             bootstrap_admin_access_controls()
@@ -233,6 +236,7 @@ app.include_router(intake_options_router)
 app.include_router(intake_submissions_router)
 app.include_router(admin_intake_submissions_router)
 app.include_router(admin_continuity_preview_router)
+app.include_router(admin_continuity_runtime_router)
 app.include_router(admin_control_center_router)
 app.include_router(admin_stripe_operations_router)
 app.include_router(projects_router)

--- a/backend/app/routes/admin_continuity_runtime.py
+++ b/backend/app/routes/admin_continuity_runtime.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
+from app.database import DatabaseUnavailableError
+from app.dependencies.auth import require_any_permission, require_permission, require_super_admin
+from app.services.continuity_runtime_service import (
+    approve_operation,
+    build_project_continuity_snapshot,
+    canonical_officer_role,
+    close_operation,
+    execute_governed_action,
+    execute_operation,
+    get_operation,
+    list_operation_events,
+    list_operations,
+    reject_operation,
+    request_operation,
+    runtime_status,
+)
+
+
+router = APIRouter(prefix="/admin/control-center/kernel", tags=["Admin Continuity Runtime"])
+
+
+class OperationRequestPayload(BaseModel):
+    action: str = Field(min_length=1)
+    target: dict[str, Any] = Field(default_factory=dict)
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    reason: str = Field(min_length=3)
+    idempotency_key: str = Field(min_length=8)
+
+
+class OperationApprovalPayload(BaseModel):
+    approval_reason: str = Field(min_length=3)
+    solo_founder_override_acknowledged: bool = False
+
+
+class OperationRejectionPayload(BaseModel):
+    rejection_reason: str = Field(min_length=3)
+
+
+class GovernedExecutionPayload(OperationRequestPayload):
+    confirmed: bool = False
+    solo_founder_override_acknowledged: bool = False
+
+
+def _raise_service_error(exc: Exception) -> None:
+    if isinstance(exc, DatabaseUnavailableError):
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    if isinstance(exc, PermissionError):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    if isinstance(exc, ValueError):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+def _assert_canonical_ceo(current_user: dict[str, Any]) -> None:
+    email = str(current_user.get("email") or "").strip().lower()
+    if email == CEO_MASTER_ADMIN_EMAIL.lower():
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Governed one-step execution is restricted to the canonical CEO Master Administrator.",
+    )
+
+
+def _write_dependency():
+    return require_any_permission(
+        [
+            "admin.control.write",
+            "admin.control.billing",
+            "admin.control.mint",
+            "admin.entitlements.write",
+        ]
+    )
+
+
+@router.get("/status")
+def get_continuity_runtime_status(
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    try:
+        payload = runtime_status()
+        payload["current_actor_role"] = canonical_officer_role(current_user) or None
+        payload["one_step_execution_allowed"] = (
+            str(current_user.get("email") or "").strip().lower() == CEO_MASTER_ADMIN_EMAIL.lower()
+        )
+        return payload
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/projects/{project_id}/snapshot")
+def get_project_kernel_snapshot(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    del current_user
+    try:
+        return build_project_continuity_snapshot(project_id)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/operations")
+def get_continuity_operations(
+    operation_state: str = Query(default="", alias="state"),
+    target_id: str = Query(default=""),
+    limit: int = Query(default=50, ge=1, le=200),
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    del current_user
+    try:
+        return list_operations(state=operation_state, target_id=target_id, limit=limit)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/operations/{operation_id}")
+def get_continuity_operation(
+    operation_id: str,
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    del current_user
+    try:
+        return get_operation(operation_id)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/operations/{operation_id}/events")
+def get_continuity_operation_events(
+    operation_id: str,
+    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+):
+    del current_user
+    try:
+        return list_operation_events(operation_id)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/operations", status_code=status.HTTP_201_CREATED)
+def create_continuity_operation(
+    payload: OperationRequestPayload,
+    current_user: dict[str, Any] = Depends(_write_dependency()),
+):
+    try:
+        return request_operation(
+            action=payload.action,
+            target=payload.target,
+            parameters=payload.parameters,
+            reason=payload.reason,
+            idempotency_key=payload.idempotency_key,
+            actor=current_user,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/operations/{operation_id}/approve")
+def approve_continuity_operation(
+    operation_id: str,
+    payload: OperationApprovalPayload,
+    current_user: dict[str, Any] = Depends(_write_dependency()),
+):
+    try:
+        return approve_operation(
+            operation_id,
+            approval_reason=payload.approval_reason,
+            actor=current_user,
+            solo_founder_override_acknowledged=payload.solo_founder_override_acknowledged,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/operations/{operation_id}/reject")
+def reject_continuity_operation(
+    operation_id: str,
+    payload: OperationRejectionPayload,
+    current_user: dict[str, Any] = Depends(_write_dependency()),
+):
+    try:
+        return reject_operation(
+            operation_id,
+            rejection_reason=payload.rejection_reason,
+            actor=current_user,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/operations/{operation_id}/execute")
+def execute_continuity_operation(
+    operation_id: str,
+    current_user: dict[str, Any] = Depends(_write_dependency()),
+):
+    try:
+        return execute_operation(operation_id, actor=current_user)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/operations/{operation_id}/close")
+def close_continuity_operation(
+    operation_id: str,
+    current_user: dict[str, Any] = Depends(_write_dependency()),
+):
+    try:
+        return close_operation(operation_id, actor=current_user)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.post("/execute")
+def execute_continuity_action_as_ceo(
+    payload: GovernedExecutionPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    _assert_canonical_ceo(current_user)
+    try:
+        return execute_governed_action(
+            action=payload.action,
+            target=payload.target,
+            parameters=payload.parameters,
+            reason=payload.reason,
+            idempotency_key=payload.idempotency_key,
+            actor=current_user,
+            confirmed=payload.confirmed,
+            solo_founder_override_acknowledged=payload.solo_founder_override_acknowledged,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)

--- a/backend/app/services/continuity_runtime_service.py
+++ b/backend/app/services/continuity_runtime_service.py
@@ -1,0 +1,1427 @@
+"""Operational Continuity Kernel orchestration.
+
+This service turns the earlier isolated Continuity Kernel contracts into a
+governed runtime around the repair capabilities that already exist in the
+Tomb of Light backend.  It does not replace the domain services.  It records
+the request, approval, evidence packet, state transitions, execution result,
+and immutable event trail before delegating to an allow-listed operation.
+
+No operation runs automatically.  Every write requires an authenticated
+admin request, an allowed officer role, a reason, an idempotency key, an
+approval, and an explicit execute call.  The solo-founder convenience path
+still records the full state machine and requires an acknowledged CEO
+override for high-risk same-requester execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from uuid import uuid4
+
+from bson import ObjectId
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import DuplicateKeyError
+
+from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
+from app.database import get_database
+from app.services import admin_control_service
+from app.services.audit_log_service import write_audit_log
+
+
+RUNTIME_VERSION = "8.0.0"
+OPERATIONS_COLLECTION = "continuity_operations"
+EVENTS_COLLECTION = "continuity_events"
+EXECUTION_KILL_SWITCH = "CONTINUITY_EXECUTION_KILL_SWITCH"
+MAX_OPERATION_LIST_LIMIT = 200
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    repair_category: str
+    risk_level: str
+    target_type: str
+    required_target_fields: tuple[str, ...] = ()
+    mutates_business_data: bool = True
+
+
+CASE_ACTION_SPECS: dict[str, ActionSpec] = {
+    "sync_package": ActionSpec("package_lane_normalization", "medium", "customer_case", ("case_id",)),
+    "normalize_package": ActionSpec("package_lane_normalization", "medium", "customer_case", ("case_id",)),
+    "assign_lane": ActionSpec("package_lane_normalization", "medium", "customer_case", ("case_id",)),
+    "link_order_to_project": ActionSpec("billing_order_payment_repair", "high", "customer_case", ("case_id",)),
+    "generate_entitlement": ActionSpec("missing_entitlement_repair", "high", "customer_case", ("case_id",)),
+    "refresh_entitlement": ActionSpec("missing_entitlement_repair", "high", "customer_case", ("case_id",)),
+    "run_readiness_check": ActionSpec(
+        "admin_repair_safety", "low", "customer_case", ("case_id",), mutates_business_data=False
+    ),
+    "queue_for_mint_review": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "repair_record": ActionSpec("admin_repair_safety", "high", "customer_case", ("case_id",)),
+    "repair_mint_status": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "rebuild_mint_summary": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "resync_mint_receipt": ActionSpec("mint_readiness_repair", "medium", "customer_case", ("case_id",)),
+    "refresh_case_data": ActionSpec(
+        "admin_repair_safety", "low", "customer_case", ("case_id",), mutates_business_data=False
+    ),
+}
+
+
+BULK_ACTION_SPECS: dict[str, ActionSpec] = {
+    "repair_missing_entitlements": ActionSpec("missing_entitlement_repair", "high", "bulk_repair"),
+    "assign_missing_lanes": ActionSpec("package_lane_normalization", "high", "bulk_repair"),
+    "link_unlinked_paid_orders": ActionSpec("billing_order_payment_repair", "high", "bulk_repair"),
+    "normalize_broken_package_records": ActionSpec("package_lane_normalization", "high", "bulk_repair"),
+    "refresh_mint_readiness": ActionSpec("mint_readiness_repair", "high", "bulk_repair"),
+    "repair_selected_records": ActionSpec("admin_repair_safety", "high", "bulk_repair"),
+    "repair_all_safe_records": ActionSpec("admin_repair_safety", "high", "bulk_repair"),
+}
+
+
+SUPER_ADMIN_ACTION_SPECS: dict[str, ActionSpec] = {
+    "package_change": ActionSpec("package_lane_normalization", "high", "project", ("project_id",)),
+    "package_revoke": ActionSpec("admin_repair_safety", "high", "project", ("project_id",)),
+    "package_restore": ActionSpec("admin_repair_safety", "high", "project", ("project_id",)),
+    "service_controls": ActionSpec("admin_repair_safety", "high", "project", ("project_id",)),
+    "officer_permissions": ActionSpec("admin_repair_safety", "high", "officer", ("officer_email",)),
+    "account_lifecycle": ActionSpec("admin_repair_safety", "high", "user", ("user_id",)),
+    "case_repair": ActionSpec("admin_repair_safety", "high", "customer_case", ("case_id",)),
+}
+
+
+ACTION_SPECS: dict[str, ActionSpec] = {
+    **CASE_ACTION_SPECS,
+    **BULK_ACTION_SPECS,
+    **SUPER_ADMIN_ACTION_SPECS,
+}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_action(value: Any) -> str:
+    return _normalize(value).lower().replace("-", "_")
+
+
+def _serialize(value: Any) -> Any:
+    if isinstance(value, ObjectId):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat() if value.tzinfo else value.replace(tzinfo=UTC).isoformat()
+    if isinstance(value, dict):
+        return {str(key): _serialize(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_serialize(item) for item in value]
+    return value
+
+
+def _operations_collection():
+    return get_database()[OPERATIONS_COLLECTION]
+
+
+def _events_collection():
+    return get_database()[EVENTS_COLLECTION]
+
+
+def execution_enabled(env: Any | None = None) -> bool:
+    environment = env if env is not None else os.environ
+    raw = _normalize(environment.get(EXECUTION_KILL_SWITCH)).lower()
+    return raw not in {"1", "true", "yes", "on", "enabled"}
+
+
+def ensure_continuity_runtime_indexes() -> None:
+    operations = _operations_collection()
+    operations.create_index([("operation_id", ASCENDING)], unique=True, name="continuity_operation_id_unique")
+    operations.create_index([("idempotency_key", ASCENDING)], unique=True, name="continuity_idempotency_unique")
+    operations.create_index([("state", ASCENDING), ("updated_at", DESCENDING)], name="continuity_state_updated")
+    operations.create_index([("target.target_id", ASCENDING), ("updated_at", DESCENDING)], name="continuity_target_updated")
+
+    events = _events_collection()
+    events.create_index([("event_id", ASCENDING)], unique=True, name="continuity_event_id_unique")
+    events.create_index([("operation_id", ASCENDING), ("created_at", ASCENDING)], name="continuity_operation_events")
+    events.create_index([("target_id", ASCENDING), ("created_at", DESCENDING)], name="continuity_target_events")
+
+
+def _actor_id(actor: dict[str, Any] | None) -> str:
+    actor = actor or {}
+    return _normalize(actor.get("_id") or actor.get("id") or actor.get("user_id"))
+
+
+def _actor_email(actor: dict[str, Any] | None) -> str:
+    return _normalize((actor or {}).get("email")).lower()
+
+
+def _actor_name(actor: dict[str, Any] | None) -> str:
+    actor = actor or {}
+    full_name = _normalize(actor.get("full_name"))
+    if full_name:
+        return full_name
+    return " ".join(
+        value for value in (_normalize(actor.get("first_name")), _normalize(actor.get("last_name"))) if value
+    )
+
+
+def canonical_officer_role(actor: dict[str, Any] | None) -> str:
+    actor = actor or {}
+    email = _actor_email(actor)
+    access_context = actor.get("_access_context") or {}
+    role_values = {
+        _normalize(actor.get("role")).lower(),
+        _normalize(actor.get("department_role")).lower(),
+        _normalize(actor.get("access_tier")).lower(),
+    }
+    role_values.update(_normalize(item).lower() for item in (actor.get("role_codes") or []))
+    role_values.update(_normalize(item).lower() for item in (access_context.get("role_codes") or []))
+
+    if email == CEO_MASTER_ADMIN_EMAIL.lower() or role_values.intersection(
+        {"ceo", "ceo_master_admin", "ceo_super_admin", "super_admin", "superadmin"}
+    ):
+        return "SUPERADMIN"
+    if role_values.intersection({"executive_tech_admin", "cto", "technical_admin"}):
+        return "EXECUTIVE_TECH_ADMIN"
+    if role_values.intersection({"coo", "operations_admin", "operations"}):
+        return "operations_admin"
+    if role_values.intersection({"cfo", "finance_admin", "finance"}):
+        return "finance_admin"
+    if role_values.intersection({"cmo", "marketing_admin", "marketing"}):
+        return "CMO"
+    return ""
+
+
+def _actor_snapshot(actor: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "actor_user_id": _actor_id(actor),
+        "actor_email": _actor_email(actor),
+        "actor_name": _actor_name(actor),
+        "actor_role": canonical_officer_role(actor),
+    }
+
+
+def _taxonomy_module():
+    module_name = "app.core." + "continuity" + "_kernel_taxonomy"
+    return import_module(module_name)
+
+
+def _validator_module():
+    module_name = "app.core." + "continuity" + "_kernel_validator"
+    try:
+        return import_module(module_name)
+    except ModuleNotFoundError as exc:
+        # The legacy isolated validator uses the repository-root import path
+        # (``backend.app``), while the deployed API is commonly launched from
+        # ``backend/`` with ``app`` as the top-level package.  Make the
+        # repository root available only for this compatibility import.
+        if exc.name != "backend":
+            raise
+        repository_root = str(Path(__file__).resolve().parents[3])
+        if repository_root not in sys.path:
+            sys.path.insert(0, repository_root)
+        fallback_name = "backend.app.core." + "continuity" + "_kernel_validator"
+        return import_module(fallback_name)
+
+
+def _assert_action_allowed_for_actor(spec: ActionSpec, actor: dict[str, Any] | None) -> str:
+    role = canonical_officer_role(actor)
+    if not role:
+        raise PermissionError("The authenticated admin role is not recognized by Continuity Kernel policy.")
+    allowed_categories = _taxonomy_module().allowed_categories_for_role(role)
+    if spec.repair_category not in allowed_categories:
+        raise PermissionError(f"Role {role} cannot approve {spec.repair_category} operations.")
+    return role
+
+
+def _require_text(value: Any, field: str, *, minimum: int = 1) -> str:
+    normalized = _normalize(value)
+    if len(normalized) < minimum:
+        raise ValueError(f"{field} is required and must contain at least {minimum} characters.")
+    return normalized
+
+
+def _target_id(spec: ActionSpec, action: str, target: dict[str, Any]) -> str:
+    for field in ("case_id", "project_id", "order_id", "user_id", "officer_email", "target_id"):
+        value = _normalize(target.get(field))
+        if value:
+            return value
+    if spec.target_type == "bulk_repair":
+        return f"bulk::{action}"
+    raise ValueError("A scoped target identifier is required.")
+
+
+def _validate_target(spec: ActionSpec, action: str, target: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(target, dict):
+        raise ValueError("target must be an object.")
+    cleaned = _serialize(target)
+    for field in spec.required_target_fields:
+        _require_text(cleaned.get(field), f"target.{field}")
+    cleaned["target_type"] = spec.target_type
+    cleaned["target_id"] = _target_id(spec, action, cleaned)
+    return cleaned
+
+
+def _safe_document(document: dict[str, Any] | None, fields: tuple[str, ...]) -> dict[str, Any] | None:
+    if not document:
+        return None
+    payload = {field: document.get(field) for field in fields if field in document}
+    if "_id" in document:
+        payload["id"] = document.get("_id")
+    return _serialize(payload)
+
+
+def _id_candidates(raw_value: Any) -> list[Any]:
+    value = _normalize(raw_value)
+    if not value:
+        return []
+    candidates: list[Any] = [value]
+    if ObjectId.is_valid(value):
+        candidates.insert(0, ObjectId(value))
+    return candidates
+
+
+def _find_by_id(collection: Any, raw_value: Any) -> dict[str, Any] | None:
+    for candidate in _id_candidates(raw_value):
+        document = collection.find_one({"_id": candidate})
+        if document is not None:
+            return document
+    return None
+
+
+def _count(collection: Any, query: dict[str, Any]) -> int:
+    try:
+        return int(collection.count_documents(query))
+    except Exception:
+        return 0
+
+
+def _project_operational_snapshot(project_id: str) -> dict[str, Any]:
+    project_id = _require_text(project_id, "project_id")
+    db = get_database()
+    project = _find_by_id(db["projects"], project_id)
+    if project is None:
+        raise ValueError("Project not found.")
+
+    project_refs = _id_candidates(project_id)
+    entitlement = db["project_entitlements"].find_one({"project_id": {"$in": project_refs}})
+    order = db["orders"].find_one(
+        {"project_id": {"$in": project_refs}},
+        sort=[("updated_at", -1), ("created_at", -1)],
+    )
+    mint_record = db["mint_records"].find_one(
+        {"project_id": {"$in": project_refs}},
+        sort=[("version_number", -1), ("updated_at", -1)],
+    )
+
+    return {
+        "project": _safe_document(
+            project,
+            (
+                "owner_user_id",
+                "owner_email",
+                "package_code",
+                "package_slug",
+                "package_name",
+                "project_lane",
+                "lane",
+                "family_id",
+                "household_id",
+                "status",
+                "workflow_state",
+                "build_status",
+                "mint_status",
+            ),
+        ),
+        "entitlement": _safe_document(
+            entitlement,
+            (
+                "project_id",
+                "user_id",
+                "package_code",
+                "package_name",
+                "package_lane",
+                "status",
+                "active_addons",
+                "maintenance_plan",
+                "maintenance_status",
+            ),
+        ),
+        "order": _safe_document(
+            order,
+            (
+                "project_id",
+                "user_id",
+                "status",
+                "source",
+                "package_code",
+                "package_name",
+                "package_lane",
+                "fulfillment_status",
+            ),
+        ),
+        "mint_record": _safe_document(
+            mint_record,
+            (
+                "project_id",
+                "status",
+                "canonical_status",
+                "version_number",
+                "token_id",
+                "chain",
+                "contract_address",
+                "tx_hash",
+            ),
+        ),
+        "membership_count": _count(db["project_members"], {"project_id": {"$in": project_refs}, "status": "active"}),
+    }
+
+
+def build_project_continuity_snapshot(project_id: str) -> dict[str, Any]:
+    """Build the canonical admin-safe read model across the Kernel domains."""
+    project_id = _require_text(project_id, "project_id")
+    db = get_database()
+    operational = _project_operational_snapshot(project_id)
+    project = _find_by_id(db["projects"], project_id) or {}
+    project_refs = _id_candidates(project_id)
+    family_id = _normalize(project.get("family_id"))
+    household_id = _normalize(project.get("household_id"))
+    family_refs = _id_candidates(family_id)
+    owner_id = _normalize(project.get("owner_user_id") or project.get("user_id"))
+    owner_email = _normalize(project.get("owner_email")).lower()
+
+    owner_query: dict[str, Any]
+    if owner_id and owner_email:
+        owner_query = {"$or": [{"_id": {"$in": _id_candidates(owner_id)}}, {"email": owner_email}]}
+    elif owner_id:
+        owner_query = {"_id": {"$in": _id_candidates(owner_id)}}
+    else:
+        owner_query = {"email": owner_email}
+    owner = db["users"].find_one(owner_query) if owner_id or owner_email else None
+
+    entitlement = operational.get("entitlement") or {}
+    order = operational.get("order") or {}
+    package_code = _normalize(
+        entitlement.get("package_code") or project.get("package_code") or project.get("package_slug")
+    )
+    order_status = _normalize(order.get("status")).lower()
+    entitlement_status = _normalize(entitlement.get("status")).lower()
+
+    upload_count = _count(db["uploads"], {"project_id": {"$in": project_refs}})
+    upload_count += _count(db["uploaded_files"], {"project_id": {"$in": project_refs}})
+    verification_count = _count(db["verification_records"], {"project_id": {"$in": project_refs}})
+    lineage_member_count = _count(db["family_members"], {"family_id": {"$in": family_refs}}) if family_refs else 0
+    relationship_count = _count(db["relationships"], {"family_id": {"$in": family_refs}}) if family_refs else 0
+    certificate = db["issued_certificates"].find_one(
+        {"project_id": {"$in": project_refs}}, sort=[("version_number", -1), ("issued_at", -1)]
+    )
+    audit_count = _count(db["audit_logs"], {"target_id": project_id})
+
+    required_gates = {
+        "identity_resolved": owner is not None,
+        "paid_order_present": order_status in {"paid", "complete", "completed", "succeeded", "active"},
+        "active_entitlement_present": bool(entitlement) and entitlement_status in {"active", "delivered"},
+        "workspace_membership_valid": int(operational.get("membership_count") or 0) > 0,
+        "lineage_root_present": bool(family_id),
+        "package_identity_resolved": bool(package_code),
+    }
+    reason_codes = [f"{name.upper()}_MISSING" for name, passed in required_gates.items() if not passed]
+
+    return {
+        "kernel_version": RUNTIME_VERSION,
+        "project_id": project_id,
+        "overall_status": "ready" if not reason_codes else "blocked",
+        "reason_codes": reason_codes,
+        "components": {
+            "identity_resolver": {
+                "resolved": owner is not None,
+                "owner_user_id": owner_id or None,
+                "owner_email": owner_email or None,
+            },
+            "entitlement_graph_resolver": {
+                "package_code": package_code or None,
+                "status": entitlement_status or None,
+                "active_addons": list(entitlement.get("active_addons") or []),
+            },
+            "workspace_access_resolver": {
+                "active_membership_count": int(operational.get("membership_count") or 0),
+                "family_id": family_id or None,
+                "household_id": household_id or None,
+            },
+            "lineage_event_ledger": {
+                "family_member_count": lineage_member_count,
+                "relationship_count": relationship_count,
+                "kernel_event_count": _count(_events_collection(), {"target_id": project_id}),
+            },
+            "viewer_manifest_compiler": {
+                "workspace_anchor_present": bool(family_id or household_id),
+                "source_upload_count": upload_count,
+                "verification_record_count": verification_count,
+            },
+            "readiness_gate_matrix": required_gates,
+            "certificate_delivery_record": {
+                "latest": _safe_document(
+                    certificate,
+                    ("project_id", "family_id", "version_number", "status", "issued_at", "integrity_hash"),
+                )
+            },
+            "mint_readiness_controller": operational.get("mint_record"),
+            "officer_policy_layer": {"governed_actions": len(ACTION_SPECS)},
+            "self_healing_repair_engine": {
+                "enabled": execution_enabled(),
+                "open_operations": _count(
+                    _operations_collection(),
+                    {"target.target_id": project_id, "state": {"$nin": ["audit_closed", "rejected"]}},
+                ),
+            },
+            "audit_timeline": {"project_audit_event_count": audit_count},
+        },
+        "operational_snapshot": operational,
+    }
+
+
+def _bulk_snapshot() -> dict[str, Any]:
+    db = get_database()
+    return {
+        "projects": _count(db["projects"], {}),
+        "orders": _count(db["orders"], {}),
+        "project_entitlements": _count(db["project_entitlements"], {}),
+        "project_members": _count(db["project_members"], {}),
+        "mint_records": _count(db["mint_records"], {}),
+    }
+
+
+def _snapshot_for_action(action: str, target: dict[str, Any]) -> dict[str, Any]:
+    project_id = _normalize(target.get("project_id"))
+    case_id = _normalize(target.get("case_id"))
+    if not project_id and case_id and not case_id.startswith(("order:", "user:")):
+        project_id = case_id
+    if project_id:
+        try:
+            return _project_operational_snapshot(project_id)
+        except ValueError:
+            return {"target": target, "snapshot_status": "project_not_resolved"}
+    if ACTION_SPECS[action].target_type == "bulk_repair":
+        return _bulk_snapshot()
+    return {"target": target}
+
+
+def _preview_action(action: str, target: dict[str, Any], parameters: dict[str, Any]) -> dict[str, Any]:
+    if action == "package_change":
+        return admin_control_service.super_admin_preview_package_change(
+            project_id=_normalize(target.get("project_id")),
+            package_code=_normalize(parameters.get("package_code")),
+            project_lane=_normalize(parameters.get("project_lane")),
+            order_status=_normalize(parameters.get("order_status")),
+        )
+    if action == "package_revoke":
+        return admin_control_service.super_admin_preview_package_revocation(
+            project_id=_normalize(target.get("project_id"))
+        )
+    if action == "service_controls":
+        return admin_control_service.super_admin_preview_service_controls(
+            project_id=_normalize(target.get("project_id")), payload=parameters
+        )
+    if action == "officer_permissions":
+        return admin_control_service.super_admin_preview_officer_permissions(
+            officer_email=_normalize(target.get("officer_email")),
+            role_assignments=list(parameters.get("role_assignments") or []),
+            grant_permissions=list(parameters.get("grant_permissions") or []),
+            revoke_permissions=list(parameters.get("revoke_permissions") or []),
+        )
+    if action == "account_lifecycle":
+        return admin_control_service.super_admin_preview_account_lifecycle(
+            user_id=_normalize(target.get("user_id")), action=_normalize(parameters.get("lifecycle_action"))
+        )
+    return {
+        "action": action,
+        "target": target,
+        "parameters": parameters,
+        "preview_type": "governed_execution_plan",
+    }
+
+
+def _enrich_before_snapshot(before_snapshot: dict[str, Any], preview: dict[str, Any]) -> dict[str, Any]:
+    action_before = preview.get("before")
+    if action_before is None and preview.get("current_package") is not None:
+        action_before = {"current_package": preview.get("current_package")}
+    if action_before is None:
+        return before_snapshot
+    return {
+        "operational_snapshot": before_snapshot,
+        "action_before": _serialize(action_before),
+    }
+
+
+def _preview_blocked_reasons(preview: dict[str, Any]) -> list[str]:
+    if preview.get("blocked") is True:
+        return ["ACTION_PREVIEW_BLOCKED"]
+    validation = preview.get("validation")
+    if isinstance(validation, dict) and validation.get("blocked") is True:
+        return ["ACTION_PREVIEW_BLOCKED"]
+    return []
+
+
+def _idempotency_payload_matches(
+    existing: dict[str, Any],
+    *,
+    action: str,
+    target: dict[str, Any],
+    parameters: dict[str, Any],
+) -> bool:
+    return (
+        _normalize(existing.get("action")) == action
+        and _serialize(existing.get("target")) == target
+        and _serialize(existing.get("parameters")) == parameters
+    )
+
+
+def _operation_audit_context(operation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "continuity_runtime_version": RUNTIME_VERSION,
+        "operation_id": operation.get("operation_id"),
+        "evidence_packet_id": operation.get("evidence_packet_id"),
+        "idempotency_key": operation.get("idempotency_key"),
+        "repair_category": operation.get("repair_category"),
+        "risk_level": operation.get("risk_level"),
+    }
+
+
+def _write_audit(
+    *, operation: dict[str, Any], actor: dict[str, Any] | None, action: str, result: str, before: Any = None, after: Any = None
+) -> None:
+    write_audit_log(
+        actor_user_id=_actor_id(actor) or None,
+        actor_email=_actor_email(actor) or None,
+        actor_name=_actor_name(actor) or None,
+        action=f"continuity_runtime.{action}",
+        target_type=_normalize(operation.get("target_type")) or "continuity_operation",
+        target_id=_normalize(operation.get("target_id")) or _normalize(operation.get("operation_id")),
+        before=_serialize(before) if isinstance(before, dict) else {},
+        after=_serialize(after) if isinstance(after, dict) else {},
+        context=_operation_audit_context(operation),
+        result=result,
+    )
+
+
+def _record_event(
+    operation: dict[str, Any], *, event_type: str, actor: dict[str, Any] | None, details: dict[str, Any] | None = None
+) -> None:
+    event = {
+        "event_id": f"ckevt_{uuid4().hex}",
+        "operation_id": operation.get("operation_id"),
+        "event_type": event_type,
+        "state": operation.get("state"),
+        "target_type": operation.get("target_type"),
+        "target_id": operation.get("target_id"),
+        "repair_category": operation.get("repair_category"),
+        "actor": _actor_snapshot(actor),
+        "details": _serialize(details or {}),
+        "created_at": _now(),
+    }
+    _events_collection().insert_one(event)
+
+
+def _serialize_operation(document: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not document:
+        return None
+    payload = _serialize(document)
+    payload["id"] = payload.pop("_id", None)
+    return payload
+
+
+def _get_operation_document(operation_id: str) -> dict[str, Any]:
+    operation_id = _require_text(operation_id, "operation_id")
+    document = _operations_collection().find_one({"operation_id": operation_id})
+    if document is None:
+        raise ValueError("Continuity operation not found.")
+    return document
+
+
+def _transition(
+    operation_id: str,
+    *,
+    expected_state: str,
+    next_state: str,
+    actor: dict[str, Any] | None,
+    action: str,
+    reason_codes: list[str] | None = None,
+    extra_set: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = _now()
+    transition = {
+        "previous_state": expected_state,
+        "next_state": next_state,
+        "actor": _actor_snapshot(actor),
+        "action": action,
+        "reason_codes": list(reason_codes or []),
+        "timestamp": now,
+    }
+    updates: dict[str, Any] = {"state": next_state, "updated_at": now, **(extra_set or {})}
+    result = _operations_collection().update_one(
+        {"operation_id": operation_id, "state": expected_state},
+        {"$set": updates, "$push": {"transitions": transition}},
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        current = _get_operation_document(operation_id)
+        if _normalize(current.get("state")) == next_state:
+            return current
+        raise RuntimeError(
+            f"Continuity operation state changed concurrently; expected {expected_state}, found {current.get('state')}."
+        )
+    return _get_operation_document(operation_id)
+
+
+def request_operation(
+    *,
+    action: str,
+    target: dict[str, Any],
+    parameters: dict[str, Any] | None,
+    reason: str,
+    idempotency_key: str,
+    actor: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not execution_enabled():
+        raise RuntimeError("Continuity execution is disabled by the emergency kill switch.")
+
+    normalized_action = _normalize_action(action)
+    spec = ACTION_SPECS.get(normalized_action)
+    if spec is None:
+        raise ValueError("Unsupported Continuity Kernel action.")
+    actor_snapshot = _actor_snapshot(actor)
+    if not actor_snapshot["actor_user_id"]:
+        raise PermissionError("Authenticated actor id is required.")
+    if not actor_snapshot["actor_role"]:
+        raise PermissionError("Authenticated actor role is not recognized.")
+
+    reason_value = _require_text(reason, "reason", minimum=3)
+    idempotency_value = _require_text(idempotency_key, "idempotency_key", minimum=8)
+    clean_target = _validate_target(spec, normalized_action, target)
+    clean_parameters = _serialize({**(parameters or {}), "reason": reason_value})
+
+    existing = _operations_collection().find_one({"idempotency_key": idempotency_value})
+    if existing is not None:
+        if not _idempotency_payload_matches(
+            existing,
+            action=normalized_action,
+            target=clean_target,
+            parameters=clean_parameters,
+        ):
+            raise ValueError("Idempotency key is already bound to a different Continuity operation.")
+        return _serialize_operation(existing) or {}
+
+    before_snapshot = _snapshot_for_action(normalized_action, clean_target)
+    proposed_after_snapshot = _preview_action(normalized_action, clean_target, clean_parameters)
+    before_snapshot = _enrich_before_snapshot(before_snapshot, proposed_after_snapshot)
+    blocked_reasons = _preview_blocked_reasons(proposed_after_snapshot)
+    operation_id = f"ckop_{uuid4().hex}"
+    now = _now()
+    target_id = _normalize(clean_target.get("target_id"))
+    operation = {
+        "operation_id": operation_id,
+        "evidence_packet_id": f"ckevidence_{uuid4().hex}",
+        "runtime_version": RUNTIME_VERSION,
+        "action": normalized_action,
+        "repair_category": spec.repair_category,
+        "risk_level": spec.risk_level,
+        "mutates_business_data": spec.mutates_business_data,
+        "target_type": spec.target_type,
+        "target_id": target_id,
+        "target": clean_target,
+        "parameters": clean_parameters,
+        "reason": reason_value,
+        "idempotency_key": idempotency_value,
+        "state": "review_requested",
+        "requested_by": actor_snapshot,
+        "approved_by": None,
+        "executed_by": None,
+        "before_snapshot": _serialize(before_snapshot),
+        "proposed_after_snapshot": _serialize(proposed_after_snapshot),
+        "rollback_plan": {
+            "strategy": "restore_from_before_snapshot",
+            "before_snapshot_ref": f"operation:{operation_id}:before_snapshot",
+            "automatic": False,
+            "requires_explicit_rollback_authorization": True,
+        },
+        "blocked_reasons": blocked_reasons,
+        "transitions": [
+            {
+                "previous_state": "dry_run_created",
+                "next_state": "review_requested",
+                "actor": actor_snapshot,
+                "action": "request_review",
+                "reason_codes": [],
+                "timestamp": now,
+            }
+        ],
+        "created_at": now,
+        "updated_at": now,
+    }
+    try:
+        _operations_collection().insert_one(operation)
+    except DuplicateKeyError:
+        existing = _operations_collection().find_one({"idempotency_key": idempotency_value})
+        if existing is not None:
+            if not _idempotency_payload_matches(
+                existing,
+                action=normalized_action,
+                target=clean_target,
+                parameters=clean_parameters,
+            ):
+                raise ValueError("Idempotency key is already bound to a different Continuity operation.")
+            return _serialize_operation(existing) or {}
+        raise
+
+    _record_event(operation, event_type="operation_requested", actor=actor, details={"reason": reason_value})
+    _write_audit(
+        operation=operation,
+        actor=actor,
+        action="operation_requested",
+        result="success",
+        before=before_snapshot,
+        after=proposed_after_snapshot,
+    )
+    return _serialize_operation(_get_operation_document(operation_id)) or {}
+
+
+def _structured_override(operation: dict[str, Any], actor: dict[str, Any], reason: str) -> dict[str, Any]:
+    actor_id = _actor_id(actor)
+    return {
+        "override_id": f"ckoverride_{uuid4().hex}",
+        "override_type": "SUPERADMIN_EMERGENCY_OVERRIDE",
+        "requested_by": _normalize((operation.get("requested_by") or {}).get("actor_user_id")),
+        "approved_by": actor_id,
+        "approval_role": "SUPERADMIN",
+        "reason_code": "SOLO_FOUNDER_OWNER_OPERATED_EXECUTION",
+        "reason_detail": reason,
+        "target_type": operation.get("target_type"),
+        "target_id": operation.get("target_id"),
+        "repair_category": operation.get("repair_category"),
+        "risk_level": operation.get("risk_level"),
+        "expires_at": (_now() + timedelta(minutes=30)).isoformat(),
+        "audit_context": {
+            "operation_id": operation.get("operation_id"),
+            "governance_posture": "solo_founder_owner_operated",
+        },
+    }
+
+
+def approve_operation(
+    operation_id: str,
+    *,
+    approval_reason: str,
+    actor: dict[str, Any] | None,
+    solo_founder_override_acknowledged: bool = False,
+) -> dict[str, Any]:
+    operation = _get_operation_document(operation_id)
+    if operation.get("state") in {"approved_for_apply", "apply_scheduled", "apply_executed", "audit_closed"}:
+        return _serialize_operation(operation) or {}
+    if operation.get("state") != "review_requested":
+        raise ValueError("Operation must be in review_requested state before approval.")
+    if operation.get("blocked_reasons"):
+        raise ValueError(
+            "Operation cannot be approved while preflight blockers remain: "
+            + ", ".join(str(reason) for reason in operation.get("blocked_reasons") or [])
+        )
+
+    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    role = _assert_action_allowed_for_actor(spec, actor)
+    reason_value = _require_text(approval_reason, "approval_reason", minimum=3)
+    requester_id = _normalize((operation.get("requested_by") or {}).get("actor_user_id"))
+    approver_id = _actor_id(actor)
+    structured_override = None
+    if operation.get("risk_level") == "high" and requester_id == approver_id:
+        if role != "SUPERADMIN" or not solo_founder_override_acknowledged:
+            raise PermissionError(
+                "High-risk same-requester approval requires SUPERADMIN and explicit solo-founder override acknowledgement."
+            )
+        structured_override = _structured_override(operation, actor or {}, reason_value)
+
+    operation = _transition(
+        operation_id,
+        expected_state="review_requested",
+        next_state="officer_reviewing",
+        actor=actor,
+        action="begin_officer_review",
+    )
+    approved_at = _now()
+    operation = _transition(
+        operation_id,
+        expected_state="officer_reviewing",
+        next_state="approved_for_apply",
+        actor=actor,
+        action="approve_for_apply",
+        reason_codes=["SOLO_FOUNDER_OVERRIDE" if structured_override else "OFFICER_APPROVAL"],
+        extra_set={
+            "approved_by": _actor_snapshot(actor),
+            "approval_role": role,
+            "approval_reason": reason_value,
+            "approved_at": approved_at,
+            "structured_override": structured_override,
+        },
+    )
+    _record_event(operation, event_type="operation_approved", actor=actor, details={"approval_reason": reason_value})
+    _write_audit(operation=operation, actor=actor, action="operation_approved", result="success")
+    return _serialize_operation(operation) or {}
+
+
+def reject_operation(operation_id: str, *, rejection_reason: str, actor: dict[str, Any] | None) -> dict[str, Any]:
+    operation = _get_operation_document(operation_id)
+    if operation.get("state") == "rejected":
+        return _serialize_operation(operation) or {}
+    if operation.get("state") not in {"review_requested", "officer_reviewing"}:
+        raise ValueError("Only an operation under review can be rejected.")
+    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    _assert_action_allowed_for_actor(spec, actor)
+    reason = _require_text(rejection_reason, "rejection_reason", minimum=3)
+    expected = _normalize(operation.get("state"))
+    if expected == "review_requested":
+        operation = _transition(
+            operation_id,
+            expected_state="review_requested",
+            next_state="officer_reviewing",
+            actor=actor,
+            action="begin_officer_review",
+        )
+        expected = "officer_reviewing"
+    operation = _transition(
+        operation_id,
+        expected_state=expected,
+        next_state="rejected",
+        actor=actor,
+        action="reject_operation",
+        reason_codes=["OFFICER_REJECTED"],
+        extra_set={"rejection_reason": reason, "rejected_at": _now()},
+    )
+    _record_event(operation, event_type="operation_rejected", actor=actor, details={"rejection_reason": reason})
+    _write_audit(operation=operation, actor=actor, action="operation_rejected", result="success")
+    return _serialize_operation(operation) or {}
+
+
+def _evidence_packet(operation: dict[str, Any], actor: dict[str, Any]) -> dict[str, Any]:
+    requested_by = _normalize((operation.get("requested_by") or {}).get("actor_user_id"))
+    approved_by = _normalize((operation.get("approved_by") or {}).get("actor_user_id"))
+    executed_by = _actor_id(actor)
+    packet = {
+        "dry_run_id": operation.get("operation_id"),
+        "evidence_packet_id": operation.get("evidence_packet_id"),
+        "actor_user_id": requested_by,
+        "requested_by": requested_by,
+        "reviewed_by": approved_by,
+        "approved_by": approved_by,
+        "executed_by": executed_by,
+        "approval_role": operation.get("approval_role"),
+        "target_type": operation.get("target_type"),
+        "target_id": operation.get("target_id"),
+        "repair_category": operation.get("repair_category"),
+        "before_snapshot": operation.get("before_snapshot") or {},
+        "proposed_after_snapshot": operation.get("proposed_after_snapshot") or {},
+        "diff_summary": {
+            "action": operation.get("action"),
+            "reason": operation.get("reason"),
+            "mutates_business_data": operation.get("mutates_business_data"),
+        },
+        "blocked_reasons": operation.get("blocked_reasons") or [],
+        "risk_level": operation.get("risk_level"),
+        "rollback_plan": operation.get("rollback_plan") or {},
+        "idempotency_key": operation.get("idempotency_key"),
+        "created_at": _serialize(operation.get("created_at")),
+        "approved_at": _serialize(operation.get("approved_at")),
+        "executed_at": _now_iso(),
+        "audit_context": _operation_audit_context(operation),
+    }
+    if operation.get("structured_override"):
+        packet["structured_override"] = operation.get("structured_override")
+    return packet
+
+
+def _authorization_decision(operation: dict[str, Any]) -> dict[str, Any]:
+    approved_by = operation.get("approved_by") or {}
+    decision = {
+        "actor_user_id": approved_by.get("actor_user_id"),
+        "actor_role": operation.get("approval_role"),
+        "requested_action": operation.get("action"),
+        "repair_category": operation.get("repair_category"),
+        "target_type": operation.get("target_type"),
+        "target_id": operation.get("target_id"),
+        "decision": "approved_for_apply",
+        "reason_codes": ["OFFICER_APPROVED"],
+        "policy_source": f"continuity_runtime_v{RUNTIME_VERSION}",
+        "evaluated_at": _now_iso(),
+    }
+    if operation.get("structured_override"):
+        decision["structured_override"] = operation.get("structured_override")
+    return decision
+
+
+def _scheduled_transition(operation: dict[str, Any], actor: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "evidence_packet_id": operation.get("evidence_packet_id"),
+        "previous_state": "approved_for_apply",
+        "next_state": "apply_scheduled",
+        "actor_user_id": _actor_id(actor),
+        "action": "schedule_approved_operation",
+        "transition_allowed": True,
+        "reason_codes": ["VALIDATED_FOR_EXECUTION"],
+        "timestamp": _now_iso(),
+        "audit_context": _operation_audit_context(operation),
+    }
+
+
+def _rollback_verification(operation: dict[str, Any]) -> dict[str, Any]:
+    rollback_plan = dict(operation.get("rollback_plan") or {})
+    return {
+        "evidence_packet_id": operation.get("evidence_packet_id"),
+        "rollback_plan": rollback_plan,
+        "before_snapshot_ref": rollback_plan.get("before_snapshot_ref"),
+        "target_type": operation.get("target_type"),
+        "target_id": operation.get("target_id"),
+        "verification_status": "before_snapshot_reference_verified",
+        "reason_codes": ["BEFORE_SNAPSHOT_CAPTURED", "MANUAL_ROLLBACK_AUTHORIZATION_REQUIRED"],
+        "verified_at": _now_iso(),
+        "audit_context": _operation_audit_context(operation),
+    }
+
+
+def _execution_failure_count(result: Any) -> int:
+    if not isinstance(result, dict):
+        return 0
+    failed_count = result.get("failed_count")
+    if isinstance(failed_count, (int, float)) and not isinstance(failed_count, bool):
+        return max(0, int(failed_count))
+    failed = result.get("failed")
+    if isinstance(failed, (int, float)) and not isinstance(failed, bool):
+        return max(0, int(failed))
+    if isinstance(failed, list):
+        return len(failed)
+    return 0
+
+
+def _record_post_execution_evidence(
+    operation: dict[str, Any],
+    *,
+    actor: dict[str, Any] | None,
+    execution_result: dict[str, Any],
+    after_snapshot: dict[str, Any],
+    execution_outcome: str,
+    failure_count: int,
+) -> dict[str, Any]:
+    evidence_errors: list[str] = []
+    try:
+        _record_event(
+            operation,
+            event_type="operation_executed",
+            actor=actor,
+            details={
+                "result": execution_result,
+                "execution_outcome": execution_outcome,
+                "execution_failure_count": failure_count,
+            },
+        )
+    except Exception as exc:
+        evidence_errors.append(f"continuity_event:{_normalize(exc) or exc.__class__.__name__}")
+    try:
+        _write_audit(
+            operation=operation,
+            actor=actor,
+            action="operation_executed",
+            result=execution_outcome,
+            before=operation.get("before_snapshot"),
+            after=after_snapshot,
+        )
+    except Exception as exc:
+        evidence_errors.append(f"audit_log:{_normalize(exc) or exc.__class__.__name__}")
+
+    evidence_status = "incomplete" if evidence_errors else "complete"
+    try:
+        _operations_collection().update_one(
+            {"operation_id": operation.get("operation_id"), "state": "apply_executed"},
+            {
+                "$set": {
+                    "evidence_recording_status": evidence_status,
+                    "evidence_recording_errors": evidence_errors,
+                    "updated_at": _now(),
+                }
+            },
+        )
+        return _get_operation_document(_normalize(operation.get("operation_id")))
+    except Exception:
+        fallback = dict(operation)
+        fallback["evidence_recording_status"] = evidence_status
+        fallback["evidence_recording_errors"] = evidence_errors
+        return fallback
+
+
+def _invoke_action(
+    action: str, target: dict[str, Any], parameters: dict[str, Any], actor: dict[str, Any] | None
+) -> dict[str, Any]:
+    if action in CASE_ACTION_SPECS:
+        return admin_control_service.execute_case_action(
+            case_id=_normalize(target.get("case_id")), action=action, actor=actor
+        )
+
+    limit = max(1, min(int(parameters.get("limit") or 500), admin_control_service.MAX_BULK_ACTION_LIMIT))
+    if action == "repair_missing_entitlements":
+        return admin_control_service.repair_missing_entitlements(limit=limit)
+    if action == "assign_missing_lanes":
+        return admin_control_service.assign_missing_lanes(limit=limit)
+    if action == "link_unlinked_paid_orders":
+        return admin_control_service.link_unlinked_paid_orders(limit=limit)
+    if action == "normalize_broken_package_records":
+        return admin_control_service.normalize_broken_package_records(limit=limit)
+    if action == "refresh_mint_readiness":
+        return admin_control_service.refresh_mint_readiness(limit=limit)
+    if action == "repair_selected_records":
+        return admin_control_service.repair_selected_records(
+            project_ids=list(parameters.get("project_ids") or []),
+            order_ids=list(parameters.get("order_ids") or []),
+        )
+    if action == "repair_all_safe_records":
+        return admin_control_service.repair_all_safe_records(limit=limit)
+
+    project_id = _normalize(target.get("project_id"))
+    reason = _normalize(parameters.get("reason"))
+    if action == "package_change":
+        return admin_control_service.super_admin_apply_package_change(
+            project_id=project_id,
+            package_code=_normalize(parameters.get("package_code")),
+            project_lane=_normalize(parameters.get("project_lane")),
+            order_status=_normalize(parameters.get("order_status")),
+            reason=reason,
+            actor=actor,
+        )
+    if action == "package_revoke":
+        return admin_control_service.super_admin_apply_package_revocation(
+            project_id=project_id, reason=reason, actor=actor
+        )
+    if action == "package_restore":
+        return admin_control_service.super_admin_restore_package(project_id=project_id, reason=reason, actor=actor)
+    if action == "service_controls":
+        payload = dict(parameters)
+        payload["reason"] = reason
+        payload["confirmed"] = True
+        return admin_control_service.super_admin_apply_service_controls(
+            project_id=project_id, payload=payload, actor=actor
+        )
+    if action == "officer_permissions":
+        return admin_control_service.super_admin_apply_officer_permissions(
+            officer_email=_normalize(target.get("officer_email")),
+            role_assignments=list(parameters.get("role_assignments") or []),
+            grant_permissions=list(parameters.get("grant_permissions") or []),
+            revoke_permissions=list(parameters.get("revoke_permissions") or []),
+            actor=actor,
+        )
+    if action == "account_lifecycle":
+        return admin_control_service.super_admin_apply_account_lifecycle(
+            user_id=_normalize(target.get("user_id")),
+            action=_normalize(parameters.get("lifecycle_action")),
+            reason=reason,
+            actor=actor,
+        )
+    if action == "case_repair":
+        payload = dict(parameters.get("repair_payload") or parameters)
+        payload["reason"] = reason
+        return admin_control_service.super_admin_repair_case_action(
+            case_id=_normalize(target.get("case_id")),
+            action=_normalize(parameters.get("repair_action") or payload.get("action")),
+            payload=payload,
+            actor=actor,
+        )
+    raise ValueError("No executor is registered for the requested Continuity action.")
+
+
+def execute_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dict[str, Any]:
+    if not execution_enabled():
+        raise RuntimeError("Continuity execution is disabled by the emergency kill switch.")
+    operation = _get_operation_document(operation_id)
+    if operation.get("state") in {"apply_executed", "audit_closed"}:
+        return _serialize_operation(operation) or {}
+    if operation.get("state") != "approved_for_apply":
+        raise ValueError("Operation must be approved_for_apply before execution.")
+
+    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    _assert_action_allowed_for_actor(spec, actor)
+    packet = _evidence_packet(operation, actor or {})
+    authorization = _authorization_decision(operation)
+    transition = _scheduled_transition(operation, actor or {})
+    rollback_verification = _rollback_verification(operation)
+    validator_result = _validator_module().validate_apply_request(
+        packet,
+        authorization,
+        transition,
+        rollback_verification,
+    )
+    if not validator_result.get("passed"):
+        _operations_collection().update_one(
+            {"operation_id": operation_id},
+            {
+                "$set": {
+                    "validator_result": _serialize(validator_result),
+                    "blocked_reasons": list(validator_result.get("reason_codes") or []),
+                    "updated_at": _now(),
+                }
+            },
+        )
+        raise ValueError("Continuity evidence validation failed: " + ", ".join(validator_result.get("reason_codes") or []))
+
+    operation = _transition(
+        operation_id,
+        expected_state="approved_for_apply",
+        next_state="apply_scheduled",
+        actor=actor,
+        action="schedule_approved_operation",
+        reason_codes=["VALIDATED_FOR_EXECUTION"],
+        extra_set={
+            "executed_by": _actor_snapshot(actor),
+            "execution_started_at": _now(),
+            "evidence_packet": _serialize(packet),
+            "authorization_decision": _serialize(authorization),
+            "validator_result": _serialize(validator_result),
+            "rollback_verification": _serialize(rollback_verification),
+        },
+    )
+    _record_event(operation, event_type="operation_scheduled", actor=actor, details={"validator_result": validator_result})
+    _write_audit(
+        operation=operation,
+        actor=actor,
+        action="operation_execution_started",
+        result="started",
+        before=operation.get("before_snapshot"),
+    )
+
+    try:
+        execution_result = _invoke_action(
+            _normalize(operation.get("action")),
+            dict(operation.get("target") or {}),
+            dict(operation.get("parameters") or {}),
+            actor,
+        )
+        after_snapshot = _snapshot_for_action(
+            _normalize(operation.get("action")), dict(operation.get("target") or {})
+        )
+        failure_count = _execution_failure_count(execution_result)
+        execution_outcome = "partial_failure" if failure_count else "success"
+        execution_reason_codes = ["EXECUTION_PARTIAL_FAILURE"] if failure_count else ["EXECUTION_SUCCEEDED"]
+        operation = _transition(
+            operation_id,
+            expected_state="apply_scheduled",
+            next_state="apply_executed",
+            actor=actor,
+            action="execute_approved_operation",
+            reason_codes=execution_reason_codes,
+            extra_set={
+                "execution_result": _serialize(execution_result),
+                "after_snapshot": _serialize(after_snapshot),
+                "execution_outcome": execution_outcome,
+                "execution_failure_count": failure_count,
+                "evidence_recording_status": "pending",
+                "execution_completed_at": _now(),
+            },
+        )
+    except Exception as exc:
+        operation = _transition(
+            operation_id,
+            expected_state="apply_scheduled",
+            next_state="apply_failed",
+            actor=actor,
+            action="execute_approved_operation",
+            reason_codes=["EXECUTION_FAILED"],
+            extra_set={
+                "execution_error": _normalize(exc) or exc.__class__.__name__,
+                "execution_failed_at": _now(),
+            },
+        )
+        try:
+            _record_event(
+                operation,
+                event_type="operation_failed",
+                actor=actor,
+                details={"error": _normalize(exc) or exc.__class__.__name__},
+            )
+        except Exception:
+            pass
+        try:
+            _write_audit(operation=operation, actor=actor, action="operation_failed", result="failed")
+        except Exception:
+            pass
+        raise
+
+    operation = _record_post_execution_evidence(
+        operation,
+        actor=actor,
+        execution_result=execution_result,
+        after_snapshot=after_snapshot,
+        execution_outcome=execution_outcome,
+        failure_count=failure_count,
+    )
+    return _serialize_operation(operation) or {}
+
+
+def close_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dict[str, Any]:
+    operation = _get_operation_document(operation_id)
+    if operation.get("state") == "audit_closed":
+        return _serialize_operation(operation) or {}
+    if operation.get("state") not in {"apply_executed", "rollback_completed"}:
+        raise ValueError("Only executed or rolled-back operations can be audit-closed.")
+    if operation.get("execution_outcome") == "partial_failure":
+        raise ValueError("Partial-failure operations require remediation before audit closure.")
+    if operation.get("evidence_recording_status") != "complete":
+        raise ValueError("Execution evidence must be complete before audit closure.")
+    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    _assert_action_allowed_for_actor(spec, actor)
+    expected = _normalize(operation.get("state"))
+    operation = _transition(
+        operation_id,
+        expected_state=expected,
+        next_state="audit_closed",
+        actor=actor,
+        action="close_operation_audit",
+        reason_codes=["AUDIT_CLOSED"],
+        extra_set={"audit_closed_at": _now()},
+    )
+    _record_event(operation, event_type="operation_audit_closed", actor=actor)
+    _write_audit(operation=operation, actor=actor, action="operation_audit_closed", result="success")
+    return _serialize_operation(operation) or {}
+
+
+def execute_governed_action(
+    *,
+    action: str,
+    target: dict[str, Any],
+    parameters: dict[str, Any] | None,
+    reason: str,
+    idempotency_key: str,
+    actor: dict[str, Any] | None,
+    confirmed: bool,
+    solo_founder_override_acknowledged: bool,
+) -> dict[str, Any]:
+    """Run request -> approval -> execution for the canonical CEO workflow."""
+    if confirmed is not True:
+        raise ValueError("confirmed must be true for governed execution.")
+    operation = request_operation(
+        action=action,
+        target=target,
+        parameters={**(parameters or {}), "reason": _normalize(reason)},
+        reason=reason,
+        idempotency_key=idempotency_key,
+        actor=actor,
+    )
+    operation_id = _normalize(operation.get("operation_id"))
+    if operation.get("blocked_reasons"):
+        return operation
+    if operation.get("state") == "review_requested":
+        operation = approve_operation(
+            operation_id,
+            approval_reason=reason,
+            actor=actor,
+            solo_founder_override_acknowledged=solo_founder_override_acknowledged,
+        )
+    if operation.get("state") == "approved_for_apply":
+        operation = execute_operation(operation_id, actor=actor)
+    return operation
+
+
+def get_operation(operation_id: str) -> dict[str, Any]:
+    return _serialize_operation(_get_operation_document(operation_id)) or {}
+
+
+def list_operations(
+    *, state: str = "", target_id: str = "", limit: int = 50
+) -> dict[str, Any]:
+    query: dict[str, Any] = {}
+    if _normalize(state):
+        query["state"] = _normalize(state)
+    if _normalize(target_id):
+        query["target_id"] = _normalize(target_id)
+    bounded_limit = max(1, min(int(limit or 50), MAX_OPERATION_LIST_LIMIT))
+    items = [
+        _serialize_operation(item)
+        for item in _operations_collection().find(query).sort("updated_at", -1).limit(bounded_limit)
+    ]
+    return {"items": [item for item in items if item], "count": len(items)}
+
+
+def list_operation_events(operation_id: str) -> dict[str, Any]:
+    operation_id = _require_text(operation_id, "operation_id")
+    items = [
+        _serialize(item)
+        for item in _events_collection().find({"operation_id": operation_id}).sort("created_at", 1)
+    ]
+    return {"operation_id": operation_id, "items": items, "count": len(items)}
+
+
+def runtime_status() -> dict[str, Any]:
+    operations = _operations_collection()
+    state_counts = {
+        state: _count(operations, {"state": state})
+        for state in (
+            "review_requested",
+            "officer_reviewing",
+            "approved_for_apply",
+            "apply_scheduled",
+            "apply_executed",
+            "apply_failed",
+            "rejected",
+            "audit_closed",
+        )
+    }
+    return {
+        "kernel_name": "Tomb of Light Continuity Kernel",
+        "runtime_version": RUNTIME_VERSION,
+        "execution_enabled": execution_enabled(),
+        "kill_switch": EXECUTION_KILL_SWITCH,
+        "governance_posture": "solo_founder_owner_operated_with_officer_policy_support",
+        "action_count": len(ACTION_SPECS),
+        "actions": {
+            name: {
+                "repair_category": spec.repair_category,
+                "risk_level": spec.risk_level,
+                "target_type": spec.target_type,
+                "mutates_business_data": spec.mutates_business_data,
+            }
+            for name, spec in sorted(ACTION_SPECS.items())
+        },
+        "state_counts": state_counts,
+        "components": [
+            "identity_resolver",
+            "entitlement_graph_resolver",
+            "workspace_access_resolver",
+            "lineage_event_ledger",
+            "viewer_manifest_compiler",
+            "readiness_gate_matrix",
+            "certificate_delivery_record",
+            "mint_readiness_controller",
+            "officer_policy_layer",
+            "self_healing_repair_engine",
+            "audit_timeline",
+        ],
+    }
+
+
+__all__ = [
+    "ACTION_SPECS",
+    "RUNTIME_VERSION",
+    "approve_operation",
+    "build_project_continuity_snapshot",
+    "canonical_officer_role",
+    "close_operation",
+    "ensure_continuity_runtime_indexes",
+    "execute_governed_action",
+    "execute_operation",
+    "execution_enabled",
+    "get_operation",
+    "list_operation_events",
+    "list_operations",
+    "reject_operation",
+    "request_operation",
+    "runtime_status",
+]

--- a/backend/docs/architecture/tomb_of_light_continuity_kernel.md
+++ b/backend/docs/architecture/tomb_of_light_continuity_kernel.md
@@ -1,6 +1,13 @@
 # Tomb of Light Continuity Kernel (Proposed Architecture)
 
-Status: design draft (documentation-only, no behavior change)
+> Operational status (Phase 8): the covered admin repair and restricted CEO
+> actions now have an authenticated execution runtime, persistent evidence and
+> event records, role/category validation, idempotency enforcement, and an
+> emergency kill switch. See
+> `backend/docs/governance/continuity_kernel_phase8_operational_runtime.md`.
+
+Status: original architecture retained as the reference model; Phase 8 now
+implements the covered operational admin execution slice.
 
 The Continuity Kernel is the protected internal architecture layer that controls identity, package entitlement, workspace/co-owner access, uploads, verification, lineage data, viewer manifests, certificates, mint readiness, admin repair, and audit history.
 

--- a/backend/docs/governance/continuity_kernel_phase8_operational_runtime.md
+++ b/backend/docs/governance/continuity_kernel_phase8_operational_runtime.md
@@ -1,0 +1,151 @@
+# Continuity Kernel Phase 8 — Operational Runtime
+
+## Decision
+
+Phase 8 replaces the test-only posture for covered admin repairs with an
+operational, authenticated execution surface. The earlier read-only preview
+route remains available for historical compatibility, but it is no longer the
+only Kernel runtime.
+
+The operational runtime is implemented by:
+
+- `backend/app/services/continuity_runtime_service.py`
+- `backend/app/routes/admin_continuity_runtime.py`
+- `admin-control-center.html`
+- `admin-control-center.js`
+
+Runtime version: `8.0.0`.
+
+## What changed from Phases 5–7
+
+The Phase 5 validator, role/category taxonomy, evidence packet, structured
+override, and state-transition contracts are now used before an allow-listed
+domain write is invoked. The Phase 6 read-only feature flag is not reused as
+an execution flag. The Phase 7 staging records remain historical evidence and
+do not authorize or block Phase 8 requests.
+
+Phase 8 persists two operational collections:
+
+- `continuity_operations`: request, approval, snapshots, validator result,
+  execution result, and lifecycle state.
+- `continuity_events`: append-only operation event records.
+
+Unique indexes enforce operation identity, event identity, and idempotency-key
+identity. The API creates these indexes during normal database startup.
+
+## Execution posture
+
+Execution is enabled unless the emergency environment variable
+`CONTINUITY_EXECUTION_KILL_SWITCH` is explicitly set to `1`, `true`, `yes`,
+`on`, or `enabled`.
+
+There is no timer, worker, startup repair, or automatic customer mutation in
+Phase 8. A write requires an authenticated admin request, a reason, an
+idempotency key, an allowed action, officer approval, evidence validation, and
+an explicit execute transition.
+
+The canonical CEO may use a one-step control-center action. It still records:
+
+1. `review_requested`
+2. `officer_reviewing`
+3. `approved_for_apply`
+4. `apply_scheduled`
+5. `apply_executed` or `apply_failed`
+
+High-risk same-requester execution requires the persisted
+`SUPERADMIN_EMERGENCY_OVERRIDE` acknowledgement. Other officers create a
+`review_requested` operation for later approval. The control center shows
+recent operations and gives the canonical CEO explicit Approve + Execute and
+Close Audit controls.
+
+## Covered live actions
+
+### Case actions
+
+- package synchronization and normalization
+- lane assignment
+- paid-order linkage
+- entitlement generation and refresh
+- mint-review readiness repairs
+- record repair and mint status reconciliation
+
+Readiness checks and case refresh remain read operations.
+
+### Bulk actions
+
+- missing entitlement repair
+- missing lane assignment
+- unlinked paid-order repair
+- broken package normalization
+- mint readiness refresh
+- selected-record repair
+- all-safe-record repair
+
+Bulk adapter results with nonzero failures are recorded as
+`execution_outcome=partial_failure`; they are not represented as full success.
+
+### CEO restricted actions
+
+- package assignment/change, revocation, and restoration
+- service controls
+- officer permission assignment
+- account lifecycle changes
+- scoped case repair tools
+
+The runtime delegates only to existing allow-listed domain services. It does
+not invent paid-order evidence, mutate Stripe payment status during package
+normalization, delete customer records, mutate immutable certificates, or
+queue an on-chain mint directly from a repair.
+
+## Kernel component map
+
+| Kernel responsibility | Phase 8 runtime source |
+| --- | --- |
+| Identity resolver | `users`, project owner fields, canonical officer identity |
+| Entitlement graph resolver | `project_entitlements`, package catalog, active add-ons |
+| Workspace access resolver | `project_members`, family and household anchors |
+| Lineage event ledger | family members, relationships, `continuity_events` |
+| Viewer manifest compiler | upload and verification source counts plus workspace anchor |
+| Readiness gate matrix | identity, paid-order, entitlement, membership, lineage, package gates |
+| Certificate delivery record | latest immutable `issued_certificates` record |
+| Mint readiness controller | canonical `mint_records` state |
+| Officer policy layer | shared Phase 5 role/category taxonomy and authenticated permissions |
+| Self-healing repair engine | allow-listed execution adapters and operation state machine |
+| Audit timeline | `audit_logs`, evidence packets, snapshots, transitions, and Kernel events |
+
+## Rollback and failure semantics
+
+Every request captures a before snapshot and a reference-verified rollback
+plan before validation. Rollback is deliberately not automatic because the
+existing domain services do not share a transaction/session boundary and bulk
+repairs may partially complete. An `apply_failed` or `partial_failure`
+operation remains open for explicit operator review; it must not be
+automatically audit-closed. If the domain write succeeds but a secondary event
+or audit-log write fails, the operation remains `apply_executed` with
+`evidence_recording_status=incomplete`; this avoids falsely relabeling a real
+business mutation as failed while still blocking audit closure.
+
+## Compatibility boundary
+
+The control center routes covered mutations through the Phase 8 Kernel.
+Legacy direct API endpoints remain present so existing integrations do not
+break during rollout. They are a documented compatibility boundary, not proof
+that every historical write surface is already Kernel-governed. A later
+hardening phase can deprecate or internally redirect those endpoints after
+callers are inventoried.
+
+## Deployment verification
+
+After deployment, an authenticated admin should verify:
+
+- `GET /admin/control-center/kernel/status` reports runtime `8.0.0` and
+  `execution_enabled=true`.
+- the two unique identity indexes exist on each Kernel collection.
+- a deliberate control-center action creates one operation and one ordered
+  event trail for its idempotency key.
+- a repeated request with that same key does not execute the domain adapter a
+  second time.
+
+Production business records must not be changed merely to prove the runtime is
+reachable. The first live operation should be an already-required customer or
+system repair with a real reason and scoped target.

--- a/backend/tests/contracts/test_continuity_kernel_phase8_operational_runtime.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase8_operational_runtime.py
@@ -1,0 +1,112 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVICE_PATH = REPO_ROOT / "backend" / "app" / "services" / "continuity_runtime_service.py"
+ROUTE_PATH = REPO_ROOT / "backend" / "app" / "routes" / "admin_continuity_runtime.py"
+MAIN_PATH = REPO_ROOT / "backend" / "app" / "main.py"
+DOC_PATH = REPO_ROOT / "backend" / "docs" / "governance" / "continuity_kernel_phase8_operational_runtime.md"
+HTML_PATH = REPO_ROOT / "admin-control-center.html"
+JS_PATH = REPO_ROOT / "admin-control-center.js"
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "continuity-kernel-guardrails.yml"
+
+
+class TestContinuityKernelPhase8OperationalRuntime(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.service = SERVICE_PATH.read_text(encoding="utf-8")
+        cls.route = ROUTE_PATH.read_text(encoding="utf-8")
+        cls.main = MAIN_PATH.read_text(encoding="utf-8")
+        cls.doc = DOC_PATH.read_text(encoding="utf-8")
+        cls.html = HTML_PATH.read_text(encoding="utf-8")
+        cls.js = JS_PATH.read_text(encoding="utf-8")
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.service_tree = ast.parse(cls.service)
+        cls.route_tree = ast.parse(cls.route)
+
+    def test_01_operational_artifacts_exist_and_compile(self) -> None:
+        for path in (SERVICE_PATH, ROUTE_PATH, DOC_PATH):
+            with self.subTest(path=path):
+                self.assertTrue(path.exists())
+        self.assertIsNotNone(self.service_tree)
+        self.assertIsNotNone(self.route_tree)
+
+    def test_02_runtime_has_persistent_operations_events_and_idempotency_indexes(self) -> None:
+        for marker in (
+            'OPERATIONS_COLLECTION = "continuity_operations"',
+            'EVENTS_COLLECTION = "continuity_events"',
+            "continuity_operation_id_unique",
+            "continuity_idempotency_unique",
+            "continuity_event_id_unique",
+        ):
+            self.assertIn(marker, self.service)
+
+    def test_03_runtime_exposes_request_approval_execution_failure_and_close_states(self) -> None:
+        for state in (
+            "review_requested",
+            "officer_reviewing",
+            "approved_for_apply",
+            "apply_scheduled",
+            "apply_executed",
+            "apply_failed",
+            "audit_closed",
+        ):
+            self.assertIn(state, self.service)
+        self.assertIn("validate_apply_request", self.service)
+        self.assertIn("SUPERADMIN_EMERGENCY_OVERRIDE", self.service)
+
+    def test_04_execution_is_explicit_and_has_an_emergency_kill_switch(self) -> None:
+        self.assertIn("CONTINUITY_EXECUTION_KILL_SWITCH", self.service)
+        self.assertIn("def execute_operation", self.service)
+        self.assertIn("def execute_governed_action", self.service)
+        service_lower = self.service.lower()
+        for prohibited_automatic_runtime in ("backgroundtasks", "celery", "apscheduler", "schedule.every"):
+            self.assertNotIn(prohibited_automatic_runtime, service_lower)
+
+    def test_05_api_is_authenticated_and_registered_at_startup(self) -> None:
+        self.assertIn('prefix="/admin/control-center/kernel"', self.route)
+        self.assertIn('Depends(require_permission("admin.control.view"))', self.route)
+        self.assertIn("Depends(require_super_admin)", self.route)
+        self.assertIn("_assert_canonical_ceo", self.route)
+        self.assertIn("app.include_router(admin_continuity_runtime_router)", self.main)
+        self.assertIn("ensure_continuity_runtime_indexes()", self.main)
+
+    def test_06_control_center_uses_the_kernel_for_covered_mutations(self) -> None:
+        for endpoint in (
+            "/admin/control-center/kernel/status",
+            "/admin/control-center/kernel/operations",
+            "/admin/control-center/kernel/execute",
+        ):
+            self.assertIn(endpoint, self.js)
+        self.assertIn("data-admin-kernel-status", self.html)
+        self.assertIn("data-admin-kernel-operations", self.html)
+        for legacy_apply_endpoint in (
+            "/package-change/apply",
+            "/service-controls/apply",
+            "/package-revoke/apply",
+            "/status-action`",
+        ):
+            self.assertNotIn(legacy_apply_endpoint, self.js)
+
+    def test_07_partial_domain_failures_are_not_labeled_full_success(self) -> None:
+        self.assertIn("def _execution_failure_count", self.service)
+        self.assertIn('execution_outcome = "partial_failure"', self.service)
+        self.assertIn("EXECUTION_PARTIAL_FAILURE", self.service)
+        self.assertIn("partial_failure", self.js)
+
+    def test_08_operational_contract_is_documented_and_dependency_tested(self) -> None:
+        for marker in (
+            "Operational Runtime",
+            "Compatibility boundary",
+            "Rollback and failure semantics",
+            "CONTINUITY_EXECUTION_KILL_SWITCH",
+            "Legacy direct API endpoints remain present",
+        ):
+            self.assertIn(marker, self.doc)
+        self.assertIn("backend.tests.test_continuity_runtime_service", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_continuity_runtime_route.py
+++ b/backend/tests/test_continuity_runtime_route.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
+from app.database import DatabaseUnavailableError
+from app.routes import admin_continuity_runtime as route_module
+
+
+def _client_for_actor(actor: dict) -> TestClient:
+    app = FastAPI()
+    app.include_router(route_module.router)
+    for route in route_module.router.routes:
+        for dependency in route.dependant.dependencies:
+            app.dependency_overrides[dependency.call] = lambda actor=actor: actor
+    return TestClient(app)
+
+
+class TestContinuityRuntimeRoute(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ceo = {
+            "_id": "ceo-user-1",
+            "email": CEO_MASTER_ADMIN_EMAIL,
+            "full_name": "CEO Operator",
+            "role_codes": ["ceo_master_admin"],
+        }
+
+    def test_status_is_actor_aware_without_exposing_write_capability_to_other_roles(self) -> None:
+        client = _client_for_actor(self.ceo)
+        with patch.object(
+            route_module,
+            "runtime_status",
+            return_value={"runtime_version": "8.0.0", "execution_enabled": True, "action_count": 27},
+        ):
+            response = client.get("/admin/control-center/kernel/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["current_actor_role"], "SUPERADMIN")
+        self.assertTrue(response.json()["one_step_execution_allowed"])
+
+    def test_canonical_ceo_route_delegates_to_governed_execution_service(self) -> None:
+        client = _client_for_actor(self.ceo)
+        expected = {"operation_id": "ckop-1", "state": "apply_executed"}
+        with patch.object(route_module, "execute_governed_action", return_value=expected) as execute:
+            response = client.post(
+                "/admin/control-center/kernel/execute",
+                json={
+                    "action": "package_change",
+                    "target": {"project_id": "project-1"},
+                    "parameters": {"package_code": "legacy_portrait"},
+                    "reason": "Reconcile canonical package state",
+                    "idempotency_key": "kernel-route-idempotency-1",
+                    "confirmed": True,
+                    "solo_founder_override_acknowledged": True,
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+        self.assertEqual(execute.call_count, 1)
+        self.assertEqual(execute.call_args.kwargs["actor"], self.ceo)
+
+    def test_noncanonical_super_admin_cannot_use_ceo_one_step_execution(self) -> None:
+        other_super_admin = {
+            "_id": "admin-user-2",
+            "email": "other-admin@example.com",
+            "role_codes": ["super_admin"],
+        }
+        client = _client_for_actor(other_super_admin)
+        with patch.object(route_module, "execute_governed_action") as execute:
+            response = client.post(
+                "/admin/control-center/kernel/execute",
+                json={
+                    "action": "package_change",
+                    "target": {"project_id": "project-1"},
+                    "parameters": {"package_code": "legacy_portrait"},
+                    "reason": "Reconcile canonical package state",
+                    "idempotency_key": "kernel-route-idempotency-2",
+                    "confirmed": True,
+                    "solo_founder_override_acknowledged": True,
+                },
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(execute.call_count, 0)
+
+    def test_database_unavailable_maps_to_service_unavailable(self) -> None:
+        with self.assertRaises(HTTPException) as raised:
+            route_module._raise_service_error(DatabaseUnavailableError("database unavailable"))
+
+        self.assertEqual(raised.exception.status_code, 503)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_continuity_runtime_service.py
+++ b/backend/tests/test_continuity_runtime_service.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
+from app.services import continuity_runtime_service as runtime
+
+
+def _value_at(document: dict, dotted_key: str):
+    value = document
+    for part in dotted_key.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _matches(document: dict, query: dict) -> bool:
+    for key, expected in query.items():
+        actual = _value_at(document, key)
+        if isinstance(expected, dict):
+            if "$nin" in expected and actual in expected["$nin"]:
+                return False
+            if "$in" in expected and actual not in expected["$in"]:
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+class _FakeCursor:
+    def __init__(self, documents: list[dict]):
+        self.documents = documents
+
+    def sort(self, key: str, direction: int):
+        del direction
+        self.documents.sort(key=lambda item: str(_value_at(item, key) or ""), reverse=True)
+        return self
+
+    def limit(self, limit: int):
+        self.documents = self.documents[:limit]
+        return self
+
+    def __iter__(self):
+        return iter(deepcopy(self.documents))
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.documents: list[dict] = []
+        self.indexes: list[tuple] = []
+
+    def create_index(self, *args, **kwargs):
+        self.indexes.append((args, kwargs))
+        return kwargs.get("name", "index")
+
+    def insert_one(self, document: dict):
+        stored = deepcopy(document)
+        stored.setdefault("_id", f"fake-{len(self.documents) + 1}")
+        self.documents.append(stored)
+        return SimpleNamespace(inserted_id=stored["_id"])
+
+    def find_one(self, query: dict, *args, **kwargs):
+        del args, kwargs
+        for document in self.documents:
+            if _matches(document, query):
+                return deepcopy(document)
+        return None
+
+    def update_one(self, query: dict, update: dict, *args, **kwargs):
+        del args, kwargs
+        for document in self.documents:
+            if not _matches(document, query):
+                continue
+            document.update(deepcopy(update.get("$set") or {}))
+            for key, value in (update.get("$push") or {}).items():
+                document.setdefault(key, []).append(deepcopy(value))
+            return SimpleNamespace(matched_count=1, modified_count=1)
+        return SimpleNamespace(matched_count=0, modified_count=0)
+
+    def find(self, query: dict):
+        return _FakeCursor([deepcopy(item) for item in self.documents if _matches(item, query)])
+
+    def count_documents(self, query: dict):
+        return sum(1 for item in self.documents if _matches(item, query))
+
+
+class _FakeDatabase(dict):
+    def __getitem__(self, key: str):
+        if key not in self:
+            self[key] = _FakeCollection()
+        return super().__getitem__(key)
+
+
+class TestContinuityRuntimeService(unittest.TestCase):
+    def setUp(self) -> None:
+        self.database = _FakeDatabase()
+        self.actor = {
+            "_id": "ceo-user-1",
+            "email": CEO_MASTER_ADMIN_EMAIL,
+            "full_name": "CEO Operator",
+            "role_codes": ["ceo_master_admin"],
+        }
+        self.executor = Mock(return_value={"changed": True})
+        self.patches = [
+            patch.object(runtime, "get_database", return_value=self.database),
+            patch.object(runtime, "write_audit_log", return_value="audit-1"),
+            patch.object(runtime, "_snapshot_for_action", return_value={"state": "canonical"}),
+            patch.object(runtime, "_preview_action", return_value={"state": "proposed"}),
+            patch.object(runtime, "_invoke_action", self.executor),
+        ]
+        for item in self.patches:
+            item.start()
+            self.addCleanup(item.stop)
+
+    def _execute(self, *, idempotency_key: str = "kernel-idempotency-0001") -> dict:
+        return runtime.execute_governed_action(
+            action="package_change",
+            target={"project_id": "project-1"},
+            parameters={"package_code": "legacy_portrait"},
+            reason="Reconcile the canonical package state",
+            idempotency_key=idempotency_key,
+            actor=self.actor,
+            confirmed=True,
+            solo_founder_override_acknowledged=True,
+        )
+
+    def test_high_risk_ceo_execution_records_the_full_state_machine(self) -> None:
+        operation = self._execute()
+
+        self.assertEqual(operation["state"], "apply_executed")
+        self.assertEqual(operation["execution_outcome"], "success")
+        self.assertTrue(operation["validator_result"]["passed"])
+        self.assertEqual(operation["structured_override"]["override_type"], "SUPERADMIN_EMERGENCY_OVERRIDE")
+        self.assertEqual(
+            [item["next_state"] for item in operation["transitions"]],
+            ["review_requested", "officer_reviewing", "approved_for_apply", "apply_scheduled", "apply_executed"],
+        )
+        self.assertEqual(self.executor.call_count, 1)
+        self.assertEqual(len(self.database[runtime.EVENTS_COLLECTION].documents), 4)
+
+    def test_idempotency_replay_returns_the_existing_execution(self) -> None:
+        first = self._execute()
+        second = self._execute()
+
+        self.assertEqual(second["operation_id"], first["operation_id"])
+        self.assertEqual(second["state"], "apply_executed")
+        self.assertEqual(self.executor.call_count, 1)
+
+    def test_successful_execution_can_be_audit_closed(self) -> None:
+        operation = self._execute(idempotency_key="kernel-idempotency-close")
+        closed = runtime.close_operation(operation["operation_id"], actor=self.actor)
+
+        self.assertEqual(operation["evidence_recording_status"], "complete")
+        self.assertEqual(closed["state"], "audit_closed")
+
+    def test_idempotency_key_cannot_be_rebound_to_a_different_target(self) -> None:
+        self._execute(idempotency_key="kernel-idempotency-conflict")
+
+        with self.assertRaisesRegex(ValueError, "different Continuity operation"):
+            runtime.request_operation(
+                action="package_change",
+                target={"project_id": "project-2"},
+                parameters={"package_code": "legacy_portrait"},
+                reason="Reconcile the canonical package state",
+                idempotency_key="kernel-idempotency-conflict",
+                actor=self.actor,
+            )
+
+    def test_high_risk_same_actor_fails_closed_without_acknowledged_override(self) -> None:
+        operation = runtime.request_operation(
+            action="package_change",
+            target={"project_id": "project-1"},
+            parameters={"package_code": "legacy_portrait"},
+            reason="Reconcile the canonical package state",
+            idempotency_key="kernel-idempotency-0002",
+            actor=self.actor,
+        )
+
+        with self.assertRaises(PermissionError):
+            runtime.approve_operation(
+                operation["operation_id"],
+                approval_reason="Reconcile the canonical package state",
+                actor=self.actor,
+                solo_founder_override_acknowledged=False,
+            )
+
+        persisted = runtime.get_operation(operation["operation_id"])
+        self.assertEqual(persisted["state"], "review_requested")
+        self.assertEqual(self.executor.call_count, 0)
+
+    def test_executor_exception_is_persisted_as_apply_failed(self) -> None:
+        self.executor.side_effect = RuntimeError("domain adapter failed")
+
+        with self.assertRaisesRegex(RuntimeError, "domain adapter failed"):
+            self._execute(idempotency_key="kernel-idempotency-0003")
+
+        operations = self.database[runtime.OPERATIONS_COLLECTION].documents
+        self.assertEqual(len(operations), 1)
+        self.assertEqual(operations[0]["state"], "apply_failed")
+        self.assertEqual(operations[0]["execution_error"], "domain adapter failed")
+
+    def test_post_execution_evidence_failure_does_not_relabel_the_domain_write(self) -> None:
+        operation = runtime.request_operation(
+            action="package_change",
+            target={"project_id": "project-1"},
+            parameters={"package_code": "legacy_portrait"},
+            reason="Reconcile the canonical package state",
+            idempotency_key="kernel-idempotency-evidence-warning",
+            actor=self.actor,
+        )
+        runtime.approve_operation(
+            operation["operation_id"],
+            approval_reason="Reconcile the canonical package state",
+            actor=self.actor,
+            solo_founder_override_acknowledged=True,
+        )
+        original_record_event = runtime._record_event
+
+        def record_event_with_failure(current_operation, *, event_type, actor, details=None):
+            if event_type == "operation_executed":
+                raise RuntimeError("event ledger unavailable")
+            return original_record_event(current_operation, event_type=event_type, actor=actor, details=details)
+
+        with patch.object(runtime, "_record_event", side_effect=record_event_with_failure):
+            executed = runtime.execute_operation(operation["operation_id"], actor=self.actor)
+
+        self.assertEqual(executed["state"], "apply_executed")
+        self.assertEqual(executed["execution_outcome"], "success")
+        self.assertEqual(executed["evidence_recording_status"], "incomplete")
+        self.assertIn("continuity_event:event ledger unavailable", executed["evidence_recording_errors"])
+        with self.assertRaisesRegex(ValueError, "evidence must be complete"):
+            runtime.close_operation(operation["operation_id"], actor=self.actor)
+
+    def test_bulk_partial_failure_is_not_reported_as_full_success(self) -> None:
+        self.executor.return_value = {"repaired": 3, "failed": 2}
+
+        operation = self._execute(idempotency_key="kernel-idempotency-0004")
+
+        self.assertEqual(operation["state"], "apply_executed")
+        self.assertEqual(operation["execution_outcome"], "partial_failure")
+        self.assertEqual(operation["execution_failure_count"], 2)
+        self.assertIn("EXECUTION_PARTIAL_FAILURE", operation["transitions"][-1]["reason_codes"])
+        with self.assertRaisesRegex(ValueError, "remediation"):
+            runtime.close_operation(operation["operation_id"], actor=self.actor)
+
+    def test_preview_blocker_fails_closed_before_approval(self) -> None:
+        runtime._preview_action.return_value = {
+            "blocked": True,
+            "warnings": ["Active paid-order cancellation workflow is required."],
+        }
+        operation = runtime.request_operation(
+            action="package_revoke",
+            target={"project_id": "project-1"},
+            parameters={},
+            reason="Revoke the inactive package assignment",
+            idempotency_key="kernel-idempotency-blocked",
+            actor=self.actor,
+        )
+
+        self.assertEqual(operation["blocked_reasons"], ["ACTION_PREVIEW_BLOCKED"])
+        with self.assertRaisesRegex(ValueError, "preflight blockers"):
+            runtime.approve_operation(
+                operation["operation_id"],
+                approval_reason="Revoke the inactive package assignment",
+                actor=self.actor,
+                solo_founder_override_acknowledged=True,
+            )
+
+    def test_action_preview_before_state_is_preserved_for_rollback_review(self) -> None:
+        runtime._preview_action.return_value = {"before": {"status": "active"}, "proposed_after": {"status": "disabled"}}
+        operation = runtime.request_operation(
+            action="account_lifecycle",
+            target={"user_id": "user-2"},
+            parameters={"lifecycle_action": "disable"},
+            reason="Disable the compromised customer account",
+            idempotency_key="kernel-idempotency-before-state",
+            actor=self.actor,
+        )
+
+        self.assertEqual(operation["before_snapshot"]["action_before"], {"status": "active"})
+        self.assertEqual(operation["before_snapshot"]["operational_snapshot"], {"state": "canonical"})
+
+    def test_kill_switch_disables_execution_only_when_explicitly_set(self) -> None:
+        self.assertTrue(runtime.execution_enabled(env={}))
+        for value in ("1", "true", "yes", "on", "enabled"):
+            with self.subTest(value=value):
+                self.assertFalse(runtime.execution_enabled(env={runtime.EXECUTION_KILL_SWITCH: value}))
+
+    def test_officer_role_can_be_resolved_from_authenticated_access_context(self) -> None:
+        actor = {"_id": "officer-2", "email": "officer@example.com", "_access_context": {"role_codes": ["finance_admin"]}}
+        self.assertEqual(runtime.canonical_officer_role(actor), "finance_admin")
+
+    def test_runtime_indexes_cover_operation_and_event_identity(self) -> None:
+        runtime.ensure_continuity_runtime_indexes()
+
+        operation_indexes = self.database[runtime.OPERATIONS_COLLECTION].indexes
+        event_indexes = self.database[runtime.EVENTS_COLLECTION].indexes
+        self.assertTrue(any(item[1].get("name") == "continuity_operation_id_unique" for item in operation_indexes))
+        self.assertTrue(any(item[1].get("name") == "continuity_idempotency_unique" for item in operation_indexes))
+        self.assertTrue(any(item[1].get("name") == "continuity_event_id_unique" for item in event_indexes))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- promotes covered admin writes into a persisted Continuity Kernel state machine
- adds CEO one-step execution, officer review, kill switch, idempotency, evidence packets, and explicit partial-failure handling
- routes covered Control Center mutations through the Kernel and adds operation/status controls
- maps the operational runtime to all 11 Continuity Kernel responsibilities

## Verification

- architecture suite: 9 passed
- contract suite: 1,240 passed, 11 skipped
- JavaScript syntax, Python compilation, adapter signatures, and diff checks passed locally
- GitHub Actions now installs backend dependencies and runs the service and route suites

## Deployment boundary

Production was checked directly and is healthy, but it currently exposes only the legacy read-only Kernel preview. The Phase 8 operational routes will not exist there until this change is reviewed, merged, and deployed.

No production data mutation was performed. This PR remains draft while CI is evaluated.

## Known compatibility boundary

Legacy direct mutation APIs remain available for compatibility. Covered Control Center actions use the Kernel; completing universal mediation of every legacy caller is a separate migration. Rollback is reference-backed/manual because the current services do not share a transaction boundary.