### PR TITLE
Add governed permanent account deletion (Phase 10.1)

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -9,7 +9,7 @@
       name="description"
       content="Internal premium operations console for Tomb of Light customer cases, repairs, entitlements, mint readiness, and audit review."
     />
-    <link rel="stylesheet" href="styles.css?v=20260821-phase10" />
+    <link rel="stylesheet" href="styles.css?v=20260821-phase10-1" />
   </head>
   <body class="admin-control-center-body">
     <div class="page-wrap">
@@ -323,7 +323,11 @@
 
               <div class="admin-workflow-grid">
                 <label class="admin-form-field admin-form-field--wide"><span>Operational reason</span><textarea rows="3" required minlength="3" data-admin-lifecycle-reason placeholder="Why this account action is authorized"></textarea></label>
-                <label class="admin-form-field admin-form-field--wide" data-admin-lifecycle-typed-wrap hidden><span>Type the account email to confirm closure</span><input type="text" autocomplete="off" data-admin-lifecycle-typed-confirm /></label>
+                <label class="admin-form-field admin-form-field--wide" data-admin-lifecycle-typed-wrap hidden>
+                  <span data-admin-lifecycle-typed-label>Type the target account email to confirm archive</span>
+                  <input type="text" autocomplete="off" spellcheck="false" data-admin-lifecycle-typed-confirm />
+                  <small class="admin-field-status" data-admin-lifecycle-typed-status aria-live="polite"></small>
+                </label>
               </div>
               <label class="admin-confirmation-check"><input type="checkbox" data-admin-lifecycle-confirm /><span data-admin-lifecycle-confirm-label>I confirm this account action and its immediate access impact.</span></label>
               <div class="admin-workflow-actions">
@@ -331,6 +335,107 @@
                 <button class="btn btn-danger" type="submit" data-admin-lifecycle-execute disabled>Execute Account Action</button>
               </div>
             </form>
+          </dialog>
+
+          <dialog class="admin-workflow-dialog" data-admin-permanent-delete-dialog aria-labelledby="admin-permanent-delete-title">
+            <form class="admin-workflow-form" data-admin-permanent-delete-form novalidate>
+              <header class="admin-workflow-header">
+                <div>
+                  <span class="eyebrow">Continuity Kernel · Irreversible Account Action</span>
+                  <h2 id="admin-permanent-delete-title">Permanently delete account</h2>
+                  <p data-admin-permanent-delete-target>No account selected.</p>
+                </div>
+                <button class="admin-dialog-close" type="button" data-admin-dialog-close="permanent-delete" aria-label="Close permanent deletion dialog">×</button>
+              </header>
+
+              <section class="admin-execution-preview" data-admin-permanent-delete-preview aria-live="polite">
+                <h3>Permanent-deletion impact</h3>
+                <p>Loading the account identity, access records, and protected business evidence…</p>
+              </section>
+
+              <div class="admin-workflow-grid">
+                <label class="admin-form-field admin-form-field--wide">
+                  <span>Authorized deletion category</span>
+                  <select required data-admin-permanent-delete-category>
+                    <option value="">Select why permanent deletion is authorized</option>
+                    <option value="customer_request">Verified customer request</option>
+                    <option value="policy_violation">Tomb of Light policy violation</option>
+                    <option value="security_incident">Security incident</option>
+                    <option value="company_authorized">CEO-authorized company decision</option>
+                  </select>
+                </label>
+                <label class="admin-form-field admin-form-field--wide">
+                  <span>Operational reason</span>
+                  <textarea rows="3" required minlength="3" data-admin-permanent-delete-reason placeholder="Document the verified request, policy violation, security incident, or company authority"></textarea>
+                </label>
+                <label class="admin-form-field admin-form-field--wide">
+                  <span data-admin-permanent-delete-email-label>Type the target account email exactly</span>
+                  <input type="text" autocomplete="off" spellcheck="false" data-admin-permanent-delete-email aria-describedby="admin-permanent-delete-email-status" />
+                  <small id="admin-permanent-delete-email-status" class="admin-field-status" data-admin-permanent-delete-email-status aria-live="polite"></small>
+                </label>
+              </div>
+              <label class="admin-confirmation-check">
+                <input type="checkbox" data-admin-permanent-delete-confirm />
+                <span>I confirm this is the correct account and understand that its login identity and access cannot be restored.</span>
+              </label>
+              <div class="admin-workflow-actions">
+                <button class="btn btn-secondary" type="button" data-admin-dialog-close="permanent-delete">Cancel</button>
+                <button class="btn btn-danger" type="submit" data-admin-permanent-delete-continue disabled>Continue to Final Warning</button>
+              </div>
+            </form>
+          </dialog>
+
+          <dialog class="admin-workflow-dialog" data-admin-permanent-delete-final-dialog aria-labelledby="admin-permanent-delete-final-title">
+            <form class="admin-workflow-form" data-admin-permanent-delete-final-form novalidate>
+              <header class="admin-workflow-header">
+                <div>
+                  <span class="eyebrow">Final Warning · Permanent Action</span>
+                  <h2 id="admin-permanent-delete-final-title">This account will be permanently closed</h2>
+                  <p data-admin-permanent-delete-final-target>No account selected.</p>
+                </div>
+                <button class="admin-dialog-close" type="button" data-admin-dialog-close="permanent-delete-final" aria-label="Close final permanent deletion warning">×</button>
+              </header>
+
+              <section class="admin-irreversible-warning" role="alert">
+                <strong>Permanent deletion cannot be undone.</strong>
+                <p>The login credentials, MFA secrets, password-reset tokens, personal profile, roles, permissions, memberships, and workspace access will be permanently closed. Any active maintenance subscription will be cancelled immediately. Required orders, billing, corporate ownership, security evidence, certificates, and audit records will remain protected.</p>
+              </section>
+
+              <div class="admin-workflow-grid">
+                <label class="admin-form-field admin-form-field--wide">
+                  <span>Type PERMANENTLY DELETE</span>
+                  <input type="text" autocomplete="off" spellcheck="false" data-admin-permanent-delete-phrase />
+                  <small class="admin-field-status" data-admin-permanent-delete-phrase-status aria-live="polite">This exact phrase is required.</small>
+                </label>
+              </div>
+              <label class="admin-confirmation-check admin-confirmation-check--danger">
+                <input type="checkbox" data-admin-permanent-delete-final-confirm />
+                <span>I understand this account cannot be restored after execution.</span>
+              </label>
+              <div class="admin-workflow-actions">
+                <button class="btn btn-secondary" type="button" data-admin-permanent-delete-back>Back</button>
+                <button class="btn btn-danger" type="submit" data-admin-permanent-delete-execute disabled>Permanently Delete Account</button>
+              </div>
+            </form>
+          </dialog>
+
+          <dialog class="admin-workflow-dialog" data-admin-deletion-receipt-dialog aria-labelledby="admin-deletion-receipt-title">
+            <div class="admin-workflow-form">
+              <header class="admin-workflow-header">
+                <div>
+                  <span class="eyebrow">Continuity Kernel · MongoDB Evidence Receipt</span>
+                  <h2 id="admin-deletion-receipt-title">Permanent deletion completed</h2>
+                  <p>The receipt below is the operational proof for this irreversible action.</p>
+                </div>
+                <button class="admin-dialog-close" type="button" data-admin-dialog-close="deletion-receipt" aria-label="Close deletion receipt">×</button>
+              </header>
+              <section class="admin-execution-preview" data-admin-deletion-receipt aria-live="polite"></section>
+              <div class="admin-workflow-actions">
+                <button class="btn btn-secondary" type="button" data-admin-deletion-receipt-copy>Copy Receipt</button>
+                <button class="btn btn-primary" type="button" data-admin-deletion-receipt-close-audit hidden>Close Audit Record</button>
+                <button class="btn btn-secondary" type="button" data-admin-dialog-close="deletion-receipt">Done</button>
+              </div>
+            </div>
           </dialog>
 
           <dialog class="admin-workflow-dialog admin-workflow-dialog--wide" data-admin-team-dialog aria-labelledby="admin-team-title">
@@ -386,8 +491,8 @@
     </div>
 
     <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260821-phase10"></script>
+    <script src="app.js?v=20260821-phase10-1"></script>
     <script src="auth.js?v=20260727-masterops1"></script>
-    <script src="admin-control-center.js?v=20260821-phase10"></script>
+    <script src="admin-control-center.js?v=20260821-phase10-1"></script>
   </body>
 </html>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -64,6 +64,8 @@
     kernelPendingIdempotency: {},
     createAccountPreview: null,
     lifecycleWorkflow: null,
+    permanentDeletionWorkflow: null,
+    deletionReceipt: null,
     teamAccess: {
       officers: [],
       roleTemplates: {},
@@ -264,6 +266,9 @@
     const selectors = {
       create: "[data-admin-create-dialog]",
       lifecycle: "[data-admin-lifecycle-dialog]",
+      "permanent-delete": "[data-admin-permanent-delete-dialog]",
+      "permanent-delete-final": "[data-admin-permanent-delete-final-dialog]",
+      "deletion-receipt": "[data-admin-deletion-receipt-dialog]",
       team: "[data-admin-team-dialog]",
     };
     const selector = selectors[name];
@@ -819,6 +824,11 @@
             operation.execution_outcome !== "partial_failure" &&
             operation.evidence_recording_status !== "incomplete",
         );
+        const canViewDeletionReceipt = Boolean(
+          normalizeLower(operation.action) === "account_permanent_delete" &&
+            operation.execution_result &&
+            operation.execution_result.deletion_receipt,
+        );
         return `
           <div class="admin-priority-repair-item">
             <span>
@@ -829,6 +839,11 @@
             ${
               canApprove
                 ? `<button class="btn btn-primary" type="button" data-admin-kernel-approve-execute="${escapeHtml(operation.operation_id)}">Approve + Execute</button>`
+                : ""
+            }
+            ${
+              canViewDeletionReceipt
+                ? `<button class="btn btn-secondary" type="button" data-admin-kernel-view-deletion-receipt="${escapeHtml(operation.operation_id)}">View Receipt</button>`
                 : ""
             }
             ${
@@ -899,6 +914,18 @@
       setPageStatus("Continuity operation audit closed.", "success");
     } catch (error) {
       setPageStatus(error.message || "Unable to close the Continuity audit record.", "error");
+    }
+  }
+
+  async function viewKernelDeletionReceipt(operationId) {
+    try {
+      const operation = await fetchJson(`/admin/control-center/kernel/operations/${encodeURIComponent(operationId)}`);
+      if (!operation || !operation.execution_result || !operation.execution_result.deletion_receipt) {
+        throw new Error("This operation does not contain a permanent-deletion receipt.");
+      }
+      renderDeletionReceipt(operation);
+    } catch (error) {
+      setPageStatus(error.message || "Unable to load the permanent-deletion receipt.", "error");
     }
   }
 
@@ -1311,6 +1338,9 @@
           ["Mint-Ready Projects", summary.mint_ready_projects],
           ["Data Mismatches", summary.projects_with_data_mismatch],
             ];
+    if (state.isSuperAdmin) {
+      cards.push(["Permanent Deletions", summary.permanently_deleted_users]);
+    }
     node.innerHTML = cards
       .map(function (item, index) {
         return `
@@ -1705,6 +1735,8 @@
         (workspace.tabs && workspace.tabs.identity && workspace.tabs.identity.user_id) ||
         "";
       const showSuperAdminControls = Boolean(state.isSuperAdmin && userId);
+      const permanentlyDeleted = normalizeLower(tabData && tabData.status) === "permanently_deleted";
+      const accountControlDisabled = permanentlyDeleted ? ' disabled aria-disabled="true"' : "";
       node.innerHTML = `
         ${warningMarkup}
         <article class="admin-dossier-card admin-dossier-card--wide">
@@ -1728,37 +1760,47 @@
           showSuperAdminControls
             ? `
               <article class="admin-dossier-card admin-dossier-card--wide">
-                <div class="admin-card-header"><span class="admin-card-badge">S</span><div><h3 class="admin-card-title">CEO Account Controls</h3><p class="card-copy">Update identity details, control access, or close the account through one governed workflow.</p></div></div>
+                <div class="admin-card-header"><span class="admin-card-badge">S</span><div><h3 class="admin-card-title">CEO Account Controls</h3><p class="card-copy">Temporary access holds, recoverable archives, and permanent deletion are separate governed actions.</p></div></div>
+                ${permanentlyDeleted ? '<div class="admin-irreversible-warning"><strong>This account was permanently deleted.</strong><p>Profile editing, password reset, restoration, and lifecycle actions are disabled. Review the Continuity Kernel receipt and audit history for proof.</p></div>' : ""}
                 <div class="admin-field-grid">
