### PR TITLE
Make authenticator MFA optional for all accounts

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -469,12 +469,7 @@ def get_current_user(
             detail="Session has been revoked. Please log in again.",
         )
 
-    if _has_internal_admin_access(normalized_user):
-        if not bool(normalized_user.get("mfa_enabled")):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="MFA enrollment is required for internal administrator accounts.",
-            )
+    if bool(normalized_user.get("mfa_enabled")):
         if not bool(payload.get("mfa")):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -13,7 +13,6 @@ from cryptography.fernet import Fernet, InvalidToken
 
 from app.config import settings
 from app.core.password_policy import validate_password_strength
-from app.core.role_catalog import has_internal_admin_role
 from app.core.security import (
     create_access_token,
     decode_access_token,
@@ -50,17 +49,6 @@ def _get_database_or_none():
 def _current_user_id_from_doc(user: dict) -> str:
     raw_value = user.get("_id") or user.get("id") or user.get("user_id")
     return _normalize_text(raw_value)
-
-
-def _requires_internal_admin_mfa(user: dict[str, Any]) -> bool:
-    role_values: list[Any] = [
-        user.get("role"),
-        user.get("access_tier"),
-        user.get("department_role"),
-    ]
-    for field_name in ("role_codes", "admin_roles", "officer_roles"):
-        role_values.extend(list(user.get(field_name) or []))
-    return has_internal_admin_role(role_values)
 
 
 def _password_reset_expiry_iso() -> str:
@@ -384,21 +372,6 @@ def authenticate_user(email: str, password: str) -> dict[str, Any] | None:
             "mfa_challenge_token": challenge,
         }
 
-    if _requires_internal_admin_mfa(user):
-        challenge = create_access_token(
-            {
-                "sub": user["email"],
-                "user_id": str(user["_id"]),
-                "purpose": "mfa_enroll",
-                "tv": _session_version(user),
-            },
-            expires_minutes=max(2, int(settings.mfa_challenge_expire_minutes or 10)),
-        )
-        return {
-            "status": "mfa_enrollment_required",
-            "mfa_challenge_token": challenge,
-        }
-
     now_iso = _now_iso()
     db.users.update_one(
         {"_id": user["_id"]},
@@ -406,6 +379,8 @@ def authenticate_user(email: str, password: str) -> dict[str, Any] | None:
             "$set": {
                 "last_login_at": now_iso,
                 **_clear_password_reset_fields(),
+                "mfa_pending_secret_encrypted": None,
+                "mfa_pending_started_at": None,
             }
         },
     )
@@ -628,8 +603,6 @@ def disable_mfa_for_user(
     recovery_code: str | None,
     actor_user_id: str,
 ) -> None:
-    if _requires_internal_admin_mfa(user):
-        raise ValueError("MFA is required for internal administrator accounts.")
     password_hash = _normalize_text(user.get("password_hash"))
     if not verify_password(current_password, password_hash):
         raise ValueError("Current password is incorrect.")

--- a/backend/docs/governance/continuity_kernel_phase9_control_surface_security.md
+++ b/backend/docs/governance/continuity_kernel_phase9_control_surface_security.md
@@ -40,7 +40,7 @@ The pre-existing Phase 8 action registry continues to cover case mutations, safe
 ## Security changes
 
 - Login and signup fail closed when the identity database is unavailable; no preview account or fallback bearer token is issued.
-- Internal administrator accounts must enroll and complete MFA, and cannot disable MFA while they retain an internal admin role.
+- Authenticator MFA is available as an account-level opt-in for customers, officers, and administrators. Accounts without MFA can authenticate with their password; accounts that enable MFA must complete it at sign-in and may later disable it after password and authenticator/recovery-code verification.
 - Production HMAC signing secrets must be unique and at least 32 bytes; allowed JWT algorithms are restricted to `HS256`, `HS384`, and `HS512`.
 - Browser bearer and user context are stored in `sessionStorage`, with legacy persistent copies removed.
 - Overview payloads are reduced server-side to finance, operations, or marketing domains for restricted officer roles.

--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -55,11 +55,13 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
             self.assertNotIn(forbidden, self.control_js)
         self.assertIn("submitGovernedOperation", self.control_js)
 
-    def test_03_authentication_fails_closed_and_admin_mfa_is_mandatory(self) -> None:
+    def test_03_authentication_fails_closed_and_mfa_is_account_opt_in(self) -> None:
         self.assertNotIn('"status": "authenticated", "access_token": token', self.auth)
-        self.assertIn("mfa_enrollment_required", self.auth)
-        self.assertIn("MFA is required for internal administrator accounts", self.auth)
-        self.assertIn("MFA enrollment is required for internal administrator accounts", self.dependencies)
+        self.assertNotIn("_requires_internal_admin_mfa", self.auth)
+        self.assertNotIn("mfa_enrollment_required", self.auth)
+        self.assertNotIn("MFA enrollment is required for internal administrator accounts", self.dependencies)
+        self.assertIn('if bool(normalized_user.get("mfa_enabled")):', self.dependencies)
+        self.assertIn("MFA verification is required for this session", self.dependencies)
 
     def test_04_bearer_and_user_context_are_tab_scoped(self) -> None:
         self.assertIn("sessionStorage.setItem(TOKEN_KEY, token)", self.app_js)

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -129,7 +129,7 @@ class RateLimitAndLockoutTests(unittest.TestCase):
 
 
 class AuthMfaTests(unittest.TestCase):
