### PR TITLE
Close Continuity Kernel backend security blockers (Phase 11)

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -2038,10 +2038,38 @@
 
     const statusNode = document.querySelector("[data-signup-status]");
     const submitBtn = form.querySelector("[data-submit-btn]");
-    const defaultSubmitLabel =
-      (submitBtn && submitBtn.textContent
-        ? submitBtn.textContent.trim()
-        : "") || "Create Private Account";
+    const activationParams = new URLSearchParams(
+      String(window.location.hash || "").replace(/^#/, ""),
+    );
+    const activationToken = String(
+      activationParams.get("activation_token") || "",
+    ).trim();
+    const activationEmail = String(
+      activationParams.get("email") || "",
+    )
+      .trim()
+      .toLowerCase();
+    const defaultSubmitLabel = activationToken
+      ? "Activate Private Account"
+      : (submitBtn && submitBtn.textContent
+          ? submitBtn.textContent.trim()
+          : "") || "Create Private Account";
+
+    if (activationToken) {
+      window.history.replaceState(
+        {},
+        document.title,
+        `${window.location.pathname}${window.location.search}`,
+      );
+      const emailInput = form.querySelector("input[name=email]");
+      if (emailInput && activationEmail) emailInput.value = activationEmail;
+      if (submitBtn) submitBtn.textContent = "Activate Private Account";
+      app.setStatus(
+        statusNode,
+        "Activation link received. Enter your account details to finish secure activation.",
+        "success",
+      );
+    }
 
     form.addEventListener("submit", async function (event) {
       event.preventDefault();
@@ -2126,7 +2154,7 @@
       }
 
       try {
-        await app.apiRequest("/auth/signup", {
+        const signupResult = await app.apiRequest("/auth/signup", {
           method: "POST",
           body: JSON.stringify({
             full_name: fullName,
@@ -2136,8 +2164,21 @@
             privacy_accepted: privacyAccepted,
             eligibility_attested: eligibilityAttested,
             policy_version: SIGNUP_POLICY_VERSION,
+            activation_token: activationToken || undefined,
           }),
         });
+
+        if (signupResult?.requires_account_activation) {
+          const activationMessage = signupResult.activation_delivery_sent
+            ? "Check your email for the secure activation link. Your account cannot be used until the email address is verified."
+            : "Your account is awaiting email verification, but the activation email was not confirmed as delivered. Contact support@tomboflight.com for assistance.";
+          app.setStatus(
+            statusNode,
+            activationMessage,
+            signupResult.activation_delivery_sent ? "success" : "error",
+          );
+          return;
+        }
 
         app.setStatus(
           statusNode,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,9 @@ SECRET_KEY="change-me"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES="60"
 CSRF_TOKEN_EXPIRE_MINUTES="120"
+PASSWORD_RESET_TOKEN_EXPIRE_MINUTES="30"
+PASSWORD_RESET_BASE_URL="https://tomboflight.com/account-security.html"
+ACCOUNT_ACTIVATION_TOKEN_EXPIRE_HOURS="24"
 
 # Upload storage + scanning
 UPLOAD_STORAGE_DIR="storage/uploads"
@@ -60,7 +63,7 @@ METADATA_BASE_URL="https://metadata.tomboflight.com/v1"
 POSTER_BASE_URL="https://posters.tomboflight.com/v1"
 PUBLIC_TOKEN_EXTERNAL_BASE_URL="https://tomboflight-api.onrender.com/tokens"
 
-# Email / Postmark (optional)
+# Email / Postmark (required in production for activation and recovery)
 POSTMARK_SERVER_TOKEN=""
 POSTMARK_SERVER_TOKEN_FILE=""
 POSTMARK_FROM_EMAIL="admin@tomboflight.com"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -151,6 +151,10 @@ class Settings(BaseSettings):
         default=30,
         validation_alias=AliasChoices("PASSWORD_RESET_TOKEN_EXPIRE_MINUTES"),
     )
+    account_activation_token_expire_hours: int = Field(
+        default=24,
+        validation_alias=AliasChoices("ACCOUNT_ACTIVATION_TOKEN_EXPIRE_HOURS"),
+    )
     password_reset_base_url: str = Field(
         default="https://tomboflight.com/account-security.html",
         validation_alias=AliasChoices("PASSWORD_RESET_BASE_URL"),

--- a/backend/app/core/admin_permission_registry.py
+++ b/backend/app/core/admin_permission_registry.py
@@ -6,6 +6,11 @@ from app.core.role_catalog import normalize_role_code
 
 CEO_MASTER_ADMIN_EMAIL = "l.robinson@tomboflight.com"
 
+
+def is_canonical_ceo_email(value: Any) -> bool:
+    """Return True only for the immutable CEO Master Administrator mailbox."""
+    return str(value or "").strip().lower() == CEO_MASTER_ADMIN_EMAIL
+
 # Job-scoped roles that the canonical CEO may assign to an active officer.
 # The CEO singleton is intentionally excluded from this collection.
 ASSIGNABLE_OFFICER_ROLE_CODES: tuple[str, ...] = (
@@ -65,7 +70,10 @@ CAPABILITY_PERMISSIONS: dict[str, set[str]] = {
 ROLE_CAPABILITIES: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit capability grants.
     "admin": set(),
-    "super_admin": {"*"},
+    # Generic super_admin is retained only as a legacy data label. Wildcard
+    # authority belongs exclusively to the canonical CEO identity and is
+    # granted through ceo_master_admin after the identity invariant is checked.
+    "super_admin": set(),
     "ceo_master_admin": {"*"},
     "ceo_super_admin": {"*"},
     "executive_tech_admin": {
@@ -106,7 +114,7 @@ ROLE_CAPABILITIES: dict[str, set[str]] = {
 ROLE_PERMISSION_MAP: dict[str, set[str]] = {
     # Deprecated generic admin role: no implicit permission grants.
     "admin": set(),
-    "super_admin": {"*"},
+    "super_admin": set(),
     "ceo_master_admin": {"*"},
     "ceo_super_admin": {"*"},
     "executive_tech_admin": {
@@ -160,8 +168,8 @@ ROLE_PERMISSION_MAP: dict[str, set[str]] = {
 
 ROLE_METADATA: dict[str, dict[str, str]] = {
     "super_admin": {
-        "name": "Super Admin",
-        "description": "Break-glass emergency full override controls.",
+        "name": "Legacy Super Admin Label",
+        "description": "Deprecated data label with no standalone authority.",
     },
     "ceo_super_admin": {
         "name": "CEO Super Admin",

--- a/backend/app/core/continuity_route_guard.py
+++ b/backend/app/core/continuity_route_guard.py
@@ -1,0 +1,47 @@
+"""HTTP boundary for legacy admin mutation routes.
+
+The Continuity Kernel delegates directly to domain services. Consequently,
+covered legacy HTTP mutation routes have no legitimate execution caller and
+must fail closed so they cannot bypass approval, idempotency, the kill switch,
+or evidence recording.
+"""
+
+from __future__ import annotations
+
+
+KERNEL_EXECUTION_PATH = "/admin/control-center/kernel/execute"
+UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def requires_continuity_kernel(method: str, path: str) -> bool:
+    normalized_method = str(method or "").strip().upper()
+    normalized_path = "/" + str(path or "").strip().lstrip("/")
+    normalized_path = normalized_path.rstrip("/") or "/"
+    if normalized_method not in UNSAFE_METHODS:
+        return False
+
+    if (
+        normalized_path == "/admin/control-center/kernel"
+        or normalized_path.startswith("/admin/control-center/kernel/")
+    ):
+        return False
+
+    if normalized_path.startswith("/admin/control-center"):
+        # Preview requests do not mutate business data and remain available so
+        # the CEO can inspect exact before/after state.
+        if normalized_path.endswith("/preview"):
+            return False
+        return True
+
+    if normalized_path.startswith("/admin/stripe-ops"):
+        return True
+
+    if normalized_path.startswith("/auth/admin/users/"):
+        return True
+
+    return normalized_path in {
+        "/orders/admin/manual-order",
+        "/orders/admin/repair-paid-package-access",
+        "/project-entitlements/apply",
+        "/users",
+    }

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2,6 +2,8 @@ from pymongo import MongoClient
 from pymongo.database import Database
 import certifi
 import logging
+import os
+from pathlib import Path
 from typing import Any
 
 from app.config import settings
@@ -48,17 +50,137 @@ def get_database() -> Database:
     return db
 
 
-def get_service_state() -> dict[str, Any]:
+def get_service_state(*, include_operational_details: bool = False) -> dict[str, Any]:
     database_connected = db is not None
     degraded_reasons = [] if database_connected else ["database_unavailable"]
     ready = database_connected
     service_mode = "ok" if ready else "degraded"
-    return {
+    release_sha = ""
+    for key in (
+        "RENDER_GIT_COMMIT",
+        "RELEASE_SHA",
+        "GIT_COMMIT",
+        "COMMIT_SHA",
+        "VERCEL_GIT_COMMIT_SHA",
+    ):
+        release_sha = str(os.environ.get(key) or "").strip()
+        if release_sha:
+            break
+
+    postmark_token_file = str(settings.postmark_server_token_file or "").strip()
+    postmark_token_configured = bool(str(settings.postmark_server_token or "").strip())
+    if not postmark_token_configured and postmark_token_file:
+        try:
+            postmark_token_configured = bool(
+                Path(postmark_token_file).is_file()
+                and Path(postmark_token_file).stat().st_size > 0
+            )
+        except OSError:
+            postmark_token_configured = False
+
+    stripe_configured = bool(
+        str(settings.stripe_secret_key or "").strip()
+        and str(settings.stripe_publishable_key or "").strip()
+        and str(settings.stripe_webhook_secret or "").strip()
+    )
+    postmark_configured = bool(
+        postmark_token_configured
+        and str(settings.postmark_from_email or "").strip()
+    )
+    scanner_hook = str(settings.upload_scan_hook or "").strip()
+    scanner_configured = bool(
+        scanner_hook
+        and ":" in scanner_hook
+        and scanner_hook.partition(":")[0].strip()
+        and scanner_hook.partition(":")[2].strip()
+    )
+    mount_path_value = str(settings.render_disk_mount_path or "").strip()
+    mount_path = Path(mount_path_value) if mount_path_value else None
+    persistent_private_storage = bool(
+        mount_path
+        and mount_path.is_dir()
+        and os.access(mount_path, os.R_OK | os.W_OK)
+    )
+    secret_key = str(settings.secret_key or "")
+    signing_key_configured = bool(
+        len(secret_key.encode("utf-8")) >= 32
+        and secret_key.strip().lower()
+        not in {"", "change-me", "changeme", "replace-me", "secret"}
+    )
+    kill_switch_raw = str(
+        os.environ.get("CONTINUITY_EXECUTION_KILL_SWITCH") or ""
+    ).strip().lower()
+    continuity_execution_enabled = kill_switch_raw not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+    operational_degraded_reasons: list[str] = list(degraded_reasons)
+    if settings.is_production_environment:
+        if not signing_key_configured:
+            operational_degraded_reasons.append("production_signing_key_invalid")
+        if not stripe_configured:
+            operational_degraded_reasons.append("stripe_configuration_incomplete")
+        if not postmark_configured:
+            operational_degraded_reasons.append("postmark_configuration_incomplete")
+        if not scanner_configured:
+            operational_degraded_reasons.append("upload_scanner_unavailable_quarantine_only")
+        if not persistent_private_storage:
+            operational_degraded_reasons.append("private_upload_storage_not_persistent")
+        if not release_sha:
+            operational_degraded_reasons.append("deployment_revision_unavailable")
+        if not continuity_execution_enabled:
+            operational_degraded_reasons.append("continuity_execution_disabled")
+
+    operational_ready = ready and not operational_degraded_reasons
+    service_state: dict[str, Any] = {
         "database_connected": database_connected,
         "service_mode": service_mode,
         "ready": ready,
         "degraded_reasons": degraded_reasons,
+        "operational_ready": operational_ready,
     }
+    if not include_operational_details:
+        # Public liveness and readiness surfaces intentionally omit exact
+        # security-control configuration. Detailed operational diagnostics are
+        # available only through the authenticated CEO endpoint.
+        return service_state
+
+    service_state.update({
+        "operational_degraded_reasons": operational_degraded_reasons,
+        "release": {
+            "version": settings.app_version,
+            "commit": release_sha or None,
+        },
+        "components": {
+            "database": {"ready": database_connected},
+            "production_signing_key": {"configured": signing_key_configured},
+            "stripe_webhooks": {"configured": stripe_configured},
+            "transactional_email": {"configured": postmark_configured},
+            "upload_scanner": {
+                "configured": scanner_configured,
+                "fail_closed": bool(settings.upload_scan_fail_closed),
+                "mode": "active" if scanner_configured else "quarantine_only",
+                "legacy_command_ignored": bool(
+                    str(settings.upload_scan_command or "").strip()
+                ),
+            },
+            "private_upload_storage": {
+                "persistent": persistent_private_storage,
+                "mode": "persistent_disk" if persistent_private_storage else "local_runtime",
+            },
+            "continuity_kernel": {
+                "execution_enabled": continuity_execution_enabled,
+            },
+            "nft_runtime": {
+                "enabled": bool(settings.nft_mint_enabled),
+            },
+        },
+    })
+    return service_state
 
 
 def close_mongo_connection() -> None:

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -12,13 +12,13 @@ from app.core.admin_permission_registry import (
     CAPABILITY_PERMISSIONS,
     ROLE_CAPABILITIES,
     ROLE_PERMISSION_MAP,
+    is_canonical_ceo_email,
 )
 from app.core.package_catalog import get_package
 from app.core.role_catalog import (
     INTERNAL_ADMIN_ROLE_CODES,
     SUPER_ADMIN_ROLE_CODES,
     collect_role_codes,
-    has_internal_admin_role,
     normalize_role_code,
 )
 from app.core.security import decode_access_token, verify_csrf_token
@@ -89,6 +89,7 @@ def _is_unsafe_method(method: str) -> bool:
 def _is_public_password_reset_route(request: Request) -> bool:
     path = str(request.url.path or "").rstrip("/")
     return path in {
+        "/auth/account-activation/request",
         "/auth/password-reset/request",
         "/auth/password-reset/confirm",
     }
@@ -98,6 +99,7 @@ def _is_cookie_csrf_exempt_route(request: Request) -> bool:
     path = str(request.url.path or "").rstrip("/")
     return path in {
         "/auth/logout",
+        "/auth/account-activation/request",
         "/auth/mfa/enroll/begin",
         "/auth/mfa/enroll/verify",
         "/auth/mfa/login/verify",
@@ -191,13 +193,20 @@ def _get_token_from_request(
 
 
 def _has_internal_admin_access(user: dict[str, Any]) -> bool:
-    return has_internal_admin_role(
+    if is_canonical_ceo_email(user.get("email")):
+        # The canonical CEO remains an administrator even if a stale database
+        # row temporarily loses its role labels. resolve_access_context applies
+        # the same singleton invariant to capabilities and permissions.
+        return True
+    role_codes = collect_role_codes(
         (
             user.get("role"),
             user.get("access_tier"),
             user.get("department_role"),
         )
     )
+    role_codes.difference_update(SUPER_ADMIN_KEYS)
+    return any(role_code in INTERNAL_ADMIN_KEYS for role_code in role_codes)
 
 
 def has_internal_admin_access(user: dict[str, Any]) -> bool:
@@ -516,7 +525,10 @@ def require_super_admin(
             )
         )
     )
-    if role_codes.intersection(SUPER_ADMIN_KEYS):
+    if (
+        is_canonical_ceo_email(current_user.get("email"))
+        and role_codes.intersection(SUPER_ADMIN_KEYS)
+    ):
         return current_user
 
     raise HTTPException(
@@ -792,9 +804,22 @@ def resolve_access_context(
         )
 
     role_codes = _collect_role_codes_for_user(user)
+    canonical_ceo = is_canonical_ceo_email(user.get("email"))
+    if canonical_ceo:
+        # The CEO singleton cannot be demoted by a stale role assignment or a
+        # compromised legacy row. Startup reconciliation persists the same
+        # invariant, while this read-time rule fails safe immediately.
+        role_codes.add("ceo_master_admin")
+    else:
+        role_codes.difference_update(SUPER_ADMIN_KEYS)
     capabilities = _collect_capabilities_for_roles(role_codes)
     permissions = _collect_permissions_for_roles(role_codes, capabilities)
     permissions.update(_collect_user_permission_overrides(user_id))
+    if not canonical_ceo:
+        # A database override must never manufacture wildcard authority for a
+        # non-CEO identity.
+        capabilities.discard("*")
+        permissions.discard("*")
 
     entitlements = list_user_project_entitlements(
         user_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.config import settings
+from app.core.continuity_route_guard import (
+    KERNEL_EXECUTION_PATH,
+    requires_continuity_kernel,
+)
 from app.database import (
     DatabaseUnavailableError,
     close_mongo_connection,
@@ -101,6 +105,7 @@ from app.routes.workspace_access import (
 from app.services.nft_runtime_validation_service import (
     validate_nft_runtime_configuration_on_startup,
 )
+from app.services.auth_service import ensure_auth_indexes
 
 
 logger = logging.getLogger(__name__)
@@ -153,6 +158,7 @@ async def lifespan(app: FastAPI):
     db = connect_to_mongo()
     app.state.db = db
     if db is not None:
+        ensure_auth_indexes()
         initialize_order_indexes()
         ensure_project_entitlement_indexes()
         initialize_mint_record_indexes()
@@ -190,7 +196,22 @@ app.add_middleware(
 
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
-    response = await call_next(request)
+    if requires_continuity_kernel(request.method, request.url.path):
+        response = JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={
+                "error": {
+                    "code": "continuity_kernel_required",
+                    "message": (
+                        "This legacy mutation route is read-only. Submit the action "
+                        "through the Continuity Kernel."
+                    ),
+                    "kernel_execution_path": KERNEL_EXECUTION_PATH,
+                }
+            },
+        )
+    else:
+        response = await call_next(request)
 
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
@@ -343,6 +364,7 @@ def root():
             "/health",
             "/health/live",
             "/health/ready",
+            "/health/operational",
             "/auth/signup",
             "/auth/login",
             "/auth/logout",

--- a/backend/app/routes/admin_control_center.py
+++ b/backend/app/routes/admin_control_center.py
@@ -696,6 +696,7 @@ def super_admin_patch_user(
     payload: SuperAdminUserUpdatePayload,
     current_user: dict[str, Any] = Depends(require_super_admin),
 ):
+    _assert_canonical_ceo(current_user)
     try:
         return super_admin_update_user(
             user_id=user_id,
@@ -765,11 +766,13 @@ def super_admin_user_password_reset(
     user_id: str,
     current_user: dict[str, Any] = Depends(require_super_admin),
 ):
+    _assert_canonical_ceo(current_user)
     try:
         return admin_issue_password_reset(
             user_id,
             admin_user_id=_current_user_id(current_user),
             admin_display=_current_user_display(current_user),
+            admin_email=_string_value(current_user.get("email")),
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -13,6 +13,7 @@ from app.dependencies.auth import (
     resolve_access_context,
 )
 from app.schemas.auth import (
+    AccountActivationRequest,
     MfaDisableRequest,
     MfaEnrollmentBeginRequest,
     MfaEnrollmentVerifyRequest,
@@ -38,6 +39,7 @@ from app.services.auth_service import (
     get_user_by_id,
     get_user_by_email,
     register_user,
+    request_account_activation,
     revoke_user_sessions,
     request_password_reset,
     reset_password_with_token,
@@ -121,7 +123,10 @@ def _clear_auth_cookie(response: Response, request: Request) -> None:
 def _rate_key_from_request(request: Request, *, principal: str = "") -> str:
     forwarded_for = str(request.headers.get("x-forwarded-for") or "").split(",")[0].strip()
     client_host = str((request.client.host if request.client else "") or "").strip()
-    base = forwarded_for or client_host or "unknown"
+    # request.client is normalized by the trusted ASGI proxy boundary. A raw
+    # X-Forwarded-For value is attacker-controlled when the application is
+    # reached directly and must never override the connected client address.
+    base = client_host or forwarded_for or "unknown"
     normalized_principal = str(principal or "").strip().lower()
     return f"{base}:{normalized_principal}" if normalized_principal else base
 
@@ -151,7 +156,14 @@ def _enforce_rate_limit_with_audit(
 
 
 @router.post("/signup", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
-def signup(payload: UserCreate, response: Response):
+def signup(payload: UserCreate, request: Request, response: Response):
+    _enforce_rate_limit_with_audit(
+        scope="auth_signup",
+        key=_rate_key_from_request(request, principal=payload.email),
+        limit=max(1, int(settings.auth_password_reset_request_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+        audit_action="signup_throttled",
+    )
     try:
         user = register_user(payload)
     except ValueError as exc:
@@ -477,6 +489,24 @@ def _current_user_display(user: dict) -> str:
     )
 
 
+@router.post("/account-activation/request", response_model=PasswordResetResponse)
+def account_activation_request_route(
+    payload: AccountActivationRequest,
+    request: Request,
+    response: Response,
+):
+    _enforce_rate_limit_with_audit(
+        scope="auth_account_activation_request",
+        key=_rate_key_from_request(request, principal=payload.email),
+        limit=max(1, int(settings.auth_password_reset_request_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+        audit_action="account_activation_request_throttled",
+    )
+    result = request_account_activation(payload.email)
+    _apply_no_store(response)
+    return result
+
+
 @router.post("/password-reset/request", response_model=PasswordResetResponse)
 def password_reset_request_route(payload: PasswordResetRequest, response: Response):
     _enforce_rate_limit_with_audit(
@@ -553,6 +583,7 @@ def admin_issue_password_reset_route(
             user_id,
             admin_user_id=_current_user_id(current_user),
             admin_display=_current_user_display(current_user),
+            admin_email=str(current_user.get("email") or ""),
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -571,6 +602,7 @@ def admin_security_reset_route(
         admin_reset_user_security(
             target_user_id=user_id,
             actor_user_id=_current_user_id(current_user),
+            actor_email=str(current_user.get("email") or ""),
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, Response, status
+from typing import Any
+
+from fastapi import APIRouter, Depends, Response, status
 
 from app.database import get_service_state
+from app.dependencies.auth import require_super_admin
 
 router = APIRouter(tags=["Health"])
 
@@ -43,6 +46,26 @@ def readiness_check(response: Response):
     )
     return {
         "status": "ok" if service_state["ready"] else "unavailable",
+        "service": "Tomb of Light API",
+        **service_state,
+    }
+
+
+@router.get("/health/operational")
+def operational_readiness_check(
+    response: Response,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    del current_user
+    service_state = get_service_state(include_operational_details=True)
+    operational_ready = bool(service_state.get("operational_ready"))
+    response.status_code = (
+        status.HTTP_200_OK
+        if operational_ready
+        else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
+    return {
+        "status": "ok" if operational_ready else "unavailable",
         "service": "Tomb of Light API",
         **service_state,
     }

--- a/backend/app/routes/stripe_webhooks.py
+++ b/backend/app/routes/stripe_webhooks.py
@@ -144,6 +144,7 @@ def _mark_event_processed(
             "$set": {
                 "processed_at": now,
                 "processing_finished_at": now,
+                "processing_status": "completed",
                 "order_result": {
                     "order_id": order_result.get("order_id"),
                     "error": order_result.get("error"),
@@ -155,9 +156,93 @@ def _mark_event_processed(
                     "type": maintenance_result.get("type"),
                 },
             },
-            "$unset": {"processing_claim": ""},
+            "$unset": {
+                "processing_claim": "",
+                "retryable_failures": "",
+                "processing_failed_at": "",
+            },
         },
     )
+
+
+def _mark_event_failed(
+    events_col: Collection[dict[str, Any]],
+    *,
+    event_id: str,
+    claim_token: str,
+    failures: list[str],
+    order_result: dict[str, Any],
+    maintenance_result: dict[str, Any],
+    now: datetime,
+) -> None:
+    if not event_id:
+        return
+    events_col.update_one(
+        {"event_id": event_id, "processing_claim": claim_token},
+        {
+            "$set": {
+                "processing_failed_at": now,
+                "processing_finished_at": now,
+                "processing_status": "retryable_failure",
+                "retryable_failures": list(failures),
+                "order_result": {
+                    "order_id": order_result.get("order_id"),
+                    "error": order_result.get("error"),
+                    "reason": order_result.get("reason"),
+                    "type": order_result.get("type"),
+                },
+                "maintenance_result": {
+                    "updated": bool(maintenance_result.get("updated")),
+                    "error": maintenance_result.get("error"),
+                    "type": maintenance_result.get("type"),
+                },
+            },
+            "$unset": {"processing_claim": "", "processed_at": ""},
+        },
+    )
+
+
+def _downstream_failures(
+    *,
+    event_type: str,
+    order_result: dict[str, Any],
+    maintenance_result: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    if event_type == "checkout.session.completed":
+        # A checkout may represent either a package purchase or a maintenance
+        # subscription. The event is complete when the relevant handler wins;
+        # an expected rejection by the non-relevant handler is not a failure.
+        checkout_persisted = bool(
+            order_result.get("order_id")
+            or order_result.get("duplicate")
+            or maintenance_result.get("updated")
+        )
+        if not checkout_persisted:
+            failures.append(
+                str(
+                    order_result.get("error")
+                    or maintenance_result.get("error")
+                    or order_result.get("reason")
+                    or maintenance_result.get("reason")
+                    or "checkout_not_persisted"
+                )
+            )
+    elif event_type in {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+        "invoice.paid",
+        "invoice.payment_failed",
+    } and not maintenance_result.get("updated"):
+        failures.append(
+            str(
+                maintenance_result.get("error")
+                or maintenance_result.get("reason")
+                or "maintenance_event_not_persisted"
+            )
+        )
+    return list(dict.fromkeys(failure for failure in failures if failure))
 
 
 @router.post("/stripe", status_code=status.HTTP_200_OK)
@@ -245,13 +330,35 @@ async def stripe_webhook(request: Request) -> Dict[str, Any]:
             logger.error("Stripe invoice maintenance sync failed", exc_info=True)
             maintenance_result = {"updated": False, "error": "maintenance_invoice_sync_failed", "type": event_type}
 
+    failures = _downstream_failures(
+        event_type=event_type,
+        order_result=order_result,
+        maintenance_result=maintenance_result,
+    )
+    finished_at = datetime.now(timezone.utc)
+    if failures:
+        _mark_event_failed(
+            events_col,
+            event_id=event_id,
+            claim_token=claim_token,
+            failures=failures,
+            order_result=order_result,
+            maintenance_result=maintenance_result,
+            now=finished_at,
+        )
+        logger.error("Stripe webhook processing failed and was released for retry")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Stripe event processing failed; delivery is safe to retry.",
+        )
+
     _mark_event_processed(
         events_col,
         event_id=event_id,
         claim_token=claim_token,
         order_result=order_result,
         maintenance_result=maintenance_result,
-        now=datetime.now(timezone.utc),
+        now=finished_at,
     )
 
     logger.info("Stripe webhook processed")

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -6,7 +6,7 @@ from app.dependencies.auth import get_current_user, require_capability, require_
 from app.schemas.experience import UserProfileResponse, UserProfileUpdate
 from app.schemas.user import UserCreate, UserResponse, build_user_response
 from app.services.auth_service import get_user_by_id
-from app.services.user_service import create_user, list_users, update_user_profile
+from app.services.user_service import list_users, update_user_profile
 from app.services.workspace_access_service import build_workspace_context_snapshot
 
 router = APIRouter(prefix="/users", tags=["Users"])
@@ -33,8 +33,14 @@ def create_user_route(
     payload: UserCreate,
     current_user: dict[str, Any] = Depends(require_capability("manage_users_full")),
 ):
-    user = create_user(payload)
-    return build_user_response(user)
+    del payload, current_user
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            "Direct account creation is retired. Use the Continuity Kernel "
+            "customer_account_create action so approval, activation, and evidence are recorded."
+        ),
+    )
 
 
 @router.get("/me/profile", response_model=UserProfileResponse)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -18,6 +18,11 @@ class UserCreate(BaseModel):
         min_length=1,
         max_length=32,
     )
+    activation_token: Optional[str] = Field(default=None, min_length=16, max_length=512)
+
+
+class AccountActivationRequest(BaseModel):
+    email: EmailStr
 
 
 class UserLogin(BaseModel):
@@ -98,6 +103,9 @@ class UserResponse(BaseModel):
     access_tier: Optional[str] = None
     department_role: Optional[str] = None
     status: str
+    requires_account_activation: bool = False
+    activation_delivery_sent: Optional[bool] = None
+    activation_delivery_error: Optional[str] = None
     mfa_enabled: bool = False
     mfa_enrolled_at: Optional[str] = None
     created_at: str

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,15 +1,13 @@
 from datetime import datetime, UTC
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class UserCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     first_name: str = Field(..., min_length=1, max_length=100)
     last_name: str = Field(..., min_length=1, max_length=100)
     email: EmailStr
-    role: str = "user"
-    access_tier: str | None = None
-    department_role: str | None = None
-    status: str | None = "active"
 
 
 class UserResponse(BaseModel):

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import os
 import re
 import secrets
@@ -17,6 +18,7 @@ from app.core.admin_permission_registry import (
     PERMISSION_REGISTRY,
     ROLE_METADATA,
     ROLE_PERMISSION_MAP,
+    is_canonical_ceo_email,
 )
 from app.core.package_catalog import (
     canonicalize_package_identifier,
@@ -691,7 +693,7 @@ def _write_admin_action_audit(
     after: dict[str, Any] | None = None,
     context: dict[str, Any] | None = None,
     details: dict[str, Any] | None = None,
-) -> None:
+) -> bool:
     actor_fields = _actor_snapshot(actor)
     try:
         write_audit_log(
@@ -707,9 +709,9 @@ def _write_admin_action_audit(
             details=details or {},
             result=result,
         )
+        return True
     except Exception:
-        # Admin repairs should not fail solely because audit persistence is unavailable.
-        return
+        return False
 
 
 def _db():
@@ -2160,7 +2162,7 @@ def super_admin_apply_package_revocation(
         "stripe_payment_mutated": False,
     }
     db["admin_package_assignments"].insert_one(history)
-    _write_admin_action_audit(
+    audit_event_created = _write_admin_action_audit(
         actor=actor,
         action="super_admin.package_revoke",
         target_type="project",
@@ -2169,7 +2171,12 @@ def super_admin_apply_package_revocation(
         after={"package_status": "revoked", "services_active": False},
         context={"surface": "admin_control_center.restricted_actions", "reason": _normalize(reason)},
     )
-    return {**preview, "revoked": True, "audit_event_created": True, "stripe_payment_mutated": False}
+    return {
+        **preview,
+        "revoked": True,
+        "audit_event_created": audit_event_created,
+        "stripe_payment_mutated": False,
+    }
 
 
 def super_admin_restore_package(
@@ -5053,30 +5060,17 @@ def _validated_role_value(role_value: str) -> str:
     return normalized_role
 
 
-def _is_internal_admin_account(user: dict[str, Any]) -> bool:
-    """Return True if the user is an internal admin account.
-
-    Used to guard super_admin role escalation: only users who are already
-    internal team members (identified by an existing admin role or explicit
-    business_admin account type) may be promoted to super_admin.
-    """
-    existing_role = normalize_role_code(_normalize(user.get("role"))) or "user"
-    if existing_role in INTERNAL_ROLE_KEYS:
-        return True
-    if _normalize(user.get("account_type")).lower() == "business_admin":
-        return True
-    return False
-
-
 def _is_canonical_ceo_master_admin_identity(user: dict[str, Any]) -> bool:
-    return _normalize_email(user.get("email")) == CEO_MASTER_ADMIN_EMAIL
+    return is_canonical_ceo_email(user.get("email"))
 
 
 def _enforce_ceo_master_admin_singleton(*, target_user: dict[str, Any], new_role: str) -> None:
-    if new_role != "ceo_master_admin":
+    if new_role not in SUPER_ADMIN_ROLE_CODES:
         return
     if not _is_canonical_ceo_master_admin_identity(target_user):
-        raise ValueError("ceo_master_admin role can only be assigned to Larry Robinson's canonical identity.")
+        raise ValueError(
+            "Wildcard administrator roles can only be assigned to Larry Robinson's canonical identity."
+        )
 
 
 def super_admin_update_user(
@@ -5090,6 +5084,19 @@ def super_admin_update_user(
         raise ValueError("User not found.")
     if _normalize(user.get("status")).lower() == "permanently_deleted" or _normalize(user.get("account_type")).lower() == "deleted_tombstone":
         raise ValueError("A permanently deleted account cannot be edited or restored.")
+    canonical_ceo_target = _is_canonical_ceo_master_admin_identity(user)
+    if canonical_ceo_target:
+        immutable_ceo_fields = {
+            "email",
+            "status",
+            "role",
+            "access_tier",
+            "department_role",
+        }.intersection(payload)
+        if immutable_ceo_fields:
+            raise ValueError(
+                "The canonical CEO identity, active status, and master administrator roles are immutable."
+            )
     db = _db()
     current_user_id = _normalize_object_id(user.get("_id")) or _normalize(user_id)
     updates: dict[str, Any] = {"updated_at": _now()}
@@ -5115,15 +5122,6 @@ def super_admin_update_user(
     if "role" in payload:
         new_role = _validated_role_value(_normalize(payload.get("role")))
         _enforce_ceo_master_admin_singleton(target_user=user, new_role=new_role)
-        # Granting super_admin role is high-impact.  Require that the target
-        # user is already an internal admin account (not a customer account).
-        # This prevents accidental or malicious escalation of customer accounts
-        # to the highest privilege level.
-        if new_role in SUPER_ADMIN_ROLE_CODES and not _is_internal_admin_account(user):
-            raise ValueError(
-                "super_admin role can only be granted to existing internal admin accounts. "
-                "The target user's current role must already be an internal admin role."
-            )
         updates["role"] = new_role
     if "access_tier" in payload:
         access_tier = normalize_role_code(_normalize(payload.get("access_tier"))) or None
@@ -5368,6 +5366,16 @@ def super_admin_create_customer(
             db["users"].delete_one({"_id": document["_id"]})
         raise
 
+    # Credentials are never handed to an administrator. The customer proves
+    # control of the mailbox through a short-lived, single-use activation link.
+    from app.services.auth_service import request_account_activation
+
+    activation_delivery = request_account_activation(
+        email,
+        include_delivery_status=True,
+    )
+    activation_sent = bool(activation_delivery.get("delivery_sent"))
+
     _write_admin_action_audit(
         actor=actor,
         action="super_admin.customer_create",
@@ -5382,7 +5390,11 @@ def super_admin_create_customer(
             "project_id": project_id,
             "package_code": package_code or None,
         },
-        context={"surface": "admin_control_center.account_360", "package_granted": bool(package_code)},
+        context={
+            "surface": "admin_control_center.account_360",
+            "package_granted": bool(package_code),
+            "activation_delivery_sent": activation_sent,
+        },
     )
     return {
         "user_id": user_id,
@@ -5395,6 +5407,16 @@ def super_admin_create_customer(
         "entitlement_status": _normalize((entitlement or {}).get("status")) or None,
         "payment_record_created": False,
         "stripe_payment_mutated": False,
+        "activation_delivery_sent": activation_sent,
+        "activation_delivery_provider": _normalize(
+            activation_delivery.get("delivery_provider")
+        )
+        or "postmark",
+        "activation_delivery_error": _normalize(
+            activation_delivery.get("delivery_error")
+        )
+        or None,
+        "failure_count": 0 if activation_sent else 1,
     }
 
 
@@ -5671,7 +5693,7 @@ def super_admin_apply_account_lifecycle(
             actor=actor,
             now_value=now_value,
         )
-    _write_admin_action_audit(
+    audit_event_created = _write_admin_action_audit(
         actor=actor,
         action=f"super_admin.account_{normalized_action}",
         target_type="user",
@@ -5690,7 +5712,7 @@ def super_admin_apply_account_lifecycle(
         "applied": True,
         "sessions_revoked": True,
         "archive_results": archive_results,
-        "audit_event_created": True,
+        "audit_event_created": audit_event_created,
     }
 
 
@@ -6258,10 +6280,122 @@ def super_admin_apply_account_permanent_deletion(
     user = _user_by_id(user_id)
     if user is None:
         raise ValueError("User not found.")
+    resolved_identity_id = _normalize_object_id(user.get("_id")) or _normalize(user_id)
+    db = _db()
+    tombstone_collection = db[ACCOUNT_DELETION_TOMBSTONES_COLLECTION]
+    existing_tombstone = tombstone_collection.find_one(
+        {"user_id": resolved_identity_id}
+    )
+    confirmation_email_value = _normalize_email(confirmation_email)
+
+    # A process may stop after identity erasure but before audit/tombstone
+    # closure. Re-entering the same governed operation resumes evidence
+    # closure without restoring credentials or repeating destructive writes.
+    if _normalize(user.get("status")).lower() == "permanently_deleted":
+        if not existing_tombstone:
+            raise RuntimeError(
+                "The identity is permanently deleted but its deletion tombstone is missing."
+            )
+        confirmation_hash = hashlib.sha256(
+            confirmation_email_value.encode("utf-8")
+        ).hexdigest()
+        if not hmac.compare_digest(
+            confirmation_hash,
+            _normalize(existing_tombstone.get("original_email_sha256")),
+        ):
+            raise ValueError(
+                "The confirmation email does not match the deletion evidence."
+            )
+        deletion_id = _normalize(existing_tombstone.get("deletion_id"))
+        if not deletion_id or _normalize(user.get("permanent_deletion_id")) != deletion_id:
+            raise RuntimeError("Permanent deletion evidence does not match the identity tombstone.")
+        records_closed = dict(existing_tombstone.get("records_closed") or {})
+        records_preserved = list(existing_tombstone.get("records_preserved") or [])
+        audit_created = bool(existing_tombstone.get("audit_event_created"))
+        if not audit_created:
+            audit_created = _write_admin_action_audit(
+                actor=actor,
+                action="super_admin.account_permanently_deleted",
+                target_type="user",
+                target_id=resolved_identity_id,
+                before={"status": "deletion_in_progress"},
+                after={
+                    "status": "permanently_deleted",
+                    "login_enabled": False,
+                    "restorable": False,
+                    "personal_profile_erased": True,
+                },
+                context={
+                    "surface": "admin_control_center.permanent_deletion.resume",
+                    "deletion_id": deletion_id,
+                    "reason_category": normalized_reason_category,
+                    "records_closed": records_closed,
+                    "records_preserved": records_preserved,
+                },
+            )
+        if not audit_created:
+            tombstone_collection.update_one(
+                {"user_id": resolved_identity_id, "deletion_id": deletion_id},
+                {
+                    "$set": {
+                        "status": "audit_pending",
+                        "phase": "identity_erased",
+                        "audit_event_created": False,
+                        "updated_at": _now(),
+                    }
+                },
+            )
+            raise RuntimeError(
+                "Identity erasure completed, but audit evidence is still pending. Retry the same Kernel operation."
+            )
+        completed_at = _now()
+        tombstone_collection.update_one(
+            {"user_id": resolved_identity_id, "deletion_id": deletion_id},
+            {
+                "$set": {
+                    "status": "completed",
+                    "phase": "completed",
+                    "audit_event_created": True,
+                    "completed_at": existing_tombstone.get("completed_at") or completed_at,
+                    "updated_at": completed_at,
+                }
+            },
+        )
+        return {
+            "user_id": resolved_identity_id,
+            "blocked": False,
+            "warnings": [],
+            "records_preserved": records_preserved,
+            "applied": True,
+            "permanent": True,
+            "restorable": False,
+            "sessions_revoked": True,
+            "audit_event_created": True,
+            "failure_count": 0,
+            "resumed": True,
+            "deletion_receipt": {
+                "deletion_id": deletion_id,
+                "continuity_operation_id": existing_tombstone.get(
+                    "continuity_operation_id"
+                ),
+                "user_id": resolved_identity_id,
+                "status": "permanently_deleted",
+                "deleted_at": _serialize_datetime(
+                    user.get("permanently_deleted_at") or completed_at
+                ),
+                "deleted_by": user.get("permanently_deleted_by"),
+                "reason_category": normalized_reason_category,
+                "personal_profile_erased": True,
+                "login_enabled": False,
+                "restorable": False,
+                "records_closed": records_closed,
+                "records_preserved": records_preserved,
+            },
+        }
     original_email = _normalize_email(user.get("email"))
     if not original_email or "@" not in original_email:
         raise ValueError("Permanent deletion requires a valid target account email for confirmation.")
-    if _normalize_email(confirmation_email) != original_email:
+    if confirmation_email_value != original_email:
         raise ValueError("The confirmation email does not match the account being permanently deleted.")
 
     preview = super_admin_preview_account_permanent_deletion(
@@ -6274,26 +6408,136 @@ def super_admin_apply_account_permanent_deletion(
     resolved_user_id = _normalize(preview.get("user_id"))
     now_value = _now()
     actor_id = _normalize((actor or {}).get("_id") or (actor or {}).get("id")) or None
-    deletion_id = f"acctdel_{secrets.token_hex(16)}"
-    deleted_email = f"deleted-{resolved_user_id}@deleted.tomboflight.invalid"
     email_sha256 = hashlib.sha256(original_email.encode("utf-8")).hexdigest()
+    reason_sha256 = hashlib.sha256(normalized_reason.encode("utf-8")).hexdigest()
+    operation_id_value = _normalize(continuity_operation_id) or None
+    existing_tombstone = tombstone_collection.find_one({"user_id": resolved_user_id})
+    if existing_tombstone:
+        if _normalize(existing_tombstone.get("status")) == "completed":
+            raise RuntimeError("Deletion evidence is completed but the user identity is not finalized.")
+        if not hmac.compare_digest(
+            email_sha256,
+            _normalize(existing_tombstone.get("original_email_sha256")),
+        ):
+            raise RuntimeError("An existing deletion attempt is bound to different identity evidence.")
+        if not hmac.compare_digest(
+            reason_sha256,
+            _normalize(existing_tombstone.get("reason_sha256")),
+        ):
+            raise ValueError("Retry the existing deletion with its original reason.")
+        existing_operation_id = _normalize(
+            existing_tombstone.get("continuity_operation_id")
+        )
+        if existing_operation_id and operation_id_value and existing_operation_id != operation_id_value:
+            raise ValueError("The deletion tombstone is bound to a different Continuity operation.")
+        deletion_id = _normalize(existing_tombstone.get("deletion_id"))
+    else:
+        deletion_id = f"acctdel_{secrets.token_hex(16)}"
+    if not deletion_id:
+        raise RuntimeError("Permanent deletion could not establish a stable deletion id.")
+
+    deleted_email = f"deleted-{resolved_user_id}@deleted.tomboflight.invalid"
+    tombstone_collection.update_one(
+        {"user_id": resolved_user_id},
+        {
+            "$set": {
+                "deletion_id": deletion_id,
+                "continuity_operation_id": operation_id_value,
+                "original_email_sha256": email_sha256,
+                "status": "started",
+                "phase": "planned",
+                "irreversible": True,
+                "restorable": False,
+                "reason_category": normalized_reason_category,
+                "reason_sha256": reason_sha256,
+                "requested_by": _actor_snapshot(actor),
+                "records_preserved": list(preview.get("records_preserved") or []),
+                "started_at": (existing_tombstone or {}).get("started_at") or now_value,
+                "updated_at": now_value,
+            },
+            "$setOnInsert": {"created_at": now_value},
+        },
+        upsert=True,
+    )
+
+    # Revoke active authentication before the first external side effect. This
+    # lock is idempotent and preserves the original email solely until final
+    # identity erasure can compare-and-set the intended account.
+    if _normalize(user.get("status")).lower() != "deletion_in_progress":
+        oid = _to_object_id(resolved_user_id)
+        lock_result = db["users"].update_one(
+            {
+                "_id": oid or resolved_user_id,
+                "email": original_email,
+                "status": {"$nin": ["permanently_deleted", "deletion_in_progress"]},
+            },
+            {
+                "$set": {
+                    "status": "deletion_in_progress",
+                    "login_enabled": False,
+                    "permanent_deletion_id": deletion_id,
+                    "session_token_version": int(user.get("session_token_version") or 0) + 1,
+                    "updated_at": now_value,
+                }
+            },
+        )
+        if int(getattr(lock_result, "matched_count", 0)) != 1:
+            raise RuntimeError("The target account changed before deletion could be locked.")
+        user = _user_by_id(resolved_user_id) or user
+    elif _normalize(user.get("permanent_deletion_id")) != deletion_id:
+        raise RuntimeError("The account is locked by a different deletion attempt.")
+    tombstone_collection.update_one(
+        {"user_id": resolved_user_id, "deletion_id": deletion_id},
+        {"$set": {"phase": "identity_locked", "updated_at": _now()}},
+    )
+
     ownership_records = _all_owned_records(user_id=resolved_user_id, user_email=original_email)
     active_subscription_ids = _active_maintenance_subscription_ids(
         ownership_records=ownership_records
     )
 
     subscription_results: list[dict[str, Any]] = []
-    for subscription_id in active_subscription_ids:
-        subscription_results.append(
-            stripe_admin_operations_service.cancel_subscription(
-                actor or {},
-                subscription_id=subscription_id,
-                at_period_end=False,
-                confirm=True,
-                reason=f"Permanent account deletion: {normalized_reason}",
-                idempotency_key=_normalize(continuity_operation_id) or deletion_id,
+    try:
+        for subscription_id in active_subscription_ids:
+            subscription_results.append(
+                stripe_admin_operations_service.cancel_subscription(
+                    actor or {},
+                    subscription_id=subscription_id,
+                    at_period_end=False,
+                    confirm=True,
+                    reason=f"Permanent account deletion: {normalized_reason}",
+                    # One deletion can own more than one subscription. Stripe
+                    # idempotency keys must therefore be stable per external
+                    # subscription, not merely per deletion operation.
+                    idempotency_key=(
+                        f"{operation_id_value or deletion_id}:{subscription_id}"
+                    ),
+                )
             )
+    except Exception as exc:
+        tombstone_collection.update_one(
+            {"user_id": resolved_user_id, "deletion_id": deletion_id},
+            {
+                "$set": {
+                    "status": "failed_retryable",
+                    "phase": "subscription_cancellation",
+                    "last_error_type": type(exc).__name__,
+                    "updated_at": _now(),
+                }
+            },
         )
+        raise
+    tombstone_collection.update_one(
+        {"user_id": resolved_user_id, "deletion_id": deletion_id},
+        {
+            "$set": {
+                "status": "started",
+                "phase": "subscriptions_cancelled",
+                "updated_at": _now(),
+            },
+            "$unset": {"last_error_type": ""},
+        },
+    )
 
     updates: dict[str, Any] = {
         "email": deleted_email,
@@ -6324,6 +6568,12 @@ def super_admin_apply_account_permanent_deletion(
         "password_reset_requested_by": None,
         "password_reset_requested_by_user_id": None,
         "password_reset_used_at": None,
+        "account_activation_token_hash": None,
+        "account_activation_expires_at": None,
+        "account_activation_requested_at": None,
+        "activation_delivery_sent": None,
+        "activation_delivery_error": None,
+        "requires_account_activation": False,
         "mfa_enabled": False,
         "mfa_secret_encrypted": None,
         "mfa_backup_code_hashes": [],
@@ -6356,33 +6606,9 @@ def super_admin_apply_account_permanent_deletion(
         "permanently_deleted_at": now_value,
         "permanently_deleted_by": actor_id,
         "permanent_deletion_reason_category": normalized_reason_category,
-        "session_token_version": int(user.get("session_token_version") or 0) + 1,
+        "session_token_version": int(user.get("session_token_version") or 0),
         "updated_at": now_value,
     }
-    db = _db()
-    tombstone_collection = db[ACCOUNT_DELETION_TOMBSTONES_COLLECTION]
-    tombstone_collection.update_one(
-        {"user_id": resolved_user_id},
-        {
-            "$set": {
-                "deletion_id": deletion_id,
-                "continuity_operation_id": _normalize(continuity_operation_id) or None,
-                "original_email_sha256": email_sha256,
-                "status": "started",
-                "irreversible": True,
-                "restorable": False,
-                "reason_category": normalized_reason_category,
-                "reason_sha256": hashlib.sha256(normalized_reason.encode("utf-8")).hexdigest(),
-                "requested_by": _actor_snapshot(actor),
-                "records_preserved": list(preview.get("records_preserved") or []),
-                "started_at": now_value,
-                "updated_at": now_value,
-            },
-            "$setOnInsert": {"created_at": now_value},
-        },
-        upsert=True,
-    )
-
     role_result = db["user_role_assignments"].update_many(
         {"user_id": {"$in": _project_id_candidates(resolved_user_id)}, "status": {"$nin": ["revoked", "deleted"]}},
         {"$set": {"status": "revoked", "revoked_at": now_value, "updated_at": now_value}},
@@ -6404,6 +6630,17 @@ def super_admin_apply_account_permanent_deletion(
     closure_results["user_role_assignments"] = int(role_result.modified_count)
     closure_results["user_permission_overrides"] = int(permission_result.modified_count)
     closure_results["stripe_subscriptions_cancelled"] = len(subscription_results)
+    tombstone_collection.update_one(
+        {"user_id": resolved_user_id, "deletion_id": deletion_id},
+        {
+            "$set": {
+                "status": "started",
+                "phase": "records_closed",
+                "records_closed": closure_results,
+                "updated_at": _now(),
+            }
+        },
+    )
 
     # Destroy the authentication identity only after linked access records are
     # closed.  The exact original email in this compare-and-set prevents a
@@ -6413,32 +6650,32 @@ def super_admin_apply_account_permanent_deletion(
         {
             "_id": oid or resolved_user_id,
             "email": original_email,
-            "status": {"$nin": ["permanently_deleted"]},
+            "status": "deletion_in_progress",
+            "permanent_deletion_id": deletion_id,
         },
         {"$set": updates},
     )
     if int(getattr(update_result, "matched_count", 0)) != 1:
         raise RuntimeError("The target account changed before permanent deletion could be applied.")
 
-    tombstone_result = tombstone_collection.update_one(
+    tombstone_collection.update_one(
         {"user_id": resolved_user_id, "deletion_id": deletion_id},
         {
             "$set": {
-                "status": "completed",
+                "status": "audit_pending",
+                "phase": "identity_erased",
                 "records_closed": closure_results,
-                "completed_at": now_value,
+                "identity_erased_at": now_value,
                 "updated_at": now_value,
             }
         },
     )
-    if int(getattr(tombstone_result, "matched_count", 0)) != 1:
-        raise RuntimeError("Permanent deletion completed, but its MongoDB tombstone could not be finalized.")
 
     refreshed = _user_by_id(resolved_user_id) or {}
     if _normalize(refreshed.get("status")).lower() != "permanently_deleted" or bool(refreshed.get("login_enabled", True)):
         raise RuntimeError("Permanent deletion verification failed after the MongoDB write.")
 
-    _write_admin_action_audit(
+    audit_event_created = _write_admin_action_audit(
         actor=actor,
         action="super_admin.account_permanently_deleted",
         target_type="user",
@@ -6458,17 +6695,50 @@ def super_admin_apply_account_permanent_deletion(
             "records_preserved": list(preview.get("records_preserved") or []),
         },
     )
+    if not audit_event_created:
+        tombstone_collection.update_one(
+            {"user_id": resolved_user_id, "deletion_id": deletion_id},
+            {
+                "$set": {
+                    "status": "audit_pending",
+                    "phase": "identity_erased",
+                    "audit_event_created": False,
+                    "updated_at": _now(),
+                }
+            },
+        )
+        raise RuntimeError(
+            "Identity erasure completed, but audit evidence is still pending. Retry the same Kernel operation."
+        )
+
+    tombstone_result = tombstone_collection.update_one(
+        {"user_id": resolved_user_id, "deletion_id": deletion_id},
+        {
+            "$set": {
+                "status": "completed",
+                "phase": "completed",
+                "audit_event_created": True,
+                "records_closed": closure_results,
+                "completed_at": now_value,
+                "updated_at": now_value,
+            }
+        },
+    )
+    if int(getattr(tombstone_result, "matched_count", 0)) != 1:
+        raise RuntimeError(
+            "Permanent deletion completed, but its MongoDB tombstone could not be finalized."
+        )
     return {
         **preview,
         "applied": True,
         "permanent": True,
         "restorable": False,
         "sessions_revoked": True,
-        "audit_event_created": True,
+        "audit_event_created": audit_event_created,
         "failure_count": 0,
         "deletion_receipt": {
             "deletion_id": deletion_id,
-            "continuity_operation_id": _normalize(continuity_operation_id) or None,
+            "continuity_operation_id": operation_id_value,
             "user_id": resolved_user_id,
             "status": "permanently_deleted",
             "deleted_at": _serialize_datetime(now_value),
@@ -6514,7 +6784,7 @@ def super_admin_transfer_project_ownership(
         {"$set": {"role": "owner", "status": "active", "updated_at": _now()}, "$setOnInsert": {"created_at": _now()}},
         upsert=True,
     )
-    _write_admin_action_audit(
+    audit_event_created = _write_admin_action_audit(
         actor=actor,
         action="super_admin.project_ownership_transfer",
         target_type="project",
@@ -6523,7 +6793,12 @@ def super_admin_transfer_project_ownership(
         after=after,
         context={"surface": "admin_control_center.account_360", "reason": _normalize(reason)},
     )
-    return {"project_id": resolved_project_id, "before": before, "after": after, "audit_event_created": True}
+    return {
+        "project_id": resolved_project_id,
+        "before": before,
+        "after": after,
+        "audit_event_created": audit_event_created,
+    }
 
 
 def legacy_admin_security_review(

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -6,12 +6,14 @@ import secrets
 import struct
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from bson import ObjectId
 from cryptography.fernet import Fernet, InvalidToken
+from pymongo import ASCENDING
 
 from app.config import settings
+from app.core.admin_permission_registry import is_canonical_ceo_email
 from app.core.password_policy import validate_password_strength
 from app.core.security import (
     create_access_token,
@@ -22,9 +24,31 @@ from app.core.security import (
 from app.database import get_database
 from app.schemas.auth import UserCreate
 from app.services.audit_log_service import create_audit_log
-from app.services.email_service import send_password_changed_email, send_password_reset_email
+from app.services.email_service import (
+    send_account_activation_email,
+    send_password_changed_email,
+    send_password_reset_email,
+)
 
 PUBLIC_SIGNUP_ROLE = "user"
+
+
+def ensure_auth_indexes() -> None:
+    """Fail closed on ambiguous email identities or duplicate live tokens."""
+    users = get_database()["users"]
+    users.create_index(
+        [("email", ASCENDING)],
+        name="idx_users_email_unique",
+        unique=True,
+    )
+    users.create_index(
+        [("account_activation_token_hash", ASCENDING)],
+        name="idx_users_activation_token_hash_unique",
+        unique=True,
+        partialFilterExpression={
+            "account_activation_token_hash": {"$type": "string"}
+        },
+    )
 
 
 def _now_iso() -> str:
@@ -58,8 +82,22 @@ def _password_reset_expiry_iso() -> str:
     return expire_at.isoformat()
 
 
+def _account_activation_expiry_iso() -> str:
+    expire_at = _now() + timedelta(
+        hours=max(1, int(settings.account_activation_token_expire_hours or 24))
+    )
+    return expire_at.isoformat()
+
+
 def _hash_password_reset_token(token: str) -> str:
     payload = f"{settings.secret_key}:{_normalize_text(token)}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _hash_account_activation_token(token: str) -> str:
+    payload = f"{settings.secret_key}:account-activation:{_normalize_text(token)}".encode(
+        "utf-8"
+    )
     return hashlib.sha256(payload).hexdigest()
 
 
@@ -160,6 +198,25 @@ def _build_password_reset_url(token: str) -> str:
     return f"{base_url}{joiner}mode=reset&token={encoded_token}"
 
 
+def _build_account_activation_url(token: str, *, email: str) -> str:
+    source = (
+        settings.password_reset_base_url_clean
+        or settings.stripe_billing_portal_return_url_clean
+        or "https://tomboflight.com"
+    )
+    parsed = urlsplit(source)
+    scheme = parsed.scheme or "https"
+    netloc = parsed.netloc or "tomboflight.com"
+    base_url = urlunsplit((scheme, netloc, "/signup.html", "", ""))
+    # The token stays in the URL fragment so it is not sent in HTTP requests,
+    # proxy logs, or Referer headers. The signup script removes the fragment
+    # immediately after reading it.
+    return (
+        f"{base_url}#activation_token={quote(_normalize_text(token), safe='')}"
+        f"&email={quote(_normalize_text(email).lower(), safe='')}"
+    )
+
+
 def _clear_password_reset_fields() -> dict[str, object]:
     return {
         "password_reset_token_hash": None,
@@ -168,6 +225,16 @@ def _clear_password_reset_fields() -> dict[str, object]:
         "password_reset_requested_via": None,
         "password_reset_requested_by": None,
         "password_reset_requested_by_user_id": None,
+    }
+
+
+def _clear_account_activation_fields() -> dict[str, object]:
+    return {
+        "account_activation_token_hash": None,
+        "account_activation_expires_at": None,
+        "account_activation_requested_at": None,
+        "activation_delivery_sent": None,
+        "activation_delivery_error": None,
     }
 
 
@@ -196,6 +263,13 @@ def build_user_response(user: dict) -> dict:
         "access_tier": user.get("access_tier"),
         "department_role": user.get("department_role"),
         "status": user.get("status", "active"),
+        "requires_account_activation": bool(user.get("requires_account_activation")),
+        "activation_delivery_sent": user.get("activation_delivery_sent"),
+        "activation_delivery_error": (
+            "activation_delivery_failed"
+            if user.get("activation_delivery_error")
+            else None
+        ),
         "mfa_enabled": bool(user.get("mfa_enabled")),
         "mfa_enrolled_at": user.get("mfa_enrolled_at"),
         "created_at": user["created_at"],
@@ -217,6 +291,153 @@ def build_user_response(user: dict) -> dict:
     }
 
 
+def _activation_token_matches(user: dict[str, Any], token: str) -> bool:
+    normalized_token = _normalize_text(token)
+    expected_hash = _normalize_text(user.get("account_activation_token_hash"))
+    if not normalized_token or not expected_hash:
+        return False
+    supplied_hash = _hash_account_activation_token(normalized_token)
+    if not hmac.compare_digest(expected_hash, supplied_hash):
+        return False
+    expires_at = _normalize_text(user.get("account_activation_expires_at"))
+    if not expires_at:
+        return False
+    try:
+        expires_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except Exception:
+        return False
+    return expires_dt >= _now()
+
+
+def _pending_activation_has_live_token(user: dict[str, Any]) -> bool:
+    if not _normalize_text(user.get("account_activation_token_hash")):
+        return False
+    expires_at = _normalize_text(user.get("account_activation_expires_at"))
+    if not expires_at:
+        return False
+    try:
+        return datetime.fromisoformat(expires_at.replace("Z", "+00:00")) >= _now()
+    except Exception:
+        return False
+
+
+def request_account_activation(
+    email: str,
+    *,
+    include_delivery_status: bool = False,
+) -> dict[str, object]:
+    normalized_email = _normalize_text(email).lower()
+    generic: dict[str, object] = {
+        "success": True,
+        "message": (
+            "If this account is awaiting activation, a new activation link has been sent."
+        ),
+        "delivery_mode": "email",
+    }
+    db = _get_database_or_none()
+    if db is None:
+        if include_delivery_status:
+            generic.update(
+                {
+                    "success": False,
+                    "delivery_sent": False,
+                    "delivery_error": "identity_store_unavailable",
+                }
+            )
+        return generic
+
+    user = db.users.find_one({"email": normalized_email})
+    pending_statuses = {"pending_activation", "checkout_pending_activation"}
+    if (
+        user is None
+        or _normalize_text(user.get("status")).lower() not in pending_statuses
+        or _normalize_text(user.get("account_type")).lower() == "deleted_tombstone"
+    ):
+        if include_delivery_status:
+            generic.update(
+                {
+                    "success": False,
+                    "delivery_sent": False,
+                    "delivery_error": "account_not_pending_activation",
+                }
+            )
+        return generic
+
+    token = secrets.token_urlsafe(32)
+    expires_at = _account_activation_expiry_iso()
+    now_iso = _now_iso()
+    db.users.update_one(
+        {"_id": user["_id"], "status": {"$in": list(pending_statuses)}},
+        {
+            "$set": {
+                "account_activation_token_hash": _hash_account_activation_token(token),
+                "account_activation_expires_at": expires_at,
+                "account_activation_requested_at": now_iso,
+                "requires_account_activation": True,
+                "activation_delivery_sent": None,
+                "activation_delivery_error": None,
+            }
+        },
+    )
+    activation_url = _build_account_activation_url(token, email=normalized_email)
+    try:
+        delivery = send_account_activation_email(
+            to_email=normalized_email,
+            activation_url=activation_url,
+            expires_at=expires_at,
+        )
+    except Exception as exc:
+        delivery = {
+            "sent": False,
+            "provider": "postmark",
+            "error": type(exc).__name__,
+        }
+    delivery = delivery if isinstance(delivery, dict) else {}
+    delivery_sent = bool(delivery.get("sent"))
+    delivery_error = (
+        None
+        if delivery_sent
+        else _normalize_text(delivery.get("error")) or "delivery_not_confirmed"
+    )
+    db.users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "activation_delivery_sent": delivery_sent,
+                "activation_delivery_error": delivery_error,
+                "activation_delivery_provider": _normalize_text(delivery.get("provider"))
+                or "postmark",
+                "activation_delivery_updated_at": _now_iso(),
+            }
+        },
+    )
+    try:
+        create_audit_log(
+            "account_activation_requested",
+            _current_user_id_from_doc(user) or None,
+            "user",
+            _current_user_id_from_doc(user),
+            {
+                "email": normalized_email,
+                "delivery_sent": delivery_sent,
+                "delivery_provider": _normalize_text(delivery.get("provider")) or "postmark",
+            },
+        )
+    except Exception:
+        pass
+    if include_delivery_status:
+        generic.update(
+            {
+                "success": delivery_sent,
+                "delivery_sent": delivery_sent,
+                "delivery_provider": _normalize_text(delivery.get("provider")) or "postmark",
+                "delivery_error": delivery_error,
+                "expires_at": expires_at,
+            }
+        )
+    return generic
+
+
 def register_user(payload: UserCreate) -> dict | None:
     if not payload.terms_accepted:
         raise ValueError("You must accept the Terms of Service.")
@@ -226,6 +447,8 @@ def register_user(payload: UserCreate) -> dict | None:
         raise ValueError(
             "You must confirm your eligibility and authority to create the account."
         )
+
+    validate_password_strength(payload.password)
 
     # Account creation must never claim success unless the account was
     # persisted. DatabaseUnavailableError is mapped to a 503 by the app.
@@ -240,6 +463,11 @@ def register_user(payload: UserCreate) -> dict | None:
             and str(existing.get("status") or "").strip().lower()
             in {"pending_activation", "checkout_pending_activation"}
         ):
+            if not _activation_token_matches(existing, payload.activation_token or ""):
+                return None
+            expected_activation_hash = _normalize_text(
+                existing.get("account_activation_token_hash")
+            )
             update_fields = {
                 "full_name": payload.full_name.strip(),
                 "role": existing.get("role") or PUBLIC_SIGNUP_ROLE,
@@ -255,31 +483,46 @@ def register_user(payload: UserCreate) -> dict | None:
                 "privacy_accepted_at": now_iso,
                 "eligibility_attested_at": now_iso,
                 **_clear_password_reset_fields(),
+                **_clear_account_activation_fields(),
                 **(
                     {}
                     if existing.get("mfa_secret_encrypted") is not None
                     else _clear_mfa_fields()
                 ),
             }
-            db.users.update_one({"_id": existing["_id"]}, {"$set": update_fields})
+            activation_result = db.users.update_one(
+                {
+                    "_id": existing["_id"],
+                    "status": {
+                        "$in": ["pending_activation", "checkout_pending_activation"]
+                    },
+                    "password_hash": {"$in": [None, ""]},
+                    "account_activation_token_hash": expected_activation_hash,
+                },
+                {"$set": update_fields},
+            )
+            if int(getattr(activation_result, "matched_count", 0)) != 1:
+                # Another request already consumed or replaced this link. A
+                # token is single-use even when two submissions race.
+                return None
             existing.update(update_fields)
             return existing
 
         return None
-
-    validate_password_strength(payload.password)
 
     user = {
         "email": normalized_email,
         "full_name": payload.full_name.strip(),
         "role": PUBLIC_SIGNUP_ROLE,
         "account_type": "customer",
-        "status": "active",
-        "password_hash": hash_password(payload.password),
-        "password_updated_at": now_iso,
+        "status": "pending_activation",
+        "password_hash": None,
+        "password_updated_at": None,
         "created_at": now_iso,
         "last_login_at": None,
         "session_token_version": 0,
+        "requires_account_activation": True,
+        **_clear_account_activation_fields(),
         **_clear_password_reset_fields(),
         "password_reset_used_at": None,
         **_clear_mfa_fields(),
@@ -291,7 +534,8 @@ def register_user(payload: UserCreate) -> dict | None:
 
     result = db.users.insert_one(user)
     user["_id"] = result.inserted_id
-    return user
+    request_account_activation(normalized_email, include_delivery_status=True)
+    return db.users.find_one({"_id": result.inserted_id}) or user
 
 
 def create_pending_checkout_user(
@@ -309,6 +553,13 @@ def create_pending_checkout_user(
 
     existing = db.users.find_one({"email": normalized_email})
     if existing is not None:
+        if (
+            _normalize_text(existing.get("status")).lower()
+            in {"pending_activation", "checkout_pending_activation"}
+            and not _pending_activation_has_live_token(existing)
+        ):
+            request_account_activation(normalized_email, include_delivery_status=True)
+            return db.users.find_one({"_id": existing["_id"]}) or existing
         return existing
 
     now_iso = _now_iso()
@@ -337,7 +588,8 @@ def create_pending_checkout_user(
 
     result = db.users.insert_one(user)
     user["_id"] = result.inserted_id
-    return user
+    request_account_activation(normalized_email, include_delivery_status=True)
+    return db.users.find_one({"_id": result.inserted_id}) or user
 
 
 def authenticate_user(email: str, password: str) -> dict[str, Any] | None:
@@ -633,10 +885,13 @@ def admin_reset_user_security(
     *,
     target_user_id: str,
     actor_user_id: str,
+    actor_email: str = "",
 ) -> None:
     user = get_user_by_id(target_user_id)
     if not user:
         raise ValueError("User account not found.")
+    if is_canonical_ceo_email(user.get("email")) and not is_canonical_ceo_email(actor_email):
+        raise ValueError("Only the canonical CEO can reset CEO account security.")
     next_version = _session_version(user) + 1
     db = get_database()
     db.users.update_one(
@@ -977,10 +1232,13 @@ def admin_issue_password_reset(
     *,
     admin_user_id: str,
     admin_display: str,
+    admin_email: str = "",
 ) -> dict[str, object]:
     user = get_user_by_id(user_id)
     if user is None:
         raise ValueError("User account not found.")
+    if is_canonical_ceo_email(user.get("email")) and not is_canonical_ceo_email(admin_email):
+        raise ValueError("Only the canonical CEO can issue a CEO password reset.")
     if (
         _normalize_text(user.get("status")).lower() == "permanently_deleted"
         or _normalize_text(user.get("account_type")).lower() == "deleted_tombstone"

--- a/backend/app/services/continuity_runtime_service.py
+++ b/backend/app/services/continuity_runtime_service.py
@@ -39,11 +39,12 @@ from app.services.auth_service import admin_issue_password_reset
 from app.services.audit_log_service import write_audit_log
 
 
-RUNTIME_VERSION = "10.1.0"
+RUNTIME_VERSION = "11.0.0"
 OPERATIONS_COLLECTION = "continuity_operations"
 EVENTS_COLLECTION = "continuity_events"
 EXECUTION_KILL_SWITCH = "CONTINUITY_EXECUTION_KILL_SWITCH"
 MAX_OPERATION_LIST_LIMIT = 200
+STALE_EXECUTION_RETRY_MINUTES = 15
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,9 @@ SUPER_ADMIN_ACTION_SPECS: dict[str, ActionSpec] = {
     "account_lifecycle": ActionSpec("admin_repair_safety", "high", "user", ("user_id",)),
     "account_permanent_delete": ActionSpec("admin_repair_safety", "high", "user", ("user_id",)),
     "case_repair": ActionSpec("admin_repair_safety", "high", "customer_case", ("case_id",)),
+    "legacy_admin_remediation": ActionSpec(
+        "admin_repair_safety", "high", "user", ("user_id",)
+    ),
 }
 
 
@@ -226,9 +230,7 @@ def canonical_officer_role(actor: dict[str, Any] | None) -> str:
     role_values.update(_normalize(item).lower() for item in (actor.get("role_codes") or []))
     role_values.update(_normalize(item).lower() for item in (access_context.get("role_codes") or []))
 
-    if email == CEO_MASTER_ADMIN_EMAIL.lower() or role_values.intersection(
-        {"ceo", "ceo_master_admin", "ceo_super_admin", "super_admin", "superadmin"}
-    ):
+    if email == CEO_MASTER_ADMIN_EMAIL.lower():
         return "SUPERADMIN"
     if role_values.intersection({"executive_tech_admin", "cto", "technical_admin"}):
         return "EXECUTIVE_TECH_ADMIN"
@@ -675,6 +677,25 @@ def _preview_action(action: str, target: dict[str, Any], parameters: dict[str, A
         return admin_control_service.super_admin_preview_customer_create(
             payload=dict(parameters.get("user_payload") or parameters)
         )
+    if action == "legacy_admin_remediation":
+        review = admin_control_service.legacy_admin_security_review()
+        if not review.get("found"):
+            return {
+                **review,
+                "blocked": True,
+                "warnings": ["The legacy privileged account no longer exists."],
+            }
+        if _normalize(review.get("user_id")) != _normalize(target.get("user_id")):
+            raise ValueError("Legacy administrator remediation target does not match the reviewed identity.")
+        return {
+            **review,
+            "blocked": not bool(review.get("safe_to_suspend")),
+            "warnings": (
+                []
+                if review.get("safe_to_suspend")
+                else ["Legacy administrator remediation requires manual dependency review."]
+            ),
+        }
     return {
         "action": action,
         "target": target,
@@ -1343,6 +1364,7 @@ def _invoke_action(
             _normalize(target.get("user_id")),
             admin_user_id=_actor_id(actor),
             admin_display=_actor_name(actor) or _actor_email(actor),
+            admin_email=_actor_email(actor),
         )
     if action == "project_ownership_transfer":
         return admin_control_service.super_admin_transfer_project_ownership(
@@ -1360,6 +1382,17 @@ def _invoke_action(
     if action == "impersonation_stop":
         return admin_control_service.stop_admin_impersonation(
             session_id=_normalize(target.get("session_id")),
+            reason=reason,
+            actor=actor,
+        )
+    if action == "legacy_admin_remediation":
+        review = admin_control_service.legacy_admin_security_review()
+        if not review.get("found"):
+            raise ValueError("The legacy privileged account no longer exists.")
+        if _normalize(review.get("user_id")) != _normalize(target.get("user_id")):
+            raise ValueError("Legacy administrator remediation target does not match the reviewed identity.")
+        return admin_control_service.legacy_admin_security_review(
+            apply=True,
             reason=reason,
             actor=actor,
         )
@@ -1452,13 +1485,56 @@ def execute_operation(operation_id: str, *, actor: dict[str, Any] | None) -> dic
     operation = _get_operation_document(operation_id)
     if operation.get("state") in {"apply_executed", "audit_closed"}:
         return _serialize_operation(operation) or {}
-    if operation.get("state") != "approved_for_apply":
-        raise ValueError("Operation must be approved_for_apply before execution.")
-
     action = _normalize(operation.get("action"))
     _assert_action_actor_scope(action, actor)
     spec = ACTION_SPECS[action]
     _assert_action_allowed_for_actor(spec, actor)
+    if operation.get("state") == "apply_failed":
+        operation = _transition(
+            operation_id,
+            expected_state="apply_failed",
+            next_state="approved_for_apply",
+            actor=actor,
+            action="retry_failed_operation",
+            reason_codes=["RETRY_SAME_IDEMPOTENT_OPERATION"],
+            extra_set={
+                "execution_retry_count": int(operation.get("execution_retry_count") or 0) + 1,
+                "execution_retry_requested_at": _now(),
+                "execution_error": None,
+                "execution_failed_at": None,
+            },
+        )
+        _record_event(
+            operation,
+            event_type="operation_retry_requested",
+            actor=actor,
+            details={"previous_state": "apply_failed"},
+        )
+    elif operation.get("state") == "apply_scheduled":
+        started_at = operation.get("execution_started_at")
+        if isinstance(started_at, str):
+            try:
+                started_at = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            except Exception:
+                started_at = None
+        stale_before = _now() - timedelta(minutes=STALE_EXECUTION_RETRY_MINUTES)
+        if not isinstance(started_at, datetime) or started_at > stale_before:
+            raise ValueError("Operation execution is already in progress and is not stale.")
+        operation = _transition(
+            operation_id,
+            expected_state="apply_scheduled",
+            next_state="approved_for_apply",
+            actor=actor,
+            action="recover_stale_execution",
+            reason_codes=["STALE_EXECUTION_RECOVERY"],
+            extra_set={
+                "execution_retry_count": int(operation.get("execution_retry_count") or 0) + 1,
+                "execution_retry_requested_at": _now(),
+            },
+        )
+    if operation.get("state") != "approved_for_apply":
+        raise ValueError("Operation must be approved_for_apply before execution.")
+
     packet = _evidence_packet(operation, actor or {})
     authorization = _authorization_decision(operation)
     transition = _scheduled_transition(operation, actor or {})
@@ -1639,6 +1715,8 @@ def execute_governed_action(
             solo_founder_override_acknowledged=solo_founder_override_acknowledged,
         )
     if operation.get("state") == "approved_for_apply":
+        operation = execute_operation(operation_id, actor=actor)
+    elif operation.get("state") in {"apply_failed", "apply_scheduled"}:
         operation = execute_operation(operation_id, actor=actor)
     return operation
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -368,6 +368,43 @@ def send_password_reset_email(
     )
 
 
+def send_account_activation_email(
+    *,
+    to_email: str,
+    activation_url: str,
+    expires_at: str,
+) -> dict[str, Any]:
+    """Send a mailbox-verification link without exposing the token in logs."""
+    safe_activation_url = escape(_normalize_text(activation_url), quote=True)
+    safe_expires_at = escape(_normalize_text(expires_at), quote=True)
+    subject = "Activate your Tomb of Light account"
+    text_body = (
+        "Hello,\n\n"
+        "Confirm this email address before creating credentials for your Tomb of Light account.\n\n"
+        f"Activate your account using this secure link:\n{activation_url}\n\n"
+        f"This link expires at {expires_at}.\n\n"
+        "If you did not request or expect this account, ignore this email. No one can activate it without this link.\n\n"
+        "Tomb of Light Security\n"
+    )
+    html_body = (
+        "<p>Hello,</p>"
+        "<p>Confirm this email address before creating credentials for your "
+        "Tomb of Light account.</p>"
+        f'<p><a href="{safe_activation_url}">Activate your account</a></p>'
+        f"<p>This link expires at {safe_expires_at}.</p>"
+        "<p>If you did not request or expect this account, ignore this email. "
+        "No one can activate it without this link.</p>"
+        "<p>Tomb of Light Security</p>"
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        email_type="account_activation",
+    )
+
+
 def send_password_changed_email(*, to_email: str) -> None:
     """Send a password-change confirmation email to *to_email*."""
     changed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -522,86 +522,11 @@ def create_order_for_user(user: dict[str, Any], payload: Any) -> dict[str, Any]:
 
 
 def create_manual_order_for_admin(admin_user: dict[str, Any], payload: Any) -> dict[str, Any]:
-    customer_email = _normalize_email(getattr(payload, "customer_email", ""))
-    if not customer_email:
-        raise ValueError("customer_email is required.")
-    reason = _normalize(getattr(payload, "reason", ""))
-    authorization_source = _normalize(getattr(payload, "authorization_source", ""))
-    idempotency_key = _normalize(getattr(payload, "idempotency_key", ""))
-    if not reason:
-        raise ValueError("reason is required.")
-    if not authorization_source:
-        raise ValueError("authorization_source is required.")
-    if not idempotency_key:
-        raise ValueError("idempotency_key is required.")
-
-    package_code = _normalize_package_code(
-        getattr(payload, "package_code", None) or getattr(payload, "package_slug", None)
+    del admin_user, payload
+    raise ValueError(
+        "Manual paid-order creation is disabled. Record real payment through Stripe, "
+        "or use the CEO package-grant action, which creates no paid order."
     )
-    if package_code == "unknown" or not get_package(package_code):
-        raise ValueError("Unknown package.")
-
-    customer_user = _get_user_by_email(customer_email) or create_pending_checkout_user(customer_email)
-    if not customer_user:
-        raise ValueError("Customer account could not be resolved.")
-
-    orders = _get_orders_collection()
-    existing = orders.find_one({"manual_idempotency_key": idempotency_key})
-    if existing:
-        return _serialize_order(existing)
-
-    package = get_package(package_code) or {}
-    package_name = _normalize(package.get("display_name")) or package_code.replace("_", " ").title()
-    order_doc = {
-        "user_id": _validated_user_object_id(customer_user),
-        "email": customer_email,
-        "package_code": package_code,
-        "package_slug": package_code,
-        "lane": _package_lane_for_code(package_code),
-        "package_lane": _package_lane_for_code(package_code),
-        "package_name": package_name,
-        "price_label": _format_price_label(_base_package_price_cents(package_code), "one_time"),
-        "item_type": "package",
-        "billing_plan": "one_time",
-        "source": "admin_manual",
-        "status": "paid",
-        "manual_reason": reason,
-        "manual_authorization_source": authorization_source,
-        "manual_idempotency_key": idempotency_key,
-        "created_at": datetime.now(UTC),
-    }
-    result = orders.insert_one(order_doc)
-    order_doc["_id"] = result.inserted_id
-
-    order_doc = _attach_project_to_paid_package_order(
-        order_id=result.inserted_id,
-        order_doc=order_doc,
-        user=customer_user,
-        package_code=package_code,
-        package_name=package_name,
-        target_project_id=_normalize(getattr(payload, "project_id", "")),
-    )
-    _trigger_package_provisioning()
-
-    from app.services.audit_log_service import write_audit_log
-
-    write_audit_log(
-        actor_user_id=_normalize(str(admin_user.get("_id") or admin_user.get("id") or admin_user.get("user_id") or "")) or None,
-        actor_email=_normalize_email(admin_user.get("email")),
-        actor_name=_normalize(admin_user.get("full_name") or admin_user.get("name")),
-        action="admin_manual_order_recorded",
-        target_type="order",
-        target_id=str(result.inserted_id),
-        details={
-            "customer_email": customer_email,
-            "package_code": package_code,
-            "reason": reason,
-            "authorization_source": authorization_source,
-            "idempotency_key": idempotency_key,
-        },
-    )
-
-    return _serialize_order(order_doc)
 
 
 def get_orders_for_user(user: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -15,9 +15,13 @@ def list_users() -> list[dict]:
 def create_user(payload: UserCreate) -> dict:
     db = get_database()
     data = payload.model_dump()
+    data["role"] = "user"
+    data["account_type"] = "customer"
     data["created_at"] = datetime.now(UTC).isoformat()
     data["full_name"] = f"{payload.first_name} {payload.last_name}".strip()
-    data["status"] = data.get("status") or "active"
+    data["status"] = "pending_activation"
+    data["password_hash"] = None
+    data["requires_account_activation"] = True
     data["last_login_at"] = None
     data["password_reset_requested_at"] = None
     data["password_reset_expires_at"] = None

--- a/backend/docs/governance/continuity_kernel_phase11_backend_security_correction.md
+++ b/backend/docs/governance/continuity_kernel_phase11_backend_security_correction.md
@@ -1,0 +1,95 @@
+# Continuity Kernel Phase 11 — Backend Security Correction
+
+Date: 2026-08-22
+
+Runtime: `11.0.0`
+
+Governed action registry: 37 actions
+
+## Outcome
+
+Phase 11 closes the blocker-class findings from the post-Phase-10 backend audit. It preserves real customer checkout and CEO execution while removing alternate authority paths that could manufacture a second master administrator, claim a passwordless pending account, fabricate a paid order, bypass covered Continuity Kernel execution, acknowledge an incomplete Stripe webhook, or strand permanent deletion between external and database writes.
+
+MFA remains optional for every account. An account that opts in must complete MFA for future sessions and may disable it only after password plus authenticator or recovery-code verification.
+
+## CEO singleton authority
+
+- `l.robinson@tomboflight.com` is the sole canonical CEO Master Administrator identity.
+- Only `ceo_master_admin` (and its canonical compatibility alias) can receive wildcard capabilities and permissions.
+- A noncanonical `super_admin` label is deprecated data with no administrator or wildcard authority, even if a stale role assignment or permission override contains `*`.
+- The canonical CEO email, active status, role, access tier, and department role cannot be changed through account controls.
+- CEO password/security resets require the canonical CEO actor.
+- The canonical CEO remains an administrator if stale role labels are temporarily missing; startup reconciliation and read-time access resolution converge on the same invariant.
+
+## Secure account activation
+
+Public signup, checkout-created accounts, and CEO-created customer accounts begin as passwordless `pending_activation` identities. Password installation requires a short-lived activation token delivered to the account email.
+
+- Only a SHA-256 token digest bound to the production `SECRET_KEY` is stored.
+- The link carries the token in a URL fragment, not a query string, so it is not sent to the web server, proxy logs, or Referer headers.
+- The browser reads the fragment and immediately removes it with `history.replaceState`.
+- Activation uses a compare-and-set on pending status, empty password, and the exact token digest, making the token single-use even under concurrent requests.
+- Startup enforces a unique normalized email index and a unique partial index for live activation-token digests.
+- A delivery failure leaves the account pending and is reported as a failure; it never creates a usable credential.
+- Administrator-created package grants create an entitlement without creating a paid order or changing Stripe payment history.
+
+## Covered mutation boundary
+
+Covered legacy mutations now fail with `409 continuity_kernel_required` and point callers to `/admin/control-center/kernel/execute`. This includes Control Center writes, protected Stripe writes, administrator password/security resets, manual paid-order creation, paid-package repair, direct entitlement apply, and direct administrator account creation.
+
+Read-only routes and exact preview routes remain available. Customer-owned profile, billing, upload, vault, household, and workspace actions remain available under their existing authorization rules; Phase 11 does not route normal customer activity through an administrator Kernel.
+
+The `legacy_admin_remediation` action brings the remaining privileged-account suspension into the persisted Kernel state machine. The target identity must match the read-only review result before execution.
+
+Manual paid-order creation is removed from the service implementation. A paid order must come from verified Stripe state. A CEO may still grant an authorized complimentary, promotional, or internal-validation package, but that operation explicitly records `payment_record_created=false` and `stripe_payment_mutated=false`.
+
+## Stripe recovery
+
+Stripe event claims are retryable leases, not completion markers.
+
+- A relevant event is marked processed only after its authoritative order or maintenance handler persists the result.
+- Failure clears the processing claim, records a minimized retryable failure, omits `processed_at`, and returns HTTP 503 so Stripe retries.
+- A Checkout Session may be a package purchase or a maintenance subscription; success by the relevant handler is sufficient and an expected rejection by the other handler is not treated as failure.
+- Subscription and invoice lifecycle events that do not update their maintenance record are retryable failures.
+- Permanent deletion derives a stable provider idempotency key per subscription, so an account with multiple subscriptions cannot collide on one Stripe idempotency key.
+
+## Resumable permanent deletion
+
+Permanent deletion remains irreversible, CEO-only, and separately confirmed twice. Execution now creates or reuses a stable MongoDB tombstone before external cancellation, revokes login before the first side effect, and records each phase.
+
+Retrying the same failed Kernel operation resumes the same deletion ID. Stripe cancellation failure leaves `status=failed_retryable` and the identity locked. If identity erasure succeeds but audit persistence fails, the tombstone remains `status=audit_pending`; retry closes the missing audit evidence without restoring credentials or repeating identity destruction. Paid orders, billing history, corporate ownership records, issued certificates, delivery records, security evidence, and Continuity/audit evidence remain preserved.
+
+## Operational readiness and disclosure boundary
+
+Public `/health`, `/health/live`, `/health/ready`, the production root, and database-error responses expose platform availability without revealing which security integrations are absent.
+
+Authenticated canonical CEO access to `/health/operational` reports:
+
+- database connectivity;
+- production signing-key validity without exposing the key;
+- Stripe publishable, secret, and webhook configuration;
+- Postmark transactional-email configuration;
+- an active upload scanner hook and fail-closed/quarantine posture;
+- readable and writable persistent private-upload storage;
+- Continuity execution kill-switch state;
+- deployed version and commit identifier;
+- optional NFT runtime state without making NFT execution a core-readiness requirement.
+
+The endpoint returns HTTP 503 when a required production control is incomplete. The public platform readiness endpoint remains compatible with Render health checks and continues to represent database-serving readiness.
+
+## Deployment gates
+
+Before treating Phase 11 as operationally ready:
+
+1. Set a unique production `SECRET_KEY` of at least 32 bytes and do not reuse the value in another environment.
+2. Configure `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`.
+3. Configure a verified Postmark server token and sender.
+4. Configure `UPLOAD_SCAN_HOOK` as a callable `module:function`; the legacy scanner command setting is intentionally not executed.
+5. Mount a readable and writable persistent disk through `RENDER_DISK_MOUNT_PATH` for private uploads.
+6. Keep `CONTINUITY_EXECUTION_KILL_SWITCH` unset for normal execution and set it only for emergency shutdown.
+7. Confirm a deployment commit identifier is present. Render normally supplies `RENDER_GIT_COMMIT`.
+8. Confirm the unique user-email index builds successfully. Duplicate historical email identities must be reviewed and corrected rather than silently accepted.
+9. Run an authenticated production walkthrough after deployment. Engineering verification in this pull request performs no production customer mutation and does not permanently delete Marquis or any other account.
+
+Provider encryption, backup, restore, edge-header, and independent penetration-test evidence remain separate launch evidence. Phase 11 does not claim SOC 2, ISO 27001, HIPAA, PCI DSS certification, end-to-end encryption, or an external penetration test.
+

--- a/backend/tests/contracts/test_continuity_kernel_phase10_1_permanent_account_deletion.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase10_1_permanent_account_deletion.py
@@ -49,7 +49,7 @@ class TestContinuityKernelPhase101PermanentAccountDeletion(unittest.TestCase):
         self.assertIn("Permanent account deletion is blocked for this identity", self.service)
 
     def test_04_kernel_registers_irreversible_execution_and_evidence_only_rollback(self) -> None:
-        self.assertIn('RUNTIME_VERSION = "10.1.0"', self.runtime)
+        self.assertIn('RUNTIME_VERSION = "11.0.0"', self.runtime)
         self.assertIn('"account_permanent_delete": ActionSpec(', self.runtime)
         self.assertIn('"strategy": "irreversible_identity_erasure"', self.runtime)
         self.assertIn('"restoration_prohibited": True', self.runtime)

--- a/backend/tests/contracts/test_continuity_kernel_phase11_backend_security_correction.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase11_backend_security_correction.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_PATH = REPO_ROOT / "backend" / "app" / "services" / "continuity_runtime_service.py"
+AUTH_PATH = REPO_ROOT / "backend" / "app" / "services" / "auth_service.py"
+PERMISSIONS_PATH = REPO_ROOT / "backend" / "app" / "core" / "admin_permission_registry.py"
+DEPENDENCIES_PATH = REPO_ROOT / "backend" / "app" / "dependencies" / "auth.py"
+GUARD_PATH = REPO_ROOT / "backend" / "app" / "core" / "continuity_route_guard.py"
+STRIPE_PATH = REPO_ROOT / "backend" / "app" / "routes" / "stripe_webhooks.py"
+DELETION_PATH = REPO_ROOT / "backend" / "app" / "services" / "admin_control_service.py"
+DATABASE_PATH = REPO_ROOT / "backend" / "app" / "database.py"
+AUTH_JS_PATH = REPO_ROOT / "auth.js"
+DOC_PATH = REPO_ROOT / "backend" / "docs" / "governance" / "continuity_kernel_phase11_backend_security_correction.md"
+
+
+class TestContinuityKernelPhase11BackendSecurityCorrection(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+        cls.auth = AUTH_PATH.read_text(encoding="utf-8")
+        cls.permissions = PERMISSIONS_PATH.read_text(encoding="utf-8")
+        cls.dependencies = DEPENDENCIES_PATH.read_text(encoding="utf-8")
+        cls.guard = GUARD_PATH.read_text(encoding="utf-8")
+        cls.stripe = STRIPE_PATH.read_text(encoding="utf-8")
+        cls.deletion = DELETION_PATH.read_text(encoding="utf-8")
+        cls.database = DATABASE_PATH.read_text(encoding="utf-8")
+        cls.auth_js = AUTH_JS_PATH.read_text(encoding="utf-8")
+        cls.doc = DOC_PATH.read_text(encoding="utf-8")
+
+    def test_01_runtime_is_phase11_and_registers_legacy_remediation(self) -> None:
+        self.assertIn('RUNTIME_VERSION = "11.0.0"', self.runtime)
+        self.assertIn('"legacy_admin_remediation": ActionSpec(', self.runtime)
+        self.assertIn("retry_failed_operation", self.runtime)
+        self.assertIn("RETRY_SAME_IDEMPOTENT_OPERATION", self.runtime)
+
+    def test_02_ceo_is_the_only_wildcard_identity(self) -> None:
+        self.assertIn('"super_admin": set()', self.permissions)
+        self.assertIn('"ceo_master_admin": {"*"}', self.permissions)
+        self.assertIn("is_canonical_ceo_email", self.dependencies)
+        self.assertIn("permissions.discard(\"*\")", self.dependencies)
+        self.assertIn("capabilities.discard(\"*\")", self.dependencies)
+
+    def test_03_activation_is_passwordless_hashed_fragment_and_atomic(self) -> None:
+        for marker in (
+            '"status": "pending_activation"',
+            '"password_hash": None',
+            "_hash_account_activation_token",
+            '"account_activation_token_hash": expected_activation_hash',
+            '"password_hash": {"$in": [None, ""]}',
+            "idx_users_email_unique",
+            "idx_users_activation_token_hash_unique",
+        ):
+            self.assertIn(marker, self.auth)
+        self.assertIn("#activation_token=", self.auth)
+        self.assertIn("window.location.hash", self.auth_js)
+        self.assertIn("window.history.replaceState", self.auth_js)
+
+    def test_04_covered_legacy_mutations_fail_into_kernel(self) -> None:
+        for marker in (
+            "continuity_kernel_required",
+            "/admin/control-center",
+            "/admin/stripe-ops",
+            "/auth/admin/users/",
+            "/orders/admin/manual-order",
+            "/project-entitlements/apply",
+        ):
+            self.assertIn(marker, self.guard + self.doc)
+
+    def test_05_stripe_failures_are_retryable_not_false_completion(self) -> None:
+        for marker in (
+            "_mark_event_failed",
+            '"processing_status": "retryable_failure"',
+            '"processed_at": ""',
+            "HTTP_503_SERVICE_UNAVAILABLE",
+            "checkout_persisted",
+            "maintenance_event_not_persisted",
+        ):
+            self.assertIn(marker, self.stripe)
+
+    def test_06_deletion_is_tombstoned_locked_and_resumable(self) -> None:
+        for marker in (
+            '"status": "deletion_in_progress"',
+            '"status": "failed_retryable"',
+            '"status": "audit_pending"',
+            '"resumed": True',
+            "Retry the same Kernel operation",
+            "subscription_id",
+        ):
+            self.assertIn(marker, self.deletion)
+
+    def test_07_operational_details_are_explicit_and_not_public_by_default(self) -> None:
+        for marker in (
+            "include_operational_details",
+            "production_signing_key_invalid",
+            "stripe_configuration_incomplete",
+            "upload_scanner_unavailable_quarantine_only",
+            "private_upload_storage_not_persistent",
+            "continuity_execution_disabled",
+            "Public liveness and readiness surfaces intentionally omit",
+        ):
+            self.assertIn(marker, self.database)
+
+    def test_08_governance_preserves_execution_constraints(self) -> None:
+        for phrase in (
+            "mfa remains optional",
+            "paid order must come from verified stripe state",
+            "no production customer mutation",
+            "does not permanently delete marquis",
+            "provider encryption",
+            "independent penetration-test evidence",
+        ):
+            self.assertIn(phrase, self.doc.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/contracts/test_continuity_kernel_phase6g_readonly_route_design.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase6g_readonly_route_design.py
@@ -123,9 +123,12 @@ class TestContinuityKernelPhase6GReadonlyRouteDesign(unittest.TestCase):
         scripts_paths = list((REPO_ROOT / "backend" / "scripts").glob("**/*.py"))
         self._assert_no_kernel_token_in_paths(scripts_paths)
 
-    def test_30_main_does_not_import_continuity_kernel_modules_yet(self) -> None:
+    def test_30_main_now_wires_the_later_governed_runtime_boundary(self) -> None:
         main_path = REPO_ROOT / "backend" / "app" / "main.py"
-        self._assert_no_kernel_token_in_paths([main_path])
+        main_source = main_path.read_text(encoding="utf-8")
+        self.assertIn("admin_continuity_runtime_router", main_source)
+        self.assertIn("requires_continuity_kernel", main_source)
+        self.assertIn("continuity_kernel_required", main_source)
 
 
 if __name__ == "__main__":

--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -25,7 +25,7 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
         cls.auth_js = AUTH_JS_PATH.read_text(encoding="utf-8")
 
     def test_01_runtime_registers_complete_control_surface_actions(self) -> None:
-        self.assertIn('RUNTIME_VERSION = "10.1.0"', self.runtime)
+        self.assertIn('RUNTIME_VERSION = "11.0.0"', self.runtime)
         for action in (
             "manual_fulfillment",
             "stripe_operation",

--- a/backend/tests/test_account_separation.py
+++ b/backend/tests/test_account_separation.py
@@ -120,9 +120,10 @@ class AccountSeparationTests(unittest.TestCase):
                 auth_dependencies.require_super_admin(request=cast(Any, object()), current_user=current_user)
         self.assertEqual(error.exception.status_code, 403)
 
-    def test_require_super_admin_allows_super_admin_role(self):
+    def test_require_super_admin_allows_only_canonical_ceo_super_admin(self):
         current_user = {
             "id": "user-1",
+            "email": "l.robinson@tomboflight.com",
             "role": "super_admin",
             "_access_context": {
                 "project_id": None,

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -187,6 +187,81 @@ class AdminPermissionContextTests(unittest.TestCase):
         self.assertNotIn("admin.control.mint", permissions)
         self.assertNotIn("uploads.admin.review", permissions)
 
+    def test_noncanonical_super_admin_label_never_grants_admin_or_wildcard_access(self):
+        user_id = ObjectId()
+        user = {
+            "_id": user_id,
+            "email": "legacy-super@example.com",
+            "role": "super_admin",
+            "status": "active",
+        }
+        db = FakeDatabase(
+            {
+                "user_role_assignments": [
+                    {
+                        "user_id": str(user_id),
+                        "role_code": "super_admin",
+                        "status": "active",
+                    }
+                ],
+                "role_capabilities": [],
+                "role_permissions": [],
+                "user_permission_overrides": [
+                    {
+                        "user_id": str(user_id),
+                        "permission_code": "*",
+                        "status": "active",
+                    }
+                ],
+                "projects": [],
+                "workflow_events": [],
+            }
+        )
+
+        with (
+            patch.object(auth_dependencies, "_load_user_by_id", return_value=user),
+            patch.object(auth_dependencies, "_db", return_value=db),
+            patch.object(auth_dependencies, "list_user_project_entitlements", return_value=[]),
+            patch.object(auth_dependencies, "list_accessible_project_ids", return_value=[]),
+        ):
+            context = auth_dependencies.resolve_access_context(str(user_id))
+
+        self.assertFalse(auth_dependencies.has_internal_admin_access(user))
+        self.assertNotIn("super_admin", context["role_codes"])
+        self.assertNotIn("*", context["capabilities"])
+        self.assertNotIn("*", context["permissions"])
+
+    def test_canonical_ceo_remains_the_single_wildcard_admin_identity(self):
+        user_id = ObjectId()
+        user = {
+            "_id": user_id,
+            "email": "l.robinson@tomboflight.com",
+            "role": "user",
+            "status": "active",
+        }
+        db = FakeDatabase(
+            {
+                "user_role_assignments": [],
+                "role_capabilities": [],
+                "role_permissions": [],
+                "user_permission_overrides": [],
+                "projects": [],
+                "workflow_events": [],
+            }
+        )
+
+        with (
+            patch.object(auth_dependencies, "_load_user_by_id", return_value=user),
+            patch.object(auth_dependencies, "_db", return_value=db),
+            patch.object(auth_dependencies, "list_user_project_entitlements", return_value=[]),
+        ):
+            context = auth_dependencies.resolve_access_context(str(user_id))
+
+        self.assertTrue(auth_dependencies.has_internal_admin_access(user))
+        self.assertIn("ceo_master_admin", context["role_codes"])
+        self.assertIn("*", context["capabilities"])
+        self.assertIn("*", context["permissions"])
+
 
 class AdminControlAccessProfileTests(unittest.TestCase):
     def test_overview_payload_is_reduced_to_each_officers_authorized_domain(self):
@@ -1180,7 +1255,16 @@ class SuperAdminControlsTests(unittest.TestCase):
                         "maintenance_status": "active",
                         "maintenance_stripe_status": "active",
                         "maintenance_stripe_subscription_id": "sub_permanent_delete_test",
-                    }
+                    },
+                    {
+                        "_id": ObjectId(),
+                        "project_id": project_id,
+                        "user_id": user_id,
+                        "status": "archived",
+                        "maintenance_status": "active",
+                        "maintenance_stripe_status": "active",
+                        "maintenance_stripe_subscription_id": "sub_permanent_delete_second",
+                    },
                 ],
                 "project_members": [
                     {"_id": ObjectId(), "project_id": str(project_id), "user_id": str(user_id), "status": "inactive"}
@@ -1255,6 +1339,7 @@ class SuperAdminControlsTests(unittest.TestCase):
 
         with (
             patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "write_audit_log", return_value="audit-delete-1"),
             patch.object(
                 admin_control_service.stripe_admin_operations_service,
                 "cancel_subscription",
@@ -1280,13 +1365,26 @@ class SuperAdminControlsTests(unittest.TestCase):
                     user_id=str(user_id), payload={"status": "active"}
                 )
 
-        cancel_subscription.assert_called_once()
+        self.assertEqual(cancel_subscription.call_count, 2)
         self.assertEqual(
-            cancel_subscription.call_args.kwargs["subscription_id"],
-            "sub_permanent_delete_test",
+            {
+                call.kwargs["subscription_id"]
+                for call in cancel_subscription.call_args_list
+            },
+            {"sub_permanent_delete_test", "sub_permanent_delete_second"},
         )
-        self.assertFalse(cancel_subscription.call_args.kwargs["at_period_end"])
-        self.assertTrue(cancel_subscription.call_args.kwargs["confirm"])
+        self.assertEqual(
+            len(
+                {
+                    call.kwargs["idempotency_key"]
+                    for call in cancel_subscription.call_args_list
+                }
+            ),
+            2,
+        )
+        for call in cancel_subscription.call_args_list:
+            self.assertFalse(call.kwargs["at_period_end"])
+            self.assertTrue(call.kwargs["confirm"])
 
         user = db["users"].documents[0]
         tombstone = db["account_deletion_tombstones"].documents[0]
@@ -1426,7 +1524,7 @@ class SuperAdminControlsTests(unittest.TestCase):
         self.assertEqual(db["users"].documents[1]["status"], "active")
         self.assertEqual(db["account_deletion_tombstones"].documents, [])
 
-    def test_permanent_deletion_fails_before_mongodb_changes_when_subscription_cancel_fails(self):
+    def test_permanent_deletion_failure_leaves_resumable_identity_lock_and_tombstone(self):
         user_id = ObjectId()
         project_id = ObjectId()
         db = FakeDatabase(
@@ -1486,10 +1584,83 @@ class SuperAdminControlsTests(unittest.TestCase):
                     actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com"},
                 )
 
-        self.assertEqual(db["users"].documents[0]["status"], "active")
-        self.assertTrue(db["users"].documents[0]["login_enabled"])
+        self.assertEqual(db["users"].documents[0]["status"], "deletion_in_progress")
+        self.assertFalse(db["users"].documents[0]["login_enabled"])
         self.assertEqual(db["projects"].documents[0]["status"], "active")
-        self.assertEqual(db["account_deletion_tombstones"].documents, [])
+        tombstone = db["account_deletion_tombstones"].documents[0]
+        self.assertEqual(tombstone["status"], "failed_retryable")
+        self.assertEqual(tombstone["phase"], "subscription_cancellation")
+        self.assertEqual(tombstone["continuity_operation_id"], "ckop_stripe_failure")
+
+    def test_permanent_deletion_resumes_audit_closure_without_recreating_identity(self):
+        user_id = ObjectId()
+        original_email = "audit-resume@example.com"
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": original_email,
+                        "full_name": "Audit Resume",
+                        "role": "user",
+                        "status": "active",
+                        "login_enabled": True,
+                        "session_token_version": 2,
+                    }
+                ],
+                "projects": [],
+                "families": [],
+                "households": [],
+                "account_deletion_tombstones": [],
+            }
+        )
+        common = {
+            "user_id": str(user_id),
+            "reason_category": "customer_request",
+            "reason": "Verified written deletion request",
+            "confirmation_email": original_email,
+            "initial_confirmation": True,
+            "final_confirmation": "PERMANENTLY DELETE",
+            "final_acknowledgement": True,
+            "continuity_operation_id": "ckop_audit_resume",
+            "actor": {
+                "_id": ObjectId(),
+                "email": "l.robinson@tomboflight.com",
+            },
+        }
+
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(
+                admin_control_service,
+                "write_audit_log",
+                side_effect=[RuntimeError("audit unavailable"), "audit-delete-resumed"],
+            ) as write_audit,
+            patch.object(
+                admin_control_service.stripe_admin_operations_service,
+                "cancel_subscription",
+            ) as cancel_subscription,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "audit evidence is still pending"):
+                admin_control_service.super_admin_apply_account_permanent_deletion(
+                    **common
+                )
+            deletion_id = db["account_deletion_tombstones"].documents[0]["deletion_id"]
+            resumed = admin_control_service.super_admin_apply_account_permanent_deletion(
+                **common
+            )
+
+        user = db["users"].documents[0]
+        tombstone = db["account_deletion_tombstones"].documents[0]
+        self.assertEqual(user["status"], "permanently_deleted")
+        self.assertEqual(user["permanent_deletion_id"], deletion_id)
+        self.assertNotEqual(user["email"], original_email)
+        self.assertTrue(resumed["resumed"])
+        self.assertEqual(resumed["deletion_receipt"]["deletion_id"], deletion_id)
+        self.assertEqual(tombstone["status"], "completed")
+        self.assertTrue(tombstone["audit_event_created"])
+        self.assertEqual(write_audit.call_count, 2)
+        cancel_subscription.assert_not_called()
 
     def test_super_admin_update_user_updates_profile_fields(self):
         user_id = ObjectId()
@@ -1527,7 +1698,7 @@ class SuperAdminControlsTests(unittest.TestCase):
         self.assertEqual(result["after"]["full_name"], "After Name")
         self.assertEqual(result["after"]["status"], "suspended")
 
-    def test_super_admin_can_promote_existing_admin_to_super_admin(self):
+    def test_non_ceo_identity_cannot_be_promoted_to_super_admin(self):
         user_id = ObjectId()
         db = FakeDatabase(
             {
@@ -1543,12 +1714,13 @@ class SuperAdminControlsTests(unittest.TestCase):
             }
         )
         with patch.object(admin_control_service, "get_database", return_value=db):
-            result = admin_control_service.super_admin_update_user(
-                user_id=str(user_id),
-                payload={"role": "super_admin"},
-                actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
-            )
-        self.assertEqual(result["after"]["role"], "super_admin")
+            with self.assertRaisesRegex(ValueError, "Wildcard administrator roles"):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(user_id),
+                    payload={"role": "super_admin"},
+                    actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com"},
+                )
+        self.assertEqual(db["users"].documents[0]["role"], "operations_admin")
 
     def test_super_admin_cannot_promote_customer_to_super_admin(self):
         user_id = ObjectId()
@@ -1566,7 +1738,7 @@ class SuperAdminControlsTests(unittest.TestCase):
             }
         )
         with patch.object(admin_control_service, "get_database", return_value=db):
-            with self.assertRaisesRegex(ValueError, "super_admin role can only be granted to existing internal admin accounts"):
+            with self.assertRaisesRegex(ValueError, "Wildcard administrator roles"):
                 admin_control_service.super_admin_update_user(
                     user_id=str(user_id),
                     payload={"role": "super_admin"},
@@ -1591,13 +1763,54 @@ class SuperAdminControlsTests(unittest.TestCase):
         with patch.object(admin_control_service, "get_database", return_value=db):
             with self.assertRaisesRegex(
                 ValueError,
-                "ceo_master_admin role can only be assigned to Larry Robinson's canonical identity",
+                "Wildcard administrator roles can only be assigned to Larry Robinson's canonical identity",
             ):
                 admin_control_service.super_admin_update_user(
                     user_id=str(user_id),
                     payload={"role": "ceo_master_admin"},
                     actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
                 )
+
+    def test_canonical_ceo_identity_and_master_roles_are_immutable(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "l.robinson@tomboflight.com",
+                        "full_name": "Larry Robinson",
+                        "role": "ceo_master_admin",
+                        "access_tier": "ceo_master_admin",
+                        "department_role": "executive_tech_admin",
+                        "status": "active",
+                    }
+                ]
+            }
+        )
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            for field, value in (
+                ("email", "attacker@example.com"),
+                ("status", "suspended"),
+                ("role", "user"),
+                ("access_tier", "operations_admin"),
+                ("department_role", "finance_admin"),
+            ):
+                with self.subTest(field=field):
+                    with self.assertRaisesRegex(ValueError, "immutable"):
+                        admin_control_service.super_admin_update_user(
+                            user_id=str(user_id),
+                            payload={field: value},
+                            actor={
+                                "_id": user_id,
+                                "email": "l.robinson@tomboflight.com",
+                            },
+                        )
+
+        user = db["users"].documents[0]
+        self.assertEqual(user["email"], "l.robinson@tomboflight.com")
+        self.assertEqual(user["status"], "active")
+        self.assertEqual(user["role"], "ceo_master_admin")
 
     def test_impersonation_session_lifecycle_readonly_to_editing_to_stop(self):
         actor_id = ObjectId()

--- a/backend/tests/test_admin_repair_guardrails.py
+++ b/backend/tests/test_admin_repair_guardrails.py
@@ -478,7 +478,7 @@ class PaymentStateGuardrailTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class RoleEscalationGuardrailTests(unittest.TestCase):
-    """Super admin role must not be granted to customer accounts."""
+    """Wildcard authority must remain exclusive to the canonical CEO."""
 
     def test_cannot_promote_customer_role_user_to_super_admin(self):
         user_id = ObjectId()
@@ -496,14 +496,14 @@ class RoleEscalationGuardrailTests(unittest.TestCase):
             }
         )
         with patch.object(admin_control_service, "get_database", return_value=db):
-            with self.assertRaisesRegex(ValueError, "super_admin role can only be granted"):
+            with self.assertRaisesRegex(ValueError, "canonical identity"):
                 admin_control_service.super_admin_update_user(
                     user_id=str(user_id),
                     payload={"role": "super_admin"},
                     actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
                 )
 
-    def test_can_promote_existing_operations_admin_to_super_admin(self):
+    def test_cannot_promote_existing_operations_admin_to_super_admin(self):
         user_id = ObjectId()
         db = FakeDatabase(
             {
@@ -519,14 +519,15 @@ class RoleEscalationGuardrailTests(unittest.TestCase):
             }
         )
         with patch.object(admin_control_service, "get_database", return_value=db):
-            result = admin_control_service.super_admin_update_user(
-                user_id=str(user_id),
-                payload={"role": "super_admin"},
-                actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
-            )
-        self.assertEqual(result["after"]["role"], "super_admin")
+            with self.assertRaisesRegex(ValueError, "canonical identity"):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(user_id),
+                    payload={"role": "super_admin"},
+                    actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com"},
+                )
+        self.assertEqual(db["users"].documents[0]["role"], "operations_admin")
 
-    def test_can_promote_business_admin_account_type_user_to_super_admin(self):
+    def test_cannot_promote_business_admin_account_type_user_to_super_admin(self):
         user_id = ObjectId()
         db = FakeDatabase(
             {
@@ -543,12 +544,13 @@ class RoleEscalationGuardrailTests(unittest.TestCase):
             }
         )
         with patch.object(admin_control_service, "get_database", return_value=db):
-            result = admin_control_service.super_admin_update_user(
-                user_id=str(user_id),
-                payload={"role": "super_admin"},
-                actor={"_id": ObjectId(), "email": "ceo@tomboflight.com"},
-            )
-        self.assertEqual(result["after"]["role"], "super_admin")
+            with self.assertRaisesRegex(ValueError, "canonical identity"):
+                admin_control_service.super_admin_update_user(
+                    user_id=str(user_id),
+                    payload={"role": "super_admin"},
+                    actor={"_id": ObjectId(), "email": "l.robinson@tomboflight.com"},
+                )
+        self.assertEqual(db["users"].documents[0]["role"], "admin")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_continuity_runtime_service.py
+++ b/backend/tests/test_continuity_runtime_service.py
@@ -204,6 +204,26 @@ class TestContinuityRuntimeService(unittest.TestCase):
         self.assertEqual(operations[0]["state"], "apply_failed")
         self.assertEqual(operations[0]["execution_error"], "domain adapter failed")
 
+    def test_failed_execution_retries_the_same_persisted_idempotent_operation(self) -> None:
+        self.executor.side_effect = RuntimeError("temporary adapter failure")
+        with self.assertRaisesRegex(RuntimeError, "temporary adapter failure"):
+            self._execute(idempotency_key="kernel-idempotency-retry")
+
+        failed = deepcopy(self.database[runtime.OPERATIONS_COLLECTION].documents[0])
+        self.executor.side_effect = None
+        self.executor.return_value = {"changed": True, "resumed": True}
+        retried = self._execute(idempotency_key="kernel-idempotency-retry")
+
+        self.assertEqual(retried["operation_id"], failed["operation_id"])
+        self.assertEqual(retried["state"], "apply_executed")
+        self.assertEqual(retried["execution_retry_count"], 1)
+        self.assertIsNone(retried["execution_error"])
+        self.assertEqual(self.executor.call_count, 2)
+        self.assertIn(
+            "retry_failed_operation",
+            [item["action"] for item in retried["transitions"]],
+        )
+
     def test_post_execution_evidence_failure_does_not_relabel_the_domain_write(self) -> None:
         operation = runtime.request_operation(
             action="package_change",
@@ -393,9 +413,10 @@ class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
             "project_ownership_transfer",
             "impersonation_start",
             "impersonation_stop",
+            "legacy_admin_remediation",
         }
-        self.assertEqual(runtime.RUNTIME_VERSION, "10.1.0")
-        self.assertEqual(len(runtime.ACTION_SPECS), 36)
+        self.assertEqual(runtime.RUNTIME_VERSION, "11.0.0")
+        self.assertEqual(len(runtime.ACTION_SPECS), 37)
         self.assertTrue(expected.issubset(runtime.ACTION_SPECS))
 
     def test_permanent_deletion_adapter_passes_both_irreversible_confirmations(self) -> None:
@@ -507,6 +528,7 @@ class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
             "user-1",
             admin_user_id="ceo-1",
             admin_display="CEO Operator",
+            admin_email=CEO_MASTER_ADMIN_EMAIL,
         )
 
     def test_delivery_failure_marks_execution_as_partial_failure(self) -> None:
@@ -515,6 +537,34 @@ class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
                 {"delivery_sent": False, "failure_count": 1}
             ),
             1,
+        )
+
+    def test_legacy_privileged_account_remediation_executes_only_for_reviewed_target(self) -> None:
+        actor = {"_id": "ceo-1", "email": CEO_MASTER_ADMIN_EMAIL}
+        review = {
+            "found": True,
+            "user_id": "legacy-admin-1",
+            "safe_to_suspend": True,
+        }
+        applied = {**review, "applied": True, "disposition": "suspended"}
+        with patch.object(
+            runtime.admin_control_service,
+            "legacy_admin_security_review",
+            side_effect=[review, applied],
+        ) as remediate:
+            result = runtime._invoke_action(
+                "legacy_admin_remediation",
+                {"user_id": "legacy-admin-1"},
+                {"reason": "Remove deprecated wildcard access"},
+                actor,
+            )
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(remediate.call_count, 2)
+        remediate.assert_called_with(
+            apply=True,
+            reason="Remove deprecated wildcard access",
+            actor=actor,
         )
 
 

--- a/backend/tests/test_health_and_db_unavailable.py
+++ b/backend/tests/test_health_and_db_unavailable.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ from starlette.datastructures import Headers, UploadFile
 from starlette.requests import Request
 
 from app import main as main_module
+from app import database as database_module
 from app.database import DatabaseUnavailableError
 from app.routes import health as health_routes
 from app.routes import uploads as upload_routes
@@ -102,6 +104,116 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
         self.assertEqual(health["status"], "degraded")
         self.assertEqual(root["service_mode"], "degraded")
         self.assertEqual(root["degraded_reasons"], ["database_unavailable"])
+
+    def test_production_operational_readiness_reports_controls_only_to_ceo_surface(self):
+        with tempfile.TemporaryDirectory() as mount_path:
+            with (
+                patch.object(database_module, "db", object()),
+                patch.object(database_module.settings, "environment", "production"),
+                patch.object(database_module.settings, "secret_key", "s" * 48),
+                patch.object(database_module.settings, "stripe_secret_key", "sk_live_configured"),
+                patch.object(database_module.settings, "stripe_publishable_key", "pk_live_configured"),
+                patch.object(database_module.settings, "stripe_webhook_secret", "whsec_configured"),
+                patch.object(database_module.settings, "postmark_server_token", "postmark-configured"),
+                patch.object(database_module.settings, "postmark_server_token_file", ""),
+                patch.object(database_module.settings, "postmark_from_email", "security@tomboflight.com"),
+                patch.object(database_module.settings, "upload_scan_hook", "scanner.module:scan"),
+                patch.object(database_module.settings, "upload_scan_command", ""),
+                patch.object(database_module.settings, "upload_scan_fail_closed", True),
+                patch.object(database_module.settings, "render_disk_mount_path", mount_path),
+                patch.dict(
+                    database_module.os.environ,
+                    {
+                        "RENDER_GIT_COMMIT": "phase11commit",
+                        "CONTINUITY_EXECUTION_KILL_SWITCH": "",
+                    },
+                ),
+            ):
+                public_state = database_module.get_service_state()
+                detailed_state = database_module.get_service_state(
+                    include_operational_details=True
+                )
+
+        self.assertTrue(public_state["operational_ready"])
+        self.assertNotIn("components", public_state)
+        self.assertNotIn("operational_degraded_reasons", public_state)
+        self.assertNotIn("release", public_state)
+        self.assertTrue(detailed_state["operational_ready"])
+        self.assertEqual(detailed_state["operational_degraded_reasons"], [])
+        self.assertEqual(detailed_state["release"]["commit"], "phase11commit")
+        self.assertTrue(detailed_state["components"]["production_signing_key"]["configured"])
+        self.assertTrue(detailed_state["components"]["stripe_webhooks"]["configured"])
+        self.assertEqual(detailed_state["components"]["upload_scanner"]["mode"], "active")
+        self.assertTrue(detailed_state["components"]["private_upload_storage"]["persistent"])
+
+    def test_production_operational_readiness_fails_closed_on_missing_controls(self):
+        release_env = {
+            "RENDER_GIT_COMMIT": "",
+            "RELEASE_SHA": "",
+            "GIT_COMMIT": "",
+            "COMMIT_SHA": "",
+            "VERCEL_GIT_COMMIT_SHA": "",
+            "CONTINUITY_EXECUTION_KILL_SWITCH": "true",
+        }
+        with (
+            patch.object(database_module, "db", object()),
+            patch.object(database_module.settings, "environment", "production"),
+            patch.object(database_module.settings, "secret_key", "change-me"),
+            patch.object(database_module.settings, "stripe_secret_key", ""),
+            patch.object(database_module.settings, "stripe_publishable_key", ""),
+            patch.object(database_module.settings, "stripe_webhook_secret", ""),
+            patch.object(database_module.settings, "postmark_server_token", ""),
+            patch.object(database_module.settings, "postmark_server_token_file", ""),
+            patch.object(database_module.settings, "upload_scan_hook", ""),
+            patch.object(database_module.settings, "upload_scan_command", "legacy-command"),
+            patch.object(database_module.settings, "render_disk_mount_path", ""),
+            patch.dict(database_module.os.environ, release_env),
+        ):
+            detailed_state = database_module.get_service_state(
+                include_operational_details=True
+            )
+
+        reasons = set(detailed_state["operational_degraded_reasons"])
+        self.assertFalse(detailed_state["operational_ready"])
+        self.assertTrue(
+            {
+                "production_signing_key_invalid",
+                "stripe_configuration_incomplete",
+                "postmark_configuration_incomplete",
+                "upload_scanner_unavailable_quarantine_only",
+                "private_upload_storage_not_persistent",
+                "deployment_revision_unavailable",
+                "continuity_execution_disabled",
+            }.issubset(reasons)
+        )
+        self.assertTrue(
+            detailed_state["components"]["upload_scanner"][
+                "legacy_command_ignored"
+            ]
+        )
+
+    def test_operational_readiness_route_sets_503_for_ceo_when_degraded(self):
+        state = {
+            **_ready_service_state(),
+            "operational_ready": False,
+            "operational_degraded_reasons": ["continuity_execution_disabled"],
+            "components": {},
+            "release": {"version": "1.0.0", "commit": "abc123"},
+        }
+        with patch.object(health_routes, "get_service_state", return_value=state) as get_state:
+            response = Response()
+            payload = health_routes.operational_readiness_check(
+                response,
+                {"email": "l.robinson@tomboflight.com"},
+            )
+
+        get_state.assert_called_once_with(include_operational_details=True)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertEqual(
+            payload["operational_degraded_reasons"],
+            ["continuity_execution_disabled"],
+        )
 
     def test_db_down_upload_route_returns_structured_503(self):
         upload = UploadFile(

--- a/backend/tests/test_order_authority_security_patch.py
+++ b/backend/tests/test_order_authority_security_patch.py
@@ -411,7 +411,7 @@ class OrderAuthoritySecurityTests(unittest.TestCase):
                 )
         self.assertEqual(exc.exception.status_code, 403)
 
-    def test_manual_order_requires_permission_reason_idempotency_and_audit_event(self):
+    def test_manual_paid_order_creation_is_disabled_even_with_finance_permission(self):
         dependency = require_any_permission(["admin.control.billing", "admin.orders.repair"])
         request = SimpleNamespace(path_params={}, query_params={})
         with patch.object(
@@ -462,17 +462,17 @@ class OrderAuthoritySecurityTests(unittest.TestCase):
             patch.object(order_service, "_trigger_package_provisioning"),
             patch("app.services.audit_log_service.write_audit_log") as audit_mock,
         ):
-            result = order_service.create_manual_order_for_admin(
-                {
-                    "_id": "507f1f77bcf86cd799439001",
-                    "email": "finance@example.com",
-                    "full_name": "Finance Admin",
-                },
-                payload,
-            )
-        self.assertEqual(result["status"], "paid")
-        self.assertEqual(audit_mock.call_count, 1)
-        self.assertEqual(len(orders.docs), 1)
+            with self.assertRaisesRegex(ValueError, "Manual paid-order creation is disabled"):
+                order_service.create_manual_order_for_admin(
+                    {
+                        "_id": "507f1f77bcf86cd799439001",
+                        "email": "finance@example.com",
+                        "full_name": "Finance Admin",
+                    },
+                    payload,
+                )
+        self.assertEqual(audit_mock.call_count, 0)
+        self.assertEqual(len(orders.docs), 0)
 
     def test_admin_manual_schema_forbids_administrative_metadata_outside_contract(self):
         with self.assertRaises(ValidationError):

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -7,11 +7,14 @@ from unittest.mock import patch
 
 from bson import ObjectId
 from fastapi import HTTPException
+from starlette.requests import Request
 
-from app.core import security as security_core
+from app.core import continuity_route_guard, security as security_core
 from app.core.security import create_csrf_token, verify_csrf_token
 from app.database import DatabaseUnavailableError
+from app.routes import auth as auth_routes
 from app.routes import uploads as upload_routes
+from app.schemas.auth import UserCreate as AuthUserCreate
 from app.services import auth_service, link_key_service, rate_limit_service, upload_scan_service
 
 
@@ -20,9 +23,21 @@ class FakeInsertResult:
         self.inserted_id = inserted_id
 
 
+class FakeUpdateResult:
+    def __init__(self, matched_count=0, modified_count=0):
+        self.matched_count = matched_count
+        self.modified_count = modified_count
+
+
 class FakeCollection:
     def __init__(self, documents=None):
         self.documents = list(documents or [])
+        self.indexes = {}
+
+    def create_index(self, keys, **options):
+        name = options.get("name") or str(keys)
+        self.indexes[name] = {"keys": keys, **options}
+        return name
 
     def find_one(self, query=None, sort=None):
         query = query or {}
@@ -45,8 +60,11 @@ class FakeCollection:
     def update_one(self, query, update):
         item = self.find_one(query)
         if not item:
-            return
+            return FakeUpdateResult()
         item.update(update.get("$set", {}))
+        for key in update.get("$unset", {}):
+            item.pop(key, None)
+        return FakeUpdateResult(matched_count=1, modified_count=1)
 
     def update_many(self, query, update):
         for item in self.find(query):
@@ -126,6 +144,27 @@ class RateLimitAndLockoutTests(unittest.TestCase):
             self.assertTrue(locked)
             with self.assertRaises(HTTPException):
                 rate_limit_service.enforce_lockout(scope="login", key=key)
+
+    def test_rate_limit_identity_does_not_trust_spoofed_forwarded_address(self):
+        request = Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": "POST",
+                "path": "/auth/login",
+                "headers": [(b"x-forwarded-for", b"198.51.100.44")],
+                "query_string": b"",
+                "client": ("203.0.113.25", 50000),
+                "scheme": "https",
+                "server": ("testserver", 443),
+            }
+        )
+        self.assertEqual(
+            auth_routes._rate_key_from_request(
+                request, principal="Customer@Example.com"
+            ),
+            "203.0.113.25:customer@example.com",
+        )
 
 
 class AuthMfaTests(unittest.TestCase):
@@ -212,6 +251,172 @@ class AuthMfaTests(unittest.TestCase):
         stored = db.users.find_one({"_id": user_id})
         self.assertFalse(stored.get("mfa_enabled"))
         self.assertIsNone(stored.get("mfa_secret_encrypted"))
+
+
+class AccountActivationSecurityTests(unittest.TestCase):
+    def _payload(self, *, email: str, activation_token: str | None = None) -> AuthUserCreate:
+        return AuthUserCreate(
+            email=email,
+            password="StrongActivationPass!123",
+            full_name="Activation Customer",
+            terms_accepted=True,
+            privacy_accepted=True,
+            eligibility_attested=True,
+            policy_version="2026-03-26",
+            activation_token=activation_token,
+        )
+
+    def test_new_public_signup_stays_passwordless_until_email_activation(self):
+        db = FakeDatabase({"users": []})
+        raw_token = "activation-token-that-is-never-stored-raw"
+        with (
+            patch.object(auth_service, "get_database", return_value=db),
+            patch.object(auth_service.secrets, "token_urlsafe", return_value=raw_token),
+            patch.object(
+                auth_service,
+                "send_account_activation_email",
+                return_value={"sent": True, "provider": "postmark"},
+            ) as send_activation,
+            patch.object(auth_service, "create_audit_log"),
+        ):
+            user = auth_service.register_user(
+                self._payload(email="new.activation@example.com")
+            )
+
+        self.assertIsNotNone(user)
+        assert user is not None
+        self.assertEqual(user["status"], "pending_activation")
+        self.assertTrue(user["requires_account_activation"])
+        self.assertIsNone(user["password_hash"])
+        self.assertNotIn(raw_token, str(db.users.documents))
+        self.assertEqual(
+            user["account_activation_token_hash"],
+            auth_service._hash_account_activation_token(raw_token),
+        )
+        activation_url = send_activation.call_args.kwargs["activation_url"]
+        self.assertIn("#activation_token=", activation_url)
+        self.assertNotIn("?activation_token=", activation_url)
+
+    def test_identity_startup_indexes_enforce_unique_email_and_live_activation_token(self):
+        db = FakeDatabase({"users": []})
+        with patch.object(auth_service, "get_database", return_value=db):
+            auth_service.ensure_auth_indexes()
+
+        email_index = db.users.indexes["idx_users_email_unique"]
+        activation_index = db.users.indexes[
+            "idx_users_activation_token_hash_unique"
+        ]
+        self.assertTrue(email_index["unique"])
+        self.assertTrue(activation_index["unique"])
+        self.assertEqual(
+            activation_index["partialFilterExpression"],
+            {"account_activation_token_hash": {"$type": "string"}},
+        )
+
+    def test_pending_account_cannot_be_claimed_without_the_live_activation_token(self):
+        user_id = ObjectId()
+        raw_token = "valid-activation-token-value"
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "pending@example.com",
+                        "full_name": "Pending Customer",
+                        "role": "user",
+                        "account_type": "customer",
+                        "status": "pending_activation",
+                        "password_hash": None,
+                        "session_token_version": 0,
+                        "account_activation_token_hash": auth_service._hash_account_activation_token(
+                            raw_token
+                        ),
+                        "account_activation_expires_at": (
+                            datetime.now(UTC) + timedelta(hours=1)
+                        ).isoformat(),
+                        "created_at": datetime.now(UTC).isoformat(),
+                    }
+                ]
+            }
+        )
+
+        with patch.object(auth_service, "get_database", return_value=db):
+            missing = auth_service.register_user(
+                self._payload(email="pending@example.com")
+            )
+            invalid = auth_service.register_user(
+                self._payload(
+                    email="pending@example.com",
+                    activation_token="invalid-activation-token",
+                )
+            )
+            activated = auth_service.register_user(
+                self._payload(
+                    email="pending@example.com",
+                    activation_token=raw_token,
+                )
+            )
+            replay = auth_service.register_user(
+                self._payload(
+                    email="pending@example.com",
+                    activation_token=raw_token,
+                )
+            )
+
+        self.assertIsNone(missing)
+        self.assertIsNone(invalid)
+        self.assertIsNotNone(activated)
+        assert activated is not None
+        self.assertEqual(activated["status"], "active")
+        self.assertTrue(
+            auth_service.verify_password(
+                "StrongActivationPass!123", activated["password_hash"]
+            )
+        )
+        self.assertIsNone(activated["account_activation_token_hash"])
+        self.assertIsNone(replay)
+
+    def test_signup_browser_consumes_activation_from_fragment_and_clears_it(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        auth_source = (repository_root / "auth.js").read_text(encoding="utf-8")
+        signup_source = (repository_root / "signup.html").read_text(encoding="utf-8")
+        self.assertIn("window.location.hash", auth_source)
+        self.assertIn("activation_token", auth_source)
+        self.assertIn("window.history.replaceState", auth_source)
+        self.assertNotIn("Email verified. Enter your account details", auth_source)
+        self.assertIn("auth.js?v=20260822-phase11", signup_source)
+
+
+class ContinuityLegacyRouteGuardTests(unittest.TestCase):
+    def test_covered_legacy_mutations_require_kernel_execution(self):
+        for method, path in (
+            ("POST", "/admin/control-center/super-admin/users"),
+            ("POST", "/admin/control-center/super-admin/legacy-admin-review"),
+            ("PATCH", "/admin/control-center/super-admin/users/user-1"),
+            ("POST", "/admin/stripe-ops/subscriptions/cancel"),
+            ("POST", "/auth/admin/users/user-1/password-reset"),
+            ("POST", "/orders/admin/manual-order"),
+            ("POST", "/orders/admin/repair-paid-package-access"),
+            ("POST", "/project-entitlements/apply"),
+            ("POST", "/users"),
+        ):
+            with self.subTest(method=method, path=path):
+                self.assertTrue(
+                    continuity_route_guard.requires_continuity_kernel(method, path)
+                )
+
+    def test_reads_previews_and_kernel_execution_remain_available(self):
+        for method, path in (
+            ("GET", "/admin/control-center/super-admin/users"),
+            ("POST", "/admin/control-center/super-admin/users/preview"),
+            ("POST", "/admin/control-center/kernel/execute"),
+            ("GET", "/admin/stripe-ops/customers/history"),
+            ("PATCH", "/users/me/profile"),
+        ):
+            with self.subTest(method=method, path=path):
+                self.assertFalse(
+                    continuity_route_guard.requires_continuity_kernel(method, path)
+                )
 
 
 class AuthDatabaseFailClosedTests(unittest.TestCase):

--- a/backend/tests/test_startup_initialization.py
+++ b/backend/tests/test_startup_initialization.py
@@ -14,6 +14,7 @@ class StartupInitializationTests(unittest.TestCase):
         with (
             patch.object(main_module, "validate_nft_runtime_configuration_on_startup") as validate_mock,
             patch.object(main_module, "connect_to_mongo", return_value={"db": "ok"}) as connect_mock,
+            patch.object(main_module, "ensure_auth_indexes") as auth_index_mock,
             patch.object(main_module, "initialize_order_indexes") as order_init_mock,
             patch.object(main_module, "ensure_project_entitlement_indexes") as entitlement_init_mock,
             patch.object(main_module, "initialize_mint_record_indexes") as mint_record_init_mock,
@@ -29,6 +30,7 @@ class StartupInitializationTests(unittest.TestCase):
 
         validate_mock.assert_called_once()
         connect_mock.assert_called_once()
+        auth_index_mock.assert_called_once()
         order_init_mock.assert_called_once()
         entitlement_init_mock.assert_called_once()
         mint_record_init_mock.assert_called_once()
@@ -48,6 +50,7 @@ class StartupInitializationTests(unittest.TestCase):
         with (
             patch.object(main_module, "validate_nft_runtime_configuration_on_startup") as validate_mock,
             patch.object(main_module, "connect_to_mongo", return_value=None) as connect_mock,
+            patch.object(main_module, "ensure_auth_indexes") as auth_index_mock,
             patch.object(main_module, "initialize_order_indexes") as order_init_mock,
             patch.object(main_module, "ensure_project_entitlement_indexes") as entitlement_init_mock,
             patch.object(main_module, "initialize_mint_record_indexes") as mint_record_init_mock,
@@ -63,6 +66,7 @@ class StartupInitializationTests(unittest.TestCase):
 
         validate_mock.assert_called_once()
         connect_mock.assert_called_once()
+        auth_index_mock.assert_not_called()
         order_init_mock.assert_not_called()
         entitlement_init_mock.assert_not_called()
         mint_record_init_mock.assert_not_called()

--- a/backend/tests/test_stripe_webhooks.py
+++ b/backend/tests/test_stripe_webhooks.py
@@ -156,6 +156,71 @@ class StripeWebhookPersistenceTests(unittest.TestCase):
         self.assertTrue(should_process)
         self.assertNotEqual(claim_token, "old-claim")
 
+    def test_failed_processing_releases_claim_for_stripe_retry(self):
+        events = FakeStripeEventsCollection()
+        now = datetime.now(timezone.utc)
+        event = {"id": "evt_retry", "type": "checkout.session.completed"}
+
+        should_process, first_claim = stripe_webhooks._claim_event_processing(
+            cast(Any, events),
+            event=event,
+            now=now,
+        )
+        self.assertTrue(should_process)
+        stripe_webhooks._mark_event_failed(
+            cast(Any, events),
+            event_id="evt_retry",
+            claim_token=first_claim,
+            failures=["order_upsert_failed"],
+            order_result={"order_id": None, "error": "order_upsert_failed"},
+            maintenance_result={"updated": False},
+            now=now,
+        )
+
+        stored = events.docs["evt_retry"]
+        self.assertEqual(stored["processing_status"], "retryable_failure")
+        self.assertNotIn("processed_at", stored)
+        self.assertNotIn("processing_claim", stored)
+
+        retry_process, retry_claim = stripe_webhooks._claim_event_processing(
+            cast(Any, events),
+            event=event,
+            now=now,
+        )
+        self.assertTrue(retry_process)
+        self.assertTrue(retry_claim)
+        self.assertNotEqual(retry_claim, first_claim)
+
+    def test_checkout_succeeds_when_either_authoritative_handler_persists_it(self):
+        package_failures = stripe_webhooks._downstream_failures(
+            event_type="checkout.session.completed",
+            order_result={"order_id": "order-1"},
+            maintenance_result={"updated": False, "reason": "not_subscription_checkout"},
+        )
+        maintenance_failures = stripe_webhooks._downstream_failures(
+            event_type="checkout.session.completed",
+            order_result={"order_id": None, "error": "not_an_approved_package"},
+            maintenance_result={"updated": True, "project_id": "project-1"},
+        )
+
+        self.assertEqual(package_failures, [])
+        self.assertEqual(maintenance_failures, [])
+
+    def test_unpersisted_relevant_events_are_retryable_failures(self):
+        checkout_failures = stripe_webhooks._downstream_failures(
+            event_type="checkout.session.completed",
+            order_result={"order_id": None, "reason": "no_matching_user"},
+            maintenance_result={"updated": False, "reason": "not_subscription_checkout"},
+        )
+        subscription_failures = stripe_webhooks._downstream_failures(
+            event_type="customer.subscription.updated",
+            order_result={"order_id": None},
+            maintenance_result={"updated": False, "reason": "missing_project_id"},
+        )
+
+        self.assertEqual(checkout_failures, ["no_matching_user"])
+        self.assertEqual(subscription_failures, ["missing_project_id"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/signup.html
+++ b/signup.html
@@ -322,6 +322,6 @@
 
     <script src="config.js?v=20260509-visualfix"></script>
     <script src="app.js?v=20260821-phase9"></script>
-    <script src="auth.js?v=20260509-visualfix"></script>
+    <script src="auth.js?v=20260822-phase11"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- advances the operational Continuity Kernel to Phase 11 / runtime v11.0.0 with 37 governed actions
- makes `l.robinson@tomboflight.com` the only wildcard CEO Master Administrator identity and strips authority from legacy noncanonical `super_admin` labels
- replaces password-bearing pending accounts with short-lived, hashed, single-use email activation; MFA remains optional and opt-in
- retires direct account creation and fabricated manual paid-order creation, while preserving CEO-authorized complimentary/package grants without falsifying Stripe history
- forces covered legacy Control Center, Stripe-admin, administrator credential-reset, entitlement, and account mutations through the Continuity Kernel
- makes Stripe webhook processing retryable when authoritative downstream persistence fails
- makes permanent deletion CEO-only, identity-locking, tombstoned, resumable, per-subscription idempotent, and truthful about audit persistence
- adds protected operational readiness diagnostics without exposing missing security controls through public health routes

## Verification

- full backend suite: **1,797 passed, 2 skipped**
- contract subtests: **85 passed**
- `pip-audit -r backend/requirements.txt`: **no known vulnerabilities**
- `pip check`: **no broken requirements**
- Bandit medium/high scan: **no findings**
- Python compilation, JavaScript syntax, adapter signatures, secret-pattern review, and `git diff --check`: **passed**

## Deployment boundary

No production customer mutation was performed. This PR does **not** delete Marquis or any other account.

Before treating the deployment as operationally ready, confirm the protected `/health/operational` surface is green and configure:

1. a unique production `SECRET_KEY` of at least 32 bytes
2. Stripe publishable, secret, and webhook keys
3. verified Postmark token and sender
4. a callable `UPLOAD_SCAN_HOOK`
5. readable/writable persistent private-upload storage
6. a deployment commit identifier
7. a clean build of the unique user-email identity index

Provider encryption, backups/restores, edge controls, and independent penetration-test evidence remain separate launch evidence.