-                  <label class="admin-field"><span>Full Name</span><input type="text" data-super-admin-user-field="full_name" value="${escapeHtml(tabData.full_name || "")}" /></label>
-                  <label class="admin-field"><span>Email</span><input type="email" data-super-admin-user-field="email" value="${escapeHtml(tabData.email || "")}" /></label>
-                  <label class="admin-field"><span>Phone Number</span><input type="text" data-super-admin-user-field="phone_number" value="${escapeHtml(tabData.phone_number || "")}" /></label>
-                  <label class="admin-field"><span>Birthday</span><input type="text" data-super-admin-user-field="birthday" value="${escapeHtml(tabData.birthday || "")}" /></label>
-                  <label class="admin-field"><span>Mailing Address</span><input type="text" data-super-admin-user-field="mailing_address" value="${escapeHtml(tabData.mailing_address || "")}" /></label>
-                  <label class="admin-field"><span>Role</span><input type="text" data-super-admin-user-field="role" value="${escapeHtml(tabData.role || "")}" /></label>
-                  <label class="admin-field"><span>Status</span><input type="text" data-super-admin-user-field="status" value="${escapeHtml(tabData.status || "")}" /></label>
-                  <label class="admin-field"><span>Access Tier</span><input type="text" data-super-admin-user-field="access_tier" value="${escapeHtml(tabData.access_tier || "")}" /></label>
-                  <label class="admin-field"><span>Department Role</span><input type="text" data-super-admin-user-field="department_role" value="${escapeHtml(tabData.department_role || "")}" /></label>
+                  <label class="admin-field"><span>Full Name</span><input type="text" data-super-admin-user-field="full_name" value="${escapeHtml(tabData.full_name || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Email</span><input type="email" data-super-admin-user-field="email" value="${escapeHtml(tabData.email || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Phone Number</span><input type="text" data-super-admin-user-field="phone_number" value="${escapeHtml(tabData.phone_number || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Birthday</span><input type="text" data-super-admin-user-field="birthday" value="${escapeHtml(tabData.birthday || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Mailing Address</span><input type="text" data-super-admin-user-field="mailing_address" value="${escapeHtml(tabData.mailing_address || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Role</span><input type="text" data-super-admin-user-field="role" value="${escapeHtml(tabData.role || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Status</span><input type="text" data-super-admin-user-field="status" value="${escapeHtml(tabData.status || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Access Tier</span><input type="text" data-super-admin-user-field="access_tier" value="${escapeHtml(tabData.access_tier || "")}"${accountControlDisabled} /></label>
+                  <label class="admin-field"><span>Department Role</span><input type="text" data-super-admin-user-field="department_role" value="${escapeHtml(tabData.department_role || "")}"${accountControlDisabled} /></label>
                 </div>
                 <div class="admin-account-control-section">
                   <div><h4>Profile &amp; sign-in</h4><p>Contact changes and account access changes are audited separately.</p></div>
                   <div class="inline-actions">
-                    <button class="btn btn-primary" type="button" data-super-admin-user-save="${escapeHtml(userId)}">Save Profile</button>
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-password-reset="${escapeHtml(userId)}">Send Password Reset</button>
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="activate" data-super-admin-user-id="${escapeHtml(userId)}">Activate</button>
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="restore" data-super-admin-user-id="${escapeHtml(userId)}">Restore</button>
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="suspend" data-super-admin-user-id="${escapeHtml(userId)}">Suspend</button>
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="disable" data-super-admin-user-id="${escapeHtml(userId)}">Disable</button>
+                    <button class="btn btn-primary" type="button" data-super-admin-user-save="${escapeHtml(userId)}"${accountControlDisabled}>Save Profile</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-password-reset="${escapeHtml(userId)}"${accountControlDisabled}>Send Password Reset</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="activate" data-super-admin-user-id="${escapeHtml(userId)}"${accountControlDisabled}>Activate</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="restore" data-super-admin-user-id="${escapeHtml(userId)}"${accountControlDisabled}>Restore Access</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="billing_hold" data-super-admin-user-id="${escapeHtml(userId)}"${accountControlDisabled}>Place on Billing Hold</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="disable" data-super-admin-user-id="${escapeHtml(userId)}"${accountControlDisabled}>Disable for Security Review</button>
                   </div>
                 </div>
                 <div class="admin-danger-zone">
                   <div>
-                    <h4>Close account</h4>
-                    <p>Preview owned projects, family workspaces, memberships, entitlements, and invites before access is archived. Orders, billing evidence, uploads, vault records, certificates, delivery records, and audit history are preserved.</p>
+                    <h4>Recoverable archive</h4>
+                    <p>Use this when access may need to be restored. Login is disabled and access records are archived, while customer and business records remain recoverable.</p>
                   </div>
                   <div class="inline-actions">
-                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="archive" data-super-admin-user-id="${escapeHtml(userId)}">Archive Account Only</button>
-                    <button class="btn btn-danger" type="button" data-super-admin-user-action="archive" data-super-admin-user-id="${escapeHtml(userId)}" data-super-admin-archive-owned="true">Close Account &amp; Workspaces</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="archive" data-super-admin-user-id="${escapeHtml(userId)}"${accountControlDisabled}>Archive Account Only</button>
+                    <button class="btn btn-secondary" type="button" data-super-admin-user-action="archive" data-super-admin-user-id="${escapeHtml(userId)}" data-super-admin-archive-owned="true"${accountControlDisabled}>Archive Account &amp; Workspaces</button>
+                  </div>
+                </div>
+                <div class="admin-danger-zone">
+                  <div>
+                    <h4>Permanent deletion</h4>
+                    <p>For a verified customer deletion request, policy violation, security incident, or CEO-authorized company decision. This destroys the login identity and permanently closes access. It cannot be restored.</p>
+                  </div>
+                  <div class="inline-actions">
+                    <button class="btn btn-danger" type="button" data-super-admin-permanent-delete="${escapeHtml(userId)}"${accountControlDisabled}>Permanently Delete Account</button>
                   </div>
                 </div>
               </article>
@@ -2775,7 +2817,7 @@
   }
 
   function lifecycleIsDestructive(workflow) {
-    return Boolean(workflow && ["suspend", "disable", "archive"].includes(workflow.action));
+    return Boolean(workflow && ["billing_hold", "suspend", "disable", "archive"].includes(workflow.action));
   }
 
   function renderLifecyclePreview(preview) {
@@ -2807,7 +2849,13 @@
       ${after.archive_owned_records ? `<div class="admin-preview-section"><span>Access records archived</span><div>${renderChipList(Object.keys((preview && preview.records_to_archive) || {}), "No owned access records")}</div></div>` : ""}
       <div class="admin-preview-section"><span>Business and evidence records preserved</span><div>${renderChipList(preview && preview.records_preserved, "Audit history")}</div></div>
       ${warnings.length ? `<div class="admin-preview-warning">${warnings.map(function (item) { return `<p>${escapeHtml(item)}</p>`; }).join("")}</div>` : ""}
-      <p class="admin-preview-assurance">Closure is a recoverable access archive, not an untraceable database deletion.</p>
+      <p class="admin-preview-assurance">${
+        after.billing_hold
+          ? "A billing hold is temporary and recoverable. Restore Access reopens the account after billing is resolved."
+          : after.archive_owned_records
+            ? "This is a recoverable access archive, not a permanent deletion."
+            : "This lifecycle action remains auditable and recoverable through CEO account controls."
+      }</p>
     `;
   }
 
@@ -2822,6 +2870,17 @@
     const confirmed = Boolean(document.querySelector("[data-admin-lifecycle-confirm]")?.checked);
     const typed = fieldValue("[data-admin-lifecycle-typed-confirm]").toLowerCase();
     const typedMatches = !workflow.closeOwned || typed === workflow.email.toLowerCase();
+    const typedStatus = document.querySelector("[data-admin-lifecycle-typed-status]");
+    if (typedStatus) {
+      typedStatus.dataset.state = !workflow.closeOwned || typedMatches ? "success" : typed ? "error" : "";
+      typedStatus.textContent = !workflow.closeOwned
+        ? ""
+        : typedMatches
+          ? "Target account confirmed."
+          : typed
+            ? `Email does not match. Enter ${workflow.email} exactly.`
+            : `Required target email: ${workflow.email}`;
+    }
     setButtonEnabled(execute, !workflow.preview.blocked && reason.length >= 3 && confirmed && typedMatches);
   }
 
@@ -2847,18 +2906,22 @@
     const title = document.querySelector("[data-admin-lifecycle-title]");
     const target = document.querySelector("[data-admin-lifecycle-target]");
     const typedWrap = document.querySelector("[data-admin-lifecycle-typed-wrap]");
+    const typedLabel = document.querySelector("[data-admin-lifecycle-typed-label]");
+    const typedInput = document.querySelector("[data-admin-lifecycle-typed-confirm]");
     const confirmLabel = document.querySelector("[data-admin-lifecycle-confirm-label]");
     const execute = document.querySelector("[data-admin-lifecycle-execute]");
-    if (title) title.textContent = closeOwned ? "Close account and owned workspaces" : `${titleize(action)} account`;
+    if (title) title.textContent = closeOwned ? "Archive account and owned workspaces" : `${titleize(action)} account`;
     if (target) target.textContent = `${state.lifecycleWorkflow.name} · ${state.lifecycleWorkflow.email || userId}`;
     if (typedWrap) typedWrap.hidden = !closeOwned;
+    if (typedLabel && closeOwned) typedLabel.textContent = `Type ${state.lifecycleWorkflow.email} to confirm the archive`;
+    if (typedInput instanceof HTMLInputElement && closeOwned) typedInput.placeholder = state.lifecycleWorkflow.email;
     if (confirmLabel) {
       confirmLabel.textContent = closeOwned
         ? "I confirm login, roles, memberships, entitlements, and active owned workspaces should be archived."
         : `I confirm this account should be ${titleize(action).toLowerCase()}.`;
     }
     if (execute instanceof HTMLButtonElement) {
-      execute.textContent = closeOwned ? "Close Account & Workspaces" : `${titleize(action)} Account`;
+      execute.textContent = closeOwned ? "Archive Account & Workspaces" : `${titleize(action)} Account`;
       execute.classList.toggle("btn-danger", lifecycleIsDestructive(state.lifecycleWorkflow));
       execute.classList.toggle("btn-primary", !lifecycleIsDestructive(state.lifecycleWorkflow));
     }
@@ -2872,7 +2935,13 @@
         { action, archive_owned_records: closeOwned, confirmed: false, reason: "" },
       );
       if (!state.lifecycleWorkflow || state.lifecycleWorkflow.userId !== userId || state.lifecycleWorkflow.action !== action) return;
+      const previewTarget = (preview && preview.target_account) || {};
+      state.lifecycleWorkflow.email = normalizeValue(previewTarget.email) || state.lifecycleWorkflow.email;
+      state.lifecycleWorkflow.name = normalizeValue(previewTarget.full_name) || state.lifecycleWorkflow.name;
       state.lifecycleWorkflow.preview = preview || {};
+      if (target) target.textContent = `${state.lifecycleWorkflow.name} · ${state.lifecycleWorkflow.email || userId}`;
+      if (typedLabel && closeOwned) typedLabel.textContent = `Type ${state.lifecycleWorkflow.email} to confirm the archive`;
+      if (typedInput instanceof HTMLInputElement && closeOwned) typedInput.placeholder = state.lifecycleWorkflow.email;
       renderLifecyclePreview(preview || {});
       syncLifecycleExecuteAvailability();
     } catch (error) {
@@ -2918,6 +2987,299 @@
     } catch (error) {
       setPageStatus(error.message || "Unable to update account status.", "error");
       syncLifecycleExecuteAvailability();
+    }
+  }
+
+  function renderPermanentDeletionPreview(preview) {
+    const node = document.querySelector("[data-admin-permanent-delete-preview]");
+    if (!node) return;
+    const before = (preview && preview.before) || {};
+    const after = (preview && preview.proposed_after) || {};
+    const ownership = (preview && preview.ownership_dependencies) || {};
+    const externalImpact = (preview && preview.external_service_impact) || {};
+    const stripeCancellationCount = Number(externalImpact.stripe_subscriptions_cancelled_immediately || 0);
+    const ownershipRows = Object.entries(ownership).filter(function (entry) { return Number(entry[1] || 0) > 0; });
+    const warnings = asArray(preview && preview.warnings);
+    const blocked = Boolean(preview && preview.blocked);
+    node.dataset.state = blocked ? "error" : "success";
+    node.innerHTML = `
+      <div class="admin-preview-heading">
+        <h3>Permanent-deletion impact</h3>
+        ${statusChip(blocked ? "Blocked" : "Eligible for CEO confirmation", blocked ? "error" : "warning")}
+      </div>
+      <div class="admin-preview-facts">
+        <div><span>Current status</span><strong>${escapeHtml(titleize(before.status || "active"))}</strong></div>
+        <div><span>Resulting status</span><strong>${escapeHtml(titleize(after.status || "permanently deleted"))}</strong></div>
+        <div><span>Login access</span><strong>Destroyed and disabled</strong></div>
+        <div><span>Restoration</span><strong>${after.restorable ? "Available" : "Not possible"}</strong></div>
+      </div>
+      <div class="admin-preview-section"><span>Owned workspace records</span><div>${
+        ownershipRows.length
+          ? ownershipRows.map(function (entry) { return `<span class="admin-scope-chip">${escapeHtml(titleize(entry[0]))}: ${escapeHtml(entry[1])}</span>`; }).join("")
+          : '<span class="admin-scope-empty">No owned workspace records</span>'
+      }</div></div>
+      <div class="admin-preview-section"><span>Erased or deidentified</span><div>${renderChipList(preview && preview.records_erased_or_deidentified, "No identity fields")}</div></div>
+      <div class="admin-preview-section"><span>Permanently closed</span><div>${renderChipList(preview && preview.records_permanently_closed, "No access records")}</div></div>
+      ${stripeCancellationCount > 0 ? `<div class="admin-preview-section"><span>External billing action</span><div><span class="admin-scope-chip">Stripe subscriptions cancelled immediately: ${escapeHtml(stripeCancellationCount)}</span></div></div>` : ""}
+      <div class="admin-preview-section"><span>Required evidence preserved</span><div>${renderChipList(preview && preview.records_preserved, "Audit evidence")}</div></div>
+      ${warnings.length ? `<div class="admin-preview-warning">${warnings.map(function (item) { return `<p>${escapeHtml(item)}</p>`; }).join("")}</div>` : ""}
+      <p class="admin-preview-assurance admin-preview-assurance--danger">This action is irreversible and cannot be restored through account controls.</p>
+    `;
+  }
+
+  function syncPermanentDeletionContinueAvailability() {
+    const workflow = state.permanentDeletionWorkflow;
+    const continueButton = document.querySelector("[data-admin-permanent-delete-continue]");
+    if (!workflow || !workflow.preview) {
+      setButtonEnabled(continueButton, false);
+      return;
+    }
+    const category = fieldValue("[data-admin-permanent-delete-category]");
+    const reason = fieldValue("[data-admin-permanent-delete-reason]");
+    const typedEmail = fieldValue("[data-admin-permanent-delete-email]").toLowerCase();
+    const emailMatches = typedEmail === workflow.email.toLowerCase();
+    const confirmed = Boolean(document.querySelector("[data-admin-permanent-delete-confirm]")?.checked);
+    const statusNode = document.querySelector("[data-admin-permanent-delete-email-status]");
+    if (statusNode) {
+      statusNode.dataset.state = emailMatches ? "success" : typedEmail ? "error" : "";
+      statusNode.textContent = emailMatches
+        ? "Target account confirmed."
+        : typedEmail
+          ? `Email does not match. Enter ${workflow.email} exactly.`
+          : `Required target email: ${workflow.email}`;
+    }
+    setButtonEnabled(
+      continueButton,
+      !workflow.preview.blocked && Boolean(category) && reason.length >= 3 && emailMatches && confirmed,
+    );
+  }
+
+  async function openPermanentDeletion(userId) {
+    if (!state.isSuperAdmin) {
+      setPageStatus("CEO Master Administrator access is required for permanent deletion.", "error");
+      return;
+    }
+    const identity = currentIdentityRecord();
+    state.permanentDeletionWorkflow = {
+      userId,
+      email: normalizeValue(identity.email),
+      name: normalizeValue(identity.full_name) || "Selected account",
+      preview: null,
+    };
+    const dialog = dialogByName("permanent-delete");
+    const form = document.querySelector("[data-admin-permanent-delete-form]");
+    if (!(dialog instanceof HTMLDialogElement) || !(form instanceof HTMLFormElement)) return;
+    form.reset();
+    const target = document.querySelector("[data-admin-permanent-delete-target]");
+    const emailLabel = document.querySelector("[data-admin-permanent-delete-email-label]");
+    const emailInput = document.querySelector("[data-admin-permanent-delete-email]");
+    const previewNode = document.querySelector("[data-admin-permanent-delete-preview]");
+    if (target) target.textContent = `${state.permanentDeletionWorkflow.name} · ${state.permanentDeletionWorkflow.email || userId}`;
+    if (emailLabel) emailLabel.textContent = `Type ${state.permanentDeletionWorkflow.email || "the target email"} exactly`;
+    if (emailInput instanceof HTMLInputElement) emailInput.placeholder = state.permanentDeletionWorkflow.email;
+    if (previewNode) previewNode.innerHTML = "<h3>Permanent-deletion impact</h3><p>Loading the account identity, access records, and protected business evidence…</p>";
+    setButtonEnabled(document.querySelector("[data-admin-permanent-delete-continue]"), false);
+    openDialog(dialog);
+    try {
+      const preview = await postJson(
+        `/admin/control-center/super-admin/users/${encodeURIComponent(userId)}/permanent-deletion/preview`,
+        { reason_category: "" },
+      );
+      if (!state.permanentDeletionWorkflow || state.permanentDeletionWorkflow.userId !== userId) return;
+      const previewTarget = (preview && preview.target_account) || {};
+      state.permanentDeletionWorkflow.email = normalizeValue(previewTarget.email) || state.permanentDeletionWorkflow.email;
+      state.permanentDeletionWorkflow.name = normalizeValue(previewTarget.full_name) || state.permanentDeletionWorkflow.name;
+      state.permanentDeletionWorkflow.preview = preview || {};
+      if (target) target.textContent = `${state.permanentDeletionWorkflow.name} · ${state.permanentDeletionWorkflow.email || userId}`;
+      if (emailLabel) emailLabel.textContent = `Type ${state.permanentDeletionWorkflow.email} exactly`;
+      if (emailInput instanceof HTMLInputElement) emailInput.placeholder = state.permanentDeletionWorkflow.email;
+      renderPermanentDeletionPreview(preview || {});
+      syncPermanentDeletionContinueAvailability();
+    } catch (error) {
+      if (previewNode) {
+        previewNode.dataset.state = "error";
+        previewNode.innerHTML = `<h3>Permanent-deletion preview unavailable</h3><p>${escapeHtml(error.message || "Unable to load the deletion impact.")}</p>`;
+      }
+      setPageStatus(error.message || "Unable to preview permanent deletion.", "error");
+    }
+  }
+
+  function continuePermanentDeletionToFinalWarning(event) {
+    if (event) event.preventDefault();
+    const workflow = state.permanentDeletionWorkflow;
+    if (!workflow || !workflow.preview) return;
+    syncPermanentDeletionContinueAvailability();
+    const continueButton = document.querySelector("[data-admin-permanent-delete-continue]");
+    if (!(continueButton instanceof HTMLButtonElement) || continueButton.disabled) {
+      setPageStatus("Complete the deletion category, reason, target email, and confirmation before continuing.", "error");
+      return;
+    }
+    workflow.reasonCategory = fieldValue("[data-admin-permanent-delete-category]");
+    workflow.reason = fieldValue("[data-admin-permanent-delete-reason]");
+    workflow.confirmationEmail = fieldValue("[data-admin-permanent-delete-email]");
+    workflow.initialConfirmation = Boolean(document.querySelector("[data-admin-permanent-delete-confirm]")?.checked);
+    const finalForm = document.querySelector("[data-admin-permanent-delete-final-form]");
+    if (finalForm instanceof HTMLFormElement) finalForm.reset();
+    const finalTarget = document.querySelector("[data-admin-permanent-delete-final-target]");
+    if (finalTarget) finalTarget.textContent = `${workflow.name} · ${workflow.email}`;
+    setButtonEnabled(document.querySelector("[data-admin-permanent-delete-execute]"), false);
+    closeDialog(dialogByName("permanent-delete"));
+    openDialog(dialogByName("permanent-delete-final"));
+  }
+
+  function syncPermanentDeletionFinalAvailability() {
+    const phrase = fieldValue("[data-admin-permanent-delete-phrase]");
+    const phraseMatches = phrase === "PERMANENTLY DELETE";
+    const confirmed = Boolean(document.querySelector("[data-admin-permanent-delete-final-confirm]")?.checked);
+    const statusNode = document.querySelector("[data-admin-permanent-delete-phrase-status]");
+    if (statusNode) {
+      statusNode.dataset.state = phraseMatches ? "success" : phrase ? "error" : "";
+      statusNode.textContent = phraseMatches
+        ? "Final deletion phrase confirmed."
+        : phrase
+          ? "The phrase must be exactly PERMANENTLY DELETE."
+          : "This exact phrase is required.";
+    }
+    setButtonEnabled(document.querySelector("[data-admin-permanent-delete-execute]"), phraseMatches && confirmed);
+  }
+
+  function backToPermanentDeletionReview() {
+    closeDialog(dialogByName("permanent-delete-final"));
+    openDialog(dialogByName("permanent-delete"));
+    syncPermanentDeletionContinueAvailability();
+  }
+
+  function deletionReceiptText(operation) {
+    const execution = (operation && operation.execution_result) || {};
+    const receipt = execution.deletion_receipt || {};
+    const recordsClosed = receipt.records_closed || {};
+    const mongoEvidence = receipt.mongo_evidence || {};
+    const lines = [
+      "TOMB OF LIGHT CONTINUITY KERNEL — PERMANENT DELETION RECEIPT",
+      `Operation ID: ${normalizeValue(operation && operation.operation_id) || "unavailable"}`,
+      `Operation state: ${normalizeValue(operation && operation.state) || "unavailable"}`,
+      `Execution outcome: ${normalizeValue(operation && operation.execution_outcome) || "unavailable"}`,
+      `Evidence status: ${normalizeValue(operation && operation.evidence_recording_status) || "unavailable"}`,
+      `Deletion ID: ${normalizeValue(receipt.deletion_id) || "unavailable"}`,
+      `Target user ID: ${normalizeValue(receipt.user_id) || "unavailable"}`,
+      `Deleted at: ${normalizeValue(receipt.deleted_at) || "unavailable"}`,
+      `Reason category: ${normalizeValue(receipt.reason_category) || "unavailable"}`,
+      "Restorable: no",
+      `MongoDB record counts: ${JSON.stringify(recordsClosed)}`,
+      `MongoDB tombstone collection: ${normalizeValue(mongoEvidence.tombstone_collection) || "unavailable"}`,
+      `MongoDB audit collection: ${normalizeValue(mongoEvidence.audit_collection) || "unavailable"}`,
+      `Continuity operation collection: ${normalizeValue(mongoEvidence.continuity_operation_collection) || "unavailable"}`,
+      `Continuity event collection: ${normalizeValue(mongoEvidence.continuity_event_collection) || "unavailable"}`,
+    ];
+    return lines.join("\n");
+  }
+
+  function renderDeletionReceipt(operation) {
+    const node = document.querySelector("[data-admin-deletion-receipt]");
+    if (!node) return;
+    const execution = (operation && operation.execution_result) || {};
+    const receipt = execution.deletion_receipt || {};
+    const mongoEvidence = receipt.mongo_evidence || {};
+    const evidenceComplete = normalizeLower(operation && operation.evidence_recording_status) === "complete";
+    const executionSucceeded = normalizeLower(operation && operation.execution_outcome) === "success";
+    node.dataset.state = evidenceComplete && executionSucceeded ? "success" : "error";
+    const closedEntries = Object.entries(receipt.records_closed || {});
+    node.innerHTML = `
+      <div class="admin-preview-heading">
+        <h3>Execution evidence</h3>
+        ${statusChip(executionSucceeded ? "Permanent deletion executed" : "Review required", executionSucceeded ? "success" : "error")}
+      </div>
+      <div class="admin-preview-facts">
+        <div><span>Operation ID</span><strong>${escapeHtml(operation && operation.operation_id || "—")}</strong></div>
+        <div><span>Operation state</span><strong>${escapeHtml(titleize(operation && operation.state || "—"))}</strong></div>
+        <div><span>Deletion ID</span><strong>${escapeHtml(receipt.deletion_id || "—")}</strong></div>
+        <div><span>Evidence status</span><strong>${escapeHtml(titleize(operation && operation.evidence_recording_status || "—"))}</strong></div>
+        <div><span>Target user ID</span><strong>${escapeHtml(receipt.user_id || "—")}</strong></div>
+        <div><span>Restorable</span><strong>No</strong></div>
+      </div>
+      <div class="admin-preview-section"><span>MongoDB records closed</span><div>${closedEntries.length
+          ? closedEntries.map(function (entry) { return `<span class="admin-scope-chip">${escapeHtml(titleize(entry[0]))}: ${escapeHtml(entry[1])}</span>`; }).join("")
+          : '<span class="admin-scope-empty">No linked access records required changes</span>'}
+      </div></div>
+      <div class="admin-preview-section"><span>Evidence collections</span><div>${renderChipList(Object.values(mongoEvidence), "Continuity evidence collections unavailable")}</div></div>
+      <div class="admin-preview-section"><span>Required evidence preserved</span><div>${renderChipList(receipt.records_preserved, "Continuity and audit evidence")}</div></div>
+      <code class="admin-receipt-code">${escapeHtml(deletionReceiptText(operation))}</code>
+    `;
+    state.deletionReceipt = { operation, text: deletionReceiptText(operation) };
+    const closeAuditButton = document.querySelector("[data-admin-deletion-receipt-close-audit]");
+    if (closeAuditButton instanceof HTMLButtonElement) {
+      const canClose = normalizeLower(operation && operation.state) === "apply_executed" && evidenceComplete && executionSucceeded;
+      closeAuditButton.hidden = !canClose;
+      closeAuditButton.setAttribute("data-admin-deletion-receipt-close-audit", canClose ? operation.operation_id : "");
+    }
+    openDialog(dialogByName("deletion-receipt"));
+  }
+
+  async function executePermanentDeletion(event) {
+    if (event) event.preventDefault();
+    const workflow = state.permanentDeletionWorkflow;
+    if (!state.isSuperAdmin || !workflow || !workflow.preview) return;
+    syncPermanentDeletionFinalAvailability();
+    const executeButton = document.querySelector("[data-admin-permanent-delete-execute]");
+    if (!(executeButton instanceof HTMLButtonElement) || executeButton.disabled) {
+      setPageStatus("Complete the final irreversible-deletion warning before execution.", "error");
+      return;
+    }
+    setButtonEnabled(executeButton, false);
+    setPageStatus("Executing permanent account deletion through the Continuity Kernel…", "info");
+    try {
+      const operation = await submitGovernedOperation(
+        "account_permanent_delete",
+        { user_id: workflow.userId },
+        {
+          reason_category: workflow.reasonCategory,
+          confirmation_email: workflow.confirmationEmail,
+          initial_confirmation: workflow.initialConfirmation === true,
+          final_confirmation: fieldValue("[data-admin-permanent-delete-phrase]"),
+          final_acknowledgement: Boolean(document.querySelector("[data-admin-permanent-delete-final-confirm]")?.checked),
+        },
+        workflow.reason,
+      );
+      if (
+        (Array.isArray(operation.blocked_reasons) && operation.blocked_reasons.length) ||
+        normalizeLower(operation.execution_outcome) !== "success" ||
+        normalizeLower(operation.evidence_recording_status) !== "complete"
+      ) {
+        throw new Error(kernelOperationMessage(operation, "Permanent account deletion did not complete."));
+      }
+      closeDialog(dialogByName("permanent-delete-final"));
+      state.permanentDeletionWorkflow = null;
+      state.selectedCaseId = "";
+      state.workspace = null;
+      await Promise.allSettled([loadKernelStatus(), loadOverview(), loadCases()]);
+      renderDeletionReceipt(operation);
+      setPageStatus(kernelOperationMessage(operation, "Account permanently deleted."), "success");
+    } catch (error) {
+      setPageStatus(error.message || "Permanent account deletion failed. No success receipt was issued.", "error");
+      syncPermanentDeletionFinalAvailability();
+    }
+  }
+
+  async function copyDeletionReceipt() {
+    const textValue = normalizeValue(state.deletionReceipt && state.deletionReceipt.text);
+    if (!textValue) return;
+    try {
+      await navigator.clipboard.writeText(textValue);
+      setPageStatus("Permanent-deletion receipt copied.", "success");
+    } catch (_error) {
+      setPageStatus("Unable to copy automatically. Select the receipt text manually.", "error");
+    }
+  }
+
+  async function closeDeletionReceiptAudit(operationId) {
+    if (!operationId) return;
+    try {
+      const operation = await postJson(`/admin/control-center/kernel/operations/${encodeURIComponent(operationId)}/close`, {});
+      await loadKernelStatus();
+      renderDeletionReceipt(operation);
+      setPageStatus("Permanent-deletion audit record closed.", "success");
+    } catch (error) {
+      setPageStatus(error.message || "Unable to close the permanent-deletion audit record.", "error");
     }
   }
 
@@ -3443,6 +3805,12 @@
         const name = dialogClose.getAttribute("data-admin-dialog-close") || "";
         closeDialog(dialogByName(name));
         if (name === "lifecycle") state.lifecycleWorkflow = null;
+        if (name === "permanent-delete" || name === "permanent-delete-final") {
+          state.permanentDeletionWorkflow = null;
+          closeDialog(dialogByName("permanent-delete"));
+          closeDialog(dialogByName("permanent-delete-final"));
+        }
+        if (name === "deletion-receipt") state.deletionReceipt = null;
         return;
       }
 
@@ -3501,6 +3869,13 @@
       if (kernelClose) {
         const operationId = kernelClose.getAttribute("data-admin-kernel-close");
         if (operationId) closeKernelOperation(operationId);
+        return;
+      }
+
+      const kernelDeletionReceipt = target.closest("[data-admin-kernel-view-deletion-receipt]");
+      if (kernelDeletionReceipt) {
+        const operationId = kernelDeletionReceipt.getAttribute("data-admin-kernel-view-deletion-receipt");
+        if (operationId) viewKernelDeletionReceipt(operationId);
         return;
       }
 
@@ -3585,6 +3960,32 @@
         const userId = superAdminUserAction.getAttribute("data-super-admin-user-id");
         const archiveOwnedRecords = superAdminUserAction.getAttribute("data-super-admin-archive-owned") === "true";
         if (action && userId) openSuperAdminLifecycle(userId, action, archiveOwnedRecords);
+        return;
+      }
+
+      const superAdminPermanentDelete = target.closest("[data-super-admin-permanent-delete]");
+      if (superAdminPermanentDelete) {
+        const userId = superAdminPermanentDelete.getAttribute("data-super-admin-permanent-delete");
+        if (userId) openPermanentDeletion(userId);
+        return;
+      }
+
+      const permanentDeleteBack = target.closest("[data-admin-permanent-delete-back]");
+      if (permanentDeleteBack) {
+        backToPermanentDeletionReview();
+        return;
+      }
+
+      const deletionReceiptCopy = target.closest("[data-admin-deletion-receipt-copy]");
+      if (deletionReceiptCopy) {
+        copyDeletionReceipt();
+        return;
+      }
+
+      const deletionReceiptCloseAudit = target.closest("[data-admin-deletion-receipt-close-audit]");
+      if (deletionReceiptCloseAudit) {
+        const operationId = deletionReceiptCloseAudit.getAttribute("data-admin-deletion-receipt-close-audit") || "";
+        if (operationId) closeDeletionReceiptAudit(operationId);
         return;
       }
 
@@ -3716,6 +4117,20 @@
       lifecycleForm.addEventListener("change", syncLifecycleExecuteAvailability);
     }
 
+    const permanentDeleteForm = document.querySelector("[data-admin-permanent-delete-form]");
+    if (permanentDeleteForm instanceof HTMLFormElement) {
+      permanentDeleteForm.addEventListener("submit", continuePermanentDeletionToFinalWarning);
+      permanentDeleteForm.addEventListener("input", syncPermanentDeletionContinueAvailability);
+      permanentDeleteForm.addEventListener("change", syncPermanentDeletionContinueAvailability);
+    }
+
+    const permanentDeleteFinalForm = document.querySelector("[data-admin-permanent-delete-final-form]");
+    if (permanentDeleteFinalForm instanceof HTMLFormElement) {
+      permanentDeleteFinalForm.addEventListener("submit", executePermanentDeletion);
+      permanentDeleteFinalForm.addEventListener("input", syncPermanentDeletionFinalAvailability);
+      permanentDeleteFinalForm.addEventListener("change", syncPermanentDeletionFinalAvailability);
+    }
+
     const teamForm = document.querySelector("[data-admin-team-form]");
     if (teamForm instanceof HTMLFormElement) {
       teamForm.addEventListener("submit", applyTeamAccess);
@@ -3740,6 +4155,12 @@
     document.querySelectorAll(".admin-workflow-dialog").forEach(function (dialog) {
       dialog.addEventListener("cancel", function () {
         if (dialog.matches("[data-admin-lifecycle-dialog]")) state.lifecycleWorkflow = null;
+        if (dialog.matches("[data-admin-permanent-delete-dialog], [data-admin-permanent-delete-final-dialog]")) {
+          state.permanentDeletionWorkflow = null;
+          closeDialog(dialogByName("permanent-delete"));
+          closeDialog(dialogByName("permanent-delete-final"));
+        }
+        if (dialog.matches("[data-admin-deletion-receipt-dialog]")) state.deletionReceipt = null;
       });
     });
 

--- a/backend/app/core/continuity_kernel_validator.py
+++ b/backend/app/core/continuity_kernel_validator.py
@@ -335,11 +335,35 @@ def _rollback_plan_references_before_snapshot(rollback_plan: Any) -> bool:
     return "before_snapshot" in rollback_plan_text or "before_snapshot_ref" in rollback_plan_text
 
 
-def _scan_prohibited_text_fields(fields: list[Any], acc: ValidationAccumulator) -> None:
+def _scan_prohibited_text_fields(
+    fields: list[Any],
+    acc: ValidationAccumulator,
+    *,
+    allowed_reason_codes: set[str] | None = None,
+) -> None:
     combined_text = " ".join(_flatten_to_text(field) for field in fields).lower()
+    allowed = allowed_reason_codes or set()
     for reason_code, signals in PROHIBITED_ACTION_SIGNALS.items():
+        if reason_code in allowed:
+            continue
         if any(signal in combined_text for signal in signals):
             _add_error(acc, reason_code, f"Prohibited action signal detected: {reason_code}")
+
+
+def _is_governed_permanent_account_deletion(packet: dict[str, Any]) -> bool:
+    diff_summary = packet.get("diff_summary")
+    proposed_snapshot = packet.get("proposed_after_snapshot")
+    if not isinstance(diff_summary, dict) or not isinstance(proposed_snapshot, dict):
+        return False
+    proposed_after = proposed_snapshot.get("proposed_after")
+    if not isinstance(proposed_after, dict):
+        return False
+    return (
+        _flatten_to_text(diff_summary.get("action")).strip() == "account_permanent_delete"
+        and proposed_snapshot.get("irreversible") is True
+        and proposed_after.get("restorable") is False
+        and _flatten_to_text(proposed_after.get("status")).strip() == "permanently_deleted"
+    )
 
 
 def _normalize_role(role: Any) -> str:
@@ -585,6 +609,11 @@ def validate_evidence_packet(packet: dict[str, Any]) -> dict[str, Any]:
         packet=packet,
     )
 
+    allowed_prohibited_signals = (
+        {"PROHIBITED_DELETE_CUSTOMER_RECORD"}
+        if _is_governed_permanent_account_deletion(packet)
+        else set()
+    )
     _scan_prohibited_text_fields(
         [
             packet.get("proposed_after_snapshot"),
@@ -593,6 +622,7 @@ def validate_evidence_packet(packet: dict[str, Any]) -> dict[str, Any]:
             packet.get("audit_context"),
         ],
         acc,
+        allowed_reason_codes=allowed_prohibited_signals,
     )
 
     risk_level = _flatten_to_text(packet.get("risk_level")).lower().strip()

--- a/backend/app/routes/admin_control_center.py
+++ b/backend/app/routes/admin_control_center.py
@@ -56,6 +56,7 @@ from app.services.admin_control_service import (
     super_admin_create_customer,
     super_admin_preview_customer_create,
     super_admin_preview_account_lifecycle,
+    super_admin_preview_account_permanent_deletion,
     super_admin_preview_officer_permissions,
     super_admin_preview_package_change,
     super_admin_preview_package_revocation,
@@ -155,6 +156,10 @@ class SuperAdminUserStateActionPayload(BaseModel):
     reason: str = Field(default="")
     confirmed: bool = False
     archive_owned_records: bool = False
+
+
+class SuperAdminPermanentDeletionPreviewPayload(BaseModel):
+    reason_category: str = Field(default="")
 
 
 class SuperAdminCustomerCreatePayload(BaseModel):
@@ -734,6 +739,22 @@ def super_admin_user_status_action_preview(
             user_id=user_id,
             action=payload.action,
             archive_owned_records=payload.archive_owned_records,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/super-admin/users/{user_id}/permanent-deletion/preview")
+def super_admin_user_permanent_deletion_preview(
+    user_id: str,
+    payload: SuperAdminPermanentDeletionPreviewPayload,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    _assert_canonical_ceo(current_user)
+    try:
+        return super_admin_preview_account_permanent_deletion(
+            user_id=user_id,
+            reason_category=payload.reason_category,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -5494,11 +5494,11 @@ def _archive_owned_account_records(
         invite_filters.append({"family_id": {"$in": family_candidates}})
     if household_candidates:
         invite_filters.append({"household_id": {"$in": household_candidates}})
-    if original_email:
+    if user_email:
         invite_filters.extend(
             [
-                {"email": original_email},
-                {"invite_email": original_email},
+                {"email": user_email},
+                {"invite_email": user_email},
             ]
         )
     if invite_filters:

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import secrets
@@ -44,6 +45,7 @@ from app.services.project_entitlement_service import (
     upsert_project_entitlement,
 )
 from app.services.project_membership_service import ensure_project_owner_membership
+from app.services import stripe_admin_operations_service
 from app.services.workspace_access_service import count_workspace_uploads
 from app.services.email_service import send_household_invite_email
 
@@ -65,6 +67,14 @@ SERVICE_CONTROL_OPERATIONS = {
 }
 OFFICER_ADMIN_EMAILS = set(OFFICER_PROFILE_FIELDS) - {str(CEO_MASTER_ADMIN_EMAIL).strip().lower()}
 TEAM_ACCESS_ROLE_TEMPLATES = ASSIGNABLE_OFFICER_ROLE_CODES
+PERMANENT_DELETE_CONFIRMATION_PHRASE = "PERMANENTLY DELETE"
+PERMANENT_DELETE_REASON_CODES = {
+    "customer_request",
+    "policy_violation",
+    "security_incident",
+    "company_authorized",
+}
+ACCOUNT_DELETION_TOMBSTONES_COLLECTION = "account_deletion_tombstones"
 
 ADMIN_CONTROL_QUEUES = [
     "overview",
@@ -284,6 +294,7 @@ SUPER_ADMIN_USER_STATUS_VALUES = {
 SUPER_ADMIN_USER_STATE_ACTIONS = {
     "activate": "active",
     "restore": "active",
+    "billing_hold": "suspended",
     "suspend": "suspended",
     "disable": "disabled",
 }
@@ -600,7 +611,7 @@ def admin_control_bulk_action_allowed(
 # Bumped alongside the static frontend cache-busting query string
 # (see admin-control-center.html / dashboard.html `?v=` suffix) whenever a
 # hotfix ships to the admin control center or dashboard assets.
-FRONTEND_ASSET_REVISION = "20260821-phase10"
+FRONTEND_ASSET_REVISION = "20260821-phase10-1"
 
 
 def _backend_release_identifier() -> str:
@@ -3169,7 +3180,18 @@ def _marketing_sections_payload(
 
 def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
     db = _db()
-    users_total = int(db["users"].count_documents({}))
+    users_record_total = int(db["users"].count_documents({}))
+    permanently_deleted_users = int(
+        db["users"].count_documents(
+            {
+                "$or": [
+                    {"status": "permanently_deleted"},
+                    {"account_type": "deleted_tombstone"},
+                ]
+            }
+        )
+    )
+    users_total = max(users_record_total - permanently_deleted_users, 0)
     users_total_admin = int(db["users"].count_documents({"account_type": "business_admin"}))
     users_total_customer = max(users_total - users_total_admin, 0)
     archived_status_values = sorted(
@@ -3421,11 +3443,24 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
             member_role_access_issues += 1
 
     unresolved_admin_cases = len(mismatches)
-    new_accounts = int(db["users"].count_documents({"created_at": {"$gte": seven_days_ago}}))
+    new_accounts = int(
+        db["users"].count_documents(
+            {
+                "created_at": {"$gte": seven_days_ago},
+                "status": {"$nin": ["permanently_deleted"]},
+                "account_type": {"$nin": ["deleted_tombstone"]},
+            }
+        )
+    )
     new_projects_accounts += new_accounts
     paid_customers = 0
     signed_up_no_purchase = 0
     for user in db["users"].find({}):
+        if (
+            _normalize(user.get("status")).lower() == "permanently_deleted"
+            or _normalize(user.get("account_type")).lower() == "deleted_tombstone"
+        ):
+            continue
         if _normalize(user.get("account_type")).lower() == "business_admin":
             continue
         email = _normalize_email(user.get("email"))
@@ -3490,6 +3525,8 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
     return {
         "summary": {
             "total_users": users_total,
+            "permanently_deleted_users": permanently_deleted_users,
+            "user_identity_records_retained": users_record_total,
             "total_customer_users": users_total_customer,
             "total_business_admin_users": users_total_admin,
             "signed_up_no_purchase_users": signed_up_no_purchase,
@@ -4422,6 +4459,7 @@ def _user_supports_search(user: dict[str, Any], search: str) -> bool:
             _normalize(user.get("access_tier")),
             _normalize(user.get("department_role")),
             _normalize(user.get("status")),
+            _normalize(user.get("permanent_deletion_id")),
             _normalize(user.get("birthday")),
             _normalize(user.get("birth_date")),
             _normalize(user.get("date_of_birth")),
@@ -4439,6 +4477,8 @@ def _classify_user_account_type(
     has_pending_verified_purchase: bool,
 ) -> str:
     status_value = _normalize(user.get("status")).lower()
+    if status_value == "permanently_deleted" or _normalize(user.get("account_type")).lower() == "deleted_tombstone":
+        return "Permanently Deleted Account"
     if status_value in {"archived"}:
         return "Archived Account"
     if status_value in {"suspended", "disabled", "locked"}:
@@ -5048,6 +5088,8 @@ def super_admin_update_user(
     user = _user_by_id(user_id)
     if user is None:
         raise ValueError("User not found.")
+    if _normalize(user.get("status")).lower() == "permanently_deleted" or _normalize(user.get("account_type")).lower() == "deleted_tombstone":
+        raise ValueError("A permanently deleted account cannot be edited or restored.")
     db = _db()
     current_user_id = _normalize_object_id(user.get("_id")) or _normalize(user_id)
     updates: dict[str, Any] = {"updated_at": _now()}
@@ -5452,6 +5494,13 @@ def _archive_owned_account_records(
         invite_filters.append({"family_id": {"$in": family_candidates}})
     if household_candidates:
         invite_filters.append({"household_id": {"$in": household_candidates}})
+    if original_email:
+        invite_filters.extend(
+            [
+                {"email": original_email},
+                {"invite_email": original_email},
+            ]
+        )
     if invite_filters:
         invite_result = db["household_invites"].update_many(
             {"$or": invite_filters, "status": {"$in": ["active", "enabled", "pending", "sent", ""]}},
@@ -5480,7 +5529,7 @@ def super_admin_preview_account_lifecycle(
     if user is None:
         raise ValueError("User not found.")
     normalized_action = _normalize(action).lower()
-    if normalized_action not in {"activate", "restore", "suspend", "disable", "archive"}:
+    if normalized_action not in {"activate", "restore", "billing_hold", "suspend", "disable", "archive"}:
         raise ValueError("Unsupported account lifecycle action.")
     if archive_owned_records and normalized_action != "archive":
         raise ValueError("archive_owned_records is only valid for account archive.")
@@ -5490,26 +5539,37 @@ def super_admin_preview_account_lifecycle(
         user_email=_normalize_email(user.get("email")),
     )
     ownership = {name: len(records) for name, records in ownership_records.items()}
+    current_status = _normalize(user.get("status")).lower() or "active"
     is_canonical_ceo = _normalize_email(user.get("email")) == str(CEO_MASTER_ADMIN_EMAIL).strip().lower()
-    ceo_protected = is_canonical_ceo and normalized_action in {"suspend", "disable", "archive"}
+    permanently_deleted = current_status == "permanently_deleted" or _normalize(user.get("account_type")).lower() == "deleted_tombstone"
+    ceo_protected = is_canonical_ceo and normalized_action in {"billing_hold", "suspend", "disable", "archive"}
     blocked_by_ownership = normalized_action == "archive" and any(ownership.values()) and not archive_owned_records
-    blocked = ceo_protected or blocked_by_ownership
+    blocked = ceo_protected or blocked_by_ownership or permanently_deleted
     target_status = "archived" if normalized_action == "archive" else SUPER_ADMIN_USER_STATE_ACTIONS.get(normalized_action)
     warnings: list[str] = []
-    if ceo_protected:
+    if permanently_deleted:
+        warnings.append("A permanently deleted account cannot be restored or changed through recoverable lifecycle controls.")
+    elif ceo_protected:
         warnings.append("The canonical CEO Master Administrator cannot be disabled or archived through routine account controls.")
     elif blocked_by_ownership:
-        warnings.append("Transfer ownership or use Close Account & Workspaces to archive the owned workspaces together.")
+        warnings.append("Transfer ownership or use Archive Account & Workspaces to archive the owned workspaces together.")
     elif normalized_action == "archive" and archive_owned_records and any(ownership.values()):
         warnings.append("Owned projects, families, households, entitlements, memberships, invites, and intake access will be archived.")
     return {
         "user_id": resolved_user_id,
         "action": normalized_action,
-        "before": {"status": _normalize(user.get("status")) or "active", "session_token_version": int(user.get("session_token_version") or 0)},
+        "target_account": {
+            "user_id": resolved_user_id,
+            "email": _normalize_email(user.get("email")),
+            "full_name": _user_display_name(user),
+        },
+        "before": {"status": current_status, "session_token_version": int(user.get("session_token_version") or 0)},
         "proposed_after": {
             "status": target_status,
-            "login_enabled": normalized_action not in {"suspend", "disable", "archive"},
+            "login_enabled": normalized_action not in {"billing_hold", "suspend", "disable", "archive"},
             "archive_owned_records": bool(archive_owned_records),
+            "recoverable": True,
+            "billing_hold": normalized_action == "billing_hold",
         },
         "ownership_dependencies": ownership,
         "records_to_archive": ownership if normalized_action == "archive" and archive_owned_records else {},
@@ -5544,7 +5604,8 @@ def super_admin_apply_account_lifecycle(
         archive_owned_records=archive_owned_records,
     )
     if preview.get("blocked"):
-        raise ValueError("Account archive is blocked while active ownership remains.")
+        warnings = "; ".join(str(item) for item in preview.get("warnings") or [])
+        raise ValueError(warnings or "Account lifecycle action is blocked.")
     user = _user_by_id(user_id) or {}
     resolved_user_id = _normalize(preview.get("user_id"))
     now_value = _now()
@@ -5557,7 +5618,8 @@ def super_admin_apply_account_lifecycle(
         "session_token_version": int(user.get("session_token_version") or 0) + 1,
         "updated_at": now_value,
     }
-    if _normalize(action).lower() == "archive":
+    normalized_action = _normalize(action).lower()
+    if normalized_action == "archive":
         updates.update(
             {
                 "archived_at": now_value,
@@ -5574,14 +5636,33 @@ def super_admin_apply_account_lifecycle(
             {"user_id": resolved_user_id, "status": {"$in": ["active", "enabled", ""]}},
             {"$set": {"status": "inactive", "updated_at": now_value}},
         )
-    elif _normalize(action).lower() == "restore":
-        updates.update({"archived_at": None, "archived_by": None, "archive_reason": None, "login_enabled": True})
+    elif normalized_action in {"restore", "activate"}:
+        updates.update(
+            {
+                "archived_at": None,
+                "archived_by": None,
+                "archive_reason": None,
+                "billing_hold_at": None,
+                "billing_hold_by": None,
+                "billing_hold_reason": None,
+                "login_enabled": True,
+            }
+        )
+    elif normalized_action == "billing_hold":
+        updates.update(
+            {
+                "billing_hold_at": now_value,
+                "billing_hold_by": _normalize((actor or {}).get("_id") or (actor or {}).get("id")) or None,
+                "billing_hold_reason": normalized_reason,
+                "login_enabled": False,
+            }
+        )
     else:
-        updates["login_enabled"] = _normalize(action).lower() == "activate"
+        updates["login_enabled"] = normalized_action == "activate"
     oid = _to_object_id(resolved_user_id)
     _db()["users"].update_one({"_id": oid or resolved_user_id}, {"$set": updates})
     archive_results: dict[str, int] = {}
-    if _normalize(action).lower() == "archive" and archive_owned_records:
+    if normalized_action == "archive" and archive_owned_records:
         archive_results = _archive_owned_account_records(
             user_id=resolved_user_id,
             user_email=_normalize_email(user.get("email")),
@@ -5592,7 +5673,7 @@ def super_admin_apply_account_lifecycle(
         )
     _write_admin_action_audit(
         actor=actor,
-        action=f"super_admin.account_{_normalize(action).lower()}",
+        action=f"super_admin.account_{normalized_action}",
         target_type="user",
         target_id=resolved_user_id,
         before=preview.get("before") or {},
@@ -5610,6 +5691,801 @@ def super_admin_apply_account_lifecycle(
         "sessions_revoked": True,
         "archive_results": archive_results,
         "audit_event_created": True,
+    }
+
+
+def _all_owned_records(*, user_id: str, user_email: str = "") -> dict[str, list[dict[str, Any]]]:
+    """Resolve owned workspaces regardless of active/archive state.
+
+    Permanent account deletion must also close records that were previously
+    archived.  The ordinary lifecycle preview intentionally ignores those
+    records because they are already outside active access.
+    """
+
+    db = _db()
+    owner_candidates = _project_id_candidates(user_id)
+    normalized_email = _normalize_email(user_email)
+    ownership_filters: list[dict[str, Any]] = [{"owner_user_id": {"$in": owner_candidates}}]
+    legacy_project_filters: list[dict[str, Any]] = [
+        {"user_id": {"$in": owner_candidates}},
+        {"created_by": {"$in": owner_candidates}},
+    ]
+    if normalized_email:
+        ownership_filters.append({"owner_email": normalized_email})
+    return {
+        "projects": list(db["projects"].find({"$or": ownership_filters + legacy_project_filters})),
+        "families": list(db["families"].find({"$or": ownership_filters})),
+        "households": list(db["households"].find({"$or": ownership_filters})),
+    }
+
+
+def _active_maintenance_subscription_ids(
+    *,
+    ownership_records: dict[str, list[dict[str, Any]]],
+) -> list[str]:
+    project_candidates = _record_reference_candidates(ownership_records.get("projects") or [])
+    if not project_candidates:
+        return []
+    subscription_ids: list[str] = []
+    for entitlement in _db()["project_entitlements"].find(
+        {"project_id": {"$in": project_candidates}}
+    ):
+        subscription_id = _normalize(entitlement.get("maintenance_stripe_subscription_id"))
+        status_value = _normalize(
+            entitlement.get("maintenance_stripe_status")
+            or entitlement.get("maintenance_status")
+        ).lower()
+        if (
+            subscription_id
+            and status_value not in {"canceled", "cancelled", "ended", "inactive"}
+            and subscription_id not in subscription_ids
+        ):
+            subscription_ids.append(subscription_id)
+    return subscription_ids
+
+
+def _permanently_close_owned_account_records(
+    *,
+    user_id: str,
+    original_email: str,
+    deleted_email: str,
+    deletion_id: str,
+    reason_category: str,
+    ownership_records: dict[str, list[dict[str, Any]]],
+    actor: dict[str, Any] | None,
+    now_value: datetime,
+) -> dict[str, int]:
+    """Permanently close access records without destroying business evidence."""
+
+    db = _db()
+    owner_candidates = _project_id_candidates(user_id)
+    actor_id = _normalize((actor or {}).get("_id") or (actor or {}).get("id")) or None
+    permanent_fields = {
+        "status": "deleted",
+        "deleted_at": now_value,
+        "deleted_by": actor_id,
+        "permanent_deletion_id": deletion_id,
+        "permanent_deletion_reason_category": reason_category,
+        "access_enabled": False,
+        "permanently_closed": True,
+        "owner_email": deleted_email,
+        "updated_at": now_value,
+    }
+    results: dict[str, int] = {}
+
+    for collection_name in ("projects", "families", "households"):
+        record_candidates = _record_reference_candidates(ownership_records.get(collection_name) or [])
+        if not record_candidates:
+            results[collection_name] = 0
+            continue
+        result = db[collection_name].update_many(
+            {"_id": {"$in": record_candidates}, "status": {"$nin": ["deleted"]}},
+            {"$set": permanent_fields},
+        )
+        results[collection_name] = int(result.modified_count)
+
+    project_candidates = _record_reference_candidates(ownership_records.get("projects") or [])
+    family_candidates = _record_reference_candidates(ownership_records.get("families") or [])
+    household_candidates = _record_reference_candidates(ownership_records.get("households") or [])
+
+    entitlement_filters: list[dict[str, Any]] = [{"user_id": {"$in": owner_candidates}}]
+    if project_candidates:
+        entitlement_filters.append({"project_id": {"$in": project_candidates}})
+    entitlement_result = db["project_entitlements"].update_many(
+        {"$or": entitlement_filters, "status": {"$nin": ["deleted"]}},
+        {
+            "$set": {
+                **permanent_fields,
+                "entitlement_access_enabled": False,
+                "maintenance_status": "canceled",
+                "maintenance_stripe_status": "canceled",
+            }
+        },
+    )
+    results["project_entitlements"] = int(entitlement_result.modified_count)
+
+    membership_filters: list[dict[str, Any]] = [{"user_id": {"$in": owner_candidates}}]
+    if project_candidates:
+        membership_filters.append({"project_id": {"$in": project_candidates}})
+    membership_result = db["project_members"].update_many(
+        {"$or": membership_filters, "status": {"$nin": ["removed"]}},
+        {
+            "$set": {
+                "status": "removed",
+                "removed_at": now_value,
+                "removed_by": actor_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["project_members"] = int(membership_result.modified_count)
+
+    invite_filters: list[dict[str, Any]] = []
+    if project_candidates:
+        invite_filters.append({"project_id": {"$in": project_candidates}})
+    if family_candidates:
+        invite_filters.append({"family_id": {"$in": family_candidates}})
+    if household_candidates:
+        invite_filters.append({"household_id": {"$in": household_candidates}})
+    if invite_filters:
+        invite_result = db["household_invites"].update_many(
+            {"$or": invite_filters, "status": {"$nin": ["cancelled"]}},
+            {
+                "$set": {
+                    "status": "cancelled",
+                    "cancelled_at": now_value,
+                    "permanently_closed": True,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["household_invites"] = int(invite_result.modified_count)
+    else:
+        results["household_invites"] = 0
+
+    intake_filters: list[dict[str, Any]] = [{"user_id": {"$in": owner_candidates}}]
+    if original_email:
+        intake_filters.append({"email": original_email})
+    intake_result = db["intake_submissions"].update_many(
+        {"$or": intake_filters, "status": {"$nin": ["deleted"]}},
+        {
+            "$set": {
+                "status": "deleted",
+                "email": deleted_email,
+                "deleted_at": now_value,
+                "deleted_by": actor_id,
+                "permanently_closed": True,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["intake_submissions"] = int(intake_result.modified_count)
+
+    upload_filters: list[dict[str, Any]] = [{"uploaded_by_user_id": {"$in": owner_candidates}}]
+    if project_candidates:
+        upload_filters.append({"project_id": {"$in": project_candidates}})
+    if original_email:
+        upload_filters.append({"uploaded_by": original_email})
+    if upload_filters:
+        upload_result = db["uploaded_files"].update_many(
+            {"$or": upload_filters},
+            {
+                "$set": {
+                    "uploaded_by": deleted_email,
+                    "owner_account_deleted": True,
+                    "account_access_enabled": False,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["uploaded_files_deidentified"] = int(upload_result.modified_count)
+    else:
+        results["uploaded_files_deidentified"] = 0
+
+    vault_item_filters: list[dict[str, Any]] = [{"owner_user_id": {"$in": owner_candidates}}]
+    if project_candidates:
+        vault_item_filters.append({"project_id": {"$in": project_candidates}})
+    vault_items = list(db["vault_items"].find({"$or": vault_item_filters}))
+    vault_item_ids = _record_reference_candidates(vault_items)
+    vault_item_result = db["vault_items"].update_many(
+        {"$or": vault_item_filters},
+        {
+            "$set": {
+                "owner_account_deleted": True,
+                "access_enabled": False,
+                "retention_state": "closed_account_retention",
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["vault_items_access_closed"] = int(vault_item_result.modified_count)
+
+    grant_filters: list[dict[str, Any]] = [{"grantee_user_id": {"$in": owner_candidates}}]
+    if vault_item_ids:
+        grant_filters.append({"vault_item_id": {"$in": vault_item_ids}})
+    grant_result = db["vault_access_grants"].update_many(
+        {"$or": grant_filters, "status": {"$nin": ["revoked", "deleted"]}},
+        {"$set": {"status": "revoked", "revoked_at": now_value, "updated_at": now_value}},
+    )
+    results["vault_access_grants_revoked"] = int(grant_result.modified_count)
+
+    link_key_filters: list[dict[str, Any]] = [
+        {"user_id": {"$in": owner_candidates}},
+        {"issuer_user_id": {"$in": owner_candidates}},
+    ]
+    if original_email:
+        link_key_filters.append({"target_email": original_email})
+    if project_candidates:
+        link_key_filters.append({"project_id": {"$in": project_candidates}})
+    link_key_result = db["project_link_keys"].update_many(
+        {"$or": link_key_filters, "status": {"$nin": ["revoked", "deleted", "expired"]}},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_at": now_value,
+                "revocation_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["project_link_keys_revoked"] = int(link_key_result.modified_count)
+
+    link_request_filters: list[dict[str, Any]] = [
+        {"requested_by_user_id": {"$in": owner_candidates}},
+        {"source_handshake_user_id": {"$in": owner_candidates}},
+        {"target_handshake_user_id": {"$in": owner_candidates}},
+    ]
+    if project_candidates:
+        link_request_filters.extend(
+            [
+                {"source_project_id": {"$in": project_candidates}},
+                {"target_project_id": {"$in": project_candidates}},
+            ]
+        )
+    link_request_result = db["link_requests"].update_many(
+        {"$or": link_request_filters, "status": {"$nin": ["cancelled", "rejected", "completed", "deleted"]}},
+        {
+            "$set": {
+                "status": "cancelled",
+                "cancelled_at": now_value,
+                "cancellation_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["link_requests_cancelled"] = int(link_request_result.modified_count)
+
+    if household_candidates:
+        household_link_result = db["household_links"].update_many(
+            {
+                "$or": [
+                    {"source_household_id": {"$in": household_candidates}},
+                    {"target_household_id": {"$in": household_candidates}},
+                ],
+                "link_status": {"$nin": ["revoked", "deleted"]},
+            },
+            {
+                "$set": {
+                    "status": "revoked",
+                    "link_status": "revoked",
+                    "revoked_at": now_value,
+                    "revocation_reason": "account_permanently_deleted",
+                    "permanent_deletion_id": deletion_id,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["household_links_revoked"] = int(household_link_result.modified_count)
+    else:
+        results["household_links_revoked"] = 0
+
+    vault_collection_filters: list[dict[str, Any]] = [
+        {"owner_user_id": {"$in": owner_candidates}},
+    ]
+    if project_candidates:
+        vault_collection_filters.append({"project_id": {"$in": project_candidates}})
+    vault_collection_result = db["vault_collections"].update_many(
+        {"$or": vault_collection_filters, "status": {"$nin": ["closed", "deleted"]}},
+        {
+            "$set": {
+                "status": "closed",
+                "access_enabled": False,
+                "closed_at": now_value,
+                "closure_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["vault_collections_closed"] = int(vault_collection_result.modified_count)
+
+    vault_release_filters: list[dict[str, Any]] = [
+        {"created_by_user_id": {"$in": owner_candidates}},
+        {"trustee_user_id": {"$in": owner_candidates}},
+    ]
+    if vault_item_ids:
+        vault_release_filters.append({"vault_item_id": {"$in": vault_item_ids}})
+    vault_release_result = db["vault_release_rules"].update_many(
+        {"$or": vault_release_filters, "status": {"$nin": ["revoked", "deleted"]}},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_at": now_value,
+                "revocation_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["vault_release_rules_revoked"] = int(vault_release_result.modified_count)
+
+    organization_invite_filters: list[dict[str, Any]] = []
+    if project_candidates:
+        organization_invite_filters.append({"project_id": {"$in": project_candidates}})
+    if original_email:
+        organization_invite_filters.append({"email": original_email})
+    if organization_invite_filters:
+        organization_invite_result = db["organization_admin_invites"].update_many(
+            {"$or": organization_invite_filters, "status": {"$nin": ["cancelled", "revoked", "deleted"]}},
+            {
+                "$set": {
+                    "status": "cancelled",
+                    "cancelled_at": now_value,
+                    "cancellation_reason": "account_permanently_deleted",
+                    "permanent_deletion_id": deletion_id,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["organization_admin_invites_cancelled"] = int(organization_invite_result.modified_count)
+    else:
+        results["organization_admin_invites_cancelled"] = 0
+
+    experience_result = db["experience_sessions"].update_many(
+        {"user_id": {"$in": owner_candidates}, "status": {"$nin": ["closed", "deleted"]}},
+        {
+            "$set": {
+                "status": "closed",
+                "access_enabled": False,
+                "closed_at": now_value,
+                "closure_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["experience_sessions_closed"] = int(experience_result.modified_count)
+
+    impersonation_result = db["admin_impersonation_sessions"].update_many(
+        {
+            "impersonated_user_id": {"$in": owner_candidates},
+            "status": {"$in": ["active"]},
+        },
+        {
+            "$set": {
+                "status": "stopped",
+                "editing_enabled": False,
+                "impersonated_customer_name": "Permanently Deleted Account",
+                "impersonated_email": deleted_email,
+                "ended_at": now_value,
+                "stop_reason": "account_permanently_deleted",
+                "permanent_deletion_id": deletion_id,
+                "updated_at": now_value,
+            }
+        },
+    )
+    results["impersonation_sessions_stopped"] = int(impersonation_result.modified_count)
+
+    if project_candidates:
+        mint_job_result = db["mint_jobs"].update_many(
+            {
+                "project_id": {"$in": project_candidates},
+                "status": {"$in": ["queued", "retry_scheduled", "processing", "in_progress"]},
+            },
+            {
+                "$set": {
+                    "status": "obsolete",
+                    "finished_at": now_value,
+                    "error_code": "account_permanently_deleted",
+                    "error_message": "Mint execution stopped because the owning account was permanently deleted.",
+                    "permanent_deletion_id": deletion_id,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["mint_jobs_stopped"] = int(mint_job_result.modified_count)
+        mint_approval_result = db["mint_approvals"].update_many(
+            {
+                "project_id": {"$in": project_candidates},
+                "status": {"$in": ["pending", "approved", "in_review"]},
+            },
+            {
+                "$set": {
+                    "status": "revoked",
+                    "revoked_at": now_value,
+                    "revocation_reason": "account_permanently_deleted",
+                    "permanent_deletion_id": deletion_id,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        results["mint_approvals_revoked"] = int(mint_approval_result.modified_count)
+    else:
+        results["mint_jobs_stopped"] = 0
+        results["mint_approvals_revoked"] = 0
+
+    return results
+
+
+def super_admin_preview_account_permanent_deletion(
+    *,
+    user_id: str,
+    reason_category: str = "",
+) -> dict[str, Any]:
+    user = _user_by_id(user_id)
+    if user is None:
+        raise ValueError("User not found.")
+    normalized_reason_category = _normalize(reason_category).lower()
+    if normalized_reason_category and normalized_reason_category not in PERMANENT_DELETE_REASON_CODES:
+        raise ValueError("A supported permanent-deletion reason category is required.")
+
+    resolved_user_id = _normalize_object_id(user.get("_id")) or _normalize(user_id)
+    email = _normalize_email(user.get("email"))
+    current_status = _normalize(user.get("status")).lower() or "active"
+    ownership_records = _all_owned_records(user_id=resolved_user_id, user_email=email)
+    ownership = {name: len(records) for name, records in ownership_records.items()}
+    active_subscription_ids = _active_maintenance_subscription_ids(
+        ownership_records=ownership_records
+    )
+    is_canonical_ceo = email == str(CEO_MASTER_ADMIN_EMAIL).strip().lower()
+    existing_tombstone = _db()[ACCOUNT_DELETION_TOMBSTONES_COLLECTION].find_one({"user_id": resolved_user_id})
+    completed_tombstone = _normalize((existing_tombstone or {}).get("status")).lower() == "completed"
+    deletion_started = _normalize((existing_tombstone or {}).get("status")).lower() == "started"
+    already_deleted = (
+        current_status == "permanently_deleted"
+        or _normalize(user.get("account_type")).lower() == "deleted_tombstone"
+        or completed_tombstone
+    )
+    blocked = is_canonical_ceo or already_deleted
+    warnings: list[str] = []
+    if is_canonical_ceo:
+        warnings.append("The canonical CEO Master Administrator can never be permanently deleted through account controls.")
+    elif already_deleted:
+        warnings.append("This account has already been permanently deleted and cannot be restored or deleted again.")
+    else:
+        warnings.extend(
+            [
+                "Permanent deletion cannot be undone or restored.",
+                "Required orders, billing, corporate ownership, security evidence, issued certificates, and audit records remain preserved.",
+            ]
+        )
+        if deletion_started:
+            warnings.append("MongoDB contains evidence of an earlier incomplete deletion attempt; a new governed execution will resume and finalize it.")
+        if active_subscription_ids:
+            warnings.append(
+                f"{len(active_subscription_ids)} active Stripe maintenance subscription(s) will be cancelled immediately before identity deletion."
+            )
+
+    return {
+        "user_id": resolved_user_id,
+        "action": "account_permanent_delete",
+        "target_account": {
+            "user_id": resolved_user_id,
+            "email": email,
+            "full_name": _user_display_name(user),
+        },
+        "before": {
+            "status": current_status,
+            "login_enabled": bool(user.get("login_enabled", current_status == "active")),
+            "session_token_version": int(user.get("session_token_version") or 0),
+        },
+        "proposed_after": {
+            "status": "permanently_deleted",
+            "login_enabled": False,
+            "restorable": False,
+            "personal_profile_erased": True,
+            "owned_workspace_access_permanently_closed": True,
+        },
+        "reason_category": normalized_reason_category or None,
+        "ownership_dependencies": ownership,
+        "external_service_impact": {
+            "stripe_subscriptions_cancelled_immediately": len(active_subscription_ids),
+        },
+        "records_erased_or_deidentified": [
+            "authentication_credentials",
+            "mfa_secrets",
+            "password_reset_tokens",
+            "personal_profile_fields",
+            "role_assignments",
+            "permission_overrides",
+        ],
+        "records_permanently_closed": [
+            "projects",
+            "families",
+            "households",
+            "entitlements",
+            "memberships",
+            "invites",
+            "intake_access",
+            "vault_access",
+        ],
+        "records_preserved": [
+            "orders",
+            "billing_history",
+            "corporate_ownership_records",
+            "issued_certificates",
+            "delivery_records",
+            "security_evidence",
+            "audit_logs",
+            "continuity_evidence",
+        ],
+        "blocked": blocked,
+        "warnings": warnings,
+        "confirmation_phrase": PERMANENT_DELETE_CONFIRMATION_PHRASE,
+        "irreversible": True,
+    }
+
+
+def super_admin_apply_account_permanent_deletion(
+    *,
+    user_id: str,
+    reason_category: str,
+    reason: str,
+    confirmation_email: str,
+    initial_confirmation: bool,
+    final_confirmation: str,
+    final_acknowledgement: bool,
+    continuity_operation_id: str = "",
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if _normalize_email((actor or {}).get("email")) != str(CEO_MASTER_ADMIN_EMAIL).strip().lower():
+        raise PermissionError("Permanent account deletion is restricted to the canonical CEO Master Administrator.")
+    normalized_reason = _normalize(reason)
+    if len(normalized_reason) < 3:
+        raise ValueError("A permanent-deletion reason of at least 3 characters is required.")
+    normalized_reason_category = _normalize(reason_category).lower()
+    if normalized_reason_category not in PERMANENT_DELETE_REASON_CODES:
+        raise ValueError("A supported permanent-deletion reason category is required.")
+    if initial_confirmation is not True:
+        raise ValueError("Confirm that the correct target account and irreversible access impact were reviewed.")
+    if _normalize(final_confirmation) != PERMANENT_DELETE_CONFIRMATION_PHRASE:
+        raise ValueError(f'Type "{PERMANENT_DELETE_CONFIRMATION_PHRASE}" to authorize permanent deletion.')
+    if final_acknowledgement is not True:
+        raise ValueError("The final permanent-closure acknowledgement is required.")
+
+    user = _user_by_id(user_id)
+    if user is None:
+        raise ValueError("User not found.")
+    original_email = _normalize_email(user.get("email"))
+    if not original_email or "@" not in original_email:
+        raise ValueError("Permanent deletion requires a valid target account email for confirmation.")
+    if _normalize_email(confirmation_email) != original_email:
+        raise ValueError("The confirmation email does not match the account being permanently deleted.")
+
+    preview = super_admin_preview_account_permanent_deletion(
+        user_id=user_id,
+        reason_category=normalized_reason_category,
+    )
+    if preview.get("blocked"):
+        raise ValueError("Permanent account deletion is blocked for this identity.")
+
+    resolved_user_id = _normalize(preview.get("user_id"))
+    now_value = _now()
+    actor_id = _normalize((actor or {}).get("_id") or (actor or {}).get("id")) or None
+    deletion_id = f"acctdel_{secrets.token_hex(16)}"
+    deleted_email = f"deleted-{resolved_user_id}@deleted.tomboflight.invalid"
+    email_sha256 = hashlib.sha256(original_email.encode("utf-8")).hexdigest()
+    ownership_records = _all_owned_records(user_id=resolved_user_id, user_email=original_email)
+    active_subscription_ids = _active_maintenance_subscription_ids(
+        ownership_records=ownership_records
+    )
+
+    subscription_results: list[dict[str, Any]] = []
+    for subscription_id in active_subscription_ids:
+        subscription_results.append(
+            stripe_admin_operations_service.cancel_subscription(
+                actor or {},
+                subscription_id=subscription_id,
+                at_period_end=False,
+                confirm=True,
+                reason=f"Permanent account deletion: {normalized_reason}",
+                idempotency_key=_normalize(continuity_operation_id) or deletion_id,
+            )
+        )
+
+    updates: dict[str, Any] = {
+        "email": deleted_email,
+        "full_name": "Permanently Deleted Account",
+        "name": None,
+        "display_name": None,
+        "first_name": None,
+        "last_name": None,
+        "given_name": None,
+        "family_name": None,
+        "phone_number": None,
+        "phone": None,
+        "birthday": None,
+        "birth_date": None,
+        "date_of_birth": None,
+        "dob": None,
+        "mailing_address": None,
+        "address": None,
+        "business_title": None,
+        "prototype_key": None,
+        "creator_credit": None,
+        "password_hash": None,
+        "password_updated_at": None,
+        "password_reset_token_hash": None,
+        "password_reset_expires_at": None,
+        "password_reset_requested_at": None,
+        "password_reset_requested_via": None,
+        "password_reset_requested_by": None,
+        "password_reset_requested_by_user_id": None,
+        "password_reset_used_at": None,
+        "mfa_enabled": False,
+        "mfa_secret_encrypted": None,
+        "mfa_backup_code_hashes": [],
+        "mfa_enrolled_at": None,
+        "mfa_last_verified_at": None,
+        "mfa_pending_secret_encrypted": None,
+        "mfa_pending_started_at": None,
+        "last_login_at": None,
+        "stripe_customer_id": None,
+        "role": "deleted_account",
+        "account_type": "deleted_tombstone",
+        "access_tier": None,
+        "department_role": None,
+        "role_codes": [],
+        "capabilities": [],
+        "permissions": [],
+        "admin_roles": [],
+        "officer_roles": [],
+        "admin_permissions": [],
+        "is_admin": False,
+        "dashboard_type": "deleted",
+        "allowed_rails": [],
+        "active_project_id": None,
+        "active_family_id": None,
+        "status": "permanently_deleted",
+        "login_enabled": False,
+        "restorable": False,
+        "personal_profile_erased": True,
+        "permanent_deletion_id": deletion_id,
+        "permanently_deleted_at": now_value,
+        "permanently_deleted_by": actor_id,
+        "permanent_deletion_reason_category": normalized_reason_category,
+        "session_token_version": int(user.get("session_token_version") or 0) + 1,
+        "updated_at": now_value,
+    }
+    db = _db()
+    tombstone_collection = db[ACCOUNT_DELETION_TOMBSTONES_COLLECTION]
+    tombstone_collection.update_one(
+        {"user_id": resolved_user_id},
+        {
+            "$set": {
+                "deletion_id": deletion_id,
+                "continuity_operation_id": _normalize(continuity_operation_id) or None,
+                "original_email_sha256": email_sha256,
+                "status": "started",
+                "irreversible": True,
+                "restorable": False,
+                "reason_category": normalized_reason_category,
+                "reason_sha256": hashlib.sha256(normalized_reason.encode("utf-8")).hexdigest(),
+                "requested_by": _actor_snapshot(actor),
+                "records_preserved": list(preview.get("records_preserved") or []),
+                "started_at": now_value,
+                "updated_at": now_value,
+            },
+            "$setOnInsert": {"created_at": now_value},
+        },
+        upsert=True,
+    )
+
+    role_result = db["user_role_assignments"].update_many(
+        {"user_id": {"$in": _project_id_candidates(resolved_user_id)}, "status": {"$nin": ["revoked", "deleted"]}},
+        {"$set": {"status": "revoked", "revoked_at": now_value, "updated_at": now_value}},
+    )
+    permission_result = db["user_permission_overrides"].update_many(
+        {"user_id": {"$in": _project_id_candidates(resolved_user_id)}, "status": {"$nin": ["revoked", "deleted"]}},
+        {"$set": {"status": "revoked", "revoked_at": now_value, "updated_at": now_value}},
+    )
+    closure_results = _permanently_close_owned_account_records(
+        user_id=resolved_user_id,
+        original_email=original_email,
+        deleted_email=deleted_email,
+        deletion_id=deletion_id,
+        reason_category=normalized_reason_category,
+        ownership_records=ownership_records,
+        actor=actor,
+        now_value=now_value,
+    )
+    closure_results["user_role_assignments"] = int(role_result.modified_count)
+    closure_results["user_permission_overrides"] = int(permission_result.modified_count)
+    closure_results["stripe_subscriptions_cancelled"] = len(subscription_results)
+
+    # Destroy the authentication identity only after linked access records are
+    # closed.  The exact original email in this compare-and-set prevents a
+    # concurrent profile edit from redirecting the irreversible operation.
+    oid = _to_object_id(resolved_user_id)
+    update_result = db["users"].update_one(
+        {
+            "_id": oid or resolved_user_id,
+            "email": original_email,
+            "status": {"$nin": ["permanently_deleted"]},
+        },
+        {"$set": updates},
+    )
+    if int(getattr(update_result, "matched_count", 0)) != 1:
+        raise RuntimeError("The target account changed before permanent deletion could be applied.")
+
+    tombstone_result = tombstone_collection.update_one(
+        {"user_id": resolved_user_id, "deletion_id": deletion_id},
+        {
+            "$set": {
+                "status": "completed",
+                "records_closed": closure_results,
+                "completed_at": now_value,
+                "updated_at": now_value,
+            }
+        },
+    )
+    if int(getattr(tombstone_result, "matched_count", 0)) != 1:
+        raise RuntimeError("Permanent deletion completed, but its MongoDB tombstone could not be finalized.")
+
+    refreshed = _user_by_id(resolved_user_id) or {}
+    if _normalize(refreshed.get("status")).lower() != "permanently_deleted" or bool(refreshed.get("login_enabled", True)):
+        raise RuntimeError("Permanent deletion verification failed after the MongoDB write.")
+
+    _write_admin_action_audit(
+        actor=actor,
+        action="super_admin.account_permanently_deleted",
+        target_type="user",
+        target_id=resolved_user_id,
+        before=preview.get("before") or {},
+        after={
+            "status": "permanently_deleted",
+            "login_enabled": False,
+            "restorable": False,
+            "personal_profile_erased": True,
+        },
+        context={
+            "surface": "admin_control_center.permanent_deletion",
+            "deletion_id": deletion_id,
+            "reason_category": normalized_reason_category,
+            "records_closed": closure_results,
+            "records_preserved": list(preview.get("records_preserved") or []),
+        },
+    )
+    return {
+        **preview,
+        "applied": True,
+        "permanent": True,
+        "restorable": False,
+        "sessions_revoked": True,
+        "audit_event_created": True,
+        "failure_count": 0,
+        "deletion_receipt": {
+            "deletion_id": deletion_id,
+            "continuity_operation_id": _normalize(continuity_operation_id) or None,
+            "user_id": resolved_user_id,
+            "status": "permanently_deleted",
+            "deleted_at": _serialize_datetime(now_value),
+            "deleted_by": actor_id,
+            "reason_category": normalized_reason_category,
+            "personal_profile_erased": True,
+            "login_enabled": False,
+            "restorable": False,
+            "records_closed": closure_results,
+            "records_preserved": list(preview.get("records_preserved") or []),
+            "mongo_evidence": {
+                "tombstone_collection": ACCOUNT_DELETION_TOMBSTONES_COLLECTION,
+                "audit_collection": "audit_logs",
+                "continuity_operation_collection": "continuity_operations",
+                "continuity_event_collection": "continuity_events",
+            },
+        },
     }
 
 
@@ -6751,6 +7627,8 @@ def list_customer_cases(
 
     cases: list[dict[str, Any]] = []
     for project in db["projects"].find({}).sort("updated_at", -1).limit(max(400, safe_limit * 10)):
+        if _normalize(project.get("status")).lower() == "deleted" and normalized_queue != "audit":
+            continue
         project_id = _normalize(project.get("_id") or project.get("id"))
         order = _latest_linked_order(project_id) or _latest_user_order_for_project(project)
         if not _project_supports_search(

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -744,6 +744,25 @@ def request_password_reset(
             )
         return generic_response
 
+    account_status = _normalize_text(user.get("status")).lower()
+    account_type = _normalize_text(user.get("account_type")).lower()
+    if account_status not in {"", "active"} or account_type == "deleted_tombstone":
+        # Do not create a credential-recovery path for suspended, archived, or
+        # permanently deleted identities. Self-service callers still receive
+        # the generic response so account state cannot be enumerated.
+        if include_delivery_status:
+            generic_response.update(
+                {
+                    "success": False,
+                    "reset_persisted": False,
+                    "delivery_sent": False,
+                    "delivery_provider": "postmark",
+                    "delivery_error": "account_not_active",
+                    "failure_count": 1,
+                }
+            )
+        return generic_response
+
     now_iso = _now_iso()
     expires_at = _password_reset_expiry_iso()
     token = secrets.token_urlsafe(32)
@@ -962,6 +981,11 @@ def admin_issue_password_reset(
     user = get_user_by_id(user_id)
     if user is None:
         raise ValueError("User account not found.")
+    if (
+        _normalize_text(user.get("status")).lower() == "permanently_deleted"
+        or _normalize_text(user.get("account_type")).lower() == "deleted_tombstone"
+    ):
+        raise ValueError("A permanently deleted account cannot receive a password reset.")
 
     response = request_password_reset(
         _normalize_text(user.get("email")).lower(),

--- a/backend/app/services/continuity_runtime_service.py
+++ b/backend/app/services/continuity_runtime_service.py
@@ -39,7 +39,7 @@ from app.services.auth_service import admin_issue_password_reset
 from app.services.audit_log_service import write_audit_log
 
 
-RUNTIME_VERSION = "9.0.0"
+RUNTIME_VERSION = "10.1.0"
 OPERATIONS_COLLECTION = "continuity_operations"
 EVENTS_COLLECTION = "continuity_events"
 EXECUTION_KILL_SWITCH = "CONTINUITY_EXECUTION_KILL_SWITCH"
@@ -94,6 +94,7 @@ SUPER_ADMIN_ACTION_SPECS: dict[str, ActionSpec] = {
     "service_controls": ActionSpec("admin_repair_safety", "high", "project", ("project_id",)),
     "officer_permissions": ActionSpec("admin_repair_safety", "high", "officer", ("officer_email",)),
     "account_lifecycle": ActionSpec("admin_repair_safety", "high", "user", ("user_id",)),
+    "account_permanent_delete": ActionSpec("admin_repair_safety", "high", "user", ("user_id",)),
     "case_repair": ActionSpec("admin_repair_safety", "high", "customer_case", ("case_id",)),
 }
 
@@ -188,6 +189,11 @@ def ensure_continuity_runtime_indexes() -> None:
     events.create_index([("operation_id", ASCENDING), ("created_at", ASCENDING)], name="continuity_operation_events")
     events.create_index([("target_id", ASCENDING), ("created_at", DESCENDING)], name="continuity_target_events")
 
+    tombstones = get_database()[admin_control_service.ACCOUNT_DELETION_TOMBSTONES_COLLECTION]
+    tombstones.create_index([("deletion_id", ASCENDING)], unique=True, name="account_deletion_id_unique")
+    tombstones.create_index([("user_id", ASCENDING)], unique=True, name="account_deletion_user_unique")
+    tombstones.create_index([("original_email_sha256", ASCENDING)], name="account_deletion_email_hash")
+
 
 def _actor_id(actor: dict[str, Any] | None) -> str:
     actor = actor or {}
@@ -277,11 +283,29 @@ def _assert_action_allowed_for_actor(spec: ActionSpec, actor: dict[str, Any] | N
     return role
 
 
+def _assert_action_actor_scope(action: str, actor: dict[str, Any] | None) -> None:
+    if _normalize(action) != "account_permanent_delete":
+        return
+    if _actor_email(actor) != str(CEO_MASTER_ADMIN_EMAIL).strip().lower():
+        raise PermissionError("Permanent account deletion is restricted to the canonical CEO Master Administrator.")
+
+
 def _require_text(value: Any, field: str, *, minimum: int = 1) -> str:
     normalized = _normalize(value)
     if len(normalized) < minimum:
         raise ValueError(f"{field} is required and must contain at least {minimum} characters.")
     return normalized
+
+
+def _require_permanent_deletion_confirmations(parameters: dict[str, Any]) -> None:
+    if parameters.get("initial_confirmation") is not True:
+        raise ValueError("The target-account permanent-deletion confirmation is required.")
+    if _normalize(parameters.get("final_confirmation")) != admin_control_service.PERMANENT_DELETE_CONFIRMATION_PHRASE:
+        raise ValueError(
+            f'Type "{admin_control_service.PERMANENT_DELETE_CONFIRMATION_PHRASE}" to authorize permanent deletion.'
+        )
+    if parameters.get("final_acknowledgement") is not True:
+        raise ValueError("The final permanent-closure acknowledgement is required.")
 
 
 def _target_id(spec: ActionSpec, action: str, target: dict[str, Any]) -> str:
@@ -642,6 +666,11 @@ def _preview_action(action: str, target: dict[str, Any], parameters: dict[str, A
             action=_normalize(parameters.get("lifecycle_action")),
             archive_owned_records=bool(parameters.get("archive_owned_records")),
         )
+    if action == "account_permanent_delete":
+        return admin_control_service.super_admin_preview_account_permanent_deletion(
+            user_id=_normalize(target.get("user_id")),
+            reason_category=_normalize(parameters.get("reason_category")),
+        )
     if action == "customer_account_create":
         return admin_control_service.super_admin_preview_customer_create(
             payload=dict(parameters.get("user_payload") or parameters)
@@ -806,6 +835,7 @@ def request_operation(
         raise PermissionError("Authenticated actor id is required.")
     if not actor_snapshot["actor_role"]:
         raise PermissionError("Authenticated actor role is not recognized.")
+    _assert_action_actor_scope(normalized_action, actor)
 
     reason_value = _require_text(reason, "reason", minimum=3)
     idempotency_value = _require_text(idempotency_key, "idempotency_key", minimum=8)
@@ -820,6 +850,8 @@ def request_operation(
             "continuity_idempotency_key": idempotency_value,
         }
     )
+    if normalized_action == "account_permanent_delete":
+        _require_permanent_deletion_confirmations(clean_parameters)
 
     existing = _operations_collection().find_one({"idempotency_key": idempotency_value})
     if existing is not None:
@@ -839,6 +871,20 @@ def request_operation(
     operation_id = f"ckop_{uuid4().hex}"
     now = _now()
     target_id = _normalize(clean_target.get("target_id"))
+    rollback_plan = {
+        "strategy": "restore_from_before_snapshot",
+        "before_snapshot_ref": f"operation:{operation_id}:before_snapshot",
+        "automatic": False,
+        "requires_explicit_rollback_authorization": True,
+    }
+    if normalized_action == "account_permanent_delete":
+        rollback_plan = {
+            "strategy": "irreversible_identity_erasure",
+            "before_snapshot_ref": f"operation:{operation_id}:before_snapshot",
+            "automatic": False,
+            "restoration_prohibited": True,
+            "evidence_only": True,
+        }
     operation = {
         "operation_id": operation_id,
         "evidence_packet_id": f"ckevidence_{uuid4().hex}",
@@ -859,12 +905,7 @@ def request_operation(
         "executed_by": None,
         "before_snapshot": _serialize(before_snapshot),
         "proposed_after_snapshot": _serialize(proposed_after_snapshot),
-        "rollback_plan": {
-            "strategy": "restore_from_before_snapshot",
-            "before_snapshot_ref": f"operation:{operation_id}:before_snapshot",
-            "automatic": False,
-            "requires_explicit_rollback_authorization": True,
-        },
+        "rollback_plan": rollback_plan,
         "blocked_reasons": blocked_reasons,
         "transitions": [
             {
@@ -946,7 +987,9 @@ def approve_operation(
             + ", ".join(str(reason) for reason in operation.get("blocked_reasons") or [])
         )
 
-    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    action = _normalize(operation.get("action"))
+    _assert_action_actor_scope(action, actor)
+    spec = ACTION_SPECS[action]
     role = _assert_action_allowed_for_actor(spec, actor)
     reason_value = _require_text(approval_reason, "approval_reason", minimum=3)
     requester_id = _normalize((operation.get("requested_by") or {}).get("actor_user_id"))
@@ -993,7 +1036,9 @@ def reject_operation(operation_id: str, *, rejection_reason: str, actor: dict[st
         return _serialize_operation(operation) or {}
     if operation.get("state") not in {"review_requested", "officer_reviewing"}:
         raise ValueError("Only an operation under review can be rejected.")
-    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    action = _normalize(operation.get("action"))
+    _assert_action_actor_scope(action, actor)
+    spec = ACTION_SPECS[action]
     _assert_action_allowed_for_actor(spec, actor)
     reason = _require_text(rejection_reason, "rejection_reason", minimum=3)
     expected = _normalize(operation.get("state"))
@@ -1092,14 +1137,23 @@ def _scheduled_transition(operation: dict[str, Any], actor: dict[str, Any]) -> d
 
 def _rollback_verification(operation: dict[str, Any]) -> dict[str, Any]:
     rollback_plan = dict(operation.get("rollback_plan") or {})
+    irreversible = _normalize(operation.get("action")) == "account_permanent_delete"
     return {
         "evidence_packet_id": operation.get("evidence_packet_id"),
         "rollback_plan": rollback_plan,
         "before_snapshot_ref": rollback_plan.get("before_snapshot_ref"),
         "target_type": operation.get("target_type"),
         "target_id": operation.get("target_id"),
-        "verification_status": "before_snapshot_reference_verified",
-        "reason_codes": ["BEFORE_SNAPSHOT_CAPTURED", "MANUAL_ROLLBACK_AUTHORIZATION_REQUIRED"],
+        "verification_status": (
+            "irreversible_evidence_reference_verified"
+            if irreversible
+            else "before_snapshot_reference_verified"
+        ),
+        "reason_codes": (
+            ["BEFORE_SNAPSHOT_CAPTURED", "IRREVERSIBLE_ACTION_EVIDENCE_ONLY"]
+            if irreversible
+            else ["BEFORE_SNAPSHOT_CAPTURED", "MANUAL_ROLLBACK_AUTHORIZATION_REQUIRED"]
+        ),
         "verified_at": _now_iso(),
         "audit_context": _operation_audit_context(operation),
     }
@@ -1368,6 +1422,18 @@ def _invoke_action(
             archive_owned_records=bool(parameters.get("archive_owned_records")),
             actor=actor,
         )
+    if action == "account_permanent_delete":
+        return admin_control_service.super_admin_apply_account_permanent_deletion(
+            user_id=_normalize(target.get("user_id")),
+            reason_category=_normalize(parameters.get("reason_category")),
+            reason=reason,
+            confirmation_email=_normalize(parameters.get("confirmation_email")),
+            initial_confirmation=parameters.get("initial_confirmation") is True,
+            final_confirmation=_normalize(parameters.get("final_confirmation")),
+            final_acknowledgement=parameters.get("final_acknowledgement") is True,
+            continuity_operation_id=_normalize(parameters.get("continuity_operation_id")),
+            actor=actor,
+        )
     if action == "case_repair":
         payload = dict(parameters.get("repair_payload") or parameters)
         payload["reason"] = reason
@@ -1389,7 +1455,9 @@ def execute_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dic
     if operation.get("state") != "approved_for_apply":
         raise ValueError("Operation must be approved_for_apply before execution.")
 
-    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    action = _normalize(operation.get("action"))
+    _assert_action_actor_scope(action, actor)
+    spec = ACTION_SPECS[action]
     _assert_action_allowed_for_actor(spec, actor)
     packet = _evidence_packet(operation, actor or {})
     authorization = _authorization_decision(operation)
@@ -1440,10 +1508,12 @@ def execute_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dic
     )
 
     try:
+        execution_parameters = dict(operation.get("parameters") or {})
+        execution_parameters["continuity_operation_id"] = operation_id
         execution_result = _invoke_action(
             _normalize(operation.get("action")),
             dict(operation.get("target") or {}),
-            dict(operation.get("parameters") or {}),
+            execution_parameters,
             actor,
         )
         after_snapshot = _snapshot_for_action(
@@ -1517,7 +1587,9 @@ def close_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dict[
         raise ValueError("Partial-failure operations require remediation before audit closure.")
     if operation.get("evidence_recording_status") != "complete":
         raise ValueError("Execution evidence must be complete before audit closure.")
-    spec = ACTION_SPECS[_normalize(operation.get("action"))]
+    action = _normalize(operation.get("action"))
+    _assert_action_actor_scope(action, actor)
+    spec = ACTION_SPECS[action]
     _assert_action_allowed_for_actor(spec, actor)
     expected = _normalize(operation.get("state"))
     operation = _transition(

--- a/backend/app/services/vault_service.py
+++ b/backend/app/services/vault_service.py
@@ -123,8 +123,11 @@ def _has_grant(
     }
     if roles:
         query["permission_role"] = {"$in": roles}
-    grant = _col("vault_access_grants").find_one(query)
-    return bool(grant)
+    grants = _col("vault_access_grants").find(query)
+    return any(
+        _normalize(grant.get("status")).lower() not in {"revoked", "deleted"}
+        for grant in grants
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -299,7 +302,11 @@ def list_vault_items(
     owned_items = list(col.find(owned_query))
 
     owned_ids = {_str_id(doc.get("_id")) for doc in owned_items}
-    grants = list(_col("vault_access_grants").find({"grantee_user_id": requesting_user_id}))
+    grants = [
+        grant
+        for grant in _col("vault_access_grants").find({"grantee_user_id": requesting_user_id})
+        if _normalize(grant.get("status")).lower() not in {"revoked", "deleted"}
+    ]
     granted_item_ids = [_normalize(g.get("vault_item_id")) for g in grants if _normalize(g.get("vault_item_id"))]
 
     granted_items: list[dict[str, Any]] = []
@@ -544,12 +551,15 @@ def list_vault_audit_events(
     canonical_item_id = _str_id(item.get("_id"))
     owner = _normalize(item.get("owner_user_id"))
     if owner != _normalize(requesting_user_id):
-        grant = _col("vault_access_grants").find_one({
+        grants = _col("vault_access_grants").find({
             "vault_item_id": canonical_item_id,
             "grantee_user_id": requesting_user_id,
             "permission_role": "executor",
         })
-        if not grant:
+        if not any(
+            _normalize(grant.get("status")).lower() not in {"revoked", "deleted"}
+            for grant in grants
+        ):
             raise PermissionError("Only the owner or executor can view audit events.")
 
     col = _col("vault_audit_events")

--- a/backend/docs/governance/continuity_kernel_phase10_1_permanent_account_deletion.md
+++ b/backend/docs/governance/continuity_kernel_phase10_1_permanent_account_deletion.md
@@ -1,0 +1,51 @@
+# Continuity Kernel 10.1 — Account Closure and Permanent Deletion
+
+Runtime: `10.1.0`
+
+## Decision
+
+Tomb of Light uses three visibly separate account lifecycle controls:
+
+1. **Billing Hold** sets the account to `suspended`, disables login, records the billing-hold reason, revokes active sessions, and remains recoverable with **Restore Access**.
+2. **Archive** disables login and archives account/workspace access while retaining a recoverable record. It is appropriate when access may be reopened.
+3. **Permanent Delete** is an irreversible CEO-only Continuity Kernel operation. It destroys the authentication identity and personal account profile, revokes roles, permissions, memberships, entitlements, invitations, and vault grants, permanently closes owned workspace access, and cannot be restored.
+
+If an owned workspace still has an active Stripe maintenance subscription, permanent deletion cancels it immediately before MongoDB identity destruction. If Stripe cancellation fails, the Kernel fails closed and does not issue a deletion-success receipt.
+
+Permanent deletion is not presented as a way to erase required business evidence. Paid orders, billing history, corporate ownership records, issued certificates, delivery records, security evidence, and audit history remain under their applicable retention requirements. A separate data-retention or privacy-erasure process may dispose of retained content when no legal, security, ownership, or contractual reason remains.
+
+## Required confirmation sequence
+
+Permanent deletion fails closed unless all of the following are present:
+
+- canonical CEO Master Administrator authorization;
+- an allowed reason category: verified customer request, policy violation, security incident, or CEO-authorized company decision;
+- an operational reason;
+- the exact target account email;
+- the first confirmation checkbox, enforced again by the backend;
+- a separate final-warning dialog stating that the account will be permanently closed;
+- the exact phrase `PERMANENTLY DELETE`;
+- the final irreversible-action checkbox, enforced again by the backend.
+
+The canonical CEO Master Administrator identity is protected from routine lifecycle controls and permanent deletion.
+
+## MongoDB execution evidence
+
+The operation is registered as `account_permanent_delete` and runs only through the persisted Continuity Kernel state machine. Evidence is stored in:
+
+- `continuity_operations` — request, approval, state transitions, before/after snapshots, execution result, and evidence status;
+- `continuity_events` — immutable-style operational event sequence;
+- `account_deletion_tombstones` — deletion ID, Continuity operation ID, target user ID, SHA-256 of the former email, reason category, actor, affected-record counts, preserved-record categories, and completion state;
+- `audit_logs` — accountable administrative and Continuity audit entries.
+
+The raw former email is not stored in the deletion tombstone. The surviving user row becomes a non-login referential tombstone with a non-routable placeholder email. This preserves database references without preserving usable credentials or a restorable account.
+
+Password-reset issuance is blocked for inactive and permanently deleted identities. Active impersonation and experience sessions are closed; project share/link keys, pending link requests, vault grants, and active mint work are revoked or stopped.
+
+The CEO overview excludes these tombstones from **Total Users** and reports them separately as **Permanent Deletions**. The Users queue can locate a tombstone by user ID or deletion ID, recent completed deletion receipts can be reopened from Governed Operations, and the complete evidence history remains in MongoDB.
+
+## Failure posture
+
+The deletion tombstone is written with `status=started` before linked access is closed. Authentication identity destruction happens last and uses an exact-email compare-and-set. The tombstone is then finalized with `status=completed` and record counts. If execution is interrupted, the incomplete tombstone and failed Continuity operation remain visible for governed remediation.
+
+No permanent-deletion success receipt is shown unless the Kernel reports both `execution_outcome=success` and `evidence_recording_status=complete`.

--- a/backend/tests/contracts/test_continuity_kernel_phase10_1_permanent_account_deletion.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase10_1_permanent_account_deletion.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HTML_PATH = REPO_ROOT / "admin-control-center.html"
+JS_PATH = REPO_ROOT / "admin-control-center.js"
+SERVICE_PATH = REPO_ROOT / "backend" / "app" / "services" / "admin_control_service.py"
+RUNTIME_PATH = REPO_ROOT / "backend" / "app" / "services" / "continuity_runtime_service.py"
+VALIDATOR_PATH = REPO_ROOT / "backend" / "app" / "core" / "continuity_kernel_validator.py"
+DOC_PATH = REPO_ROOT / "backend" / "docs" / "governance" / "continuity_kernel_phase10_1_permanent_account_deletion.md"
+
+
+class TestContinuityKernelPhase101PermanentAccountDeletion(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = HTML_PATH.read_text(encoding="utf-8")
+        cls.javascript = JS_PATH.read_text(encoding="utf-8")
+        cls.service = SERVICE_PATH.read_text(encoding="utf-8")
+        cls.runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+        cls.validator = VALIDATOR_PATH.read_text(encoding="utf-8")
+        cls.doc = DOC_PATH.read_text(encoding="utf-8")
+
+    def test_01_recoverable_and_irreversible_controls_are_separate(self) -> None:
+        self.assertIn('data-super-admin-user-action="billing_hold"', self.javascript)
+        self.assertIn("Place on Billing Hold", self.javascript)
+        self.assertIn("Recoverable archive", self.javascript)
+        self.assertIn("data-super-admin-permanent-delete", self.javascript)
+        self.assertIn("Permanent deletion", self.javascript)
+
+    def test_02_permanent_deletion_has_a_separate_final_warning(self) -> None:
+        for marker in (
+            "data-admin-permanent-delete-dialog",
+            "data-admin-permanent-delete-final-dialog",
+            "This account will be permanently closed",
+            "Type PERMANENTLY DELETE",
+            "data-admin-permanent-delete-final-confirm",
+            "Permanently Delete Account",
+        ):
+            self.assertIn(marker, self.html)
+
+    def test_03_both_confirmations_are_enforced_by_backend_execution(self) -> None:
+        self.assertIn('PERMANENT_DELETE_CONFIRMATION_PHRASE = "PERMANENTLY DELETE"', self.service)
+        self.assertIn("confirmation_email", self.service)
+        self.assertIn("initial_confirmation", self.service)
+        self.assertIn("final_confirmation", self.service)
+        self.assertIn("final_acknowledgement", self.service)
+        self.assertIn("The confirmation email does not match", self.service)
+        self.assertIn("Permanent account deletion is blocked for this identity", self.service)
+
+    def test_04_kernel_registers_irreversible_execution_and_evidence_only_rollback(self) -> None:
+        self.assertIn('RUNTIME_VERSION = "10.1.0"', self.runtime)
+        self.assertIn('"account_permanent_delete": ActionSpec(', self.runtime)
+        self.assertIn('"strategy": "irreversible_identity_erasure"', self.runtime)
+        self.assertIn('"restoration_prohibited": True', self.runtime)
+        self.assertIn('"evidence_only": True', self.runtime)
+        self.assertIn("super_admin_apply_account_permanent_deletion", self.runtime)
+        self.assertIn("Permanent account deletion is restricted to the canonical CEO Master Administrator", self.runtime)
+
+    def test_05_mongodb_receipt_and_tombstone_are_first_class_records(self) -> None:
+        for marker in (
+            'ACCOUNT_DELETION_TOMBSTONES_COLLECTION = "account_deletion_tombstones"',
+            '"continuity_operation_id"',
+            '"original_email_sha256"',
+            '"status": "started"',
+            '"status": "completed"',
+            '"records_closed"',
+            '"mongo_evidence"',
+            '"continuity_operations"',
+            '"continuity_events"',
+        ):
+            self.assertIn(marker, self.service + self.runtime)
+        self.assertIn("data-admin-kernel-view-deletion-receipt", self.javascript)
+
+    def test_06_login_identity_is_destroyed_but_required_evidence_is_preserved(self) -> None:
+        for marker in (
+            '"password_hash": None',
+            '"mfa_secret_encrypted": None',
+            '"stripe_customer_id": None',
+            '"status": "permanently_deleted"',
+            '"login_enabled": False',
+            '"restorable": False',
+            '"orders"',
+            '"billing_history"',
+            '"corporate_ownership_records"',
+            '"audit_logs"',
+            '"project_link_keys"',
+            '"admin_impersonation_sessions"',
+            "stripe_admin_operations_service.cancel_subscription",
+        ):
+            self.assertIn(marker, self.service)
+
+    def test_07_validator_exception_is_narrowly_scoped_to_structured_deletion(self) -> None:
+        self.assertIn("_is_governed_permanent_account_deletion", self.validator)
+        self.assertIn('"PROHIBITED_DELETE_CUSTOMER_RECORD"', self.validator)
+        self.assertIn('== "account_permanent_delete"', self.validator)
+        self.assertIn('proposed_after.get("restorable") is False', self.validator)
+
+    def test_08_governance_document_explains_retention_and_interrupted_execution(self) -> None:
+        for phrase in (
+            "billing hold",
+            "permanent delete",
+            "corporate ownership records",
+            "raw former email is not stored",
+            "status=started",
+            "status=completed",
+            "no permanent-deletion success receipt",
+        ):
+            self.assertIn(phrase, self.doc.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
@@ -22,10 +22,10 @@ class TestContinuityKernelPhase10CommandCenter(unittest.TestCase):
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     def test_01_control_center_assets_use_phase10_revision(self) -> None:
-        self.assertIn("styles.css?v=20260821-phase10", self.html)
-        self.assertIn("app.js?v=20260821-phase10", self.html)
-        self.assertIn("admin-control-center.js?v=20260821-phase10", self.html)
-        self.assertIn('FRONTEND_ASSET_REVISION = "20260821-phase10"', self.service)
+        self.assertIn("styles.css?v=20260821-phase10-1", self.html)
+        self.assertIn("app.js?v=20260821-phase10-1", self.html)
+        self.assertIn("admin-control-center.js?v=20260821-phase10-1", self.html)
+        self.assertIn('FRONTEND_ASSET_REVISION = "20260821-phase10-1"', self.service)
 
     def test_02_account_creation_and_closure_are_visible_previewed_workflows(self) -> None:
         for marker in (

--- a/backend/tests/contracts/test_continuity_kernel_phase5d_validator_runtime.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase5d_validator_runtime.py
@@ -146,6 +146,36 @@ class TestContinuityKernelPhase5DValidatorRuntime(unittest.TestCase):
         result = self.module.validate_evidence_packet(packet)
         self.assertFalse(result["passed"])
 
+    def test_explicit_governed_permanent_account_deletion_is_not_treated_as_an_ordinary_repair(self) -> None:
+        packet = self._valid_packet()
+        packet.update(
+            {
+                "target_type": "user",
+                "target_id": "user-1",
+                "repair_category": "admin_repair_safety",
+                "proposed_after_snapshot": {
+                    "irreversible": True,
+                    "proposed_after": {
+                        "status": "permanently_deleted",
+                        "restorable": False,
+                    },
+                },
+                "diff_summary": {
+                    "action": "account_permanent_delete",
+                    "reason": "Verified request to delete customer record",
+                    "mutates_business_data": True,
+                },
+                "rollback_plan": {
+                    "strategy": "irreversible_identity_erasure",
+                    "before_snapshot_ref": "snapshot-1",
+                    "restoration_prohibited": True,
+                    "evidence_only": True,
+                },
+            }
+        )
+        result = self.module.validate_evidence_packet(packet)
+        self.assertTrue(result["passed"])
+
     def test_unknown_role_fails_closed(self) -> None:
         auth = self._valid_authorization()
         auth["actor_role"] = "unknown_role"

--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -25,7 +25,7 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
         cls.auth_js = AUTH_JS_PATH.read_text(encoding="utf-8")
 
     def test_01_runtime_registers_complete_control_surface_actions(self) -> None:
-        self.assertIn('RUNTIME_VERSION = "9.0.0"', self.runtime)
+        self.assertIn('RUNTIME_VERSION = "10.1.0"', self.runtime)
         for action in (
             "manual_fulfillment",
             "stripe_operation",
@@ -114,7 +114,7 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
             if path.name in separately_managed_commercial_pages:
                 continue
             app_pages.append(path.name)
-            expected_revision = "20260821-phase10" if path.name == "admin-control-center.html" else "20260821-phase9"
+            expected_revision = "20260821-phase10-1" if path.name == "admin-control-center.html" else "20260821-phase9"
             self.assertIn(f"app.js?v={expected_revision}", source, path.name)
             csp_match = re.search(
                 r'http-equiv="Content-Security-Policy"\s+content="([^"]+)"',

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -1080,7 +1080,7 @@ class SuperAdminControlsTests(unittest.TestCase):
             preview = admin_control_service.super_admin_preview_account_lifecycle(
                 user_id=str(user_id), action="archive", archive_owned_records=True
             )
-            with self.assertRaisesRegex(ValueError, "blocked"):
+            with self.assertRaisesRegex(ValueError, "canonical CEO Master Administrator"):
                 admin_control_service.super_admin_apply_account_lifecycle(
                     user_id=str(user_id),
                     action="archive",

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -1091,6 +1092,405 @@ class SuperAdminControlsTests(unittest.TestCase):
         self.assertTrue(preview["blocked"])
         self.assertEqual(db["users"].documents[0]["status"], "active")
 
+    def test_billing_hold_is_recoverable_and_restore_clears_the_hold(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "past.due@example.com",
+                        "full_name": "Past Due Customer",
+                        "role": "user",
+                        "status": "active",
+                        "session_token_version": 1,
+                    }
+                ],
+                "projects": [],
+                "families": [],
+                "households": [],
+                "audit_logs": [],
+            }
+        )
+        actor = {"_id": ObjectId(), "email": "l.robinson@tomboflight.com"}
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            held = admin_control_service.super_admin_apply_account_lifecycle(
+                user_id=str(user_id),
+                action="billing_hold",
+                reason="Monthly maintenance payment is past due",
+                actor=actor,
+            )
+            restored = admin_control_service.super_admin_apply_account_lifecycle(
+                user_id=str(user_id),
+                action="restore",
+                reason="Billing balance resolved",
+                actor=actor,
+            )
+
+        user = db["users"].documents[0]
+        self.assertTrue(held["proposed_after"]["billing_hold"])
+        self.assertEqual(held["proposed_after"]["status"], "suspended")
+        self.assertEqual(restored["proposed_after"]["status"], "active")
+        self.assertEqual(user["status"], "active")
+        self.assertTrue(user["login_enabled"])
+        self.assertIsNone(user["billing_hold_at"])
+        self.assertIsNone(user["billing_hold_reason"])
+        self.assertEqual(user["session_token_version"], 3)
+
+    def test_permanent_deletion_erases_identity_closes_access_and_writes_mongodb_receipt(self):
+        user_id = ObjectId()
+        project_id = ObjectId()
+        family_id = ObjectId()
+        household_id = ObjectId()
+        original_email = "departed.permanent@example.com"
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": original_email,
+                        "full_name": "Departed Permanent",
+                        "phone_number": "757-555-0100",
+                        "mailing_address": "Protected address",
+                        "password_hash": "hashed-password",
+                        "mfa_enabled": True,
+                        "mfa_secret_encrypted": "encrypted-secret",
+                        "role": "user",
+                        "status": "archived",
+                        "login_enabled": False,
+                        "session_token_version": 4,
+                    }
+                ],
+                "projects": [
+                    {"_id": project_id, "owner_user_id": str(user_id), "owner_email": original_email, "status": "archived"}
+                ],
+                "families": [
+                    {"_id": family_id, "owner_user_id": str(user_id), "owner_email": original_email, "status": "archived"}
+                ],
+                "households": [
+                    {"_id": household_id, "owner_user_id": str(user_id), "owner_email": original_email, "status": "archived"}
+                ],
+                "project_entitlements": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": project_id,
+                        "user_id": user_id,
+                        "status": "archived",
+                        "maintenance_status": "active",
+                        "maintenance_stripe_status": "active",
+                        "maintenance_stripe_subscription_id": "sub_permanent_delete_test",
+                    }
+                ],
+                "project_members": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "user_id": str(user_id), "status": "inactive"}
+                ],
+                "household_invites": [
+                    {"_id": ObjectId(), "household_id": str(household_id), "status": "cancelled"}
+                ],
+                "household_links": [
+                    {"_id": ObjectId(), "source_household_id": str(household_id), "target_household_id": "other-household", "link_status": "approved"}
+                ],
+                "intake_submissions": [
+                    {"_id": ObjectId(), "user_id": user_id, "email": original_email, "status": "archived"}
+                ],
+                "uploaded_files": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": str(project_id),
+                        "uploaded_by_user_id": str(user_id),
+                        "uploaded_by": original_email,
+                    }
+                ],
+                "vault_items": [
+                    {"_id": "vault-item-1", "project_id": str(project_id), "owner_user_id": str(user_id), "access_enabled": True}
+                ],
+                "vault_access_grants": [
+                    {"_id": ObjectId(), "vault_item_id": "vault-item-1", "grantee_user_id": str(user_id), "status": "active"}
+                ],
+                "vault_collections": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "owner_user_id": str(user_id), "status": "active"}
+                ],
+                "vault_release_rules": [
+                    {"_id": ObjectId(), "vault_item_id": "vault-item-1", "created_by_user_id": str(user_id), "status": "scheduled"}
+                ],
+                "organization_admin_invites": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "email": original_email, "status": "pending"}
+                ],
+                "project_link_keys": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "issuer_user_id": str(user_id), "status": "active"}
+                ],
+                "link_requests": [
+                    {"_id": ObjectId(), "source_project_id": str(project_id), "requested_by_user_id": str(user_id), "status": "pending"}
+                ],
+                "experience_sessions": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "user_id": str(user_id), "status": "active"}
+                ],
+                "admin_impersonation_sessions": [
+                    {
+                        "_id": ObjectId(),
+                        "impersonated_user_id": str(user_id),
+                        "impersonated_email": original_email,
+                        "status": "active",
+                        "editing_enabled": True,
+                    }
+                ],
+                "mint_jobs": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "status": "queued"}
+                ],
+                "mint_approvals": [
+                    {"_id": ObjectId(), "project_id": str(project_id), "status": "approved"}
+                ],
+                "user_role_assignments": [
+                    {"_id": ObjectId(), "user_id": user_id, "status": "active", "role_code": "marketing_admin"}
+                ],
+                "user_permission_overrides": [
+                    {"_id": ObjectId(), "user_id": str(user_id), "status": "active", "permission": "admin.control_center"}
+                ],
+                "orders": [{"_id": ObjectId(), "user_id": user_id, "email": original_email, "status": "paid", "amount": 79900}],
+                "account_deletion_tombstones": [],
+                "audit_logs": [],
+            }
+        )
+
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service.stripe_admin_operations_service,
+                "cancel_subscription",
+                return_value={"subscription_id": "sub_permanent_delete_test", "status": "canceled"},
+            ) as cancel_subscription,
+        ):
+            result = admin_control_service.super_admin_apply_account_permanent_deletion(
+                user_id=str(user_id),
+                reason_category="customer_request",
+                reason="Verified written request to permanently close the account",
+                confirmation_email=original_email,
+                initial_confirmation=True,
+                final_confirmation="PERMANENTLY DELETE",
+                final_acknowledgement=True,
+                continuity_operation_id="ckop_test_permanent_delete",
+                actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com", "full_name": "Larry Robinson"},
+            )
+            restore_preview = admin_control_service.super_admin_preview_account_lifecycle(
+                user_id=str(user_id), action="restore"
+            )
+            with self.assertRaisesRegex(ValueError, "permanently deleted"):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(user_id), payload={"status": "active"}
+                )
+
+        cancel_subscription.assert_called_once()
+        self.assertEqual(
+            cancel_subscription.call_args.kwargs["subscription_id"],
+            "sub_permanent_delete_test",
+        )
+        self.assertFalse(cancel_subscription.call_args.kwargs["at_period_end"])
+        self.assertTrue(cancel_subscription.call_args.kwargs["confirm"])
+
+        user = db["users"].documents[0]
+        tombstone = db["account_deletion_tombstones"].documents[0]
+        self.assertTrue(result["permanent"])
+        self.assertFalse(result["restorable"])
+        self.assertEqual(user["status"], "permanently_deleted")
+        self.assertEqual(user["account_type"], "deleted_tombstone")
+        self.assertFalse(user["login_enabled"])
+        self.assertIsNone(user["password_hash"])
+        self.assertIsNone(user["mfa_secret_encrypted"])
+        self.assertIsNone(user["phone_number"])
+        self.assertNotEqual(user["email"], original_email)
+        self.assertEqual(user["session_token_version"], 5)
+        self.assertTrue(restore_preview["blocked"])
+        self.assertEqual(db["projects"].documents[0]["status"], "deleted")
+        self.assertEqual(db["families"].documents[0]["status"], "deleted")
+        self.assertEqual(db["households"].documents[0]["status"], "deleted")
+        self.assertEqual(db["project_entitlements"].documents[0]["status"], "deleted")
+        self.assertEqual(db["project_entitlements"].documents[0]["maintenance_status"], "canceled")
+        self.assertEqual(db["project_members"].documents[0]["status"], "removed")
+        self.assertEqual(db["uploaded_files"].documents[0]["uploaded_by"], user["email"])
+        self.assertFalse(db["vault_items"].documents[0]["access_enabled"])
+        self.assertEqual(db["vault_access_grants"].documents[0]["status"], "revoked")
+        self.assertEqual(db["vault_collections"].documents[0]["status"], "closed")
+        self.assertEqual(db["vault_release_rules"].documents[0]["status"], "revoked")
+        self.assertEqual(db["project_link_keys"].documents[0]["status"], "revoked")
+        self.assertEqual(db["link_requests"].documents[0]["status"], "cancelled")
+        self.assertEqual(db["household_links"].documents[0]["link_status"], "revoked")
+        self.assertEqual(db["organization_admin_invites"].documents[0]["status"], "cancelled")
+        self.assertEqual(db["experience_sessions"].documents[0]["status"], "closed")
+        self.assertEqual(db["admin_impersonation_sessions"].documents[0]["status"], "stopped")
+        self.assertFalse(db["admin_impersonation_sessions"].documents[0]["editing_enabled"])
+        self.assertEqual(db["mint_jobs"].documents[0]["status"], "obsolete")
+        self.assertEqual(db["mint_approvals"].documents[0]["status"], "revoked")
+        self.assertEqual(db["user_role_assignments"].documents[0]["status"], "revoked")
+        self.assertEqual(db["user_permission_overrides"].documents[0]["status"], "revoked")
+        self.assertEqual(db["orders"].documents[0]["status"], "paid")
+        self.assertEqual(db["orders"].documents[0]["amount"], 79900)
+        self.assertEqual(tombstone["status"], "completed")
+        self.assertEqual(tombstone["continuity_operation_id"], "ckop_test_permanent_delete")
+        self.assertEqual(tombstone["original_email_sha256"], hashlib.sha256(original_email.encode()).hexdigest())
+        self.assertNotIn(original_email, str(tombstone))
+        self.assertEqual(
+            result["deletion_receipt"]["mongo_evidence"]["tombstone_collection"],
+            "account_deletion_tombstones",
+        )
+
+    def test_permanent_deletion_requires_exact_email_phrase_and_never_deletes_ceo(self):
+        target_id = ObjectId()
+        ceo_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {"_id": target_id, "email": "target@example.com", "full_name": "Target", "role": "user", "status": "active"},
+                    {"_id": ceo_id, "email": "l.robinson@tomboflight.com", "full_name": "Larry Robinson", "role": "ceo_master_admin", "status": "active"},
+                ],
+                "projects": [],
+                "families": [],
+                "households": [],
+                "account_deletion_tombstones": [],
+            }
+        )
+        common = {
+            "user_id": str(target_id),
+            "reason_category": "policy_violation",
+            "reason": "Documented policy violation",
+            "actor": {"_id": ceo_id, "email": "l.robinson@tomboflight.com"},
+            "continuity_operation_id": "ckop_test_validation",
+        }
+
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            with self.assertRaisesRegex(PermissionError, "canonical CEO"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    user_id=str(target_id),
+                    reason_category="policy_violation",
+                    reason="Documented policy violation",
+                    confirmation_email="target@example.com",
+                    initial_confirmation=True,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=True,
+                    actor={"_id": ObjectId(), "email": "operations@example.com"},
+                )
+            with self.assertRaisesRegex(ValueError, "correct target account"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    **common,
+                    confirmation_email="target@example.com",
+                    initial_confirmation=False,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=True,
+                )
+            with self.assertRaisesRegex(ValueError, "final permanent-closure"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    **common,
+                    confirmation_email="target@example.com",
+                    initial_confirmation=True,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=False,
+                )
+            with self.assertRaisesRegex(ValueError, "confirmation email"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    **common,
+                    confirmation_email="wrong@example.com",
+                    initial_confirmation=True,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=True,
+                )
+            with self.assertRaisesRegex(ValueError, "PERMANENTLY DELETE"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    **common,
+                    confirmation_email="target@example.com",
+                    initial_confirmation=True,
+                    final_confirmation="delete",
+                    final_acknowledgement=True,
+                )
+            with self.assertRaisesRegex(ValueError, "Invalid account status"):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(target_id), payload={"status": "permanently_deleted"}
+                )
+            ceo_preview = admin_control_service.super_admin_preview_account_permanent_deletion(
+                user_id=str(ceo_id), reason_category="company_authorized"
+            )
+            with self.assertRaisesRegex(ValueError, "blocked"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    user_id=str(ceo_id),
+                    reason_category="company_authorized",
+                    reason="Attempted CEO deletion",
+                    confirmation_email="l.robinson@tomboflight.com",
+                    initial_confirmation=True,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=True,
+                    continuity_operation_id="ckop_test_ceo_protection",
+                    actor={"_id": ceo_id, "email": "l.robinson@tomboflight.com"},
+                )
+
+        self.assertTrue(ceo_preview["blocked"])
+        self.assertEqual(db["users"].documents[0]["status"], "active")
+        self.assertEqual(db["users"].documents[1]["status"], "active")
+        self.assertEqual(db["account_deletion_tombstones"].documents, [])
+
+    def test_permanent_deletion_fails_before_mongodb_changes_when_subscription_cancel_fails(self):
+        user_id = ObjectId()
+        project_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "subscribed@example.com",
+                        "full_name": "Subscribed Customer",
+                        "role": "user",
+                        "status": "active",
+                        "login_enabled": True,
+                    }
+                ],
+                "projects": [
+                    {
+                        "_id": project_id,
+                        "owner_user_id": str(user_id),
+                        "owner_email": "subscribed@example.com",
+                        "status": "active",
+                    }
+                ],
+                "families": [],
+                "households": [],
+                "project_entitlements": [
+                    {
+                        "_id": ObjectId(),
+                        "project_id": str(project_id),
+                        "user_id": str(user_id),
+                        "status": "active",
+                        "maintenance_status": "active",
+                        "maintenance_stripe_subscription_id": "sub_cancel_failure",
+                    }
+                ],
+                "account_deletion_tombstones": [],
+            }
+        )
+
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service.stripe_admin_operations_service,
+                "cancel_subscription",
+                side_effect=RuntimeError("Stripe cancellation unavailable"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Stripe cancellation unavailable"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    user_id=str(user_id),
+                    reason_category="customer_request",
+                    reason="Verified deletion request",
+                    confirmation_email="subscribed@example.com",
+                    initial_confirmation=True,
+                    final_confirmation="PERMANENTLY DELETE",
+                    final_acknowledgement=True,
+                    continuity_operation_id="ckop_stripe_failure",
+                    actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com"},
+                )
+
+        self.assertEqual(db["users"].documents[0]["status"], "active")
+        self.assertTrue(db["users"].documents[0]["login_enabled"])
+        self.assertEqual(db["projects"].documents[0]["status"], "active")
+        self.assertEqual(db["account_deletion_tombstones"].documents, [])
+
     def test_super_admin_update_user_updates_profile_fields(self):
         user_id = ObjectId()
         db = FakeDatabase(
@@ -1373,6 +1773,12 @@ class AdminConsoleOverviewTests(unittest.TestCase):
                     {"_id": ObjectId(), "email": "l.robinson@tomboflight.com", "account_type": "business_admin"},
                     {"_id": ObjectId(), "email": "customer-paid@example.com", "account_type": "customer"},
                     {"_id": ObjectId(), "email": "customer-unpaid@example.com", "account_type": "customer"},
+                    {
+                        "_id": ObjectId(),
+                        "email": "deleted-fixture@deleted.tomboflight.invalid",
+                        "account_type": "deleted_tombstone",
+                        "status": "permanently_deleted",
+                    },
                 ],
                 "projects": [],
                 "orders": [
@@ -1400,6 +1806,8 @@ class AdminConsoleOverviewTests(unittest.TestCase):
         self.assertEqual(summary["total_users"], 3)
         self.assertEqual(summary["total_business_admin_users"], 1)
         self.assertEqual(summary["total_customer_users"], 2)
+        self.assertEqual(summary["permanently_deleted_users"], 1)
+        self.assertEqual(summary["user_identity_records_retained"], 4)
         self.assertEqual(summary["paid_customer_users"], 1)
         self.assertEqual(summary["signed_up_no_purchase_users"], 1)
 

--- a/backend/tests/test_continuity_runtime_service.py
+++ b/backend/tests/test_continuity_runtime_service.py
@@ -285,6 +285,80 @@ class TestContinuityRuntimeService(unittest.TestCase):
         self.assertEqual(operation["before_snapshot"]["action_before"], {"status": "active"})
         self.assertEqual(operation["before_snapshot"]["operational_snapshot"], {"state": "canonical"})
 
+    def test_permanent_deletion_has_evidence_only_irreversible_plan(self) -> None:
+        operation = runtime.request_operation(
+            action="account_permanent_delete",
+            target={"user_id": "user-3"},
+            parameters={
+                "reason_category": "customer_request",
+                "confirmation_email": "target@example.com",
+                "initial_confirmation": True,
+                "final_confirmation": "PERMANENTLY DELETE",
+                "final_acknowledgement": True,
+            },
+            reason="Verified account deletion request",
+            idempotency_key="kernel-idempotency-permanent-delete",
+            actor=self.actor,
+        )
+
+        self.assertEqual(operation["rollback_plan"]["strategy"], "irreversible_identity_erasure")
+        self.assertTrue(operation["rollback_plan"]["restoration_prohibited"])
+        self.assertTrue(operation["rollback_plan"]["evidence_only"])
+
+    def test_permanent_deletion_request_is_restricted_to_canonical_ceo(self) -> None:
+        with self.assertRaisesRegex(PermissionError, "canonical CEO"):
+            runtime.request_operation(
+                action="account_permanent_delete",
+                target={"user_id": "user-3"},
+                parameters={
+                    "reason_category": "policy_violation",
+                    "confirmation_email": "target@example.com",
+                    "initial_confirmation": True,
+                    "final_confirmation": "PERMANENTLY DELETE",
+                    "final_acknowledgement": True,
+                },
+                reason="Documented policy violation",
+                idempotency_key="kernel-idempotency-non-ceo-delete",
+                actor={
+                    "_id": "operations-1",
+                    "email": "operations@example.com",
+                    "role_codes": ["operations_admin"],
+                },
+            )
+
+    def test_permanent_deletion_request_requires_both_server_side_acknowledgements(self) -> None:
+        with self.assertRaisesRegex(ValueError, "target-account"):
+            runtime.request_operation(
+                action="account_permanent_delete",
+                target={"user_id": "user-3"},
+                parameters={
+                    "reason_category": "customer_request",
+                    "confirmation_email": "target@example.com",
+                    "initial_confirmation": False,
+                    "final_confirmation": "PERMANENTLY DELETE",
+                    "final_acknowledgement": True,
+                },
+                reason="Verified account deletion request",
+                idempotency_key="kernel-delete-confirmation-missing",
+                actor=self.actor,
+            )
+
+        with self.assertRaisesRegex(ValueError, "final permanent-closure"):
+            runtime.request_operation(
+                action="account_permanent_delete",
+                target={"user_id": "user-3"},
+                parameters={
+                    "reason_category": "customer_request",
+                    "confirmation_email": "target@example.com",
+                    "initial_confirmation": True,
+                    "final_confirmation": "PERMANENTLY DELETE",
+                    "final_acknowledgement": False,
+                },
+                reason="Verified account deletion request",
+                idempotency_key="kernel-delete-final-ack-missing",
+                actor=self.actor,
+            )
+
     def test_kill_switch_disables_execution_only_when_explicitly_set(self) -> None:
         self.assertTrue(runtime.execution_enabled(env={}))
         for value in ("1", "true", "yes", "on", "enabled"):
@@ -300,9 +374,12 @@ class TestContinuityRuntimeService(unittest.TestCase):
 
         operation_indexes = self.database[runtime.OPERATIONS_COLLECTION].indexes
         event_indexes = self.database[runtime.EVENTS_COLLECTION].indexes
+        tombstone_indexes = self.database["account_deletion_tombstones"].indexes
         self.assertTrue(any(item[1].get("name") == "continuity_operation_id_unique" for item in operation_indexes))
         self.assertTrue(any(item[1].get("name") == "continuity_idempotency_unique" for item in operation_indexes))
         self.assertTrue(any(item[1].get("name") == "continuity_event_id_unique" for item in event_indexes))
+        self.assertTrue(any(item[1].get("name") == "account_deletion_id_unique" for item in tombstone_indexes))
+        self.assertTrue(any(item[1].get("name") == "account_deletion_user_unique" for item in tombstone_indexes))
 
 
 class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
@@ -317,9 +394,44 @@ class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
             "impersonation_start",
             "impersonation_stop",
         }
-        self.assertEqual(runtime.RUNTIME_VERSION, "9.0.0")
-        self.assertEqual(len(runtime.ACTION_SPECS), 35)
+        self.assertEqual(runtime.RUNTIME_VERSION, "10.1.0")
+        self.assertEqual(len(runtime.ACTION_SPECS), 36)
         self.assertTrue(expected.issubset(runtime.ACTION_SPECS))
+
+    def test_permanent_deletion_adapter_passes_both_irreversible_confirmations(self) -> None:
+        actor = {"_id": "ceo-1", "email": CEO_MASTER_ADMIN_EMAIL}
+        with patch.object(
+            runtime.admin_control_service,
+            "super_admin_apply_account_permanent_deletion",
+            return_value={"permanent": True, "failure_count": 0},
+        ) as execute:
+            result = runtime._invoke_action(
+                "account_permanent_delete",
+                {"user_id": "user-3"},
+                {
+                    "reason_category": "security_incident",
+                    "confirmation_email": "target@example.com",
+                    "initial_confirmation": True,
+                    "final_confirmation": "PERMANENTLY DELETE",
+                    "final_acknowledgement": True,
+                    "continuity_operation_id": "ckop-adapter-test",
+                    "reason": "Verified account compromise",
+                },
+                actor,
+            )
+
+        self.assertTrue(result["permanent"])
+        execute.assert_called_once_with(
+            user_id="user-3",
+            reason_category="security_incident",
+            reason="Verified account compromise",
+            confirmation_email="target@example.com",
+            initial_confirmation=True,
+            final_confirmation="PERMANENTLY DELETE",
+            final_acknowledgement=True,
+            continuity_operation_id="ckop-adapter-test",
+            actor=actor,
+        )
 
     def test_manual_fulfillment_adapter_preserves_kernel_idempotency(self) -> None:
         actor = {"_id": "ceo-1", "email": CEO_MASTER_ADMIN_EMAIL}

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -307,6 +307,60 @@ class AuthDatabaseFailClosedTests(unittest.TestCase):
         self.assertNotIn("reset_token", result)
         self.assertTrue(db["users"].documents[0].get("password_reset_token_hash"))
 
+    def test_permanently_deleted_identity_cannot_receive_password_reset(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": f"deleted+{user_id}@accounts.invalid",
+                        "status": "permanently_deleted",
+                        "account_type": "deleted_tombstone",
+                    }
+                ]
+            }
+        )
+        with (
+            patch.object(auth_service, "_get_database_or_none", return_value=db),
+            patch.object(auth_service, "send_password_reset_email") as send_reset,
+        ):
+            result = auth_service.request_password_reset(
+                f"deleted+{user_id}@accounts.invalid",
+                requested_via="admin_assist",
+                include_delivery_status=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertFalse(result["reset_persisted"])
+        self.assertFalse(result["delivery_sent"])
+        self.assertEqual(result["delivery_error"], "account_not_active")
+        self.assertNotIn("password_reset_token_hash", db["users"].documents[0])
+        send_reset.assert_not_called()
+
+    def test_admin_cannot_issue_reset_for_permanently_deleted_identity(self):
+        user_id = str(ObjectId())
+        with (
+            patch.object(
+                auth_service,
+                "get_user_by_id",
+                return_value={
+                    "_id": ObjectId(user_id),
+                    "email": f"deleted+{user_id}@accounts.invalid",
+                    "status": "permanently_deleted",
+                    "account_type": "deleted_tombstone",
+                },
+            ),
+            patch.object(auth_service, "request_password_reset") as request_reset,
+        ):
+            with self.assertRaisesRegex(ValueError, "permanently deleted"):
+                auth_service.admin_issue_password_reset(
+                    user_id,
+                    admin_user_id="ceo-1",
+                    admin_display="CEO Operator",
+                )
+        request_reset.assert_not_called()
+
 
 class LinkKeyHardeningTests(unittest.TestCase):
     def test_generate_link_key_stores_hash_only(self):

--- a/backend/tests/test_vault_security.py
+++ b/backend/tests/test_vault_security.py
@@ -205,6 +205,38 @@ class VaultSecurityTests(unittest.TestCase):
         assert owner_item is not None
         self.assertEqual(owner_item["id"], str(item_id))
 
+    def test_revoked_grant_cannot_open_vault_item(self):
+        item_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "vault_items": [
+                    {
+                        "_id": item_id,
+                        "project_id": "project-a",
+                        "owner_user_id": "owner-1",
+                        "title": "Closed account evidence",
+                    }
+                ],
+                "vault_access_grants": [
+                    {
+                        "_id": ObjectId(),
+                        "vault_item_id": str(item_id),
+                        "grantee_user_id": "deleted-user",
+                        "permission_role": "viewer",
+                        "status": "revoked",
+                    }
+                ],
+            }
+        )
+
+        with patch.object(vault_service, "get_database", return_value=db):
+            with self.assertRaisesRegex(ValueError, "Access denied"):
+                vault_service.get_vault_item(
+                    str(item_id),
+                    "deleted-user",
+                    authorized_project_id="project-a",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -792,7 +792,8 @@ test("[account360] validates all tabs + loading/empty/denied/error states and se
   await expect(page.locator("body")).not.toContainText("sk_live_");
   await expect(page.locator("body")).not.toContainText("private_key");
   await expect(page.locator("body")).not.toContainText("token=");
-  await expect(page.locator("body")).not.toContainText("password");
+  await expect(page.locator("body")).not.toContainText("password_hash");
+  await expect(page.locator("body")).not.toContainText("password=");
 });
 
 test("[errors] backend case-search failures include actionable code + retry guidance", async ({ page }) => {

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -238,8 +238,8 @@ async function installApiRoutes(page, env) {
     }
     if (method === "GET" && path === "/admin/control-center/kernel/status") {
       return json({
-        runtime_version: "9.0.0",
-        action_count: 35,
+        runtime_version: "10.1.0",
+        action_count: 36,
         execution_enabled: true,
         one_step_execution_allowed: true,
       });
@@ -267,13 +267,40 @@ async function installApiRoutes(page, env) {
         env.state.activeImpersonation = null;
         env.stats.impersonationAuditEvents += 1;
       }
-      return json({
+      const operation = {
         operation_id: `kernel-operation-${env.stats.kernelExecutions.length}`,
-        state: "executed",
+        state: "apply_executed",
         execution_outcome: "success",
         evidence_recording_status: "complete",
-        execution_result: { applied: true },
-      });
+        execution_result: body.action === "account_permanent_delete"
+          ? {
+              applied: true,
+              permanent: true,
+              deletion_receipt: {
+                deletion_id: "acctdel-browser-fixture",
+                user_id: body.target.user_id,
+                deleted_at: new Date().toISOString(),
+                reason_category: body.parameters.reason_category,
+                restorable: false,
+                records_closed: { projects: 1, project_entitlements: 1, project_members: 1, vault_access_grants_revoked: 1 },
+                records_preserved: ["orders", "billing_history", "audit_logs", "continuity_evidence"],
+                mongo_evidence: {
+                  tombstone_collection: "account_deletion_tombstones",
+                  audit_collection: "audit_logs",
+                  continuity_operation_collection: "continuity_operations",
+                  continuity_event_collection: "continuity_events",
+                },
+              },
+            }
+          : { applied: true },
+      };
+      if (body.action === "account_permanent_delete") env.state.lastDeletionOperation = operation;
+      return json(operation);
+    }
+    if (method === "POST" && /\/admin\/control-center\/kernel\/operations\/[^/]+\/close$/.test(path)) {
+      if (!env.state.lastDeletionOperation) return json({ detail: "Operation not found." }, 404);
+      env.state.lastDeletionOperation = { ...env.state.lastDeletionOperation, state: "audit_closed" };
+      return json(env.state.lastDeletionOperation);
     }
     if (method === "POST" && path === "/admin/control-center/super-admin/users/preview") {
       const body = JSON.parse(request.postData() || "{}");
@@ -311,8 +338,35 @@ async function installApiRoutes(page, env) {
         records_preserved: ["orders", "billing_history", "uploads", "vault_metadata", "certificates", "delivery_records", "audit_logs"],
         blocked: body.action === "archive" && !body.archive_owned_records,
         warnings: body.action === "archive" && !body.archive_owned_records
-          ? ["Use Close Account & Workspaces because this account owns active records."]
+          ? ["Use Archive Account & Workspaces because this account owns active records."]
           : [],
+      });
+    }
+    if (method === "POST" && path.includes("/permanent-deletion/preview")) {
+      return json({
+        action: "account_permanent_delete",
+        target_account: {
+          user_id: "user-customer",
+          email: "customer.fixture@tomboflight.test",
+          full_name: "Customer Fixture",
+        },
+        before: { status: "archived", login_enabled: false, session_token_version: 1 },
+        proposed_after: {
+          status: "permanently_deleted",
+          login_enabled: false,
+          restorable: false,
+          personal_profile_erased: true,
+          owned_workspace_access_permanently_closed: true,
+        },
+        ownership_dependencies: { projects: 1, families: 1, households: 0 },
+        external_service_impact: { stripe_subscriptions_cancelled_immediately: 1 },
+        records_erased_or_deidentified: ["authentication_credentials", "mfa_secrets", "personal_profile_fields"],
+        records_permanently_closed: ["projects", "entitlements", "memberships", "vault_access"],
+        records_preserved: ["orders", "billing_history", "corporate_ownership_records", "audit_logs", "continuity_evidence"],
+        blocked: false,
+        warnings: ["Permanent deletion cannot be undone or restored."],
+        confirmation_phrase: "PERMANENTLY DELETE",
+        irreversible: true,
       });
     }
     if (method === "GET" && path === "/admin/control-center/cases") {
@@ -541,6 +595,53 @@ test("[account controls] creates an account with a package and closes owned work
   expect(env.stats.kernelExecutions[1].action).toBe("account_lifecycle");
   expect(env.stats.kernelExecutions[1].parameters.lifecycle_action).toBe("archive");
   expect(env.stats.kernelExecutions[1].parameters.archive_owned_records).toBe(true);
+});
+
+test("[permanent deletion] requires two confirmations and returns MongoDB evidence", async ({ page }) => {
+  const env = page.__env;
+  await expect(page.locator("[data-super-admin-permanent-delete]")).toBeVisible();
+  await page.locator("[data-super-admin-permanent-delete]").click();
+
+  const reviewDialog = page.locator("[data-admin-permanent-delete-dialog]");
+  await expect(reviewDialog).toBeVisible();
+  await expect(page.locator("[data-admin-permanent-delete-preview]")).toContainText("Permanent deletion cannot be undone");
+  await expect(page.locator("[data-admin-permanent-delete-preview]")).toContainText("Stripe subscriptions cancelled immediately: 1");
+  await page.locator("[data-admin-permanent-delete-category]").selectOption("customer_request");
+  await page.locator("[data-admin-permanent-delete-reason]").fill("Verified written request for permanent account closure");
+  await page.locator("[data-admin-permanent-delete-email]").fill("wrong@tomboflight.test");
+  await page.locator("[data-admin-permanent-delete-confirm]").check();
+  await expect(page.locator("[data-admin-permanent-delete-continue]")).toBeDisabled();
+  await expect(page.locator("[data-admin-permanent-delete-email-status]")).toContainText("Email does not match");
+
+  await page.locator("[data-admin-permanent-delete-email]").fill("customer.fixture@tomboflight.test");
+  await expect(page.locator("[data-admin-permanent-delete-continue]")).toBeEnabled();
+  await page.locator("[data-admin-permanent-delete-continue]").click();
+
+  const finalDialog = page.locator("[data-admin-permanent-delete-final-dialog]");
+  await expect(finalDialog).toBeVisible();
+  await expect(finalDialog).toContainText("This account will be permanently closed");
+  await page.locator("[data-admin-permanent-delete-phrase]").fill("DELETE");
+  await page.locator("[data-admin-permanent-delete-final-confirm]").check();
+  await expect(page.locator("[data-admin-permanent-delete-execute]")).toBeDisabled();
+  await page.locator("[data-admin-permanent-delete-phrase]").fill("PERMANENTLY DELETE");
+  await expect(page.locator("[data-admin-permanent-delete-execute]")).toBeEnabled();
+  await page.locator("[data-admin-permanent-delete-execute]").click();
+
+  await expect.poll(() => env.stats.kernelExecutions.length).toBe(1);
+  expect(env.stats.kernelExecutions[0].action).toBe("account_permanent_delete");
+  expect(env.stats.kernelExecutions[0].parameters.reason_category).toBe("customer_request");
+  expect(env.stats.kernelExecutions[0].parameters.confirmation_email).toBe("customer.fixture@tomboflight.test");
+  expect(env.stats.kernelExecutions[0].parameters.initial_confirmation).toBe(true);
+  expect(env.stats.kernelExecutions[0].parameters.final_confirmation).toBe("PERMANENTLY DELETE");
+  expect(env.stats.kernelExecutions[0].parameters.final_acknowledgement).toBe(true);
+
+  const receiptDialog = page.locator("[data-admin-deletion-receipt-dialog]");
+  await expect(receiptDialog).toBeVisible();
+  await expect(page.locator("[data-admin-deletion-receipt]")).toContainText("acctdel-browser-fixture");
+  await expect(page.locator("[data-admin-deletion-receipt]")).toContainText("MongoDB records closed");
+  await expect(page.locator("[data-admin-deletion-receipt-close-audit]")).toBeVisible();
+  await page.locator("[data-admin-deletion-receipt-close-audit]").click();
+  await expect(page.locator("[data-admin-deletion-receipt]")).toContainText("Audit Closed");
 });
 
 test("[theme] ignores stored admin appearance while disabled", async ({ page }) => {

--- a/styles.css
+++ b/styles.css
@@ -9792,6 +9792,14 @@ body.admin-interface-mode textarea {
   background: var(--admin-danger-button-hover) !important;
 }
 
+.admin-control-center-body .btn:disabled,
+.admin-control-center-body .btn[aria-disabled="true"] {
+  opacity: 0.48 !important;
+  cursor: not-allowed !important;
+  filter: grayscale(0.2);
+  box-shadow: none !important;
+}
+
 .admin-account-control-section,
 .admin-danger-zone {
   display: grid;
@@ -10095,6 +10103,71 @@ body.admin-interface-mode textarea {
   color: var(--admin-success) !important;
   font-size: 0.84rem;
   font-weight: 750;
+}
+
+.admin-preview-assurance--danger {
+  color: var(--admin-danger) !important;
+}
+
+.admin-irreversible-warning {
+  padding: 15px;
+  border: 2px solid var(--admin-danger-button);
+  border-radius: 13px;
+  background: var(--admin-danger-soft);
+  color: var(--admin-danger);
+}
+
+.admin-irreversible-warning strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--admin-danger);
+  font-size: 1.05rem;
+}
+
+.admin-irreversible-warning p {
+  margin: 0;
+  color: var(--admin-text);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.admin-field-status {
+  color: var(--admin-muted);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.admin-field-status[data-state="error"] {
+  color: var(--admin-danger);
+  font-weight: 750;
+}
+
+.admin-field-status[data-state="success"] {
+  color: var(--admin-success);
+  font-weight: 750;
+}
+
+.admin-confirmation-check--danger {
+  border-color: #d9a6a6;
+  background: var(--admin-danger-soft);
+}
+
+.admin-confirmation-check--danger input {
+  accent-color: var(--admin-danger-button);
+}
+
+.admin-receipt-code {
+  display: block;
+  margin-top: 10px;
+  padding: 10px;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--admin-border);
+  border-radius: 10px;
+  background: var(--admin-panel);
+  color: var(--admin-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
 }
 
 .admin-confirmation-check {


### PR DESCRIPTION
## Summary

- separates temporary billing hold, recoverable archive, and irreversible permanent deletion
- adds a CEO-only Continuity Kernel `account_permanent_delete` action with two independent confirmations
- cancels active Stripe maintenance subscriptions before identity destruction and fails closed if cancellation fails
- destroys credentials, MFA, reset paths, roles, permissions, sessions, memberships, invitations, and workspace access
- preserves required orders, billing, corporate ownership, certificate, delivery, security, audit, and Continuity evidence
- writes a MongoDB deletion tombstone and exposes a copyable/reopenable execution receipt
- protects the canonical CEO Master Administrator from deletion
- excludes deleted identity tombstones from active user totals and reports them separately

## Evidence

- architecture suite: 9 passed
- Continuity contract suite: 1,264 passed, 11 skipped
- focused Phase 10.1 contracts: 39 passed
- JavaScript syntax and Python compilation passed
- Playwright discovered all 17 browser workflows, including the two-stage deletion workflow
- the local Chromium executable is unavailable in this workspace; GitHub Actions installs Chromium and runs the browser suite

## Deployment boundary

No production account or business record was changed while preparing this PR. Marquis's live record was not modified. Permanent deletion becomes available only after review, merge, deployment, and successful production configuration.