-    def test_internal_admin_without_mfa_must_enroll_before_authentication(self):
+    def test_internal_admin_without_mfa_authenticates_normally(self):
         user_id = ObjectId()
         db = FakeDatabase(
             {
@@ -151,9 +151,12 @@ class AuthMfaTests(unittest.TestCase):
             result = auth_service.authenticate_user("admin@example.com", "StrongPass!123")
         self.assertIsNotNone(result)
         assert result is not None
-        self.assertEqual(result["status"], "mfa_enrollment_required")
-        self.assertTrue(result.get("mfa_challenge_token"))
-        self.assertFalse(result.get("access_token"))
+        self.assertEqual(result["status"], "authenticated")
+        self.assertTrue(result.get("access_token"))
+        self.assertFalse(result.get("mfa_challenge_token"))
+        stored = db.users.find_one({"_id": user_id})
+        self.assertIsNone(stored.get("mfa_pending_secret_encrypted"))
+        self.assertIsNone(stored.get("mfa_pending_started_at"))
 
     def test_mfa_enabled_user_requires_verification(self):
         user_id = ObjectId()
@@ -180,18 +183,35 @@ class AuthMfaTests(unittest.TestCase):
         self.assertEqual(result["status"], "mfa_required")
         self.assertTrue(result.get("mfa_challenge_token"))
 
-    def test_internal_admin_cannot_disable_required_mfa(self):
-        with self.assertRaisesRegex(
-            ValueError,
-            "MFA is required for internal administrator accounts",
+    def test_internal_admin_can_disable_opted_in_mfa(self):
+        user_id = ObjectId()
+        user = {
+            "_id": user_id,
+            "email": "admin@example.com",
+            "role": "admin",
+            "access_tier": "super_admin",
+            "password_hash": "stored-password-hash",
+            "mfa_enabled": True,
+            "mfa_secret_encrypted": "encrypted-secret",
+        }
+        db = FakeDatabase({"users": [user]})
+        with (
+            patch.object(auth_service, "verify_password", return_value=True),
+            patch.object(auth_service, "_mfa_decrypt_secret", return_value="secret"),
+            patch.object(auth_service, "_verify_totp", return_value=True),
+            patch.object(auth_service, "get_database", return_value=db),
+            patch.object(auth_service, "create_audit_log"),
         ):
             auth_service.disable_mfa_for_user(
-                user={"role": "admin", "access_tier": "super_admin"},
+                user=user,
                 current_password="StrongPass!123",
                 code="123456",
                 recovery_code=None,
                 actor_user_id="admin-1",
             )
+        stored = db.users.find_one({"_id": user_id})
+        self.assertFalse(stored.get("mfa_enabled"))
+        self.assertIsNone(stored.get("mfa_secret_encrypted"))
 
 
 class AuthDatabaseFailClosedTests(unittest.TestCase):

--- a/security.html
+++ b/security.html
@@ -141,7 +141,7 @@
                   <article class="policy-card">
                     <h3>Account and Sign-In Protection</h3>
                     <p class="card-copy">
-                      Passwords are one-way hashed with bcrypt. New passwords require at least 12 characters. Sign-in and verification endpoints use rate limits and account lockouts, and internal administrator accounts require authenticator-based multi-factor authentication.
+                      Passwords are one-way hashed with bcrypt. New passwords require at least 12 characters. Sign-in and verification endpoints use rate limits and account lockouts. Customers, officers, and administrators can opt into authenticator-based multi-factor authentication; when enabled, it is enforced at sign-in.
                     </p>
                   </article>
 


### PR DESCRIPTION
## Summary

- changes authenticator MFA from mandatory administrator enrollment to an account-level opt-in for customers, officers, and administrators
- allows accounts without MFA to authenticate normally with email and password
- continues to require an authenticator or recovery code at sign-in for any account that has enabled MFA
- allows administrators to disable their own opted-in MFA after password and authenticator/recovery-code verification
- clears abandoned pending enrollment secrets on the next successful password login
- updates the public security statement and Phase 9 governance documentation so Tomb of Light no longer claims mandatory administrator MFA

## Expected login behavior

- **MFA not enabled:** email + password → role-appropriate dashboard
- **MFA enabled:** email + password → authenticator/recovery-code challenge → role-appropriate dashboard
- optional enrollment remains available from **Account Security**

## Verification

- focused security and Phase 9 contract suite: **23 passed**
- complete backend suite: **1,739 passed, 2 skipped; 66 subtests passed**
- Python compilation and diff checks passed

## Production note

After this hotfix is merged and Render redeploys, the CEO account's next successful password login will clear the abandoned pending setup secret exposed during the prior enrollment attempt. No customer or administrator record was mutated while preparing this change.