### PR TITLE
Phase 13 — Family Operating Machine

### DIFF
--- a/add-member.html
+++ b/add-member.html
@@ -90,45 +90,87 @@
                 </label>
 
                 <label>
-                  Generation
-                  <input
-                    type="number"
-                    name="generation"
-                    placeholder="Example: 1"
-                    min="0"
-                    required
-                  />
+                  Tree Placement
+                  <input type="text" value="Calculated automatically from relationships" disabled />
                 </label>
               </div>
 
               <div class="form-grid two-col">
                 <label>
-                  Father ID
-                  <input
-                    type="text"
+                  Parent / Guardian 1
+                  <select
                     name="father_id"
-                    placeholder="Optional existing member ID"
-                  />
+                  >
+                    <option value="">Select a family first</option>
+                  </select>
                 </label>
 
                 <label>
-                  Mother ID
-                  <input
-                    type="text"
-                    name="mother_id"
-                    placeholder="Optional existing member ID"
-                  />
+                  Parent / Guardian 1 Type
+                  <select name="father_relationship_type">
+                    <option value="parent_unspecified">Parent (type not specified)</option>
+                    <option value="biological_parent">Biological parent</option>
+                    <option value="gestational_parent">Gestational parent</option>
+                    <option value="donor_parent">Donor parent</option>
+                    <option value="intended_parent">Intended parent</option>
+                    <option value="adoptive_parent">Adoptive parent</option>
+                    <option value="foster_parent">Foster parent</option>
+                    <option value="step_parent">Step-parent</option>
+                    <option value="guardian">Guardian</option>
+                    <option value="chosen_parent">Chosen parent</option>
+                    <option value="community_parent">Community parent</option>
+                    <option value="spiritual_parent">Spiritual parent</option>
+                  </select>
                 </label>
               </div>
 
-              <label>
-                Spouse ID
-                <input
-                  type="text"
-                  name="spouse_id"
-                  placeholder="Optional existing member ID"
-                />
-              </label>
+              <div class="form-grid two-col">
+                <label>
+                  Parent / Guardian 2
+                  <select
+                    name="mother_id"
+                  >
+                    <option value="">Select a family first</option>
+                  </select>
+                </label>
+
+                <label>
+                  Parent / Guardian 2 Type
+                  <select name="mother_relationship_type">
+                    <option value="parent_unspecified">Parent (type not specified)</option>
+                    <option value="biological_parent">Biological parent</option>
+                    <option value="gestational_parent">Gestational parent</option>
+                    <option value="donor_parent">Donor parent</option>
+                    <option value="intended_parent">Intended parent</option>
+                    <option value="adoptive_parent">Adoptive parent</option>
+                    <option value="foster_parent">Foster parent</option>
+                    <option value="step_parent">Step-parent</option>
+                    <option value="guardian">Guardian</option>
+                    <option value="chosen_parent">Chosen parent</option>
+                    <option value="community_parent">Community parent</option>
+                    <option value="spiritual_parent">Spiritual parent</option>
+                  </select>
+                </label>
+              </div>
+
+              <div class="form-grid two-col">
+                <label>
+                  Spouse / Partner
+                  <select name="spouse_id">
+                    <option value="">Select a family first</option>
+                  </select>
+                </label>
+                <label>
+                  Partnership Type
+                  <select name="partner_relationship_type">
+                    <option value="spouse">Spouse</option>
+                    <option value="domestic_partner">Domestic partner</option>
+                    <option value="co_parent">Co-parent</option>
+                    <option value="former_spouse">Former spouse</option>
+                    <option value="former_partner">Former partner</option>
+                  </select>
+                </label>
+              </div>
 
               <label>
                 Bio / Notes
@@ -138,6 +180,41 @@
                   placeholder="Optional family notes, short biography, or lineage context."
                 ></textarea>
               </label>
+
+              <label style="display: flex; gap: 0.65rem; align-items: flex-start">
+                <input type="checkbox" name="identity_matching_consent" style="margin-top: 0.2rem" />
+                <span>
+                  Allow Tomb of Light to look for a possible duplicate of this person
+                  in other consented family records. A match is never merged automatically.
+                </span>
+              </label>
+
+              <label style="display: flex; gap: 0.65rem; align-items: flex-start">
+                <input type="checkbox" name="account_required" style="margin-top: 0.2rem" />
+                <span>
+                  This person should have their own private Tomb of Light account.
+                  Their password and private files will remain separate.
+                </span>
+              </label>
+
+              <div class="form-grid two-col">
+                <label>
+                  Account Email
+                  <input
+                    type="email"
+                    name="invite_email"
+                    maxlength="320"
+                    placeholder="Required when an account is expected"
+                  />
+                </label>
+                <label>
+                  Family Workspace Role
+                  <select name="account_member_role">
+                    <option value="viewer">Viewer — can review shared records</option>
+                    <option value="contributor">Contributor — can add permitted materials</option>
+                  </select>
+                </label>
+              </div>
 
               <div
                 class="helper"
@@ -171,7 +248,7 @@
                 <div class="card-number">2</div>
                 <h3>Generation placement</h3>
                 <p class="card-copy">
-                  The generation field helps place the person inside the lineage structure.
+                  Relationships calculate the person’s generation automatically and reject conflicting placement.
                 </p>
               </div>
 
@@ -179,7 +256,7 @@
                 <div class="card-number">3</div>
                 <h3>Relationship readiness</h3>
                 <p class="card-copy">
-                  Parent and spouse IDs prepare the member for future relationship mapping.
+                  Guided parent, guardian, step, adoptive, chosen-family, and partner selections create the relationship map with the person.
                 </p>
               </div>
             </div>

--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -34,6 +34,8 @@
             <a href="admin-control-center.html" aria-current="page">Control Center</a>
             <a href="admin-intake-queue.html">Admin Intake Queue</a>
             <a href="admin-family-manager.html">Family Manager</a>
+            <a href="admin-portrait-review.html">Portrait Review</a>
+            <a href="admin-verification-review.html">Evidence Review</a>
             <a href="faq.html">FAQ</a>
           </nav>
 

--- a/admin-portrait-review.html
+++ b/admin-portrait-review.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
+    <title>Master Portrait Review | Tomb of Light</title>
+    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+  </head>
+  <body class="portal-dashboard-body">
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html">Tomb of Light<span class="brand-symbol">™</span></a>
+          <nav class="site-nav" aria-label="Admin navigation">
+            <a href="admin-control-center.html">Control Center</a>
+            <a href="admin-portrait-review.html" aria-current="page">Portrait Review</a>
+            <a href="admin-verification-review.html">Evidence Review</a>
+            <a href="admin-family-manager.html">Family Manager</a>
+          </nav>
+          <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
+        </div>
+      </header>
+      <main data-admin-portrait-review>
+        <section class="page-hero"><div class="container"><div class="page-hero-panel">
+          <span class="eyebrow">Master Account Review</span>
+          <h1>Approve portraits before automatic placement.</h1>
+          <p data-review-status>Loading portrait submissions…</p>
+          <div class="notice" style="margin-top: 1rem">
+            Approval is available only after a clean security scan and recorded
+            customer consent and authority attestations.
+          </div>
+        </div></div></section>
+        <section class="page-sections"><div class="container form-shell">
+          <div class="form-panel">
+            <div class="inline-actions">
+              <button class="btn btn-primary" type="button" data-refresh-review>Refresh Queue</button>
+            </div>
+          </div>
+          <div class="grid-3" data-review-list></div>
+          <div class="form-panel" data-review-empty style="display: none">
+            <h2>No portrait submissions are waiting.</h2>
+          </div>
+        </div></section>
+      </main>
+    </div>
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260821-phase9"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="admin-portrait-review.js?v=20260823-phase13"></script>
+  </body>
+</html>

--- a/admin-portrait-review.js
+++ b/admin-portrait-review.js
@@ -1,0 +1,150 @@
+(function () {
+  "use strict";
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") return;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function setStatus(message) {
+    const node = document.querySelector("[data-review-status]");
+    if (node) node.textContent = message;
+  }
+
+  function canApprove(item) {
+    return (
+      String(item.scan_status || "").toLowerCase() === "clean" &&
+      !item.quarantined &&
+      item.consent_attested &&
+      item.authority_attested
+    );
+  }
+
+  function render(items) {
+    const list = document.querySelector("[data-review-list]");
+    const empty = document.querySelector("[data-review-empty]");
+    if (!items.length) {
+      list.innerHTML = "";
+      empty.style.display = "";
+      return;
+    }
+    empty.style.display = "none";
+    list.innerHTML = items.map(function (item) {
+      const ready = canApprove(item);
+      return `
+        <article class="family-record-card" data-review-card="${escapeHtml(item.id)}">
+          <span class="eyebrow">${escapeHtml(item.scan_status || "pending scan")}</span>
+          <h3>${escapeHtml(item.member_name || "Unnamed family member")}</h3>
+          <p class="card-copy"><strong>Family:</strong> ${escapeHtml(item.family_name || item.family_id || "—")}</p>
+          <p class="card-copy"><strong>File:</strong> ${escapeHtml(item.original_filename || "—")}</p>
+          <p class="card-copy"><strong>Consent:</strong> ${item.consent_attested ? "Attested" : "Missing"}</p>
+          <p class="card-copy"><strong>Authority:</strong> ${item.authority_attested ? "Attested" : "Missing"}</p>
+          <p class="card-copy"><strong>Current status:</strong> ${escapeHtml(item.master_review_status || item.verification_status || "pending")}</p>
+          <div data-review-preview style="margin: 0.75rem 0"></div>
+          <div class="inline-actions">
+            <button class="btn btn-secondary" type="button" data-preview-id="${escapeHtml(item.id)}">Preview</button>
+            <button class="btn btn-primary" type="button" data-review-decision="approve" data-upload-id="${escapeHtml(item.id)}" ${ready ? "" : "disabled"}>Approve &amp; Place</button>
+            <button class="btn btn-secondary" type="button" data-review-decision="reject" data-upload-id="${escapeHtml(item.id)}">Reject</button>
+          </div>
+        </article>
+      `;
+    }).join("");
+  }
+
+  async function loadQueue() {
+    setStatus("Loading portrait review queue…");
+    const payload = await app.apiRequest(
+      "/uploads/admin/review?category=member_photo&limit=500",
+      { method: "GET" },
+    );
+    const items = (Array.isArray(payload.items) ? payload.items : []).filter(
+      function (item) {
+        const status = String(item.master_review_status || "pending").toLowerCase();
+        return !item.approved_for_cinematic && status !== "rejected";
+      },
+    );
+    render(items);
+    setStatus(`${items.length} portrait submission(s) in the review queue.`);
+  }
+
+  async function preview(uploadId, button) {
+    const token = app.getToken ? app.getToken() : "";
+    const base = typeof app.getApiBaseUrl === "function" ? app.getApiBaseUrl() : "";
+    const response = await fetch(
+      `${base}/uploads/${encodeURIComponent(uploadId)}/download`,
+      {
+        credentials: "include",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      },
+    );
+    if (!response.ok) throw new Error("Unable to load the portrait preview.");
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const card = button.closest("[data-review-card]");
+    const node = card.querySelector("[data-review-preview]");
+    node.innerHTML = "";
+    const image = document.createElement("img");
+    image.src = url;
+    image.alt = "Portrait submitted for master review";
+    image.style.cssText = "width:100%;max-height:320px;object-fit:cover;border-radius:8px";
+    image.addEventListener("load", function () { URL.revokeObjectURL(url); }, { once: true });
+    node.appendChild(image);
+  }
+
+  async function decide(uploadId, decision) {
+    const approving = decision === "approve";
+    const reviewNotes = window.prompt(
+      approving ? "Optional approval note:" : "Reason for rejection:",
+      "",
+    ) || "";
+    await app.apiRequest(
+      `/uploads/${encodeURIComponent(uploadId)}/cinematic-approval`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          approved_for_cinematic: approving,
+          verification_status: approving ? "approved" : "rejected",
+          consent_status: approving ? "approved" : "rejected",
+          review_notes: reviewNotes,
+        }),
+      },
+    );
+    await loadQueue();
+  }
+
+  async function setup() {
+    const page = document.querySelector("[data-admin-portrait-review]");
+    if (!page) return;
+    try {
+      await app.apiRequest("/auth/me", { method: "GET" });
+      await loadQueue();
+      document.querySelector("[data-refresh-review]").addEventListener("click", loadQueue);
+      document.addEventListener("click", async function (event) {
+        const previewButton = event.target.closest("[data-preview-id]");
+        const decisionButton = event.target.closest("[data-review-decision]");
+        try {
+          if (previewButton) {
+            await preview(previewButton.getAttribute("data-preview-id"), previewButton);
+          } else if (decisionButton) {
+            await decide(
+              decisionButton.getAttribute("data-upload-id"),
+              decisionButton.getAttribute("data-review-decision"),
+            );
+          }
+        } catch (error) {
+          setStatus(error.message || "Portrait review action failed.");
+        }
+      });
+    } catch (error) {
+      setStatus(error.message || "You do not have master portrait-review access.");
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", setup);
+})();

--- a/admin-verification-review.html
+++ b/admin-verification-review.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
+    <title>Master Verification Review | Tomb of Light</title>
+    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+  </head>
+  <body class="portal-dashboard-body">
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html">Tomb of Light<span class="brand-symbol">™</span></a>
+          <nav class="site-nav" aria-label="Admin navigation">
+            <a href="admin-control-center.html">Control Center</a>
+            <a href="admin-portrait-review.html">Portrait Review</a>
+            <a href="admin-verification-review.html" aria-current="page">Evidence Review</a>
+            <a href="admin-family-manager.html">Family Manager</a>
+          </nav>
+          <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
+        </div>
+      </header>
+      <main data-admin-verification-review>
+        <section class="page-hero"><div class="container"><div class="page-hero-panel">
+          <span class="eyebrow">Master Account Review</span>
+          <h1>Decide family verification evidence.</h1>
+          <p data-verification-review-status>Loading evidence review queue…</p>
+          <div class="notice" style="margin-top: 1rem">
+            Approved evidence may support the Verified Tree. The document itself
+            remains private and is never placed in the public NFT metadata.
+          </div>
+        </div></div></section>
+        <section class="page-sections"><div class="container form-shell">
+          <div class="form-panel"><div class="inline-actions">
+            <button class="btn btn-primary" type="button" data-refresh-verification-review>Refresh Queue</button>
+          </div></div>
+          <div class="grid-3" data-verification-review-list></div>
+          <div class="form-panel" data-verification-review-empty style="display: none">
+            <h2>No verification evidence is waiting.</h2>
+          </div>
+        </div></section>
+      </main>
+    </div>
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260821-phase9"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="admin-verification-review.js?v=20260823-phase13"></script>
+  </body>
+</html>

--- a/admin-verification-review.js
+++ b/admin-verification-review.js
@@ -1,0 +1,146 @@
+(function () {
+  "use strict";
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") return;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function setStatus(message) {
+    const node = document.querySelector("[data-verification-review-status]");
+    if (node) node.textContent = message;
+  }
+
+  function canApprove(item) {
+    return (
+      String(item.scan_status || "").toLowerCase() === "clean" &&
+      !item.quarantined
+    );
+  }
+
+  function render(items) {
+    const list = document.querySelector("[data-verification-review-list]");
+    const empty = document.querySelector("[data-verification-review-empty]");
+    if (!items.length) {
+      list.innerHTML = "";
+      empty.style.display = "";
+      return;
+    }
+    empty.style.display = "none";
+    list.innerHTML = items.map(function (item) {
+      return `
+        <article class="family-record-card" data-evidence-card="${escapeHtml(item.id)}">
+          <span class="eyebrow">${escapeHtml(item.scan_status || "pending scan")}</span>
+          <h3>${escapeHtml(item.member_name || "Unnamed family member")}</h3>
+          <p class="card-copy"><strong>Family:</strong> ${escapeHtml(item.family_name || item.family_id || "—")}</p>
+          <p class="card-copy"><strong>Evidence:</strong> ${escapeHtml(item.verification_type || item.evidence_kind || "Family record")}</p>
+          <p class="card-copy"><strong>File:</strong> ${escapeHtml(item.original_filename || "—")}</p>
+          <p class="card-copy"><strong>Status:</strong> ${escapeHtml(item.verification_status || "pending")}</p>
+          <div class="inline-actions">
+            <button class="btn btn-secondary" type="button" data-evidence-preview="${escapeHtml(item.id)}">Open Secure Preview</button>
+            <button class="btn btn-primary" type="button" data-evidence-decision="approved" data-upload-id="${escapeHtml(item.id)}" ${canApprove(item) ? "" : "disabled"}>Approve</button>
+            <button class="btn btn-secondary" type="button" data-evidence-decision="needs_correction" data-upload-id="${escapeHtml(item.id)}">Needs Correction</button>
+            <button class="btn btn-secondary" type="button" data-evidence-decision="rejected" data-upload-id="${escapeHtml(item.id)}">Reject</button>
+          </div>
+        </article>`;
+    }).join("");
+  }
+
+  async function loadQueue() {
+    setStatus("Loading evidence review queue…");
+    const payload = await app.apiRequest(
+      "/uploads/admin/review?category=verification_evidence&limit=500",
+      { method: "GET" },
+    );
+    const items = (Array.isArray(payload.items) ? payload.items : []).filter(
+      function (item) {
+        return !["approved", "rejected"].includes(
+          String(item.verification_status || "pending").toLowerCase(),
+        );
+      },
+    );
+    render(items);
+    setStatus(`${items.length} verification submission(s) need a decision.`);
+  }
+
+  async function preview(uploadId) {
+    const previewWindow = window.open("about:blank", "_blank");
+    const token = app.getToken ? app.getToken() : "";
+    const base = typeof app.getApiBaseUrl === "function" ? app.getApiBaseUrl() : "";
+    const response = await fetch(
+      `${base}/uploads/${encodeURIComponent(uploadId)}/download`,
+      {
+        credentials: "include",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      },
+    );
+    if (!response.ok) {
+      if (previewWindow) previewWindow.close();
+      throw new Error("Unable to open this evidence record.");
+    }
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    if (previewWindow) {
+      previewWindow.opener = null;
+      previewWindow.location.replace(url);
+    } else {
+      const link = document.createElement("a");
+      link.href = url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.click();
+    }
+    window.setTimeout(function () { URL.revokeObjectURL(url); }, 60000);
+  }
+
+  async function decide(uploadId, decision) {
+    const notes = window.prompt(
+      decision === "approved" ? "Optional verification note:" : "Review note:",
+      "",
+    ) || "";
+    await app.apiRequest(
+      `/uploads/${encodeURIComponent(uploadId)}/verification-review`,
+      {
+        method: "POST",
+        body: JSON.stringify({ decision, review_notes: notes }),
+      },
+    );
+    await loadQueue();
+  }
+
+  async function setup() {
+    if (!document.querySelector("[data-admin-verification-review]")) return;
+    try {
+      await app.apiRequest("/auth/me", { method: "GET" });
+      await loadQueue();
+      document.querySelector("[data-refresh-verification-review]")
+        .addEventListener("click", loadQueue);
+      document.addEventListener("click", async function (event) {
+        const previewButton = event.target.closest("[data-evidence-preview]");
+        const decisionButton = event.target.closest("[data-evidence-decision]");
+        try {
+          if (previewButton) {
+            await preview(previewButton.getAttribute("data-evidence-preview"));
+          } else if (decisionButton) {
+            await decide(
+              decisionButton.getAttribute("data-upload-id"),
+              decisionButton.getAttribute("data-evidence-decision"),
+            );
+          }
+        } catch (error) {
+          setStatus(error.message || "Evidence review action failed.");
+        }
+      });
+    } catch (error) {
+      setStatus(error.message || "You do not have master evidence-review access.");
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", setup);
+})();

--- a/backend/app/core/relationship_catalog.py
+++ b/backend/app/core/relationship_catalog.py
@@ -2,55 +2,199 @@ from __future__ import annotations
 
 from typing import Any
 
+# Relationship records always read source -> target. Parent-style labels therefore
+# mean "source is this kind of parent/elder of target". Keeping direction explicit
+# prevents a child/parent selection from silently landing in the wrong generation.
 RELATIONSHIP_TYPE_ALIASES: dict[str, str] = {
     "parent_child": "biological_parent",
     "parent-child": "biological_parent",
-    "biological_parent": "biological_parent",
+    "parent": "biological_parent",
+    "father": "biological_parent",
+    "mother": "biological_parent",
     "biological-parent": "biological_parent",
-    "spouse": "spouse",
-    "spousal": "spouse",
-    "former_spouse": "former_spouse",
-    "former-spouse": "former_spouse",
-    "sibling": "sibling",
-    "guardian": "guardian",
+    "gestational-parent": "gestational_parent",
+    "donor-parent": "donor_parent",
+    "intended-parent": "intended_parent",
     "adoptive_parent_child": "adoptive_parent",
     "adoptive-parent-child": "adoptive_parent",
-    "adoptive_parent": "adoptive_parent",
     "adoptive-parent": "adoptive_parent",
+    "foster-parent": "foster_parent",
     "step_parent_child": "step_parent",
     "step-parent-child": "step_parent",
-    "step_parent": "step_parent",
     "step-parent": "step_parent",
     "step parent": "step_parent",
     "stepparent": "step_parent",
-    "household_member": "household_member",
+    "legal-guardian": "guardian",
+    "chosen-parent": "chosen_parent",
+    "community-parent": "community_parent",
+    "spiritual-parent": "spiritual_parent",
+    "spousal": "spouse",
+    "former-spouse": "former_spouse",
+    "domestic-partner": "domestic_partner",
+    "former-partner": "former_partner",
+    "co-parent": "co_parent",
+    "half-sibling": "half_sibling",
+    "stepsibling": "step_sibling",
+    "step-sibling": "step_sibling",
+    "adoptive-sibling": "adoptive_sibling",
+    "chosen-sibling": "chosen_sibling",
+    "grand-parent": "grandparent",
+    "grand_parent": "grandparent",
+    "aunt": "aunt_uncle",
+    "uncle": "aunt_uncle",
+    "aunt-uncle": "aunt_uncle",
+    "god-parent": "godparent",
+    "god_parent": "godparent",
+    "clan-elder": "clan_elder",
+    "spiritual-elder": "spiritual_elder",
+    "in-law": "in_law",
+    "family-friend": "family_friend",
     "household-member": "household_member",
-    "linked_household": "linked_household",
     "linked-household": "linked_household",
+    "same_person": "identity_bridge",
+    "same-person": "identity_bridge",
 }
 
 ALLOWED_RELATIONSHIP_TYPES: tuple[str, ...] = (
+    "parent_unspecified",
     "biological_parent",
+    "gestational_parent",
+    "donor_parent",
+    "intended_parent",
     "adoptive_parent",
+    "foster_parent",
     "step_parent",
     "guardian",
+    "chosen_parent",
+    "community_parent",
+    "spiritual_parent",
     "spouse",
     "former_spouse",
+    "domestic_partner",
+    "former_partner",
+    "co_parent",
     "sibling",
+    "half_sibling",
+    "step_sibling",
+    "adoptive_sibling",
+    "chosen_sibling",
+    "cousin",
+    "grandparent",
+    "aunt_uncle",
+    "godparent",
+    "mentor",
+    "clan_elder",
+    "spiritual_elder",
+    "in_law",
+    "other_relative",
+    "family_friend",
     "household_member",
+    "identity_bridge",
     "linked_household",
 )
 
 ALLOWED_RELATIONSHIP_TYPE_SET: frozenset[str] = frozenset(ALLOWED_RELATIONSHIP_TYPES)
-SYMMETRIC_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
-    {"spouse", "former_spouse", "sibling", "household_member"}
+
+PARENT_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        "parent_unspecified",
+        "biological_parent",
+        "gestational_parent",
+        "donor_parent",
+        "intended_parent",
+        "adoptive_parent",
+        "foster_parent",
+        "step_parent",
+        "guardian",
+        "chosen_parent",
+        "community_parent",
+        "spiritual_parent",
+    }
 )
 ANCESTRY_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
-    {"biological_parent", "adoptive_parent", "step_parent", "guardian"}
+    {*PARENT_RELATIONSHIP_TYPES, "grandparent", "aunt_uncle"}
 )
+PARTNER_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {"spouse", "former_spouse", "domestic_partner", "former_partner", "co_parent"}
+)
+SIBLING_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {"sibling", "half_sibling", "step_sibling", "adoptive_sibling", "chosen_sibling"}
+)
+SYMMETRIC_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        *PARTNER_RELATIONSHIP_TYPES,
+        *SIBLING_RELATIONSHIP_TYPES,
+        "cousin",
+        "in_law",
+        "family_friend",
+        "household_member",
+        "identity_bridge",
+    }
+)
+PEER_PLACEMENT_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        *PARTNER_RELATIONSHIP_TYPES,
+        *SIBLING_RELATIONSHIP_TYPES,
+        "cousin",
+        "identity_bridge",
+    }
+)
+
 BIOLOGICAL_PARENT_RELATIONSHIP_TYPE = "biological_parent"
 LINKED_HOUSEHOLD_RELATIONSHIP_TYPE = "linked_household"
 
+# Cross-household handshakes also need the inverse point of view. Internal
+# family relationships remain canonical parent -> child records, while these
+# bridge-only labels let a requester accurately say "my member is the child of
+# their member" without swapping households or guessing at generation math.
+LINK_BRIDGE_INVERSE_GENERATION_DELTAS: dict[str, int] = {
+    "child": -1,
+    "biological_child": -1,
+    "gestational_child": -1,
+    "donor_conceived_child": -1,
+    "intended_child": -1,
+    "adopted_child": -1,
+    "foster_child": -1,
+    "step_child": -1,
+    "ward": -1,
+    "chosen_child": -1,
+    "community_child": -1,
+    "spiritual_child": -1,
+    "grandchild": -2,
+    "niece_nephew": -1,
+}
+LINK_BRIDGE_INVERSE_CANONICAL_TYPES: dict[str, str] = {
+    "child": "parent_unspecified",
+    "biological_child": "biological_parent",
+    "gestational_child": "gestational_parent",
+    "donor_conceived_child": "donor_parent",
+    "intended_child": "intended_parent",
+    "adopted_child": "adoptive_parent",
+    "foster_child": "foster_parent",
+    "step_child": "step_parent",
+    "ward": "guardian",
+    "chosen_child": "chosen_parent",
+    "community_child": "community_parent",
+    "spiritual_child": "spiritual_parent",
+    "grandchild": "grandparent",
+    "niece_nephew": "aunt_uncle",
+}
+
+ALLOWED_RELATIONSHIP_MODES: frozenset[str] = frozenset({"verified", "narrative"})
+ALLOWED_RELATIONSHIP_STATUS_MARKERS: frozenset[str] = frozenset(
+    {"verified", "narrative", "pending", "disputed", "unknown"}
+)
+ALLOWED_RELATIONSHIP_PRIVACY_SCOPES: frozenset[str] = frozenset(
+    {
+        "private_to_owner",
+        "private_to_owner_and_co_owner",
+        "household_private",
+        "branch_shared",
+        "linked_family_shared",
+        "public_memorial",
+        "minor_protected",
+    }
+)
 
 
 def normalize_relationship_type(value: Any) -> str:
@@ -58,6 +202,25 @@ def normalize_relationship_type(value: Any) -> str:
     return RELATIONSHIP_TYPE_ALIASES.get(normalized, normalized)
 
 
-
 def is_allowed_relationship_type(value: Any) -> bool:
     return normalize_relationship_type(value) in ALLOWED_RELATIONSHIP_TYPE_SET
+
+
+def relationship_generation_delta(value: Any) -> int | None:
+    """Return target generation minus source generation for a directed edge."""
+    normalized = normalize_relationship_type(value)
+    if normalized in PARENT_RELATIONSHIP_TYPES:
+        return 1
+    if normalized == "grandparent":
+        return 2
+    if normalized == "aunt_uncle":
+        return 1
+    if normalized in PEER_PLACEMENT_RELATIONSHIP_TYPES:
+        return 0
+    if normalized in LINK_BRIDGE_INVERSE_GENERATION_DELTAS:
+        return LINK_BRIDGE_INVERSE_GENERATION_DELTAS[normalized]
+    return None
+
+
+def relationship_supports_tree_placement(value: Any) -> bool:
+    return relationship_generation_delta(value) is not None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from app.routes.families import router as families_router
 from app.routes.family_graph import router as family_graph_router
 from app.routes.family_members import router as family_members_router
 from app.routes.family_networks import router as family_networks_router
+from app.routes.family_reunion import router as family_reunion_router
 from app.routes.graph_integrity import router as graph_integrity_router
 from app.routes.health import router as health_router
 from app.routes.household_links import router as household_links_router
@@ -278,6 +279,7 @@ app.include_router(family_members_router)
 app.include_router(lineage_nodes_router)
 app.include_router(tree_router)
 app.include_router(family_networks_router)
+app.include_router(family_reunion_router)
 app.include_router(households_router)
 app.include_router(household_links_router)
 app.include_router(relationships_router)

--- a/backend/app/routes/client_review.py
+++ b/backend/app/routes/client_review.py
@@ -143,8 +143,13 @@ def _build_review_context(
                 {
                     "project_id": project_id,
                     "customer_visible": True,
-                    "approved_for_cinematic": True,
+                    "scan_status": "clean",
                     "quarantined": {"$ne": True},
+                    "approved_for_cinematic": True,
+                    "verification_status": "approved",
+                    "consent_status": "approved",
+                    "consent_attested": True,
+                    "authority_attested": True,
                     "category": {"$in": ["member_photo"]},
                 }
             )

--- a/backend/app/routes/family_members.py
+++ b/backend/app/routes/family_members.py
@@ -1,18 +1,26 @@
-from typing import Any, Dict
+from typing import Any
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.core.metadata import apply_create_metadata, apply_update_metadata
 from app.database import get_database
-from app.dependencies.auth import enforce_limit, get_current_user, has_internal_admin_access
 from app.dependencies.auth import (
     enforce_limit,
     get_current_user,
     has_internal_admin_access,
 )
+from app.core.relationship_catalog import (
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    normalize_relationship_type,
+)
+from app.schemas.family_member import FamilyMemberCreate, FamilyMemberUpdate
+from app.schemas.relationship import RelationshipCreate
 from app.services.audit_log_service import create_audit_log
+from app.services.family_placement_service import rebuild_family_placement
 from app.services.matching import generate_match_candidates_for_member
+from app.services.relationship_guardrails import RelationshipGuardrailService
 from app.services.workspace_access_service import (
     family_is_visible_to_user,
     list_accessible_families_for_user,
@@ -169,6 +177,7 @@ def _serialize_member(member: dict[str, Any]) -> dict[str, Any]:
         "last_name": member.get("last_name"),
         "birth_year": member.get("birth_year"),
         "generation": member.get("generation"),
+        "placement_status": member.get("placement_status") or "unplaced",
         "father_id": member.get("father_id"),
         "mother_id": member.get("mother_id"),
         "spouse_id": member.get("spouse_id"),
@@ -176,6 +185,12 @@ def _serialize_member(member: dict[str, Any]) -> dict[str, Any]:
         "created_at": member.get("created_at"),
         "is_verified": member.get("is_verified"),
         "verification_status": member.get("verification_status"),
+        "approved_photo_upload_id": member.get("approved_photo_upload_id"),
+        "pending_photo_upload_id": member.get("pending_photo_upload_id"),
+        "identity_matching_consent": bool(member.get("identity_matching_consent")),
+        "account_required": bool(member.get("account_required")),
+        "invite_email": member.get("invite_email"),
+        "account_member_role": member.get("account_member_role") or "viewer",
     }
 
 
@@ -227,14 +242,14 @@ def list_family_members_index(current_user: dict[str, Any] = Depends(get_current
 
 @router.post("")
 def create_family_member(
-    payload: Dict[str, Any],
+    payload: FamilyMemberCreate,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    family_id = str(payload.get("family_id") or "").strip()
+    family_id = str(payload.family_id or "").strip()
     context = require_workspace_capability(
         current_user,
         family_id=family_id,
@@ -249,18 +264,109 @@ def create_family_member(
 
     user_id = _current_user_id(current_user)
 
-    payload = dict(payload)
-    payload["family_id"] = str(context["family"].get("_id"))
+    payload_data = payload.model_dump()
+    payload_data["family_id"] = str(context["family"].get("_id"))
+    relationship_mode = str(payload_data.pop("relationship_mode") or "narrative").strip().lower()
+    relationship_privacy_scope = str(
+        payload_data.pop("privacy_scope") or "household_private"
+    ).strip().lower()
+    father_relationship_type = normalize_relationship_type(
+        payload_data.pop("father_relationship_type")
+    )
+    mother_relationship_type = normalize_relationship_type(
+        payload_data.pop("mother_relationship_type")
+    )
+    partner_relationship_type = normalize_relationship_type(
+        payload_data.pop("partner_relationship_type")
+    )
+    if bool(payload_data.get("account_required")) and not str(
+        payload_data.get("invite_email") or ""
+    ).strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="An invite email is required when this person needs an account.",
+        )
+    if payload_data.get("generation") is not None or bool(
+        payload_data.get("generation_locked")
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Generation and placement locks are calculated from relationships "
+                "and cannot be supplied when creating a family member."
+            ),
+        )
+    if relationship_mode != "narrative":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Verified relationships require approved evidence and must be "
+                "created through the guided relationship workflow."
+            ),
+        )
+    if father_relationship_type not in PARENT_RELATIONSHIP_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid father/parent relationship type.")
+    if mother_relationship_type not in PARENT_RELATIONSHIP_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid mother/parent relationship type.")
+    if partner_relationship_type not in PARTNER_RELATIONSHIP_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid spouse/partner relationship type.")
+    payload_data["generation"] = 0
+    payload_data["generation_locked"] = False
 
     current_member_count = db.family_members.count_documents(
-        {"family_id": {"$in": _family_id_candidates(payload["family_id"])}}
+        {"family_id": {"$in": _family_id_candidates(payload_data["family_id"])}}
     )
     enforce_limit("family_members", current_member_count + 1, context=context)
 
-    payload = apply_create_metadata(payload, user_id)
-    result = db.family_members.insert_one(payload)
+    payload_data = apply_create_metadata(payload_data, user_id)
+    result = db.family_members.insert_one(payload_data)
 
     member_id = str(result.inserted_id)
+    relationship_service = RelationshipGuardrailService(db)
+    created_relationship_ids: list[str] = []
+    requested_relationships = [
+        (payload_data.get("father_id"), father_relationship_type, "father/parent"),
+        (payload_data.get("mother_id"), mother_relationship_type, "mother/parent"),
+    ]
+    if payload_data.get("spouse_id"):
+        requested_relationships.append(
+            (payload_data.get("spouse_id"), partner_relationship_type, "spouse/partner")
+        )
+
+    try:
+        for related_member_id, relationship_type, label in requested_relationships:
+            related_id = str(related_member_id or "").strip()
+            if not related_id:
+                continue
+            source_member_id = (
+                member_id if relationship_type in PARTNER_RELATIONSHIP_TYPES else related_id
+            )
+            target_member_id = (
+                related_id if relationship_type in PARTNER_RELATIONSHIP_TYPES else member_id
+            )
+            created_relationship = relationship_service.create_relationship(
+                RelationshipCreate(
+                    family_id=payload_data["family_id"],
+                    source_member_id=source_member_id,
+                    target_member_id=target_member_id,
+                    relationship_type=relationship_type,
+                    relationship_mode="narrative",
+                    status_marker="narrative",
+                    privacy_scope=relationship_privacy_scope,
+                    relationship_label=label,
+                    created_by=user_id,
+                )
+            )
+            created_relationship_ids.append(str(created_relationship.get("_id") or ""))
+        if not requested_relationships or not created_relationship_ids:
+            rebuild_family_placement(db, payload_data["family_id"])
+    except Exception:
+        for relationship_id in created_relationship_ids:
+            if ObjectId.is_valid(relationship_id):
+                db.relationships.delete_one({"_id": ObjectId(relationship_id)})
+        db.family_members.delete_one({"_id": result.inserted_id})
+        rebuild_family_placement(db, payload_data["family_id"])
+        raise
 
     create_audit_log(
         action="family_member_created",
@@ -268,12 +374,17 @@ def create_family_member(
         entity_type="family_member",
         entity_id=member_id,
         details={
-            "family_id": payload["family_id"],
-            "payload_keys": list(payload.keys()),
+            "family_id": payload_data["family_id"],
+            "payload_keys": list(payload_data.keys()),
+            "relationship_ids": created_relationship_ids,
         },
     )
 
-    created_candidates = generate_match_candidates_for_member(member_id, user_id)
+    created_candidates = (
+        generate_match_candidates_for_member(member_id, user_id)
+        if bool(payload_data.get("identity_matching_consent"))
+        else []
+    )
 
     return {
         "message": "Family member created successfully.",
@@ -285,7 +396,7 @@ def create_family_member(
 @router.put("/{member_id}")
 def update_family_member(
     member_id: str,
-    payload: Dict[str, Any],
+    payload: FamilyMemberUpdate,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = get_database()
@@ -305,22 +416,32 @@ def update_family_member(
     )
     existing = context["member"]
 
-    if "family_id" in payload:
-        incoming_family_id = str(payload.get("family_id") or "").strip()
-        existing_family_id = str(existing.get("family_id") or "").strip()
-
-        if incoming_family_id and incoming_family_id != existing_family_id:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="family_id cannot be changed through this endpoint.",
-            )
-
     user_id = _current_user_id(current_user)
-    payload = apply_update_metadata(dict(payload), user_id)
+    payload_data = payload.model_dump(exclude_unset=True)
+    if "generation" in payload_data or "generation_locked" in payload_data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Generation and placement locks are calculated from relationships "
+                "and cannot be edited directly."
+            ),
+        )
+    effective_account_required = bool(
+        payload_data.get("account_required", existing.get("account_required"))
+    )
+    effective_invite_email = str(
+        payload_data.get("invite_email", existing.get("invite_email")) or ""
+    ).strip()
+    if effective_account_required and not effective_invite_email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="An invite email is required when this person needs an account.",
+        )
+    payload_data = apply_update_metadata(payload_data, user_id)
 
     db.family_members.update_one(
         {"_id": ObjectId(member_id)},
-        {"$set": payload},
+        {"$set": payload_data},
     )
 
     create_audit_log(
@@ -328,10 +449,14 @@ def update_family_member(
         actor_user_id=user_id,
         entity_type="family_member",
         entity_id=member_id,
-        details={"updated_keys": list(payload.keys())},
+        details={"updated_keys": list(payload_data.keys())},
     )
 
-    created_candidates = generate_match_candidates_for_member(member_id, user_id)
+    created_candidates = (
+        generate_match_candidates_for_member(member_id, user_id)
+        if bool(payload_data.get("identity_matching_consent") or existing.get("identity_matching_consent"))
+        else []
+    )
 
     return {
         "message": "Family member updated successfully.",

--- a/backend/app/routes/family_reunion.py
+++ b/backend/app/routes/family_reunion.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies.auth import get_current_user
+from app.services.family_reunion_service import build_family_reunion_readiness
+from app.services.workspace_access_service import resolve_workspace_context
+
+router = APIRouter(prefix="/projects", tags=["Family Reunion Readiness"])
+
+
+def _current_user_id(user: dict[str, Any]) -> str:
+    value = user.get("id") or user.get("_id") or user.get("user_id")
+    if value is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user id is missing.",
+        )
+    return str(value)
+
+
+@router.get("/{project_id}/family-reunion-readiness")
+def get_family_reunion_readiness(
+    project_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    context = resolve_workspace_context(current_user, project_id=project_id)
+    try:
+        return build_family_reunion_readiness(
+            project_id,
+            _current_user_id(current_user),
+            workspace_context=context,
+        )
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+

--- a/backend/app/routes/link_keys.py
+++ b/backend/app/routes/link_keys.py
@@ -15,7 +15,7 @@ from app.services.link_key_service import (
     get_active_key_for_project,
     list_link_keys_for_user,
     revoke_link_key,
-    user_can_access_project,
+    user_can_manage_project,
 )
 
 router = APIRouter(prefix="/link-keys", tags=["Link Keys"])
@@ -57,6 +57,7 @@ def list_my_link_keys(
         user_email=user_email,
         project_id=project_id,
         include_revoked=True,
+        allow_admin=_is_admin(current_user),
     )
     return {"items": [build_link_key_response(item) for item in items]}
 
@@ -70,7 +71,7 @@ def get_my_active_link_key(
     user_email = _current_user_email(current_user)
     allow_admin = _is_admin(current_user)
 
-    if not allow_admin and not user_can_access_project(project_id, user_id, user_email):
+    if not allow_admin and not user_can_manage_project(project_id, user_id, user_email):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to access this project link key.",

--- a/backend/app/routes/link_keys.py
+++ b/backend/app/routes/link_keys.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from app.dependencies.auth import (
     get_current_user,
     has_internal_admin_access,
+    resolve_access_context,
 )
 from app.schemas.link_key import LinkKeyResponse, build_link_key_response
 from app.services.link_key_service import (
@@ -42,7 +43,14 @@ def _current_user_email(user: dict[str, Any]) -> str:
 
 
 def _is_admin(user: dict[str, Any]) -> bool:
-    return has_internal_admin_access(user)
+    if not has_internal_admin_access(user):
+        return False
+    context = resolve_access_context(
+        _current_user_id(user),
+        user_email=_current_user_email(user),
+    )
+    permissions = set(context.get("permissions") or [])
+    return "*" in permissions or "admin.intake.write" in permissions
 
 
 @router.get("/my-list")

--- a/backend/app/routes/link_requests.py
+++ b/backend/app/routes/link_requests.py
@@ -9,6 +9,7 @@ from app.dependencies.auth import (
     get_current_user,
     has_internal_admin_access,
     require_permission,
+    resolve_access_context,
 )
 from app.schemas.link_request import (
     LinkRequestCreate,
@@ -53,12 +54,19 @@ def _current_user_display(user: dict[str, Any]) -> str:
 
 
 def _is_admin(user: dict[str, Any]) -> bool:
-    return has_internal_admin_access(user)
+    if not has_internal_admin_access(user):
+        return False
+    context = resolve_access_context(
+        _current_user_id(user),
+        user_email=_current_user_email(user),
+    )
+    permissions = set(context.get("permissions") or [])
+    return "*" in permissions or "admin.intake.write" in permissions
 
 
 @router.get("/", response_model=list[LinkRequestResponse])
 def get_link_requests(
-    current_user: dict[str, Any] = Depends(require_permission("admin.control.view")),
+    current_user: dict[str, Any] = Depends(require_permission("admin.intake.write")),
 ):
     requests = list_link_requests()
     return [build_link_request_response(item) for item in requests]

--- a/backend/app/routes/link_requests.py
+++ b/backend/app/routes/link_requests.py
@@ -28,6 +28,7 @@ router = APIRouter(prefix="/link-requests", tags=["Link Requests"])
 
 class LinkRequestDecision(BaseModel):
     notes: str | None = Field(default=None, max_length=1000)
+    target_anchor_member_id: str | None = Field(default=None, min_length=1)
 
 
 def _current_user_id(user: dict[str, Any]) -> str:
@@ -120,6 +121,9 @@ def approve_link_request_route(
             approver_user_id=_current_user_id(current_user),
             approver_user_email=_current_user_email(current_user),
             approval_notes=(payload.notes if payload else None),
+            target_anchor_member_id=(
+                payload.target_anchor_member_id if payload else None
+            ),
             is_admin=_is_admin(current_user),
         )
     except PermissionError as exc:

--- a/backend/app/routes/mint_records.py
+++ b/backend/app/routes/mint_records.py
@@ -27,7 +27,10 @@ from app.services.mint_record_service import (
     list_mint_records,
 )
 from app.services.public_manifest_service import get_public_manifest_by_token_id
-from app.services.workspace_access_service import resolve_workspace_context
+from app.services.workspace_access_service import (
+    require_workspace_member_role,
+    resolve_workspace_context,
+)
 
 router = APIRouter(tags=["Mint Records"])
 
@@ -80,6 +83,24 @@ def _project_for_request(current_user: dict[str, Any], project_id: str) -> dict[
             detail="Project not found.",
         )
     return project
+
+
+def _require_customer_mint_owner(
+    current_user: dict[str, Any],
+    project_id: str,
+) -> dict[str, Any]:
+    context = _project_context(current_user, project_id)
+    if context.get("is_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Internal administrators cannot create customer mint consent.",
+        )
+    require_workspace_member_role(
+        context,
+        allowed_roles=("billing_owner", "co_owner"),
+        detail="Only the billing owner or co-owner can approve public mint consent.",
+    )
+    return context
 
 
 
@@ -285,7 +306,7 @@ def approve_project_mint_record_customer(
     payload: CustomerMintApprovalPayload,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    _project_for_request(current_user, project_id)
+    _require_customer_mint_owner(current_user, project_id)
     _require_project_match(project_id, mint_record_id)
 
     try:
@@ -314,26 +335,15 @@ def approve_project_mint_record_customer_admin(
     payload: CustomerMintApprovalPayload,
     current_user: dict[str, Any] = Depends(require_permission("admin.control.mint")),
 ):
-    _project_for_request(current_user, project_id)
-    _require_project_match(project_id, mint_record_id)
-
-    try:
-        return approve_customer_mint_record(
-            mint_record_id,
-            approved_by_user_id=_current_user_id(current_user),
-            approved_by_email=_current_user_email(current_user),
-            notes=payload.notes or "Approved by internal admin override.",
-            wallet_address=payload.wallet_address,
-            approved_poster_opt_in=payload.approved_poster_opt_in,
-            public_title_opt_in=payload.public_title_opt_in,
-            public_title=payload.public_title,
-            public_title_kind=payload.public_title_kind,
-        )
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
-        ) from exc
+    del project_id, mint_record_id, payload, current_user
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Customer wallet and public-content consent cannot be fabricated "
+            "through an administrator override. The billing owner or co-owner "
+            "must approve it from their own authenticated account."
+        ),
+    )
 
 
 

--- a/backend/app/routes/relationships.py
+++ b/backend/app/routes/relationships.py
@@ -10,6 +10,7 @@ from app.dependencies.auth import (
 )
 from app.schemas.relationship import RelationshipCreate, RelationshipResponse
 from app.services.relationship_guardrails import RelationshipGuardrailService
+from app.services.family_placement_service import rebuild_family_placement
 from app.services.workspace_access_service import (
     family_is_visible_to_user,
     require_workspace_capability,
@@ -153,6 +154,13 @@ async def create_relationship(
         source_member_id=payload.source_member_id,
         target_member_id=payload.target_member_id,
         relationship_type=payload.relationship_type,
+        relationship_mode=payload.relationship_mode,
+        status_marker=payload.status_marker,
+        privacy_scope=payload.privacy_scope,
+        relationship_label=payload.relationship_label,
+        evidence_record_ids=payload.evidence_record_ids,
+        valid_from=payload.valid_from,
+        valid_to=payload.valid_to,
         notes=payload.notes,
         created_by=created_by,
     )
@@ -177,6 +185,13 @@ async def create_relationship(
         source_member_id=created["source_member_id"],
         target_member_id=created["target_member_id"],
         relationship_type=normalize_relationship_type(created["relationship_type"]),
+        relationship_mode=created.get("relationship_mode") or "narrative",
+        status_marker=created.get("status_marker") or "narrative",
+        privacy_scope=created.get("privacy_scope") or "household_private",
+        relationship_label=created.get("relationship_label"),
+        evidence_record_ids=list(created.get("evidence_record_ids") or []),
+        valid_from=created.get("valid_from"),
+        valid_to=created.get("valid_to"),
         notes=created.get("notes"),
         created_by=created.get("created_by"),
         created_at=created["created_at"],
@@ -211,6 +226,13 @@ async def get_family_relationships(
                 "relationship_type": normalize_relationship_type(
                     rel.get("relationship_type")
                 ),
+                "relationship_mode": rel.get("relationship_mode") or "narrative",
+                "status_marker": rel.get("status_marker") or "narrative",
+                "privacy_scope": rel.get("privacy_scope") or "household_private",
+                "relationship_label": rel.get("relationship_label"),
+                "evidence_record_ids": list(rel.get("evidence_record_ids") or []),
+                "valid_from": rel.get("valid_from"),
+                "valid_to": rel.get("valid_to"),
                 "notes": rel.get("notes"),
                 "created_by": rel.get("created_by"),
                 "created_at": rel.get("created_at"),
@@ -258,6 +280,13 @@ async def get_member_relationships(
                 "relationship_type": normalize_relationship_type(
                     rel.get("relationship_type")
                 ),
+                "relationship_mode": rel.get("relationship_mode") or "narrative",
+                "status_marker": rel.get("status_marker") or "narrative",
+                "privacy_scope": rel.get("privacy_scope") or "household_private",
+                "relationship_label": rel.get("relationship_label"),
+                "evidence_record_ids": list(rel.get("evidence_record_ids") or []),
+                "valid_from": rel.get("valid_from"),
+                "valid_to": rel.get("valid_to"),
                 "notes": rel.get("notes"),
                 "created_by": rel.get("created_by"),
                 "created_at": rel.get("created_at"),
@@ -287,6 +316,10 @@ async def delete_relationship(
     )
 
     db["relationships"].delete_one({"_id": ObjectId(relationship_id)})
+    rebuild_family_placement(
+        db,
+        str(relationship.get("family_id") or "").strip(),
+    )
 
     deleted_by = (
         current_user.get("email")

--- a/backend/app/routes/tree.py
+++ b/backend/app/routes/tree.py
@@ -1,17 +1,13 @@
 from typing import Any
 
-from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.database import get_database
-from app.dependencies.auth import (
-    get_current_user,
-)
+from app.dependencies.auth import get_current_user
 from app.services.workspace_access_service import require_workspace_capability
 from app.services.tree_service import (
+    get_authorized_linked_family_tree,
     get_family_tree,
     get_filtered_family_tree,
-    get_linked_family_tree,
 )
 
 router = APIRouter(prefix="/tree", tags=["Tree"])
@@ -27,21 +23,6 @@ def _current_user_id(user: dict[str, Any]) -> str:
     return str(raw_id)
 
 
-def _current_user_email(user: dict[str, Any]) -> str:
-    raw_email = user.get("email")
-    if not raw_email:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authenticated user email is missing.",
-        )
-    return str(raw_email).strip().lower()
-
-
-def _current_user_display_name(user: dict[str, Any]) -> str:
-    raw_name = user.get("full_name") or user.get("name") or ""
-    return str(raw_name).strip()
-
-
 @router.get("/{family_id}")
 def get_tree(
     family_id: str,
@@ -54,12 +35,9 @@ def get_tree(
         detail="Your active package does not include family tree access.",
     )
     resolved_family_id = str(context["family"].get("_id"))
-
     tree = get_family_tree(resolved_family_id)
-
     if not tree["members"] and not tree["nodes"] and not tree["relationships"]:
         raise HTTPException(status_code=404, detail="Family tree not found.")
-
     return tree
 
 
@@ -74,8 +52,10 @@ def get_verified_tree(
         capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    tree = get_filtered_family_tree(str(context["family"].get("_id")), "verified")
-    return tree
+    return get_filtered_family_tree(
+        str(context["family"].get("_id")),
+        "verified",
+    )
 
 
 @router.get("/{family_id}/narrative")
@@ -89,8 +69,10 @@ def get_narrative_tree(
         capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    tree = get_filtered_family_tree(str(context["family"].get("_id")), "narrative")
-    return tree
+    return get_filtered_family_tree(
+        str(context["family"].get("_id")),
+        "narrative",
+    )
 
 
 @router.get("/{family_id}/private")
@@ -104,8 +86,10 @@ def get_private_tree(
         capabilities=("can_build_family_tree",),
         detail="Your active package does not include family tree access.",
     )
-    tree = get_filtered_family_tree(str(context["family"].get("_id")), "private")
-    return tree
+    return get_filtered_family_tree(
+        str(context["family"].get("_id")),
+        "private",
+    )
 
 
 @router.get("/{family_id}/linked")
@@ -120,8 +104,20 @@ def get_linked_tree(
         capabilities=("can_link_households",),
         detail="Your active package does not include linked family graph access.",
     )
-    resolved_family_id = str(context["family"].get("_id"))
     normalized_mode = str(mode or "default").strip().lower()
     if normalized_mode not in {"default", "verified", "narrative", "private"}:
         raise HTTPException(status_code=400, detail="Invalid linked tree mode.")
-    return get_linked_family_tree(resolved_family_id, normalized_mode)
+
+    project_id = str((context.get("project") or {}).get("_id") or "").strip()
+    if not project_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The active family has no project for linked-tree alignment.",
+        )
+    return get_authorized_linked_family_tree(
+        str(context["family"].get("_id")),
+        normalized_mode,
+        project_id=project_id,
+        current_user_id=_current_user_id(current_user),
+        workspace_context=context,
+    )

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -191,6 +191,12 @@ class UploadCinematicApprovalPayload(BaseModel):
     approved_for_cinematic: bool = Field(default=True)
     verification_status: str = Field(default="approved", max_length=50)
     consent_status: str = Field(default="approved", max_length=50)
+    review_notes: str = Field(default="", max_length=1000)
+
+
+class UploadVerificationReviewPayload(BaseModel):
+    decision: Literal["approved", "rejected", "needs_correction"]
+    review_notes: str = Field(default="", max_length=1000)
 
 
 def _normalize_value(value: Any) -> str:
@@ -488,6 +494,9 @@ def _public_upload_record(record: dict[str, Any]) -> dict[str, Any]:
     serialized.pop("absolute_path", None)
     serialized.pop("storage_path", None)
     serialized.pop("uploaded_by_user_id", None)
+    serialized.pop("master_review_notes", None)
+    serialized.pop("verification_review_notes", None)
+    serialized.pop("verified_by", None)
     return serialized
 
 
@@ -536,6 +545,13 @@ def _serialize_admin_upload_review(
         "family_name": _normalize_value((family or {}).get("family_name")) or None,
         "member_id": member_id or None,
         "member_name": _display_member_name(member),
+        "master_review_notes": _normalize_value(
+            record.get("master_review_notes")
+        ),
+        "verification_review_notes": _normalize_value(
+            record.get("verification_review_notes")
+        ),
+        "verified_by": _normalize_value(record.get("verified_by")) or None,
     }
 
 
@@ -960,6 +976,8 @@ def list_admin_uploads(
 async def upload_member_photo(
     family_id: str = Form(...),
     member_id: str = Form(...),
+    consent_attested: bool = Form(...),
+    authority_attested: bool = Form(...),
     file: UploadFile = File(...),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
@@ -1012,6 +1030,8 @@ async def upload_member_photo(
         upload=file,
         uploaded_by=_actor_label(current_user),
         uploaded_by_user_id=_current_user_id(current_user),
+        consent_attested=consent_attested,
+        authority_attested=authority_attested,
     )
     upload_record = _scan_and_quarantine_upload(db=db, upload_record=upload_record)
 
@@ -1182,9 +1202,7 @@ async def upload_private_media(
 def list_member_uploads(
     member_id: str,
     category: Optional[str] = Query(default=None),
-    current_user: dict[str, Any] = Depends(
-        require_entitlement("can_upload_portraits", allow_internal_admin=True)
-    ),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     context = require_workspace_capability(
         current_user,
@@ -1228,9 +1246,7 @@ def list_member_uploads(
 def list_family_uploads(
     family_id: str,
     category: Optional[str] = Query(default=None),
-    current_user: dict[str, Any] = Depends(
-        require_entitlement("can_upload_portraits", allow_internal_admin=True)
-    ),
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     context = require_workspace_capability(
         current_user,
@@ -1413,37 +1429,159 @@ def update_upload_privacy(
 def update_upload_cinematic_approval(
     upload_id: str,
     payload: UploadCinematicApprovalPayload,
-    current_user: dict[str, Any] = Depends(get_current_user),
+    current_user: dict[str, Any] = Depends(
+        require_permission("uploads.admin.review")
+    ),
 ):
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
     upload_record, context = _require_upload_management_access(upload_id, db, current_user)
-    if not context.get("is_admin") and _normalize_value(context.get("member_role")) not in {
-        "billing_owner",
-        "co_owner",
-        "family_manager",
-    }:
+    if _normalize_value(upload_record.get("category")) != "member_photo":
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not authorized to approve cinematic assets.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only member portraits can be approved for cinematic placement.",
+        )
+    approving = bool(payload.approved_for_cinematic)
+    if approving and (
+        _normalize_value(upload_record.get("scan_status")).lower() != "clean"
+        or bool(upload_record.get("quarantined"))
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Portrait must pass malware scanning before master approval.",
+        )
+    if approving and not (
+        bool(upload_record.get("consent_attested"))
+        and bool(upload_record.get("authority_attested"))
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Portrait is missing the required consent and authority attestations.",
+        )
+    verification_status = (
+        _normalize_value(payload.verification_status).lower()
+        or ("approved" if approving else "rejected")
+    )
+    consent_status = (
+        _normalize_value(payload.consent_status).lower()
+        or ("approved" if approving else "rejected")
+    )
+    if approving and (
+        verification_status != "approved" or consent_status != "approved"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cinematic approval requires approved verification and consent decisions.",
         )
     now = datetime.now(UTC).isoformat()
     db["uploaded_files"].update_one(
         {"_id": ObjectId(upload_id)},
         {
             "$set": {
-                "approved_for_cinematic": bool(payload.approved_for_cinematic),
+                "approved_for_cinematic": approving,
                 "approved_by": _actor_label(current_user),
                 "approved_by_user_id": _current_user_id(current_user),
-                "verification_status": _normalize_value(payload.verification_status).lower() or "approved",
-                "consent_status": _normalize_value(payload.consent_status).lower() or "approved",
+                "verification_status": verification_status,
+                "consent_status": consent_status,
+                "master_review_status": "approved" if approving else "rejected",
+                "master_reviewed_at": now,
+                "master_review_notes": _normalize_value(payload.review_notes),
                 "updated_at": now,
             }
         },
     )
     updated = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)}) or upload_record
+    member_id = _normalize_value(upload_record.get("member_id"))
+    if member_id and ObjectId.is_valid(member_id):
+        member_update: dict[str, Any] = {
+            "pending_photo_upload_id": None,
+            "photo_submission_status": "approved" if approving else "rejected",
+            "updated_at": now,
+        }
+        if approving:
+            member_update.update(
+                {
+                    "approved_photo_upload_id": upload_id,
+                    "photo_upload_id": upload_id,
+                    "photo_path": upload_record.get("relative_path"),
+                    "photo_original_filename": upload_record.get("original_filename"),
+                    "photo_content_type": upload_record.get("content_type"),
+                    "photo_size_bytes": upload_record.get("size_bytes"),
+                    "portrait_approved_at": now,
+                }
+            )
+        else:
+            member = db["family_members"].find_one({"_id": ObjectId(member_id)}) or {}
+            if _normalize_value(member.get("approved_photo_upload_id")) == upload_id:
+                member_update.update(
+                    {
+                        "approved_photo_upload_id": None,
+                        "photo_upload_id": None,
+                        "photo_path": None,
+                        "portrait_approved_at": None,
+                    }
+                )
+        db["family_members"].update_one(
+            {"_id": ObjectId(member_id)},
+            {"$set": member_update},
+        )
+    return {"upload": _public_upload_record(updated)}
+
+
+@router.post("/{upload_id}/verification-review")
+def update_upload_verification_review(
+    upload_id: str,
+    payload: UploadVerificationReviewPayload,
+    current_user: dict[str, Any] = Depends(
+        require_permission("uploads.admin.review")
+    ),
+):
+    db = get_database()
+    if db is None:
+        raise HTTPException(status_code=500, detail="Database is not connected.")
+
+    upload_record, _context = _require_upload_management_access(
+        upload_id,
+        db,
+        current_user,
+    )
+    if _normalize_value(upload_record.get("category")) != "verification_evidence":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only verification evidence can be decided through this review.",
+        )
+
+    decision = _normalize_value(payload.decision).lower()
+    if decision == "approved" and (
+        _normalize_value(upload_record.get("scan_status")).lower() != "clean"
+        or bool(upload_record.get("quarantined"))
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Verification evidence must pass malware scanning before approval.",
+        )
+
+    now = datetime.now(UTC).isoformat()
+    db["uploaded_files"].update_one(
+        {"_id": ObjectId(upload_id)},
+        {
+            "$set": {
+                "verification_status": decision,
+                "verified_by": _actor_label(current_user),
+                "verified_by_user_id": _current_user_id(current_user),
+                "verified_at": now,
+                "verification_review_notes": _normalize_value(
+                    payload.review_notes
+                ),
+                "updated_at": now,
+            }
+        },
+    )
+    updated = db["uploaded_files"].find_one(
+        {"_id": ObjectId(upload_id)}
+    ) or upload_record
     return {"upload": _public_upload_record(updated)}
 
 
@@ -1463,7 +1601,11 @@ def list_cinematic_assets(
         raise HTTPException(status_code=500, detail="Database is not connected.")
     query = {
         "family_id": _normalize_value((context.get("family") or {}).get("_id")),
+        "scan_status": "clean",
+        "quarantined": {"$ne": True},
         "approved_for_cinematic": True,
+        "verification_status": "approved",
+        "consent_status": "approved",
     }
     records = list(db["uploaded_files"].find(query).sort("created_at", -1))
     user_id = _current_user_id(current_user)

--- a/backend/app/schemas/family_member.py
+++ b/backend/app/schemas/family_member.py
@@ -1,17 +1,72 @@
 from datetime import datetime, UTC
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class FamilyMemberCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     family_id: str = Field(..., min_length=1)
     first_name: str = Field(..., min_length=1, max_length=100)
     last_name: str = Field(..., min_length=1, max_length=100)
-    birth_year: int | None = None
-    generation: int = Field(..., ge=0)
+    middle_name: str | None = Field(default=None, max_length=100)
+    birth_year: int | None = Field(default=None, ge=1000, le=2200)
+    birth_date: str | None = Field(default=None, max_length=50)
+    generation: int | None = Field(default=None, ge=0)
+    generation_locked: bool = False
     father_id: str | None = None
     mother_id: str | None = None
     spouse_id: str | None = None
-    bio: str | None = None
+    father_relationship_type: str = "biological_parent"
+    mother_relationship_type: str = "biological_parent"
+    partner_relationship_type: str = "spouse"
+    relationship_mode: str = "narrative"
+    privacy_scope: str = "household_private"
+    identity_matching_consent: bool = False
+    account_required: bool = False
+    invite_email: str | None = Field(default=None, max_length=320)
+    account_member_role: Literal["viewer", "contributor"] = "viewer"
+    is_deceased: bool = False
+    bio: str | None = Field(default=None, max_length=5000)
+
+    @field_validator("invite_email")
+    @classmethod
+    def _normalize_invite_email(cls, value: str | None) -> str | None:
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return None
+        if "@" not in normalized or normalized.startswith("@") or normalized.endswith("@"):
+            raise ValueError("invite_email must be a valid email address")
+        return normalized
+
+
+class FamilyMemberUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    first_name: str | None = Field(default=None, min_length=1, max_length=100)
+    middle_name: str | None = Field(default=None, max_length=100)
+    last_name: str | None = Field(default=None, min_length=1, max_length=100)
+    birth_year: int | None = Field(default=None, ge=1000, le=2200)
+    birth_date: str | None = Field(default=None, max_length=50)
+    generation: int | None = Field(default=None, ge=0)
+    generation_locked: bool | None = None
+    identity_matching_consent: bool | None = None
+    account_required: bool | None = None
+    invite_email: str | None = Field(default=None, max_length=320)
+    account_member_role: Literal["viewer", "contributor"] | None = None
+    is_deceased: bool | None = None
+    bio: str | None = Field(default=None, max_length=5000)
+
+    @field_validator("invite_email")
+    @classmethod
+    def _normalize_invite_email(cls, value: str | None) -> str | None:
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return None
+        if "@" not in normalized or normalized.startswith("@") or normalized.endswith("@"):
+            raise ValueError("invite_email must be a valid email address")
+        return normalized
 
 
 class FamilyMemberResponse(BaseModel):
@@ -20,7 +75,7 @@ class FamilyMemberResponse(BaseModel):
     first_name: str
     last_name: str
     birth_year: int | None = None
-    generation: int
+    generation: int = 0
     father_id: str | None = None
     mother_id: str | None = None
     spouse_id: str | None = None

--- a/backend/app/schemas/link_request.py
+++ b/backend/app/schemas/link_request.py
@@ -3,13 +3,30 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.core.relationship_catalog import (
+    normalize_relationship_type,
+    relationship_supports_tree_placement,
+)
 
 
 class LinkRequestCreate(BaseModel):
     source_project_id: str = Field(..., min_length=1)
+    source_anchor_member_id: str = Field(..., min_length=1)
+    bridge_relationship_type: str = Field(default="identity_bridge", min_length=1)
     target_key: str = Field(..., min_length=1, max_length=150)
     notes: str | None = Field(default=None, max_length=1000)
+
+    @field_validator("bridge_relationship_type")
+    @classmethod
+    def _validate_bridge_relationship_type(cls, value: str) -> str:
+        normalized = normalize_relationship_type(value)
+        if not relationship_supports_tree_placement(normalized):
+            raise ValueError(
+                "The selected cross-household relationship cannot determine tree placement."
+            )
+        return normalized
 
 
 class LinkRequestResponse(BaseModel):
@@ -18,6 +35,12 @@ class LinkRequestResponse(BaseModel):
     target_project_id: str
     source_household_id: str | None = None
     target_household_id: str | None = None
+    source_anchor_member_id: str | None = None
+    target_anchor_member_id: str | None = None
+    bridge_relationship_type: str | None = None
+    generation_delta: int | None = None
+    target_generation_offset: int | None = None
+    alignment_status: str | None = None
     source_key: str
     target_key: str
     status: str
@@ -68,6 +91,36 @@ def build_link_request_response(data: dict[str, Any]) -> LinkRequestResponse:
             str(data.get("target_household_id"))
             if data.get("target_household_id") is not None
             and str(data.get("target_household_id")).strip()
+            else None
+        ),
+        source_anchor_member_id=(
+            str(data.get("source_anchor_member_id"))
+            if data.get("source_anchor_member_id")
+            else None
+        ),
+        target_anchor_member_id=(
+            str(data.get("target_anchor_member_id"))
+            if data.get("target_anchor_member_id")
+            else None
+        ),
+        bridge_relationship_type=(
+            str(data.get("bridge_relationship_type"))
+            if data.get("bridge_relationship_type")
+            else None
+        ),
+        generation_delta=(
+            int(data.get("generation_delta"))
+            if data.get("generation_delta") is not None
+            else None
+        ),
+        target_generation_offset=(
+            int(data.get("target_generation_offset"))
+            if data.get("target_generation_offset") is not None
+            else None
+        ),
+        alignment_status=(
+            str(data.get("alignment_status"))
+            if data.get("alignment_status")
             else None
         ),
         source_key=str(data.get("source_key") or ""),

--- a/backend/app/schemas/relationship.py
+++ b/backend/app/schemas/relationship.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.core.relationship_catalog import (
+    ALLOWED_RELATIONSHIP_MODES,
+    ALLOWED_RELATIONSHIP_PRIVACY_SCOPES,
+    ALLOWED_RELATIONSHIP_STATUS_MARKERS,
     ALLOWED_RELATIONSHIP_TYPES,
     ALLOWED_RELATIONSHIP_TYPE_SET,
     normalize_relationship_type,
@@ -15,6 +18,23 @@ class RelationshipCreate(BaseModel):
     source_member_id: str = Field(..., min_length=1)
     target_member_id: str = Field(..., min_length=1)
     relationship_type: str = Field(..., min_length=1)
+    relationship_mode: Literal["verified", "narrative"] = "narrative"
+    status_marker: Literal[
+        "verified", "narrative", "pending", "disputed", "unknown"
+    ] = "narrative"
+    privacy_scope: Literal[
+        "private_to_owner",
+        "private_to_owner_and_co_owner",
+        "household_private",
+        "branch_shared",
+        "linked_family_shared",
+        "public_memorial",
+        "minor_protected",
+    ] = "household_private"
+    relationship_label: Optional[str] = Field(default=None, max_length=100)
+    evidence_record_ids: list[str] = Field(default_factory=list, max_length=25)
+    valid_from: Optional[str] = Field(default=None, max_length=50)
+    valid_to: Optional[str] = Field(default=None, max_length=50)
     notes: Optional[str] = None
     created_by: Optional[str] = None
 
@@ -28,6 +48,30 @@ class RelationshipCreate(BaseModel):
             )
         return normalized
 
+    @field_validator("relationship_mode")
+    @classmethod
+    def _validate_relationship_mode(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in ALLOWED_RELATIONSHIP_MODES:
+            raise ValueError("relationship_mode must be verified or narrative")
+        return normalized
+
+    @field_validator("status_marker")
+    @classmethod
+    def _validate_status_marker(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in ALLOWED_RELATIONSHIP_STATUS_MARKERS:
+            raise ValueError("Invalid relationship status marker")
+        return normalized
+
+    @field_validator("privacy_scope")
+    @classmethod
+    def _validate_privacy_scope(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in ALLOWED_RELATIONSHIP_PRIVACY_SCOPES:
+            raise ValueError("Invalid relationship privacy scope")
+        return normalized
+
 
 class RelationshipInDB(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -37,6 +81,13 @@ class RelationshipInDB(BaseModel):
     source_member_id: str
     target_member_id: str
     relationship_type: str
+    relationship_mode: str = "narrative"
+    status_marker: str = "narrative"
+    privacy_scope: str = "household_private"
+    relationship_label: Optional[str] = None
+    evidence_record_ids: list[str] = Field(default_factory=list)
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
     notes: Optional[str] = None
     created_by: Optional[str] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -48,6 +99,13 @@ class RelationshipResponse(BaseModel):
     source_member_id: str
     target_member_id: str
     relationship_type: str
+    relationship_mode: str = "narrative"
+    status_marker: str = "narrative"
+    privacy_scope: str = "household_private"
+    relationship_label: Optional[str] = None
+    evidence_record_ids: list[str] = Field(default_factory=list)
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
     notes: Optional[str] = None
     created_by: Optional[str] = None
     created_at: datetime

--- a/backend/app/services/blockchain_mint_service.py
+++ b/backend/app/services/blockchain_mint_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Callable
 
 from app.config import settings
 
@@ -290,6 +290,8 @@ def mint_anchor(
     metadata_uri: str,
     recipient_wallet: str | None,
     token_type: str,
+    on_transaction_prepared: Callable[[dict[str, Any]], None] | None = None,
+    on_transaction_broadcast: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     _require_mint_runtime()
 
@@ -324,10 +326,14 @@ def mint_anchor(
         token_type=token_type,
     )
 
+    try:
+        nonce = client.eth.get_transaction_count(signer.address, "pending")
+    except TypeError:
+        nonce = client.eth.get_transaction_count(signer.address)
     transaction = contract_function.build_transaction(
         {
             "from": signer.address,
-            "nonce": client.eth.get_transaction_count(signer.address),
+            "nonce": nonce,
             "chainId": int(client.eth.chain_id),
             **_gas_fields(client),
         }
@@ -341,8 +347,48 @@ def mint_anchor(
         transaction,
         private_key=_normalize(settings.nft_minter_private_key),
     )
-    tx_hash = client.eth.send_raw_transaction(signed.raw_transaction)
-    tx_hash_hex = _normalize_tx_hash(tx_hash.hex())
+    raw_transaction = getattr(signed, "raw_transaction", None) or getattr(
+        signed,
+        "rawTransaction",
+        None,
+    )
+    if raw_transaction is None:
+        raise RuntimeError("Signed mint transaction bytes are unavailable.")
+    signed_hash = getattr(signed, "hash", None)
+    if signed_hash is None:
+        signed_hash = client.keccak(raw_transaction)
+    tx_hash_hex = _normalize_tx_hash(
+        signed_hash.hex() if hasattr(signed_hash, "hex") else signed_hash
+    )
+    raw_transaction_hex = (
+        raw_transaction.hex()
+        if hasattr(raw_transaction, "hex")
+        else bytes(raw_transaction).hex()
+    )
+    if on_transaction_prepared is not None:
+        on_transaction_prepared(
+            {
+                "tx_hash": tx_hash_hex,
+                "nonce": int(nonce),
+                "signed_transaction": raw_transaction_hex,
+                "broadcast_state": "prepared",
+            }
+        )
+
+    tx_hash = client.eth.send_raw_transaction(raw_transaction)
+    broadcast_hash = _normalize_tx_hash(
+        tx_hash.hex() if hasattr(tx_hash, "hex") else tx_hash
+    )
+    if broadcast_hash and broadcast_hash != tx_hash_hex:
+        raise RuntimeError("Broadcast transaction hash did not match the signed transaction.")
+    if on_transaction_broadcast is not None:
+        on_transaction_broadcast(
+            {
+                "tx_hash": tx_hash_hex,
+                "nonce": int(nonce),
+                "broadcast_state": "submitted",
+            }
+        )
 
     receipt = None
     try:
@@ -365,6 +411,33 @@ def mint_anchor(
         "recipient_wallet": recipient,
         "block_number": int(receipt.blockNumber) if receipt is not None else None,
     }
+
+
+def rebroadcast_signed_transaction(raw_transaction_hex: str) -> str:
+    _require_mint_runtime()
+    normalized = _normalize(raw_transaction_hex)
+    if normalized.lower().startswith("0x"):
+        normalized = normalized[2:]
+    if not normalized:
+        raise ValueError("Signed transaction is required for rebroadcast.")
+    raw_transaction = bytes.fromhex(normalized)
+    client = _web3_client()
+    expected_hash = _normalize_tx_hash(client.keccak(raw_transaction).hex())
+    try:
+        result = client.eth.send_raw_transaction(raw_transaction)
+        returned_hash = _normalize_tx_hash(
+            result.hex() if hasattr(result, "hex") else result
+        )
+        if returned_hash and returned_hash != expected_hash:
+            raise RuntimeError("Rebroadcast transaction hash mismatch.")
+    except Exception as exc:
+        message = str(exc).lower()
+        if not any(
+            marker in message
+            for marker in ("already known", "known transaction", "nonce too low")
+        ):
+            raise
+    return expected_hash
 
 
 def sync_mint_receipt(tx_hash: str) -> dict[str, Any]:

--- a/backend/app/services/family_placement_service.py
+++ b/backend/app/services/family_placement_service.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.core.relationship_catalog import (
+    PARENT_RELATIONSHIP_TYPES,
+    normalize_relationship_type,
+    relationship_generation_delta,
+)
+
+
+class FamilyPlacementError(ValueError):
+    pass
+
+
+def _value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _member_id(document: dict[str, Any]) -> str:
+    return _value(document.get("_id") or document.get("id") or document.get("member_id"))
+
+
+def _family_candidates(family_id: str) -> list[Any]:
+    values: list[Any] = [family_id]
+    if ObjectId.is_valid(family_id):
+        values.append(ObjectId(family_id))
+    return values
+
+
+def _constraints(
+    relationships: list[dict[str, Any]],
+) -> list[tuple[str, str, int, str]]:
+    result: list[tuple[str, str, int, str]] = []
+    for relationship in relationships:
+        source_id = _value(relationship.get("source_member_id"))
+        target_id = _value(relationship.get("target_member_id"))
+        relationship_type = normalize_relationship_type(
+            relationship.get("relationship_type")
+        )
+        delta = relationship_generation_delta(relationship_type)
+        if not source_id or not target_id or delta is None:
+            continue
+        result.append((source_id, target_id, delta, relationship_type))
+    return result
+
+
+def calculate_family_placement(
+    db: Any,
+    family_id: str,
+    *,
+    extra_relationship: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    members = list(
+        db["family_members"].find(
+            {"family_id": {"$in": _family_candidates(family_id)}}
+        )
+    )
+    member_by_id = {
+        _member_id(member): member for member in members if _member_id(member)
+    }
+    relationships = list(
+        db["relationships"].find(
+            {"family_id": {"$in": _family_candidates(family_id)}}
+        )
+    )
+    if extra_relationship:
+        relationships.append(dict(extra_relationship))
+
+    constraints = _constraints(relationships)
+    adjacency: dict[str, list[tuple[str, int]]] = {
+        member_id: [] for member_id in member_by_id
+    }
+    for source_id, target_id, delta, _relationship_type in constraints:
+        if source_id not in member_by_id or target_id not in member_by_id:
+            continue
+        adjacency[source_id].append((target_id, delta))
+        adjacency[target_id].append((source_id, -delta))
+
+    assignments: dict[str, int] = {}
+    placement_status: dict[str, str] = {}
+    visited: set[str] = set()
+
+    for seed_id in sorted(member_by_id):
+        if seed_id in visited:
+            continue
+        component: list[str] = []
+        relative: dict[str, int] = {seed_id: 0}
+        queue: deque[str] = deque([seed_id])
+
+        while queue:
+            current = queue.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+            component.append(current)
+            for neighbor, delta in adjacency.get(current, []):
+                expected = relative[current] + delta
+                if neighbor in relative and relative[neighbor] != expected:
+                    raise FamilyPlacementError(
+                        "Relationship placement conflict: the selected links require "
+                        "the same person to occupy two different generations."
+                    )
+                if neighbor not in relative:
+                    relative[neighbor] = expected
+                    queue.append(neighbor)
+
+        has_structure = any(adjacency.get(member_id) for member_id in component)
+        locked_offsets: set[int] = set()
+        for member_id in component:
+            member = member_by_id[member_id]
+            if not bool(member.get("generation_locked")):
+                continue
+            try:
+                locked_generation = int(member.get("generation"))
+            except (TypeError, ValueError):
+                continue
+            locked_offsets.add(locked_generation - relative[member_id])
+
+        if len(locked_offsets) > 1:
+            raise FamilyPlacementError(
+                "Locked generation values conflict with the selected family relationships."
+            )
+
+        if locked_offsets:
+            offset = next(iter(locked_offsets))
+        elif has_structure:
+            offset = -min(relative.values())
+        elif len(member_by_id) == 1:
+            offset = 0
+        else:
+            offset = 0
+
+        for member_id in component:
+            generation = relative[member_id] + offset
+            if generation < 0:
+                raise FamilyPlacementError(
+                    "Relationship placement would create a negative generation."
+                )
+            member = member_by_id[member_id]
+            if has_structure or len(member_by_id) == 1 or bool(member.get("generation_locked")):
+                assignments[member_id] = generation
+                placement_status[member_id] = (
+                    "root" if len(member_by_id) == 1 and not has_structure else "placed"
+                )
+            else:
+                try:
+                    assignments[member_id] = max(0, int(member.get("generation") or 0))
+                except (TypeError, ValueError):
+                    assignments[member_id] = 0
+                placement_status[member_id] = "unplaced"
+
+    return {
+        "family_id": family_id,
+        "assignments": assignments,
+        "placement_status": placement_status,
+        "constraints": constraints,
+        "members": member_by_id,
+    }
+
+
+def _find_lineage_node(db: Any, family_id: str, member_id: str) -> dict[str, Any] | None:
+    return db["lineage_nodes"].find_one(
+        {
+            "family_id": {"$in": _family_candidates(family_id)},
+            "member_id": member_id,
+        }
+    )
+
+
+def rebuild_family_placement(db: Any, family_id: str) -> dict[str, Any]:
+    placement = calculate_family_placement(db, family_id)
+    assignments: dict[str, int] = placement["assignments"]
+    statuses: dict[str, str] = placement["placement_status"]
+    now = datetime.now(UTC).isoformat()
+
+    by_generation: dict[int, list[str]] = {}
+    for member_id, generation in assignments.items():
+        by_generation.setdefault(generation, []).append(member_id)
+
+    coordinates: dict[str, tuple[float, float]] = {}
+    for generation, member_ids in by_generation.items():
+        for row, member_id in enumerate(sorted(member_ids)):
+            coordinates[member_id] = (float(generation * 360), float(row * 180))
+
+    for member_id, generation in assignments.items():
+        db["family_members"].update_one(
+            {"_id": ObjectId(member_id) if ObjectId.is_valid(member_id) else member_id},
+            {
+                "$set": {
+                    "generation": generation,
+                    "placement_status": statuses.get(member_id, "unplaced"),
+                    "placement_basis": "relationships",
+                    "placement_updated_at": now,
+                    "updated_at": now,
+                }
+            },
+        )
+        x, y = coordinates.get(member_id, (float(generation * 360), 0.0))
+        node_payload = {
+            "family_id": family_id,
+            "member_id": member_id,
+            "generation": generation,
+            "x": x,
+            "y": y,
+            "parent_node_ids": [],
+            "child_node_ids": [],
+            "placement_status": statuses.get(member_id, "unplaced"),
+            "updated_at": now,
+        }
+        existing = _find_lineage_node(db, family_id, member_id)
+        if existing:
+            db["lineage_nodes"].update_one(
+                {"_id": existing["_id"]},
+                {"$set": node_payload},
+            )
+        else:
+            node_payload["created_at"] = now
+            db["lineage_nodes"].insert_one(node_payload)
+
+    node_by_member: dict[str, dict[str, Any]] = {}
+    for member_id in assignments:
+        node = _find_lineage_node(db, family_id, member_id)
+        if node:
+            node_by_member[member_id] = node
+
+    parent_nodes: dict[str, set[str]] = {member_id: set() for member_id in assignments}
+    child_nodes: dict[str, set[str]] = {member_id: set() for member_id in assignments}
+    for source_id, target_id, _delta, relationship_type in placement["constraints"]:
+        if relationship_type not in PARENT_RELATIONSHIP_TYPES:
+            continue
+        source_node = node_by_member.get(source_id)
+        target_node = node_by_member.get(target_id)
+        if not source_node or not target_node:
+            continue
+        child_nodes[source_id].add(_value(target_node.get("_id")))
+        parent_nodes[target_id].add(_value(source_node.get("_id")))
+
+    for member_id, node in node_by_member.items():
+        db["lineage_nodes"].update_one(
+            {"_id": node["_id"]},
+            {
+                "$set": {
+                    "parent_node_ids": sorted(parent_nodes.get(member_id, set())),
+                    "child_node_ids": sorted(child_nodes.get(member_id, set())),
+                    "updated_at": now,
+                }
+            },
+        )
+
+    return {
+        "family_id": family_id,
+        "assigned_count": len(assignments),
+        "unplaced_member_ids": sorted(
+            member_id
+            for member_id, marker in statuses.items()
+            if marker == "unplaced"
+        ),
+        "generations": assignments,
+    }
+

--- a/backend/app/services/family_reunion_service.py
+++ b/backend/app/services/family_reunion_service.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bson import ObjectId
+
+from app.database import get_database
+from app.services.linked_network_service import build_linked_network
+
+
+def _value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _id_candidates(value: str) -> list[Any]:
+    values: list[Any] = [value]
+    if ObjectId.is_valid(value):
+        values.append(ObjectId(value))
+    return values
+
+
+def _member_name(member: dict[str, Any]) -> str:
+    return (
+        _value(member.get("display_name"))
+        or f"{_value(member.get('first_name'))} {_value(member.get('last_name'))}".strip()
+        or "Unnamed family member"
+    )
+
+
+def _portrait_status(uploads: list[dict[str, Any]]) -> tuple[str, str | None]:
+    if not uploads:
+        return "missing", None
+    ordered = sorted(
+        uploads,
+        key=lambda item: _value(item.get("created_at")),
+        reverse=True,
+    )
+    for upload in ordered:
+        if (
+            _value(upload.get("scan_status")).lower() == "clean"
+            and not bool(upload.get("quarantined"))
+            and bool(upload.get("approved_for_cinematic"))
+            and _value(upload.get("verification_status")).lower() == "approved"
+            and _value(upload.get("consent_status")).lower() == "approved"
+            and bool(upload.get("consent_attested"))
+            and bool(upload.get("authority_attested"))
+        ):
+            return "approved", _value(upload.get("_id")) or None
+
+    latest = ordered[0]
+    if bool(latest.get("quarantined")) or _value(latest.get("scan_status")).lower() in {
+        "infected",
+        "error",
+    }:
+        return "security_blocked", None
+    if _value(latest.get("scan_status")).lower() != "clean":
+        return "pending_scan", None
+    if _value(latest.get("verification_status")).lower() == "rejected":
+        return "rejected", None
+    if not (
+        bool(latest.get("consent_attested"))
+        and bool(latest.get("authority_attested"))
+    ):
+        return "consent_missing", None
+    return "pending_master_review", None
+
+
+def _verification_status(member: dict[str, Any], uploads: list[dict[str, Any]]) -> str:
+    if bool(member.get("is_verified")) or _value(member.get("verification_status")).lower() == "verified":
+        return "verified"
+    if any(
+        _value(upload.get("scan_status")).lower() == "clean"
+        and not bool(upload.get("quarantined"))
+        and _value(upload.get("verification_status")).lower() == "approved"
+        for upload in uploads
+    ):
+        return "verified"
+    if uploads:
+        return "pending"
+    return "not_submitted"
+
+
+def _single_household_network(
+    project_id: str,
+    workspace_context: dict[str, Any],
+) -> dict[str, Any]:
+    db = get_database()
+    project = workspace_context.get("project") or {}
+    family = workspace_context.get("family") or {}
+    family_id = _value(family.get("_id") or project.get("family_id"))
+    household_id = _value(project.get("household_id") or family.get("household_id"))
+    household = None
+    if household_id:
+        household = db["households"].find_one(
+            {"_id": ObjectId(household_id) if ObjectId.is_valid(household_id) else household_id}
+        )
+    members = (
+        list(db["family_members"].find({"family_id": {"$in": _id_candidates(family_id)}}))
+        if family_id
+        else []
+    )
+    return {
+        "network_summary": {
+            "root_project_id": project_id,
+            "total_households": 1,
+            "total_members": len(members),
+            "alignment_conflict_count": 0,
+            "unplaced_household_count": 0,
+        },
+        "households": [
+            {
+                "household_id": household_id,
+                "household_name": _value((household or {}).get("household_name"))
+                or _value(family.get("family_name"))
+                or "Primary Household",
+                "project_id": project_id,
+                "family_id": family_id,
+                "member_count": len(members),
+                "is_own_household": True,
+                "generation_offset": 0,
+                "alignment_status": "aligned",
+            }
+        ],
+        "nodes": [
+            {
+                "id": _value(member.get("_id")),
+                "source_project_id": project_id,
+                "source_household_id": household_id,
+            }
+            for member in members
+        ],
+        "edges": [],
+        "alignment_conflicts": [],
+    }
+
+
+def build_family_reunion_readiness(
+    project_id: str,
+    current_user_id: str,
+    *,
+    workspace_context: dict[str, Any],
+) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    entitlements = workspace_context.get("resolved_entitlements") or {}
+    if bool(entitlements.get("can_link_households")):
+        network = build_linked_network(
+            project_id,
+            current_user_id,
+            workspace_context=workspace_context,
+        )
+    else:
+        network = _single_household_network(project_id, workspace_context)
+
+    visible_nodes = {
+        _value(node.get("id")): node
+        for node in network.get("nodes") or []
+        if _value(node.get("id"))
+    }
+    member_rows: list[dict[str, Any]] = []
+
+    for member_id, node in visible_nodes.items():
+        if not ObjectId.is_valid(member_id):
+            continue
+        member = db["family_members"].find_one({"_id": ObjectId(member_id)})
+        if not member:
+            continue
+        project_id_for_member = _value(node.get("source_project_id")) or project_id
+        photos = list(
+            db["uploaded_files"].find(
+                {
+                    "project_id": project_id_for_member,
+                    "member_id": member_id,
+                    "category": "member_photo",
+                }
+            )
+        )
+        evidence = list(
+            db["uploaded_files"].find(
+                {
+                    "project_id": project_id_for_member,
+                    "member_id": member_id,
+                    "category": "verification_evidence",
+                }
+            )
+        )
+        portrait_status, approved_photo_upload_id = _portrait_status(photos)
+        verification_status = _verification_status(member, evidence)
+        placement_status = _value(member.get("placement_status")) or "unplaced"
+
+        account_required = bool(
+            member.get("account_required")
+            or member.get("invite_email")
+            or member.get("account_email")
+        )
+        account_claimed = bool(
+            member.get("account_user_id")
+            or member.get("claimed_by_user_id")
+            or member.get("user_id")
+        )
+        invite_email = _value(member.get("invite_email")).lower()
+        if not account_claimed and invite_email:
+            project_member = db["project_members"].find_one(
+                {
+                    "project_id": {"$in": _id_candidates(project_id_for_member)},
+                    "$or": [
+                        {"user_email": invite_email},
+                        {"email": invite_email},
+                    ],
+                    "status": {"$nin": ["suspended", "revoked"]},
+                }
+            )
+            account_claimed = bool(
+                project_member
+                and (
+                    project_member.get("user_id")
+                    or _value(project_member.get("status")).lower() == "active"
+                )
+            )
+        if account_claimed:
+            account_status = "claimed"
+        elif account_required:
+            account_status = "not_claimed"
+        else:
+            account_status = "not_required"
+
+        verification_required = bool(member.get("verification_required"))
+        incomplete_reasons: list[str] = []
+        if portrait_status != "approved":
+            incomplete_reasons.append(f"portrait_{portrait_status}")
+        if placement_status not in {"placed", "root"}:
+            incomplete_reasons.append("tree_placement_incomplete")
+        if account_required and not account_claimed:
+            incomplete_reasons.append("account_not_claimed")
+        if verification_required and verification_status != "verified":
+            incomplete_reasons.append("verification_incomplete")
+
+        member_rows.append(
+            {
+                "member_id": member_id,
+                "display_name": _member_name(member),
+                "household_id": _value(node.get("source_household_id")),
+                "project_id": project_id_for_member,
+                "generation": member.get("generation"),
+                "placement_status": placement_status,
+                "portrait_status": portrait_status,
+                "approved_photo_upload_id": approved_photo_upload_id,
+                "verification_status": verification_status,
+                "account_status": account_status,
+                "account_required": account_required,
+                "slide_ready": (
+                    portrait_status == "approved"
+                    and placement_status in {"placed", "root"}
+                ),
+                "complete": not incomplete_reasons,
+                "incomplete_reasons": incomplete_reasons,
+            }
+        )
+
+    household_rows: list[dict[str, Any]] = []
+    for household in network.get("households") or []:
+        household_id = _value(household.get("household_id"))
+        members = [
+            member for member in member_rows if member["household_id"] == household_id
+        ]
+        completed = sum(1 for member in members if member["complete"])
+        household_rows.append(
+            {
+                **household,
+                "completion": {
+                    "complete_members": completed,
+                    "total_members": len(members),
+                    "percent": round((completed / len(members)) * 100)
+                    if members
+                    else 0,
+                },
+                "members": members,
+            }
+        )
+
+    complete_members = sum(1 for member in member_rows if member["complete"])
+    return {
+        "project_id": project_id,
+        "ready": bool(member_rows)
+        and complete_members == len(member_rows)
+        and not (network.get("alignment_conflicts") or []),
+        "summary": {
+            "household_count": len(household_rows),
+            "member_count": len(member_rows),
+            "complete_member_count": complete_members,
+            "incomplete_member_count": len(member_rows) - complete_members,
+            "slide_ready_count": sum(1 for member in member_rows if member["slide_ready"]),
+            "alignment_conflict_count": len(network.get("alignment_conflicts") or []),
+        },
+        "households": household_rows,
+        "alignment_conflicts": network.get("alignment_conflicts") or [],
+        "privacy_boundary": (
+            "This view contains completion states only. Private files, passwords, "
+            "wallet secrets, and unshared living-person records are not exposed."
+        ),
+    }

--- a/backend/app/services/link_key_service.py
+++ b/backend/app/services/link_key_service.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 
 from app.config import settings
 from app.core.package_catalog import get_package
+from app.core.role_catalog import normalize_project_member_role
 from app.database import get_database
 from app.services.audit_log_service import create_audit_log
 from app.services.entitlement_service import resolve_project_entitlements
@@ -22,6 +23,7 @@ ALLOWED_KEY_TYPES = {
     "branch_link_key",
     "viewer_share_key",
 }
+LINK_KEY_MANAGER_ROLES = frozenset({"billing_owner", "co_owner"})
 
 
 def _utcnow_iso() -> str:
@@ -329,6 +331,29 @@ def project_supports_link_keys(project_id: str) -> bool:
     return bool(package.get("can_use_link_keys", False))
 
 
+def project_supports_household_links(project_id: str) -> bool:
+    entitlement = _get_project_entitlement(project_id)
+    if entitlement:
+        try:
+            resolved = resolve_project_entitlements(
+                str(entitlement.get("package_code") or "").strip(),
+                list(entitlement.get("active_addons", [])),
+            )
+        except Exception:
+            resolved = entitlement.get("resolved_entitlements") or {}
+        if "can_link_households" in resolved:
+            return bool(resolved.get("can_link_households"))
+
+    paid_order = _get_paid_package_order(project_id)
+    package_code = str(
+        (paid_order or {}).get("package_code")
+        or (paid_order or {}).get("package_slug")
+        or ""
+    ).strip()
+    package = get_package(package_code) or {}
+    return bool(package.get("can_link_households", False))
+
+
 def user_can_access_project(
     project_id: str,
     user_id: str,
@@ -348,6 +373,30 @@ def user_can_access_project(
     if not project:
         return False
     return _project_has_access_signal(str(project.get("_id")), project)
+
+
+def user_can_manage_project(
+    project_id: str,
+    user_id: str,
+    user_email: str = "",
+) -> bool:
+    project = get_project_by_id(project_id)
+    if not project or not _project_has_access_signal(str(project.get("_id")), project):
+        return False
+    snapshot = get_project_access_snapshot(
+        project,
+        user_id=str(user_id or "").strip(),
+        email=str(user_email or "").strip().lower(),
+    )
+    if not snapshot.get("accessible"):
+        return False
+    role = normalize_project_member_role(
+        snapshot.get("member_role")
+        or (snapshot.get("membership") or {}).get("member_role")
+        or (snapshot.get("membership") or {}).get("role"),
+        default="viewer",
+    )
+    return role in LINK_KEY_MANAGER_ROLES
 
 
 def list_accessible_link_key_project_ids(
@@ -473,13 +522,18 @@ def list_link_keys_for_user(
     user_email: str = "",
     project_id: str | None = None,
     include_revoked: bool = True,
+    allow_admin: bool = False,
 ) -> list[dict[str, Any]]:
     if project_id:
-        if not user_can_access_project(project_id, user_id, user_email):
+        if not allow_admin and not user_can_manage_project(project_id, user_id, user_email):
             return []
         owned_project_ids = [str(project_id)]
     else:
-        owned_project_ids = list_accessible_link_key_project_ids(user_id, user_email)
+        owned_project_ids = [
+            candidate
+            for candidate in list_accessible_link_key_project_ids(user_id, user_email)
+            if allow_admin or user_can_manage_project(candidate, user_id, user_email)
+        ]
 
     if not owned_project_ids:
         return []
@@ -510,10 +564,12 @@ def generate_link_key(
     normalized_key_type = _normalize_value(key_type).lower() or "branch_link_key"
     if normalized_key_type not in ALLOWED_KEY_TYPES:
         raise ValueError("Invalid key type.")
-    if not allow_admin and not user_can_access_project(project_id, user_id, user_email):
+    if not allow_admin and not user_can_manage_project(project_id, user_id, user_email):
         raise PermissionError("Not authorized to generate a link key for this project.")
 
-    if not project_supports_link_keys(project_id):
+    if normalized_key_type == "branch_link_key" and not project_supports_household_links(project_id):
+        raise ValueError("This package does not include linked-household structure.")
+    if normalized_key_type != "branch_link_key" and not project_supports_link_keys(project_id):
         raise ValueError("This package does not include link capabilities.")
 
     project_summary = get_project_summary(project_id)
@@ -591,7 +647,7 @@ def revoke_link_key(
         return None
 
     project_id = str(document.get("project_id") or "")
-    if not allow_admin and not user_can_access_project(
+    if not allow_admin and not user_can_manage_project(
         project_id,
         actor_user_id,
         actor_user_email,

--- a/backend/app/services/link_request_service.py
+++ b/backend/app/services/link_request_service.py
@@ -4,10 +4,13 @@ from datetime import UTC, datetime
 from typing import Any
 
 from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
 
 from app.core.package_catalog import get_package
 from app.core.relationship_catalog import (
     LINKED_HOUSEHOLD_RELATIONSHIP_TYPE,
+    normalize_relationship_type,
+    relationship_generation_delta,
 )
 from app.database import get_database
 from app.schemas.link_request import LinkRequestCreate
@@ -18,8 +21,8 @@ from app.services.link_key_service import (
     get_key_doc_by_value,
     get_project_summary,
     list_accessible_link_key_project_ids,
-    project_supports_link_keys,
-    user_can_access_project,
+    project_supports_household_links as project_supports_link_keys,
+    user_can_manage_project as user_can_access_project,
 )
 
 
@@ -61,6 +64,14 @@ def _entitlements_collection():
 
 def _normalize_value(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _active_project_pair_key(source_project_id: str, target_project_id: str) -> str:
+    return "::".join(sorted([source_project_id, target_project_id]))
+
+
+def _household_pair_key(source_household_id: str, target_household_id: str) -> str:
+    return "::".join(sorted([source_household_id, target_household_id]))
 
 
 def _project_id_candidates(project_id: str) -> list[Any]:
@@ -147,6 +158,117 @@ def _household_ids_for_project(project_id: str) -> set[str]:
                 household_ids.add(candidate)
 
     return household_ids
+
+
+def _resolve_single_household_id(project_id: str) -> str:
+    households = list(
+        _households_collection().find(
+            {"project_id": {"$in": _project_id_candidates(project_id)}}
+        )
+    )
+    if len(households) > 1:
+        raise ValueError(
+            "Workspace has multiple household records. Reconcile it before linking."
+        )
+    if len(households) == 1:
+        return _normalize_value(households[0].get("_id"))
+
+    summary = get_project_summary(project_id) or {}
+    household_id = _normalize_value(summary.get("household_id"))
+    if household_id:
+        query_value: Any = (
+            ObjectId(household_id) if ObjectId.is_valid(household_id) else household_id
+        )
+        household = _households_collection().find_one(
+            {"$or": [{"_id": query_value}, {"household_id": household_id}]}
+        )
+        if household:
+            return _normalize_value(household.get("_id") or household.get("household_id"))
+
+    raise ValueError(
+        "Workspace does not have one resolvable household record. Complete workspace setup before linking."
+    )
+
+
+def _member_for_project(project_id: str, member_id: str) -> dict[str, Any]:
+    normalized_member_id = _normalize_value(member_id)
+    if not ObjectId.is_valid(normalized_member_id):
+        raise ValueError("Selected household anchor member id is invalid.")
+    db = get_database()
+    member = db["family_members"].find_one({"_id": ObjectId(normalized_member_id)})
+    if not member:
+        raise ValueError("Selected household anchor member was not found.")
+
+    summary = get_project_summary(project_id) or {}
+    family_id = _normalize_value(summary.get("family_id"))
+    if not family_id:
+        family = db["families"].find_one(
+            {"project_id": {"$in": _project_id_candidates(project_id)}}
+        )
+        family_id = _normalize_value((family or {}).get("_id"))
+    if not family_id or _normalize_value(member.get("family_id")) != family_id:
+        raise ValueError("Selected anchor member does not belong to this workspace.")
+
+    placement_status = _normalize_value(member.get("placement_status")).lower()
+    if placement_status not in {"placed", "root"}:
+        raise ValueError(
+            "Selected anchor member is not placed in a validated generation yet."
+        )
+    try:
+        int(member.get("generation"))
+    except (TypeError, ValueError):
+        raise ValueError("Selected anchor member does not have a valid generation.")
+    return member
+
+
+def _assert_key_has_available_use(key_document: dict[str, Any], *, label: str) -> None:
+    max_uses = max(1, int(key_document.get("max_uses") or 1))
+    use_count = max(0, int(key_document.get("use_count") or 0))
+    if use_count >= max_uses:
+        raise ValueError(f"The {label} link key has reached its use limit.")
+
+
+def _reserve_key_use(key_document: dict[str, Any], *, label: str) -> None:
+    key_id = key_document.get("_id")
+    if key_id is None:
+        raise ValueError(f"The {label} link key is invalid.")
+    max_uses = max(1, int(key_document.get("max_uses") or 1))
+    now = _utcnow_iso()
+    result = get_database()["project_link_keys"].update_one(
+        {
+            "_id": key_id,
+            "status": "active",
+            "$or": [
+                {"use_count": {"$lt": max_uses}},
+                {"use_count": {"$exists": False}},
+            ],
+        },
+        {
+            "$inc": {"use_count": 1},
+            "$set": {"last_used_at": now, "updated_at": now},
+        },
+    )
+    modified_count = getattr(result, "modified_count", None)
+    if modified_count is None:
+        refreshed = get_database()["project_link_keys"].find_one({"_id": key_id}) or {}
+        modified_count = int(refreshed.get("use_count") or 0) - int(
+            key_document.get("use_count") or 0
+        )
+    if int(modified_count or 0) != 1:
+        raise ValueError(f"The {label} link key has reached its use limit.")
+
+
+def _release_key_use(key_document: dict[str, Any]) -> None:
+    key_id = key_document.get("_id")
+    if key_id is None:
+        return
+    get_database()["project_link_keys"].update_one(
+        {"_id": key_id, "use_count": {"$gt": 0}},
+        {
+            "$inc": {"use_count": -1},
+            "$set": {"updated_at": _utcnow_iso()},
+        },
+    )
 
 
 def _linked_household_component(seed_household_ids: set[str]) -> set[str]:
@@ -286,6 +408,15 @@ def create_link_request(
 ) -> dict:
     source_project_id = str(payload.source_project_id or "").strip()
     target_key = str(payload.target_key or "").strip()
+    source_anchor_member_id = _normalize_value(payload.source_anchor_member_id)
+    bridge_relationship_type = normalize_relationship_type(
+        payload.bridge_relationship_type
+    )
+    generation_delta = relationship_generation_delta(bridge_relationship_type)
+    if generation_delta is None:
+        raise ValueError(
+            "The selected relationship cannot align the linked household tree."
+        )
 
     if not user_can_access_project(
         source_project_id,
@@ -295,7 +426,7 @@ def create_link_request(
         raise PermissionError("Not authorized to create a link request for this project.")
 
     if not project_supports_link_keys(source_project_id):
-        raise ValueError("Your package does not include link capabilities.")
+        raise ValueError("Your package does not include linked-household structure.")
 
     source_project = get_project_summary(source_project_id)
     if not source_project:
@@ -306,6 +437,11 @@ def create_link_request(
         raise ValueError("Generate a link key for your workspace before requesting a link.")
     if _normalize_value(source_key_doc.get("key_type") or "branch_link_key") != "branch_link_key":
         raise ValueError("The active source key must be a branch link key.")
+    _assert_key_has_available_use(source_key_doc, label="requesting workspace")
+    source_anchor_member = _member_for_project(
+        source_project_id,
+        source_anchor_member_id,
+    )
 
     target_key_doc = get_key_doc_by_value(target_key)
     if target_key_doc is None:
@@ -322,6 +458,7 @@ def create_link_request(
         raise ValueError("Target link key was not found or is no longer active.")
     if _normalize_value(target_key_doc.get("key_type") or "branch_link_key") != "branch_link_key":
         raise ValueError("The target key must be a branch link key.")
+    _assert_key_has_available_use(target_key_doc, label="receiving workspace")
 
     target_project_id = str(target_key_doc.get("project_id") or "").strip()
     if not target_project_id:
@@ -331,13 +468,15 @@ def create_link_request(
         raise ValueError("You cannot link a project to itself.")
 
     if not project_supports_link_keys(target_project_id):
-        raise ValueError("The target workspace does not support link capabilities.")
+        raise ValueError("The target workspace does not support linked-household structure.")
 
     target_project = get_project_summary(target_project_id)
     if not target_project:
         raise ValueError("Target project not found.")
 
     _assert_household_branch_capacity(source_project_id, target_project_id)
+    source_household_id = _resolve_single_household_id(source_project_id)
+    target_household_id = _resolve_single_household_id(target_project_id)
 
     existing = _requests_collection().find_one(
         {
@@ -357,13 +496,32 @@ def create_link_request(
     if existing is not None:
         raise ValueError("A pending or approved link already exists between these workspaces.")
 
+    _requests_collection().create_index(
+        [("active_project_pair_key", 1)],
+        name="active_project_pair_key_1_unique",
+        unique=True,
+        sparse=True,
+    )
+
     data = {
         "source_project_id": source_project_id,
         "target_project_id": target_project_id,
-        "source_household_id": source_project.get("household_id"),
-        "target_household_id": target_project.get("household_id"),
-        "source_key": str(source_key_doc.get("key_value") or ""),
-        "target_key": str(target_key_doc.get("key_value") or ""),
+        "source_household_id": source_household_id,
+        "target_household_id": target_household_id,
+        "source_anchor_member_id": source_anchor_member_id,
+        "target_anchor_member_id": None,
+        "bridge_relationship_type": bridge_relationship_type,
+        "generation_delta": generation_delta,
+        "source_anchor_generation": int(source_anchor_member.get("generation")),
+        "target_generation_offset": None,
+        "alignment_status": "awaiting_target_anchor",
+        "active_project_pair_key": _active_project_pair_key(
+            source_project_id,
+            target_project_id,
+        ),
+        # Raw keys are never persisted; the hashes bind both sides of the handshake.
+        "source_key": "",
+        "target_key": "",
         "source_key_hash": _normalize_value(source_key_doc.get("key_hash")),
         "target_key_hash": _normalize_value(target_key_doc.get("key_hash")),
         "status": "pending",
@@ -386,7 +544,24 @@ def create_link_request(
         "updated_at": _utcnow_iso(),
     }
 
-    result = _requests_collection().insert_one(data)
+    source_reserved = False
+    target_reserved = False
+    try:
+        _reserve_key_use(source_key_doc, label="requesting workspace")
+        source_reserved = True
+        _reserve_key_use(target_key_doc, label="receiving workspace")
+        target_reserved = True
+        result = _requests_collection().insert_one(data)
+    except Exception as exc:
+        if target_reserved:
+            _release_key_use(target_key_doc)
+        if source_reserved:
+            _release_key_use(source_key_doc)
+        if isinstance(exc, DuplicateKeyError):
+            raise ValueError(
+                "A pending or approved link already exists between these workspaces."
+            ) from exc
+        raise
     data["_id"] = result.inserted_id
     try:
         create_audit_log(
@@ -475,6 +650,7 @@ def approve_link_request(
     approver_user_id: str,
     approver_user_email: str = "",
     approval_notes: str | None = None,
+    target_anchor_member_id: str | None = None,
     is_admin: bool = False,
 ) -> dict | None:
     object_id = _to_object_id(request_id)
@@ -501,21 +677,134 @@ def approve_link_request(
     if not source_project_id or not target_project_id:
         raise ValueError("Link request project references are invalid.")
     if not project_supports_link_keys(source_project_id):
-        raise ValueError("The requesting workspace no longer supports link capabilities.")
+        raise ValueError("The requesting workspace no longer supports linked-household structure.")
     if not project_supports_link_keys(target_project_id):
-        raise ValueError("The receiving workspace no longer supports link capabilities.")
+        raise ValueError("The receiving workspace no longer supports linked-household structure.")
 
     _assert_household_branch_capacity(source_project_id, target_project_id)
 
     _validate_active_handshake_keys(request)
 
     now = _utcnow_iso()
+    normalized_target_anchor_id = _normalize_value(target_anchor_member_id)
+    source_anchor_member_id = _normalize_value(request.get("source_anchor_member_id"))
+    legacy_unanchored = not source_anchor_member_id
+    if not normalized_target_anchor_id and not legacy_unanchored:
+        raise ValueError(
+            "Select the receiving household member who anchors this family connection."
+        )
+    if legacy_unanchored:
+        source_household_id = _normalize_value(request.get("source_household_id"))
+        target_household_id = _normalize_value(request.get("target_household_id"))
+        if not source_household_id or not target_household_id:
+            raise ValueError(
+                "Legacy link request has no resolvable household references."
+            )
+        bridge_relationship_type = LINKED_HOUSEHOLD_RELATIONSHIP_TYPE
+        generation_delta = None
+        source_generation = None
+        target_generation = None
+        target_generation_offset = None
+        alignment_status = "unplaced_legacy_link"
+    else:
+        source_anchor = _member_for_project(source_project_id, source_anchor_member_id)
+        target_anchor = _member_for_project(
+            target_project_id,
+            normalized_target_anchor_id,
+        )
+        bridge_relationship_type = normalize_relationship_type(
+            request.get("bridge_relationship_type")
+        )
+        generation_delta = relationship_generation_delta(bridge_relationship_type)
+        if generation_delta is None:
+            raise ValueError("The household bridge cannot determine generation placement.")
+
+        source_household_id = _resolve_single_household_id(source_project_id)
+        target_household_id = _resolve_single_household_id(target_project_id)
+        source_generation = int(source_anchor.get("generation"))
+        target_generation = int(target_anchor.get("generation"))
+        target_generation_offset = (
+            source_generation + generation_delta - target_generation
+        )
+        alignment_status = "aligned"
+    link_document = {
+        "source_household_id": source_household_id,
+        "target_household_id": target_household_id,
+        "source_project_id": source_project_id,
+        "target_project_id": target_project_id,
+        "source_anchor_member_id": source_anchor_member_id,
+        "target_anchor_member_id": normalized_target_anchor_id,
+        "bridge_relationship_type": bridge_relationship_type,
+        "generation_delta": generation_delta,
+        "source_anchor_generation": source_generation,
+        "target_anchor_generation": target_generation,
+        "target_generation_offset": target_generation_offset,
+        "alignment_status": alignment_status,
+        "relationship_type": LINKED_HOUSEHOLD_RELATIONSHIP_TYPE,
+        "link_status": "approved",
+        "link_request_id": str(object_id),
+        "source_key_hash": _normalize_value(request.get("source_key_hash")),
+        "target_key_hash": _normalize_value(request.get("target_key_hash")),
+        "household_pair_key": _household_pair_key(
+            source_household_id,
+            target_household_id,
+        ),
+        "updated_at": now,
+    }
+    _household_links_collection().create_index(
+        [("household_pair_key", 1)],
+        name="household_pair_key_1_unique",
+        unique=True,
+        sparse=True,
+    )
+    existing_link = _household_links_collection().find_one(
+        {
+            "$or": [
+                {
+                    "source_household_id": source_household_id,
+                    "target_household_id": target_household_id,
+                },
+                {
+                    "source_household_id": target_household_id,
+                    "target_household_id": source_household_id,
+                },
+            ]
+        }
+    )
+    # The durable household link is written before the request is marked approved,
+    # so a partial database failure never produces a false completed handshake.
+    if existing_link is None:
+        link_document["created_at"] = now
+        try:
+            _household_links_collection().insert_one(link_document)
+        except DuplicateKeyError:
+            raced_link = _household_links_collection().find_one(
+                {"household_pair_key": link_document["household_pair_key"]}
+            )
+            if raced_link is None:
+                raise
+            _household_links_collection().update_one(
+                {"_id": raced_link["_id"]},
+                {"$set": link_document},
+            )
+    else:
+        _household_links_collection().update_one(
+            {"_id": existing_link["_id"]},
+            {"$set": link_document},
+        )
+
     _requests_collection().update_one(
-        {"_id": object_id},
+        {"_id": object_id, "status": "pending"},
         {
             "$set": {
                 "status": "approved",
                 "handshake_state": "complete",
+                "source_household_id": source_household_id,
+                "target_household_id": target_household_id,
+                "target_anchor_member_id": normalized_target_anchor_id,
+                "generation_delta": generation_delta,
+                "target_generation_offset": target_generation_offset,
+                "alignment_status": alignment_status,
                 "target_handshake_at": now,
                 "target_handshake_by": approved_by,
                 "target_handshake_user_id": approver_user_id,
@@ -527,41 +816,6 @@ def approve_link_request(
             }
         },
     )
-
-    source_household_id = str(request.get("source_household_id") or "").strip()
-    target_household_id = str(request.get("target_household_id") or "").strip()
-
-    if source_household_id and target_household_id:
-        existing_link = _household_links_collection().find_one(
-            {
-                "$or": [
-                    {
-                        "source_household_id": source_household_id,
-                        "target_household_id": target_household_id,
-                    },
-                    {
-                        "source_household_id": target_household_id,
-                        "target_household_id": source_household_id,
-                    },
-                ]
-            }
-        )
-
-        if existing_link is None:
-            _household_links_collection().insert_one(
-                {
-                    "source_household_id": source_household_id,
-                    "target_household_id": target_household_id,
-                    # This non-ancestry relationship marker is intentionally excluded from lineage traversal.
-                    "relationship_type": LINKED_HOUSEHOLD_RELATIONSHIP_TYPE,
-                    "link_status": "approved",
-                    "linked_by_key": request.get("source_key"),
-                    "source_key": request.get("source_key"),
-                    "target_key": request.get("target_key"),
-                    "created_at": now,
-                    "updated_at": now,
-                }
-            )
 
     updated = _requests_collection().find_one({"_id": object_id})
     try:
@@ -620,6 +874,7 @@ def reject_link_request(
                 "rejected_by": rejected_by,
                 "rejected_at": now,
                 "rejection_notes": rejection_notes,
+                "active_project_pair_key": None,
                 "updated_at": now,
             }
         },
@@ -681,6 +936,7 @@ def revoke_link_request(
                 "revoked_by": revoked_by,
                 "revoked_at": now,
                 "revoke_notes": revoke_notes,
+                "active_project_pair_key": None,
                 "updated_at": now,
             }
         },
@@ -690,8 +946,7 @@ def revoke_link_request(
     target_household_id = str(request.get("target_household_id") or "").strip()
 
     if source_household_id and target_household_id:
-        _household_links_collection().delete_many(
-            {
+        link_query = {
                 "$or": [
                     {
                         "source_household_id": source_household_id,
@@ -703,7 +958,19 @@ def revoke_link_request(
                     },
                 ]
             }
-        )
+        for household_link in _household_links_collection().find(link_query):
+            _household_links_collection().update_one(
+                {"_id": household_link["_id"]},
+                {
+                "$set": {
+                    "link_status": "revoked",
+                    "revoked_at": now,
+                    "revoked_by": revoked_by,
+                    "revoke_notes": revoke_notes,
+                    "updated_at": now,
+                }
+                },
+            )
 
     updated = _requests_collection().find_one({"_id": object_id})
     try:

--- a/backend/app/services/linked_network_service.py
+++ b/backend/app/services/linked_network_service.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from bson import ObjectId
 from pymongo.collection import Collection
 
+from app.core.relationship_catalog import LINK_BRIDGE_INVERSE_CANONICAL_TYPES
 from app.database import get_database
 from app.services.workspace_access_service import (
     resolve_strict_paid_active_project_entitlement,
@@ -24,6 +25,64 @@ def _str_id(value: Any) -> str:
     if isinstance(value, ObjectId):
         return str(value)
     return str(value or "").strip()
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _approved_portrait_for_network(
+    member: dict[str, Any],
+    *,
+    family_id: str,
+    is_own_household: bool,
+) -> dict[str, Any] | None:
+    member_id = _str_id(member.get("_id"))
+    uploads = _col("uploaded_files")
+    candidates: list[dict[str, Any]] = []
+    approved_id = _str_id(member.get("approved_photo_upload_id"))
+    if approved_id and ObjectId.is_valid(approved_id):
+        approved = uploads.find_one({"_id": ObjectId(approved_id)})
+        if approved:
+            candidates.append(approved)
+    if not candidates:
+        candidates = list(
+            uploads.find(
+                {
+                    "family_id": family_id,
+                    "member_id": member_id,
+                    "category": "member_photo",
+                }
+            )
+        )
+        candidates.sort(
+            key=lambda item: _str_id(item.get("created_at")),
+            reverse=True,
+        )
+
+    for upload in candidates:
+        ready = bool(
+            _str_id(upload.get("scan_status")).lower() == "clean"
+            and not bool(upload.get("quarantined"))
+            and bool(upload.get("approved_for_cinematic"))
+            and _str_id(upload.get("verification_status")).lower() == "approved"
+            and _str_id(upload.get("consent_status")).lower() == "approved"
+            and bool(upload.get("consent_attested"))
+            and bool(upload.get("authority_attested"))
+        )
+        if not ready:
+            continue
+        if not is_own_household and not (
+            bool(upload.get("share_with_linked_families"))
+            or _str_id(upload.get("visibility_scope")).lower()
+            in {"linked_family_shared", "public_memorial"}
+        ):
+            continue
+        return upload
+    return None
 
 
 def build_linked_network(
@@ -73,6 +132,7 @@ def build_linked_network(
 
     visited_household_ids: set[str] = set()
     all_households: list[dict[str, Any]] = []
+    traversed_links: dict[str, dict[str, Any]] = {}
 
     queue: deque[tuple[str, int]] = deque()
     for hh in seed_households:
@@ -98,6 +158,9 @@ def build_linked_network(
         )
 
         for link in links:
+            link_id = _str_id(link.get("_id"))
+            if link_id:
+                traversed_links[link_id] = link
             src = _str_id(link.get("source_household_id"))
             tgt = _str_id(link.get("target_household_id"))
             neighbor_id = tgt if src == current_hid else src
@@ -108,6 +171,44 @@ def build_linked_network(
                 if neighbor_hh:
                     all_households.append(neighbor_hh)
                     queue.append((neighbor_id, depth + 1))
+
+    household_generation_offsets: dict[str, int] = {}
+    alignment_conflicts: list[dict[str, Any]] = []
+    if seed_households:
+        household_generation_offsets[_str_id(seed_households[0].get("_id"))] = 0
+    changed = True
+    while changed:
+        changed = False
+        for link_id, link in traversed_links.items():
+            source_id = _str_id(link.get("source_household_id"))
+            target_id = _str_id(link.get("target_household_id"))
+            if link.get("target_generation_offset") is None:
+                continue
+            try:
+                target_delta = int(link.get("target_generation_offset"))
+            except (TypeError, ValueError):
+                continue
+            if source_id in household_generation_offsets:
+                expected_target = household_generation_offsets[source_id] + target_delta
+                if target_id in household_generation_offsets:
+                    if household_generation_offsets[target_id] != expected_target:
+                        alignment_conflicts.append(
+                            {
+                                "link_id": link_id,
+                                "source_household_id": source_id,
+                                "target_household_id": target_id,
+                                "expected_offset": expected_target,
+                                "actual_offset": household_generation_offsets[target_id],
+                            }
+                        )
+                else:
+                    household_generation_offsets[target_id] = expected_target
+                    changed = True
+            elif target_id in household_generation_offsets:
+                household_generation_offsets[source_id] = (
+                    household_generation_offsets[target_id] - target_delta
+                )
+                changed = True
 
     # Determine the requesting user's household_id (for visibility)
     user_household_ids: set[str] = {_str_id(hh.get("_id")) for hh in seed_households}
@@ -167,6 +268,12 @@ def build_linked_network(
             "family_id": family_id,
             "member_count": len(members),
             "is_own_household": is_own_household,
+            "generation_offset": household_generation_offsets.get(hh_id),
+            "alignment_status": (
+                "aligned"
+                if hh_id in household_generation_offsets
+                else "unplaced_link"
+            ),
         })
 
         # Apply visibility rules and add provenance
@@ -185,10 +292,10 @@ def build_linked_network(
             )
 
             # Visibility logic
-            if member_household_id not in user_household_ids and not (
-                is_deceased
-                or approved_cross_branch
-            ):
+            # Death never overrides the household's privacy choice. A record is
+            # visible across a household boundary only when that household has
+            # explicitly shared it (including an explicit public memorial).
+            if member_household_id not in user_household_ids and not approved_cross_branch:
                 continue
 
             if is_deceased or visibility_scope in {"memorial", "public_memorial"}:
@@ -199,6 +306,14 @@ def build_linked_network(
                 effective_scope = "linked"
 
             seen_member_ids.add(mid)
+            approved_portrait = _approved_portrait_for_network(
+                member,
+                family_id=family_id or "",
+                is_own_household=is_own_household,
+            )
+            approved_portrait_id = _str_id(
+                (approved_portrait or {}).get("_id")
+            )
             all_nodes.append({
                 "id": mid,
                 "first_name": member.get("first_name"),
@@ -206,18 +321,43 @@ def build_linked_network(
                 "display_name": member.get("display_name"),
                 "birth_year": member.get("birth_year"),
                 "generation": member.get("generation"),
+                "local_generation": member.get("generation"),
+                "aligned_generation": (
+                    _int_or_none(member.get("generation"))
+                    + household_generation_offsets[hh_id]
+                    if hh_id in household_generation_offsets
+                    and _int_or_none(member.get("generation")) is not None
+                    else None
+                ),
+                "placement_status": member.get("placement_status") or "unplaced",
                 "bio": member.get("bio"),
                 "is_deceased": is_deceased,
                 "source_project_id": hh_project_id,
                 "source_household_id": hh_id,
                 "source_household_name": hh_name,
+                "family_id": family_id,
                 "visibility_scope": effective_scope,
                 "is_verified": bool(member.get("is_verified", False)),
+                "approved_photo_upload_id": approved_portrait_id or None,
+                "portrait_url": (
+                    f"/uploads/{approved_portrait_id}/download"
+                    if approved_portrait_id
+                    else ""
+                ),
             })
 
         for rel in relationships:
             rid = _str_id(rel.get("_id"))
             if rid in seen_relationship_ids:
+                continue
+            relationship_privacy = str(
+                rel.get("privacy_scope") or "household_private"
+            ).strip().lower()
+            if not is_own_household and not (
+                bool(rel.get("share_with_linked_families"))
+                or relationship_privacy
+                in {"linked_family_shared", "branch_shared", "public_memorial"}
+            ):
                 continue
             source_member_id = _str_id(rel.get("source_member_id") or "")
             target_member_id = _str_id(rel.get("target_member_id") or "")
@@ -231,10 +371,58 @@ def build_linked_network(
                 "source_member_id": source_member_id,
                 "target_member_id": target_member_id,
                 "relationship_type": rel.get("relationship_type"),
+                "relationship_mode": rel.get("relationship_mode") or "narrative",
+                "status_marker": rel.get("status_marker") or "narrative",
+                "privacy_scope": relationship_privacy,
+                "relationship_label": rel.get("relationship_label"),
                 "notes": rel.get("notes"),
                 "source_project_id": hh_project_id,
                 "source_household_id": hh_id,
             })
+
+    for link_id, link in traversed_links.items():
+        source_member_id = _str_id(link.get("source_anchor_member_id"))
+        target_member_id = _str_id(link.get("target_anchor_member_id"))
+        if not source_member_id or not target_member_id:
+            continue
+        if source_member_id not in seen_member_ids or target_member_id not in seen_member_ids:
+            continue
+        bridge_relationship_type = _str_id(
+            link.get("bridge_relationship_type")
+        ) or "linked_household"
+        original_bridge_relationship_type = bridge_relationship_type
+        canonical_generation_delta = link.get("generation_delta")
+        if bridge_relationship_type in LINK_BRIDGE_INVERSE_CANONICAL_TYPES:
+            source_member_id, target_member_id = (
+                target_member_id,
+                source_member_id,
+            )
+            bridge_relationship_type = LINK_BRIDGE_INVERSE_CANONICAL_TYPES[
+                bridge_relationship_type
+            ]
+            try:
+                canonical_generation_delta = -int(canonical_generation_delta)
+            except (TypeError, ValueError):
+                canonical_generation_delta = None
+        all_edges.append(
+            {
+                "id": f"household-bridge::{link_id}",
+                "source_member_id": source_member_id,
+                "target_member_id": target_member_id,
+                "relationship_type": bridge_relationship_type,
+                "bridge_relationship_type": original_bridge_relationship_type,
+                "relationship_label": original_bridge_relationship_type,
+                "relationship_mode": "verified",
+                "status_marker": "verified",
+                "privacy_scope": "linked_family_shared",
+                "source_household_id": _str_id(link.get("source_household_id")),
+                "target_household_id": _str_id(link.get("target_household_id")),
+                "generation_delta": canonical_generation_delta,
+                "bridge_generation_delta": link.get("generation_delta"),
+                "is_household_bridge": True,
+                "alignment_status": link.get("alignment_status") or "unplaced_link",
+            }
+        )
 
     return {
         "network_summary": {
@@ -242,9 +430,19 @@ def build_linked_network(
             "total_members": len(all_nodes),
             "total_relationships": len(all_edges),
             "root_project_id": normalized_project_id,
+            "alignment_conflict_count": len(alignment_conflicts),
+            "unplaced_household_count": len(
+                [
+                    household
+                    for household in all_households
+                    if _str_id(household.get("_id"))
+                    not in household_generation_offsets
+                ]
+            ),
         },
         "households": household_summaries,
         "nodes": all_nodes,
         "edges": all_edges,
         "link_count": len(all_households) - len(seed_households),
+        "alignment_conflicts": alignment_conflicts,
     }

--- a/backend/app/services/matching.py
+++ b/backend/app/services/matching.py
@@ -34,6 +34,7 @@ def normalize_member(member: Dict[str, Any]) -> Dict[str, Any]:
         "last_name": last_name,
         "full_name": full_name,
         "birth_date": normalize_string(member.get("birth_date")),
+        "birth_year": normalize_string(member.get("birth_year")),
         "gender": normalize_string(member.get("gender")),
         "household_id": str(member.get("household_id")) if member.get("household_id") else "",
         "father_name": normalize_string(member.get("father_name")),
@@ -76,6 +77,9 @@ def score_match(member_a: Dict[str, Any], member_b: Dict[str, Any]) -> Tuple[flo
     if a["birth_date"] and b["birth_date"] and a["birth_date"] == b["birth_date"]:
         score += 0.20
         reasons.append("Exact matching birth date")
+    elif a["birth_year"] and b["birth_year"] and a["birth_year"] == b["birth_year"]:
+        score += 0.12
+        reasons.append("Matching birth year")
 
     if a["gender"] and b["gender"] and a["gender"] == b["gender"]:
         score += 0.05
@@ -186,12 +190,21 @@ def generate_match_candidates_for_member(member_id: str, actor_user_id: Optional
     current_member = db.family_members.find_one({"_id": ObjectId(member_id)})
     if not current_member:
         return []
+    if not bool(current_member.get("identity_matching_consent")):
+        return []
 
     created_candidate_ids: List[str] = []
 
-    others = db.family_members.find({"_id": {"$ne": ObjectId(member_id)}})
+    others = db.family_members.find(
+        {
+            "_id": {"$ne": ObjectId(member_id)},
+            "identity_matching_consent": True,
+        }
+    )
 
     for other in others:
+        if not _members_share_authorized_identity_scope(db, current_member, other):
+            continue
         score, reasons = score_match(current_member, other)
         if score >= MATCH_THRESHOLD:
             candidate_id = create_match_candidate(
@@ -205,3 +218,65 @@ def generate_match_candidates_for_member(member_id: str, actor_user_id: Optional
                 created_candidate_ids.append(candidate_id)
 
     return created_candidate_ids
+
+
+def _members_share_authorized_identity_scope(
+    db: Any,
+    member_a: Dict[str, Any],
+    member_b: Dict[str, Any],
+) -> bool:
+    family_a_id = str(member_a.get("family_id") or "").strip()
+    family_b_id = str(member_b.get("family_id") or "").strip()
+    if not family_a_id or not family_b_id:
+        return False
+    if family_a_id == family_b_id:
+        return True
+
+    def family_document(family_id: str) -> Dict[str, Any] | None:
+        if ObjectId.is_valid(family_id):
+            found = db.families.find_one({"_id": ObjectId(family_id)})
+            if found:
+                return found
+        return db.families.find_one({"family_id": family_id})
+
+    family_a = family_document(family_a_id) or {}
+    family_b = family_document(family_b_id) or {}
+
+    def household_id_for_family(family: Dict[str, Any]) -> str:
+        direct = str(family.get("household_id") or "").strip()
+        if direct:
+            return direct
+        project_id = str(family.get("project_id") or "").strip()
+        if not project_id:
+            return ""
+        candidates: List[Any] = [project_id]
+        if ObjectId.is_valid(project_id):
+            candidates.append(ObjectId(project_id))
+        household = db.households.find_one(
+            {"project_id": {"$in": candidates}}
+        )
+        return str((household or {}).get("_id") or "").strip()
+
+    household_a = household_id_for_family(family_a)
+    household_b = household_id_for_family(family_b)
+    if not household_a or not household_b:
+        return False
+
+    return (
+        db.household_links.find_one(
+            {
+                "link_status": "approved",
+                "$or": [
+                    {
+                        "source_household_id": household_a,
+                        "target_household_id": household_b,
+                    },
+                    {
+                        "source_household_id": household_b,
+                        "target_household_id": household_a,
+                    },
+                ],
+            }
+        )
+        is not None
+    )

--- a/backend/app/services/mint_job_service.py
+++ b/backend/app/services/mint_job_service.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import logging
+from uuid import uuid4
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from bson import ObjectId
 from pymongo import ReturnDocument
 from pymongo.collection import Collection
-from pymongo.errors import OperationFailure
+from pymongo.errors import DuplicateKeyError, OperationFailure
 
 from app.database import get_database
-from app.services.blockchain_mint_service import mint_anchor, sync_mint_receipt
+from app.services.blockchain_mint_service import (
+    mint_anchor,
+    rebroadcast_signed_transaction,
+    sync_mint_receipt,
+)
 from app.services.mint_record_service import (
     ACTIVE_MINT_JOB_STATUSES,
     _object_id_or_text,
@@ -83,6 +88,77 @@ def _records_collection() -> Collection[dict[str, Any]]:
     return cast(Collection[dict[str, Any]], db["mint_records"])
 
 
+def _mint_runtime_locks_collection() -> Collection[dict[str, Any]]:
+    db = get_database()
+    return cast(Collection[dict[str, Any]], db["mint_runtime_locks"])
+
+
+def _clear_completed_signed_transaction(mint_record_id: str) -> None:
+    record_id = _to_object_id(mint_record_id)
+    if record_id is None:
+        return
+    _records_collection().update_one(
+        {"_id": record_id},
+        {
+            "$set": {
+                "signed_transaction": None,
+                "broadcast_state": "confirmed",
+                "transaction_confirmed_at": _now(),
+                "updated_at": _now(),
+            }
+        },
+    )
+
+
+def _acquire_signer_lease(mint_record_id: str) -> str:
+    now = _now()
+    lease_token = f"{mint_record_id}:{uuid4().hex}"
+    try:
+        document = _mint_runtime_locks_collection().find_one_and_update(
+            {
+                "_id": "evm_mint_signer",
+                "$or": [
+                    {"expires_at": {"$lte": now}},
+                    {"lease_token": lease_token},
+                ],
+            },
+            {
+                "$set": {
+                    "lease_token": lease_token,
+                    "mint_record_id": mint_record_id,
+                    "locked_at": now,
+                    "expires_at": now + timedelta(minutes=4),
+                }
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+    except DuplicateKeyError as exc:
+        raise RuntimeError(
+            "Another mint transaction currently owns the blockchain signer lease."
+        ) from exc
+    if document is None or _normalize(document.get("lease_token")) != lease_token:
+        raise RuntimeError(
+            "Another mint transaction currently owns the blockchain signer lease."
+        )
+    return lease_token
+
+
+def _release_signer_lease(lease_token: str) -> None:
+    now = _now()
+    _mint_runtime_locks_collection().update_one(
+        {"_id": "evm_mint_signer", "lease_token": lease_token},
+        {
+            "$set": {
+                "lease_token": None,
+                "mint_record_id": None,
+                "released_at": now,
+                "expires_at": now,
+            }
+        },
+    )
+
+
 def ensure_mint_job_indexes() -> None:
     collection = _collection()
     existing = collection.index_information()
@@ -102,6 +178,14 @@ def ensure_mint_job_indexes() -> None:
             collection.create_index(keys, name=name)
         except OperationFailure:
             continue
+    # This sparse idempotency key closes the check-then-insert race without
+    # invalidating historical rows created before job keys existed.
+    collection.create_index(
+        [("job_key", 1)],
+        name="job_key_1_unique",
+        unique=True,
+        sparse=True,
+    )
 
 
 def _serialize_job(document: dict[str, Any]) -> dict[str, Any]:
@@ -163,10 +247,14 @@ def enqueue_job(
         raise ValueError("Mint job belongs to a non-canonical mint record.")
 
     now = _now()
+    job_key = (
+        f"{_normalize(project_id)}:{_normalize(mint_record_id)}:{normalized_job_type}"
+    )
     document = {
         "project_id": _object_id_or_text(project_id),
         "mint_record_id": _object_id_or_text(mint_record_id),
         "job_type": normalized_job_type,
+        "job_key": job_key,
         "status": "queued",
         "attempt_count": 0,
         "max_attempts": 5,
@@ -195,7 +283,43 @@ def enqueue_job(
     if existing is not None:
         return _serialize_job(existing)
 
-    result = _collection().insert_one(document)
+    terminal_existing = _collection().find_one({"job_key": job_key})
+    if terminal_existing is not None:
+        terminal_status = _normalize(terminal_existing.get("status")).lower()
+        attempts = int(terminal_existing.get("attempt_count") or 0)
+        max_attempts = int(terminal_existing.get("max_attempts") or 5)
+        if (
+            terminal_status in {"failed", "succeeded", "canceled"}
+            and attempts < max_attempts
+            and normalized_job_type == "sync_receipt"
+        ):
+            _collection().update_one(
+                {"_id": terminal_existing["_id"]},
+                {
+                    "$set": {
+                        "status": "queued",
+                        "run_after": run_after or now,
+                        "locked_by": None,
+                        "locked_at": None,
+                        "started_at": None,
+                        "finished_at": None,
+                        "error_code": None,
+                        "error_message": None,
+                        "updated_at": now,
+                    }
+                },
+            )
+            refreshed = _collection().find_one({"_id": terminal_existing["_id"]})
+            return _serialize_job(refreshed or terminal_existing)
+        return _serialize_job(terminal_existing)
+
+    try:
+        result = _collection().insert_one(document)
+    except DuplicateKeyError:
+        raced = _collection().find_one({"job_key": job_key})
+        if raced is None:
+            raise
+        return _serialize_job(raced)
     saved = _collection().find_one({"_id": result.inserted_id}) or document
     return _serialize_job(saved)
 
@@ -327,12 +451,73 @@ def _execute_mint_anchor(job: dict[str, Any], record: dict[str, Any]) -> dict[st
     if manifest is None:
         raise RuntimeError("Public manifest is missing for this mint record.")
 
-    mark_mint_minting(record["id"])
-    mint_result = mint_anchor(
-        metadata_uri=manifest["metadata_uri"],
-        recipient_wallet=record.get("customer_wallet"),
-        token_type=record.get("token_type") or "portrait_anchor",
-    )
+    lease_token = _acquire_signer_lease(record["id"])
+    try:
+        raw_record = _records_collection().find_one(
+            {"_id": _to_object_id(record["id"])}
+        ) or {}
+        existing_tx_hash = _normalize_tx_hash(
+            raw_record.get("tx_hash") or record.get("tx_hash")
+        )
+        if existing_tx_hash:
+            if (
+                _normalize(raw_record.get("broadcast_state")).lower() == "prepared"
+                and _normalize(raw_record.get("signed_transaction"))
+            ):
+                rebroadcast_signed_transaction(
+                    _normalize(raw_record.get("signed_transaction"))
+                )
+                _records_collection().update_one(
+                    {"_id": _to_object_id(record["id"])},
+                    {
+                        "$set": {
+                            "broadcast_state": "submitted",
+                            "broadcast_recovered_at": _now(),
+                            "updated_at": _now(),
+                        }
+                    },
+                )
+            return sync_receipt_for_mint_record(record["id"])
+
+        def persist_prepared_transaction(payload: dict[str, Any]) -> None:
+            tx_hash = _normalize_tx_hash(payload.get("tx_hash"))
+            _records_collection().update_one(
+                {"_id": _to_object_id(record["id"])},
+                {
+                    "$set": {
+                        "tx_hash": tx_hash,
+                        "mint_nonce": payload.get("nonce"),
+                        "signed_transaction": payload.get("signed_transaction"),
+                        "broadcast_state": "prepared",
+                        "transaction_prepared_at": _now(),
+                        "updated_at": _now(),
+                    }
+                },
+            )
+            mark_mint_minting(record["id"], tx_hash=tx_hash)
+
+        def persist_broadcast(payload: dict[str, Any]) -> None:
+            _records_collection().update_one(
+                {"_id": _to_object_id(record["id"])},
+                {
+                    "$set": {
+                        "broadcast_state": "submitted",
+                        "transaction_broadcast_at": _now(),
+                        "updated_at": _now(),
+                    }
+                },
+            )
+
+        mark_mint_minting(record["id"])
+        mint_result = mint_anchor(
+            metadata_uri=manifest["metadata_uri"],
+            recipient_wallet=record.get("customer_wallet"),
+            token_type=record.get("token_type") or "portrait_anchor",
+            on_transaction_prepared=persist_prepared_transaction,
+            on_transaction_broadcast=persist_broadcast,
+        )
+    finally:
+        _release_signer_lease(lease_token)
 
     token_id = _normalize(mint_result.get("token_id"))
     tx_hash = _normalize_tx_hash(mint_result.get("tx_hash"))
@@ -347,6 +532,7 @@ def _execute_mint_anchor(job: dict[str, Any], record: dict[str, Any]) -> dict[st
             contract_address=mint_result.get("contract_address"),
             chain=mint_result.get("chain"),
         )
+        _clear_completed_signed_transaction(record["id"])
 
     return mint_result
 
@@ -417,7 +603,7 @@ def sync_receipt_for_mint_record(mint_record_id: str) -> dict[str, Any]:
         )
 
     if token_id and synced_status in {"minted", "confirmed"}:
-        return mark_mint_minted(
+        minted = mark_mint_minted(
             mint_record_id,
             token_id=token_id,
             tx_hash=synced_tx_hash,
@@ -425,6 +611,8 @@ def sync_receipt_for_mint_record(mint_record_id: str) -> dict[str, Any]:
             contract_address=receipt.get("contract_address"),
             chain=receipt.get("chain"),
         )
+        _clear_completed_signed_transaction(mint_record_id)
+        return minted
 
     if synced_status == "confirmed":
         return mark_mint_failed(
@@ -470,7 +658,28 @@ def _finish_job(
 
 def run_next_job(worker_id: str) -> dict[str, Any]:
     now = _now()
-    job = _collection().find_one_and_update(
+    stale_before = now - timedelta(minutes=5)
+    collection = _collection()
+    if hasattr(collection, "update_many"):
+        collection.update_many(
+            {
+                "status": "started",
+                "locked_at": {"$lte": stale_before},
+            },
+            {
+                "$set": {
+                    "status": "queued",
+                    "locked_by": None,
+                    "locked_at": None,
+                    "started_at": None,
+                    "run_after": now,
+                    "error_code": "stale_worker_lease_recovered",
+                    "error_message": "A stale worker lease was recovered automatically.",
+                    "updated_at": now,
+                }
+            },
+        )
+    job = collection.find_one_and_update(
         {
             "status": "queued",
             "run_after": {"$lte": now},
@@ -597,14 +806,23 @@ def run_next_job(worker_id: str) -> dict[str, Any]:
             serialized_job["job_type"] == "sync_receipt"
             and _normalize((result or {}).get("status")).lower() == "pending"
         ):
-            enqueue_job(
-                project_id=record["project_id"],
-                mint_record_id=record["id"],
-                job_type="sync_receipt",
-                priority=60,
-                run_after=_now() + timedelta(seconds=60),
-                payload={"version_number": record["version_number"]},
+            _collection().update_one(
+                {"_id": job["_id"]},
+                {
+                    "$set": {
+                        "status": "queued",
+                        "run_after": _now() + timedelta(seconds=60),
+                        "locked_by": None,
+                        "locked_at": None,
+                        "started_at": None,
+                        "finished_at": None,
+                        "result": result or {},
+                        "updated_at": _now(),
+                    }
+                },
             )
+            refreshed = _collection().find_one({"_id": job["_id"]}) or job
+            return _serialize_job(refreshed)
 
         return _finish_job(
             job["_id"],
@@ -624,21 +842,28 @@ def run_next_job(worker_id: str) -> dict[str, Any]:
                 "tx_hash": record.get("tx_hash"),
             },
         )
-        mark_mint_failed(
-            record["id"],
-            error_code="mint_job_failed",
-            error_message=str(exc),
-        )
         retry_delay = now + timedelta(minutes=5)
+        attempt_count = int(serialized_job.get("attempt_count") or 0)
+        max_attempts = int(serialized_job.get("max_attempts") or 5)
+        will_retry = attempt_count < max_attempts
+        if not will_retry:
+            mark_mint_failed(
+                record["id"],
+                error_code="mint_job_failed",
+                error_message=str(exc),
+            )
         _collection().update_one(
             {"_id": job["_id"]},
             {
                 "$set": {
-                    "status": "failed",
+                    "status": "queued" if will_retry else "failed",
                     "run_after": retry_delay,
+                    "locked_by": None,
+                    "locked_at": None,
+                    "started_at": None if will_retry else serialized_job.get("started_at"),
                     "error_code": "mint_job_failed",
                     "error_message": str(exc),
-                    "finished_at": _now(),
+                    "finished_at": None if will_retry else _now(),
                     "updated_at": _now(),
                 }
             },

--- a/backend/app/services/relationship_guardrails.py
+++ b/backend/app/services/relationship_guardrails.py
@@ -10,10 +10,18 @@ from app.core.relationship_catalog import (
     ALLOWED_RELATIONSHIP_TYPES,
     ANCESTRY_RELATIONSHIP_TYPES,
     BIOLOGICAL_PARENT_RELATIONSHIP_TYPE,
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    SIBLING_RELATIONSHIP_TYPES,
     SYMMETRIC_RELATIONSHIP_TYPES,
     normalize_relationship_type,
 )
 from app.schemas.relationship import RelationshipCreate
+from app.services.family_placement_service import (
+    FamilyPlacementError,
+    calculate_family_placement,
+    rebuild_family_placement,
+)
 
 MIN_PARENT_CHILD_AGE_GAP = 12
 logger = logging.getLogger(__name__)
@@ -62,6 +70,23 @@ class RelationshipGuardrailService:
                 ),
             )
         payload.relationship_type = normalized_relationship_type
+
+        if payload.relationship_mode == "verified":
+            if payload.status_marker != "verified":
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Verified relationships must use the verified status marker.",
+                )
+            if not payload.evidence_record_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Verified relationships require at least one approved evidence record.",
+                )
+        elif payload.status_marker == "verified":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A verified marker cannot be used for a narrative relationship.",
+            )
 
         if payload.source_member_id == payload.target_member_id:
             raise HTTPException(
@@ -112,6 +137,8 @@ class RelationshipGuardrailService:
                 detail="Cross-family links are not allowed. Members belong to different families.",
             )
 
+        self._validate_evidence_records(payload)
+
         duplicate = self._find_duplicate(payload)
         if duplicate:
             raise HTTPException(
@@ -123,6 +150,22 @@ class RelationshipGuardrailService:
             self._validate_no_ancestry_cycle(payload)
 
         self._validate_relationship_rules(payload, source_member, target_member)
+        try:
+            calculate_family_placement(
+                self.db,
+                payload.family_id,
+                extra_relationship={
+                    "family_id": payload.family_id,
+                    "source_member_id": payload.source_member_id,
+                    "target_member_id": payload.target_member_id,
+                    "relationship_type": payload.relationship_type,
+                },
+            )
+        except FamilyPlacementError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            ) from exc
 
     def create_relationship(self, payload: RelationshipCreate) -> dict[str, Any]:
         self.ensure_indexes()
@@ -133,14 +176,54 @@ class RelationshipGuardrailService:
             "source_member_id": payload.source_member_id,
             "target_member_id": payload.target_member_id,
             "relationship_type": payload.relationship_type,
+            "relationship_mode": payload.relationship_mode,
+            "status_marker": payload.status_marker,
+            "privacy_scope": payload.privacy_scope,
+            "relationship_label": payload.relationship_label,
+            "evidence_record_ids": list(payload.evidence_record_ids),
+            "valid_from": payload.valid_from,
+            "valid_to": payload.valid_to,
             "notes": payload.notes,
             "created_by": payload.created_by,
             "created_at": datetime.now(timezone.utc),
         }
 
         result = self.relationships.insert_one(document)
+        rebuild_family_placement(self.db, payload.family_id)
         created = self.relationships.find_one({"_id": result.inserted_id})
         return normalize_mongo_doc(created)
+
+    def _validate_evidence_records(self, payload: RelationshipCreate) -> None:
+        if not payload.evidence_record_ids:
+            return
+
+        for evidence_id in payload.evidence_record_ids:
+            if not ObjectId.is_valid(evidence_id):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Relationship evidence contains an invalid record id.",
+                )
+            evidence = self.db["uploaded_files"].find_one({"_id": ObjectId(evidence_id)})
+            if not evidence:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Relationship evidence record was not found.",
+                )
+            if str(evidence.get("family_id") or "") != payload.family_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Relationship evidence belongs to a different family.",
+                )
+            if (
+                str(evidence.get("category") or "") != "verification_evidence"
+                or str(evidence.get("scan_status") or "").lower() != "clean"
+                or bool(evidence.get("quarantined"))
+                or str(evidence.get("verification_status") or "").lower() != "approved"
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Verified relationships require clean, approved verification evidence.",
+                )
 
     def _find_member(self, member_id: str):
         member = self.family_members.find_one({"_id": self._to_object_id_or_raw(member_id)})
@@ -238,8 +321,8 @@ class RelationshipGuardrailService:
 
         pair_relationships = self._get_pair_relationships(family_id, source_id, target_id)
 
-        if rel_type == "spouse":
-            forbidden = {"sibling"} | ANCESTRY_RELATIONSHIP_TYPES
+        if rel_type in PARTNER_RELATIONSHIP_TYPES:
+            forbidden = set(SIBLING_RELATIONSHIP_TYPES) | ANCESTRY_RELATIONSHIP_TYPES
             if any(r["relationship_type"] in forbidden for r in pair_relationships):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -249,8 +332,8 @@ class RelationshipGuardrailService:
                     ),
                 )
 
-        elif rel_type == "sibling":
-            forbidden = {"spouse"} | ANCESTRY_RELATIONSHIP_TYPES
+        elif rel_type in SIBLING_RELATIONSHIP_TYPES:
+            forbidden = set(PARTNER_RELATIONSHIP_TYPES) | ANCESTRY_RELATIONSHIP_TYPES
             if any(r["relationship_type"] in forbidden for r in pair_relationships):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -261,7 +344,7 @@ class RelationshipGuardrailService:
                 )
 
         elif rel_type in ANCESTRY_RELATIONSHIP_TYPES:
-            forbidden = {"spouse", "sibling"}
+            forbidden = set(PARTNER_RELATIONSHIP_TYPES) | set(SIBLING_RELATIONSHIP_TYPES)
             if any(r["relationship_type"] in forbidden for r in pair_relationships):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -298,7 +381,7 @@ class RelationshipGuardrailService:
         source_member: dict[str, Any],
         target_member: dict[str, Any],
     ) -> None:
-        if payload.relationship_type not in ANCESTRY_RELATIONSHIP_TYPES:
+        if payload.relationship_type not in PARENT_RELATIONSHIP_TYPES:
             return
 
         source_birth_date = self._extract_birth_date(source_member)
@@ -307,7 +390,7 @@ class RelationshipGuardrailService:
         if not source_birth_date or not target_birth_date:
             return
 
-        if source_birth_date >= target_birth_date:
+        if source_birth_date < target_birth_date:
             age_gap = self._calculate_year_gap(source_birth_date, target_birth_date)
             if age_gap < MIN_PARENT_CHILD_AGE_GAP:
                 raise HTTPException(
@@ -321,7 +404,7 @@ class RelationshipGuardrailService:
 
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid ancestry relationship. Parent/guardian cannot be younger than child.",
+            detail="Invalid ancestry relationship. Parent/guardian cannot be the same age as or younger than child.",
         )
 
     def _validate_reverse_ancestry_conflict(self, payload: RelationshipCreate) -> None:

--- a/backend/app/services/tree_service.py
+++ b/backend/app/services/tree_service.py
@@ -6,10 +6,13 @@ from bson import ObjectId
 
 from app.core.relationship_catalog import (
     ALLOWED_RELATIONSHIP_TYPES,
-    ANCESTRY_RELATIONSHIP_TYPES,
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    SYMMETRIC_RELATIONSHIP_TYPES,
     normalize_relationship_type,
 )
 from app.database import get_database
+from app.services.linked_network_service import build_linked_network
 
 
 def _json_safe(value: Any) -> Any:
@@ -68,6 +71,12 @@ def _serialize_member(member: dict) -> dict:
             ).strip(),
             "birth_year": member.get("birth_year"),
             "generation": member.get("generation"),
+            "placement_status": member.get("placement_status") or "unplaced",
+            "approved_photo_upload_id": _string_or_none(
+                member.get("_approved_photo_upload_id")
+                or member.get("approved_photo_upload_id")
+            ),
+            "portrait_url": member.get("_approved_portrait_url") or "",
             "father_id": _string_or_none(member.get("father_id")),
             "mother_id": _string_or_none(member.get("mother_id")),
             "spouse_id": _string_or_none(member.get("spouse_id")),
@@ -120,8 +129,17 @@ def _serialize_relationship(rel: dict) -> dict:
             ),
             "relationship_mode": rel.get("relationship_mode"),
             "status_marker": rel.get("status_marker"),
+            "privacy_scope": rel.get("privacy_scope"),
+            "relationship_label": rel.get("relationship_label"),
+            "evidence_record_ids": list(rel.get("evidence_record_ids") or []),
+            "valid_from": rel.get("valid_from"),
+            "valid_to": rel.get("valid_to"),
             "notes": rel.get("notes"),
             "created_at": rel.get("created_at"),
+            "source_household_id": rel.get("source_household_id"),
+            "target_household_id": rel.get("target_household_id"),
+            "is_household_bridge": bool(rel.get("is_household_bridge")),
+            "alignment_status": rel.get("alignment_status"),
         }
     )
 
@@ -139,6 +157,8 @@ def _build_edges(relationships: list[dict]) -> list[dict]:
                     ),
                     "relationship_mode": rel.get("relationship_mode"),
                     "status_marker": rel.get("status_marker"),
+                    "is_household_bridge": bool(rel.get("is_household_bridge")),
+                    "alignment_status": rel.get("alignment_status"),
                 }
             )
         )
@@ -192,7 +212,7 @@ def _collect_tree_relationships(members: list[dict], relationships: list[dict]) 
     normalized: list[dict] = []
     seen_keys: set[tuple[str | None, str | None, str]] = set()
 
-    symmetric_types = {"spouse", "former_spouse", "sibling", "household_member"}
+    symmetric_types = SYMMETRIC_RELATIONSHIP_TYPES
 
     for rel in relationships:
         candidate = _normalized_relationship_document(rel)
@@ -248,8 +268,8 @@ def _relationship_allowed_for_mode(rel: dict, mode: str) -> bool:
 
 
 def _build_union_nodes(people: dict[str, dict[str, Any]], relationships: list[dict]) -> list[dict[str, Any]]:
-    primary_parent_types = {"biological_parent", "adoptive_parent"}
-    spouse_types = {"spouse", "former_spouse"}
+    primary_parent_types = PARENT_RELATIONSHIP_TYPES
+    spouse_types = PARTNER_RELATIONSHIP_TYPES
     spouse_pairs: dict[tuple[str, str], str] = {}
     for rel in relationships:
         rel_type = normalize_relationship_type(rel.get("relationship_type"))
@@ -332,15 +352,15 @@ def _build_tree_model(members: list[dict], relationships: list[dict]) -> dict[st
         if not source_id or not target_id:
             continue
 
-        if source_id in people and rel_type in ANCESTRY_RELATIONSHIP_TYPES:
+        if source_id in people and rel_type in PARENT_RELATIONSHIP_TYPES:
             current = set(people[source_id]["child_ids"])
             current.add(target_id)
             people[source_id]["child_ids"] = sorted(current)
-        if target_id in people and rel_type in ANCESTRY_RELATIONSHIP_TYPES:
+        if target_id in people and rel_type in PARENT_RELATIONSHIP_TYPES:
             current = set(people[target_id]["parent_ids"])
             current.add(source_id)
             people[target_id]["parent_ids"] = sorted(current)
-        if rel_type in {"spouse", "former_spouse"}:
+        if rel_type in PARTNER_RELATIONSHIP_TYPES:
             if source_id in people:
                 current = set(people[source_id]["spouse_ids"])
                 current.add(target_id)
@@ -354,7 +374,7 @@ def _build_tree_model(members: list[dict], relationships: list[dict]) -> dict[st
             related_people_by_id[source_id].append(
                 {"person_id": target_id, "relationship_type": rel_type}
             )
-        if rel_type in {"spouse", "former_spouse", "sibling", "household_member"} and target_id in related_people_by_id:
+        if rel_type in SYMMETRIC_RELATIONSHIP_TYPES and target_id in related_people_by_id:
             related_people_by_id[target_id].append(
                 {"person_id": source_id, "relationship_type": rel_type}
             )
@@ -395,7 +415,75 @@ def _find_family(db, family_id: str):
 
 def _find_members(db, family_id: str) -> list[dict]:
     candidates = _family_id_candidates(family_id)
-    return list(db.family_members.find({"family_id": {"$in": candidates}}))
+    members = list(db.family_members.find({"family_id": {"$in": candidates}}))
+    uploads = db["uploaded_files"]
+    for member in members:
+        member_id = str(member.get("_id") or "")
+        approved_upload = None
+        approved_upload_id = str(member.get("approved_photo_upload_id") or "").strip()
+        if approved_upload_id and ObjectId.is_valid(approved_upload_id):
+            approved_upload = uploads.find_one({"_id": ObjectId(approved_upload_id)})
+
+        if not _portrait_upload_is_ready(
+            approved_upload,
+            family_id=str(member.get("family_id") or family_id),
+            member_id=member_id,
+        ):
+            candidates_for_member = list(
+                uploads.find(
+                    {
+                        "family_id": str(member.get("family_id") or family_id),
+                        "member_id": member_id,
+                        "category": "member_photo",
+                    }
+                )
+            )
+            candidates_for_member.sort(
+                key=lambda item: str(item.get("created_at") or ""),
+                reverse=True,
+            )
+            approved_upload = next(
+                (
+                    upload
+                    for upload in candidates_for_member
+                    if _portrait_upload_is_ready(
+                        upload,
+                        family_id=str(member.get("family_id") or family_id),
+                        member_id=member_id,
+                    )
+                ),
+                None,
+            )
+
+        if approved_upload:
+            upload_id = str(approved_upload.get("_id") or "")
+            member["_approved_photo_upload_id"] = upload_id
+            member["_approved_portrait_url"] = (
+                f"/uploads/{upload_id}/download" if upload_id else ""
+            )
+    return members
+
+
+def _portrait_upload_is_ready(
+    upload: dict[str, Any] | None,
+    *,
+    family_id: str,
+    member_id: str,
+) -> bool:
+    if not upload:
+        return False
+    return bool(
+        str(upload.get("category") or "") == "member_photo"
+        and str(upload.get("family_id") or "") == family_id
+        and str(upload.get("member_id") or "") == member_id
+        and str(upload.get("scan_status") or "").lower() == "clean"
+        and not bool(upload.get("quarantined"))
+        and bool(upload.get("approved_for_cinematic"))
+        and str(upload.get("verification_status") or "").lower() == "approved"
+        and str(upload.get("consent_status") or "").lower() == "approved"
+        and bool(upload.get("consent_attested"))
+        and bool(upload.get("authority_attested"))
+    )
 
 
 def _find_nodes(db, family_id: str) -> list[dict]:
@@ -666,5 +754,150 @@ def get_linked_family_tree(family_id: str, mode: str = "default") -> dict:
         ],
         "edges": _build_edges(relationships),
         "linked_family_ids": seen_family_ids,
+        "tree_model": _build_tree_model(members, relationships),
+    }
+
+
+def get_authorized_linked_family_tree(
+    family_id: str,
+    mode: str,
+    *,
+    project_id: str,
+    current_user_id: str,
+    workspace_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the privacy-filtered, generation-aligned linked tree.
+
+    The older linked-tree builder joined families by household id but did not
+    apply bridge offsets or cross-household privacy. This adapter uses the same
+    authorized linked-network graph as reunion readiness, then presents it in
+    the shape consumed by the tree UI.
+    """
+    db = get_database()
+    if db is None:
+        return {
+            "family_id": family_id,
+            "mode": mode,
+            "family": None,
+            "members": [],
+            "nodes": [],
+            "relationships": [],
+            "edges": [],
+            "linked_family_ids": [],
+            "households": [],
+            "alignment_conflicts": [],
+        }
+
+    network = build_linked_network(
+        project_id,
+        current_user_id,
+        workspace_context=workspace_context,
+    )
+    members: list[dict[str, Any]] = []
+    for node in network.get("nodes") or []:
+        aligned_generation = node.get("aligned_generation")
+        generation = (
+            aligned_generation
+            if aligned_generation is not None
+            else node.get("local_generation")
+        )
+        members.append(
+            {
+                "_id": node.get("id"),
+                "family_id": node.get("family_id"),
+                "household_id": node.get("source_household_id"),
+                "first_name": node.get("first_name"),
+                "last_name": node.get("last_name"),
+                "display_name": node.get("display_name"),
+                "birth_year": node.get("birth_year"),
+                "generation": generation,
+                "local_generation": node.get("local_generation"),
+                "placement_status": node.get("placement_status") or "unplaced",
+                "bio": node.get("bio"),
+                "privacy_marker": node.get("visibility_scope"),
+                "is_verified": node.get("is_verified"),
+                "_approved_photo_upload_id": node.get(
+                    "approved_photo_upload_id"
+                ),
+                "_approved_portrait_url": node.get("portrait_url") or "",
+            }
+        )
+
+    relationships: list[dict[str, Any]] = []
+    for edge in network.get("edges") or []:
+        relationship = {
+            "_id": edge.get("id"),
+            "family_id": family_id,
+            "source_member_id": edge.get("source_member_id"),
+            "target_member_id": edge.get("target_member_id"),
+            "relationship_type": edge.get("relationship_type"),
+            "relationship_mode": edge.get("relationship_mode") or "narrative",
+            "status_marker": edge.get("status_marker") or "narrative",
+            "privacy_scope": edge.get("privacy_scope") or "household_private",
+            "relationship_label": edge.get("relationship_label"),
+            "notes": edge.get("notes"),
+            "source_household_id": edge.get("source_household_id"),
+            "target_household_id": edge.get("target_household_id"),
+            "is_household_bridge": bool(edge.get("is_household_bridge")),
+            "alignment_status": edge.get("alignment_status"),
+        }
+        if str(mode or "default").strip().lower() != "default" and not (
+            _relationship_allowed_for_mode(relationship, mode)
+        ):
+            continue
+        relationships.append(relationship)
+
+    members_by_generation: dict[int, list[dict[str, Any]]] = {}
+    for member in members:
+        try:
+            generation = int(member.get("generation"))
+        except (TypeError, ValueError):
+            generation = 0
+        members_by_generation.setdefault(generation, []).append(member)
+
+    lineage_nodes: list[dict[str, Any]] = []
+    for generation, generation_members in sorted(members_by_generation.items()):
+        for row, member in enumerate(
+            sorted(
+                generation_members,
+                key=lambda item: str(item.get("_id") or ""),
+            )
+        ):
+            member_id = str(member.get("_id") or "")
+            lineage_nodes.append(
+                {
+                    "_id": f"linked-node::{member_id}",
+                    "family_id": family_id,
+                    "member_id": member_id,
+                    "generation": generation,
+                    "x": float(generation * 360),
+                    "y": float(row * 180),
+                    "parent_node_ids": [],
+                    "child_node_ids": [],
+                }
+            )
+
+    family_ids = sorted(
+        {
+            str(household.get("family_id") or "")
+            for household in network.get("households") or []
+            if str(household.get("family_id") or "")
+        }
+    )
+    return {
+        "family_id": family_id,
+        "mode": mode,
+        "family": _serialize_family(_find_family(db, family_id)),
+        "members": [_serialize_member(member) for member in members],
+        "nodes": [_serialize_node(node) for node in lineage_nodes],
+        "relationships": [
+            _serialize_relationship(relationship)
+            for relationship in relationships
+        ],
+        "edges": _build_edges(relationships),
+        "linked_family_ids": family_ids,
+        "households": network.get("households") or [],
+        "alignment_conflicts": network.get("alignment_conflicts") or [],
+        "network_summary": network.get("network_summary") or {},
         "tree_model": _build_tree_model(members, relationships),
     }

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -131,6 +131,8 @@ def serialize_upload_record(record: dict[str, Any]) -> dict[str, Any]:
         "verification_type": record.get("verification_type"),
         "original_filename": record.get("original_filename"),
         "stored_filename": record.get("stored_filename"),
+        # Internal callers need this to run malware scanning. Public routes remove it.
+        "relative_path": record.get("relative_path"),
         "content_type": record.get("content_type"),
         "size_bytes": record.get("size_bytes"),
         "uploaded_by": record.get("uploaded_by"),
@@ -145,8 +147,17 @@ def serialize_upload_record(record: dict[str, Any]) -> dict[str, Any]:
         "asset_type": record.get("asset_type") or record.get("category"),
         "verification_status": record.get("verification_status") or "pending",
         "consent_status": record.get("consent_status") or "pending",
+        "consent_attested": bool(record.get("consent_attested")),
+        "authority_attested": bool(record.get("authority_attested")),
+        "consent_attested_at": record.get("consent_attested_at"),
         "approved_for_cinematic": bool(record.get("approved_for_cinematic")),
         "approved_by": record.get("approved_by"),
+        "master_review_status": record.get("master_review_status") or "pending",
+        "master_reviewed_at": record.get("master_reviewed_at"),
+        "master_review_notes": record.get("master_review_notes") or "",
+        "verified_by": record.get("verified_by"),
+        "verified_at": record.get("verified_at"),
+        "verification_review_notes": record.get("verification_review_notes") or "",
         "share_with_linked_families": bool(record.get("share_with_linked_families")),
         "customer_visible": bool(record.get("customer_visible", True)),
         "internal_only": bool(record.get("internal_only")),
@@ -168,7 +179,14 @@ async def store_member_photo_upload(
     upload: UploadFile,
     uploaded_by: str,
     uploaded_by_user_id: str = "",
+    consent_attested: bool = False,
+    authority_attested: bool = False,
 ) -> dict[str, Any]:
+    if not consent_attested or not authority_attested:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Portrait consent and upload authority must both be confirmed.",
+        )
     content_type = str(upload.content_type or "").strip().lower()
     if content_type not in IMAGE_CONTENT_TYPES:
         raise HTTPException(
@@ -211,8 +229,15 @@ async def store_member_photo_upload(
         "asset_type": "portrait",
         "verification_status": "pending",
         "consent_status": "pending",
+        "consent_attested": True,
+        "authority_attested": True,
+        "consent_attested_at": now_iso,
+        "consent_attested_by_user_id": uploaded_by_user_id,
         "approved_for_cinematic": False,
         "approved_by": None,
+        "master_review_status": "pending",
+        "master_reviewed_at": None,
+        "master_review_notes": "",
         "share_with_linked_families": False,
         "evidence_kind": "",
         "verification_type": "",
@@ -240,11 +265,8 @@ async def store_member_photo_upload(
         {"_id": ObjectId(member_id)},
         {
             "$set": {
-                "photo_upload_id": upload_id,
-                "photo_path": upload_record["relative_path"],
-                "photo_original_filename": original_filename,
-                "photo_content_type": content_type,
-                "photo_size_bytes": size_bytes,
+                "pending_photo_upload_id": upload_id,
+                "photo_submission_status": "pending_scan",
                 "updated_at": now_iso,
                 "updated_by": uploaded_by,
                 "updated_by_user_id": uploaded_by_user_id,

--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -8,9 +8,15 @@ from bson import ObjectId
 from app.core.package_type_catalog import normalize_package_type
 from app.core.state_catalog import normalize_visibility_state
 from app.core.package_catalog import get_package, normalize_package_code
+from app.core.relationship_catalog import (
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    normalize_relationship_type,
+)
 from app.database import get_database
 from app.dependencies.auth import has_internal_admin_access
 from app.services.entitlement_service import resolve_project_entitlements
+from app.services.family_placement_service import rebuild_family_placement
 from app.services.project_entitlement_service import get_project_entitlement
 from app.services.project_service import list_projects
 
@@ -540,7 +546,9 @@ def ensure_project_workspace_anchor(
             "family_id": family_id,
             "first_name": first_name,
             "last_name": last_name,
-            "generation": 1,
+            "generation": 0,
+            "generation_locked": False,
+            "placement_status": "root",
             "bio": _build_anchor_description(
                 lane=lane,
                 project=project,
@@ -559,6 +567,7 @@ def ensure_project_workspace_anchor(
         result = family_members.insert_one(member_payload)
         member_payload["_id"] = result.inserted_id
         primary_member = member_payload
+        rebuild_family_placement(db, family_id)
 
     return family_doc, primary_member, project
 
@@ -651,7 +660,9 @@ def _sequence_members_for_viewer(
     members_with_photos = [
         member
         for member in _sort_members(members)
-        if _normalize_value(member.get("photo_upload_id"))
+        if _normalize_value(
+            member.get("approved_photo_upload_id") or member.get("photo_upload_id")
+        )
     ]
 
     primary_member_id = _normalize_value((primary_member or {}).get("_id"))
@@ -685,7 +696,9 @@ def _resolve_member_photo_upload(
     member_id = _normalize_value(member.get("_id"))
     candidate_upload_ids: list[str] = []
 
-    primary_upload_id = _normalize_value(member.get("photo_upload_id"))
+    primary_upload_id = _normalize_value(
+        member.get("approved_photo_upload_id") or member.get("photo_upload_id")
+    )
     if primary_upload_id:
         candidate_upload_ids.append(primary_upload_id)
 
@@ -709,19 +722,71 @@ def _resolve_member_photo_upload(
         upload = uploads.find_one({"_id": ObjectId(upload_id)})
         if upload is None:
             continue
-        if _normalize_value(upload.get("category")) != "member_photo":
-            continue
-        if _normalize_value(upload.get("project_id")) != project_id:
-            continue
-        if _normalize_value(upload.get("family_id")) != family_id:
-            continue
-        if _normalize_value(upload.get("member_id")) != member_id:
-            continue
-        if not _normalize_value(upload.get("relative_path")):
-            continue
-        return upload
+        if _upload_is_cinematic_ready(
+            upload,
+            project_id=project_id,
+            family_id=family_id,
+            member_id=member_id,
+        ):
+            return upload
 
     return None
+
+
+def _upload_is_cinematic_ready(
+    upload: dict[str, Any] | None,
+    *,
+    project_id: str,
+    family_id: str,
+    member_id: str,
+) -> bool:
+    if not upload:
+        return False
+    return bool(
+        _normalize_value(upload.get("category")) == "member_photo"
+        and _normalize_value(upload.get("project_id")) == project_id
+        and _normalize_value(upload.get("family_id")) == family_id
+        and _normalize_value(upload.get("member_id")) == member_id
+        and _normalize_value(upload.get("relative_path"))
+        and _normalize_value(upload.get("scan_status")).lower() == "clean"
+        and not bool(upload.get("quarantined"))
+        and bool(upload.get("approved_for_cinematic"))
+        and _normalize_value(upload.get("verification_status")).lower() == "approved"
+        and _normalize_value(upload.get("consent_status")).lower() == "approved"
+        and bool(upload.get("consent_attested"))
+        and bool(upload.get("authority_attested"))
+    )
+
+
+def _relationship_navigation(
+    relationships: list[dict[str, Any]],
+    visible_member_ids: set[str],
+) -> dict[str, dict[str, list[str]]]:
+    navigation = {
+        member_id: {"parents": [], "children": [], "partners": [], "branches": []}
+        for member_id in visible_member_ids
+    }
+    for relationship in relationships:
+        source_id = _normalize_value(relationship.get("source_member_id"))
+        target_id = _normalize_value(relationship.get("target_member_id"))
+        if source_id not in visible_member_ids or target_id not in visible_member_ids:
+            continue
+        relationship_type = normalize_relationship_type(
+            relationship.get("relationship_type")
+        )
+        if relationship_type in PARENT_RELATIONSHIP_TYPES:
+            navigation[source_id]["children"].append(target_id)
+            navigation[target_id]["parents"].append(source_id)
+        elif relationship_type in PARTNER_RELATIONSHIP_TYPES:
+            navigation[source_id]["partners"].append(target_id)
+            navigation[target_id]["partners"].append(source_id)
+        else:
+            navigation[source_id]["branches"].append(target_id)
+            navigation[target_id]["branches"].append(source_id)
+    for member_navigation in navigation.values():
+        for key, member_ids in member_navigation.items():
+            member_navigation[key] = sorted(set(member_ids))
+    return navigation
 
 
 def build_viewer_manifest(
@@ -792,7 +857,17 @@ def build_viewer_manifest(
                 upload_id = _normalize_value(member.get("photo_upload_id"))
                 if upload_id and ObjectId.is_valid(upload_id):
                     candidate = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
-                    if candidate and _normalize_value(candidate.get("project_id")) == project_id_value:
+                    if (
+                        candidate
+                        and _normalize_value(candidate.get("project_id")) == project_id_value
+                        and _normalize_value(candidate.get("scan_status")).lower() == "clean"
+                        and not bool(candidate.get("quarantined"))
+                        and bool(candidate.get("approved_for_cinematic"))
+                        and _normalize_value(candidate.get("verification_status")).lower() == "approved"
+                        and _normalize_value(candidate.get("consent_status")).lower() == "approved"
+                        and bool(candidate.get("consent_attested"))
+                        and bool(candidate.get("authority_attested"))
+                    ):
                         upload_record = candidate
             else:
                 upload_record = _resolve_member_photo_upload(
@@ -803,6 +878,20 @@ def build_viewer_manifest(
                 )
             if upload_record is not None:
                 valid_member_views.append((member, upload_record))
+
+        visible_member_ids = {
+            _normalize_value(member.get("_id"))
+            for member, _upload in valid_member_views
+        }
+        family_relationships = (
+            list(db["relationships"].find({"family_id": family_id_value}))
+            if family_id_value
+            else []
+        )
+        relationship_navigation = _relationship_navigation(
+            family_relationships,
+            visible_member_ids,
+        )
 
         for index, (member, upload_record) in enumerate(valid_member_views):
             member_id = _normalize_value(member.get("_id"))
@@ -835,8 +924,44 @@ def build_viewer_manifest(
                     "node": title,
                     "description": description,
                     "narration": description,
-                    "left_state_id": f"member-{_normalize_value(valid_member_views[index - 1][0].get('_id'))}" if index > 0 else None,
-                    "right_state_id": f"member-{_normalize_value(valid_member_views[index + 1][0].get('_id'))}" if index + 1 < len(valid_member_views) else None,
+                    "generation": _coerce_int(member.get("generation")),
+                    "placement_status": _normalize_value(
+                        member.get("placement_status")
+                    ) or "unplaced",
+                    "left_state_id": (
+                        f"member-{relationship_navigation.get(member_id, {}).get('parents', [])[0]}"
+                        if relationship_navigation.get(member_id, {}).get("parents")
+                        else (
+                            f"member-{_normalize_value(valid_member_views[index - 1][0].get('_id'))}"
+                            if index > 0
+                            else None
+                        )
+                    ),
+                    "right_state_id": (
+                        f"member-{relationship_navigation.get(member_id, {}).get('children', [])[0]}"
+                        if relationship_navigation.get(member_id, {}).get("children")
+                        else (
+                            f"member-{_normalize_value(valid_member_views[index + 1][0].get('_id'))}"
+                            if index + 1 < len(valid_member_views)
+                            else None
+                        )
+                    ),
+                    "parent_state_ids": [
+                        f"member-{related_id}"
+                        for related_id in relationship_navigation.get(member_id, {}).get("parents", [])
+                    ],
+                    "child_state_ids": [
+                        f"member-{related_id}"
+                        for related_id in relationship_navigation.get(member_id, {}).get("children", [])
+                    ],
+                    "partner_state_ids": [
+                        f"member-{related_id}"
+                        for related_id in relationship_navigation.get(member_id, {}).get("partners", [])
+                    ],
+                    "branch_state_ids": [
+                        f"member-{related_id}"
+                        for related_id in relationship_navigation.get(member_id, {}).get("branches", [])
+                    ],
                     "eye_targets": DEFAULT_EYE_TARGETS,
                 }
             )

--- a/backend/docs/governance/tomb_of_light_family_operating_model.md
+++ b/backend/docs/governance/tomb_of_light_family_operating_model.md
@@ -1,0 +1,213 @@
+# Tomb of Light Family Operating Model
+
+Status: Phase 13 implementation contract  
+Source design reviewed: `verified and narrative breakdown-3.pdf` (53 pages)
+
+## Product promise
+
+Tomb of Light is a network of independently controlled household trees. A
+household owns and edits its own records, connects to another household only by
+a two-sided Family Key handshake, and shares only the records explicitly made
+available at that boundary. Private family files, passwords, MFA data, wallet
+secrets, and the detailed living-person record stay out of linked-family views
+and out of public NFT metadata.
+
+The operating sequence is:
+
+`signup/provisioning -> family intake -> people -> relationships -> automatic placement -> named portrait dropboxes -> security scan -> master review -> tree + cinematic slides -> family review -> mint readiness -> blockchain anchor -> continuity`
+
+## Truth and privacy layers
+
+| Layer | Meaning | Enforcement |
+| --- | --- | --- |
+| Verified Tree | A relationship supported by an approved family record | Requires at least one `verification_evidence` upload that is clean, not quarantined, and master-approved |
+| Narrative Tree | Lived, family-held, cultural, step, guardian, adoptive, or chosen-family truth | Clearly marked `narrative`; it cannot claim the verified marker |
+| Privacy | Who may see the relationship or person | Owner-only, owner/co-owner, household-private, branch-shared, linked-family-shared, public memorial, or minor-protected |
+
+A death flag never overrides privacy. Public memorial sharing must still be an
+explicit privacy choice.
+
+## Relationship coverage and direction
+
+Inside one household, every ancestry record is canonical: **source is the
+parent/elder and target is the child/younger-generation member**. Child labels
+are derived from that edge. This avoids contradictory parent and child records
+for the same fact.
+
+| Group | Supported relationship types |
+| --- | --- |
+| Biological and reproductive parents | Biological parent, gestational parent, donor parent, intended parent |
+| Legal and caregiving parents | Adoptive parent, foster parent, step-parent, guardian |
+| Narrative parents | Chosen parent, community parent, spiritual parent |
+| Partners | Spouse, former spouse, domestic partner, former partner, co-parent |
+| Siblings and peers | Sibling, half-sibling, step-sibling, adoptive sibling, chosen sibling, cousin |
+| Extended family | Grandparent, aunt/uncle, in-law, other relative |
+| Cultural and community | Godparent, mentor, clan/cultural elder, spiritual elder, family friend, household member |
+| Technical graph links | Same-person identity bridge, linked-household bridge |
+
+The customer form spells out `parent -> child`, including
+`step-parent -> stepchild`, and uses member selectors rather than typed database
+IDs. The add-member form provides two guided parent/guardian boxes and one
+partner box.
+
+For cross-household links, both directions are offered. A requester may say
+that their anchor is the parent, grandparent, aunt/uncle, spouse, sibling, or
+cousin of the receiving anchor, or that their anchor is the biological,
+gestational, donor-conceived, intended, adopted, foster, step, chosen,
+community, or spiritual child, ward, grandchild, or niece/nephew of the
+receiving anchor.
+
+## Automatic placement
+
+| Edge | Target generation relative to source |
+| --- | ---: |
+| Parent/guardian/caregiving parent -> child | +1 |
+| Grandparent -> grandchild | +2 |
+| Aunt/uncle -> niece/nephew | +1 |
+| Partner, sibling, cousin, same-person bridge | 0 |
+| Child -> parent (cross-household bridge choice) | -1 |
+| Grandchild -> grandparent (cross-household bridge choice) | -2 |
+
+Customers cannot type or lock a generation. The placement solver derives every
+generation from relationship constraints, creates/updates one lineage node per
+member, and rejects a relationship that would put one person in two different
+generations or create an ancestry cycle. Isolated people in a multi-member
+family remain visibly `unplaced` instead of being silently guessed into a row.
+
+## Family Keys and household links
+
+### Availability and authority
+
+| Action | Who can do it | Package requirement |
+| --- | --- | --- |
+| Generate, view metadata for, or revoke a branch key | Billing owner or co-owner; authorized internal admin | `can_link_households` |
+| Request a household link | Billing owner or co-owner | Both workspaces must have `can_link_households` and branch capacity |
+| Accept/reject a link | Billing owner or co-owner of the receiving workspace | Receiving workspace must remain eligible |
+| View the privacy-filtered linked network/reunion status | Authenticated workspace member with package access | Linked-household package for network traversal |
+
+The raw Family Key is displayed once. Only its cryptographic hash is stored.
+The key authorizes a handshake; it does not merge accounts, reveal passwords,
+or transfer ownership. The durable link stores both household IDs, both
+selected member anchors, the relationship direction, the generation delta,
+and the computed household generation offset. Both active keys must still
+match when the receiving owner accepts.
+
+Key uses are reserved atomically against `max_uses`, so simultaneous requests
+cannot silently overrun a one-use key. Revocation changes status and preserves
+the audit evidence rather than deleting it.
+
+Linked-tree and reunion views consume the same approved link graph. They apply
+household offsets, flag alignment conflicts, and exclude an external living or
+deceased person unless the owning household explicitly enabled cross-branch
+sharing. External relationship facts require their own linked/branch/public
+privacy scope. Portraits cross the boundary only when the portrait upload also
+allows linked-family sharing.
+
+## Portrait dropbox and automatic placement
+
+1. The Portrait Upload page loads the selected family and creates one named
+   dropbox for every family member.
+2. The uploader chooses the image inside that person's box and must attest both
+   lawful authority and the required living-person/guardian consent.
+3. The backend validates file type/size, stores the file in that member's
+   private family path, and records it as a pending submission. A pending file
+   never replaces the active portrait.
+4. Malware scanning runs against the actual stored path. Infected, failed, or
+   unscanned files cannot be downloaded or approved.
+5. A master account with `uploads.admin.review` reviews the portrait. Approval
+   is impossible unless the scan is clean and both attestations exist.
+6. Approval updates the member's active `approved_photo_upload_id`. Rejection
+   does not remove a previously approved different portrait.
+7. The normal tree and authorized linked tree resolve only a clean,
+   non-quarantined, consent-attested, master-approved portrait.
+8. The private cinematic manifest dynamically creates a slide for every
+   approved member portrait. The slide carries the solved generation and
+   relationship-aware parent, child, partner, and branch navigation. No manual
+   slide copying is required.
+
+The Evidence Review queue is separate. It lets the master account approve,
+reject, or request correction for clean verification documents. Approved
+documents may support the Verified Tree, but the documents themselves remain
+private and never become NFT content.
+
+## Family reunion command view
+
+The Family Reunion page shows completion states for every person visible
+through the authorized linked network:
+
+- portrait: missing, pending scan, security blocked, consent missing, pending
+  master review, rejected, or approved;
+- placement: root, placed, or unplaced;
+- account: not required, not claimed, or claimed;
+- verification: not submitted, pending, or verified;
+- automatic cinematic slide: ready or not ready.
+
+It groups results by household and shows completion percentages. It does not
+return passwords, MFA information, wallet secrets, private files, or the
+unshared records of another household.
+
+## Canonical people and duplicate prevention
+
+Person matching is opt-in on both records. Same-household comparisons are
+allowed; cross-household comparisons require an approved direct household
+link. Exact birth year now contributes when a complete birth date is not
+available. A match is a review candidate only—people are never merged
+automatically. This protects the PDF's hardest rule: one real person may appear
+in several household views but must not be silently duplicated or collapsed.
+
+## Blockchain minting
+
+The NFT is a public-safe continuity anchor, not the storage location for the
+private tree or vault and not, by itself, a legal transfer of family ownership.
+The configured token types support portrait, household, branch, and
+organization anchors.
+
+Minting is staged:
+
+1. An internal mint operator prepares a versioned mint record and public-safe
+   poster choice.
+2. The internal operator records production approval.
+3. The authenticated billing owner or co-owner records customer consent,
+   public-title/poster choices, and the recipient wallet. An administrator is
+   forbidden from fabricating this customer consent.
+4. Policy, package, project state, public-content approval, fee, and readiness
+   gates must all pass.
+5. Idempotent jobs build the public manifest, generate the poster, submit the
+   anchor transaction, and synchronize the receipt.
+6. A signer lease serializes nonce use. The pending nonce is used, and the
+   signed transaction hash and exact signed bytes are persisted **before**
+   broadcast. A crash retries the same transaction rather than signing a second
+   mint.
+7. The receipt must succeed and emit an ERC-721 Transfer token ID. Tomb of Light
+   then saves chain, contract, token ID, transaction hash, metadata URI, and
+   public artifact hashes. Completed signed bytes are cleared.
+
+An already canonical minted record is not reminted by client review, delivery,
+maintenance, or this Phase 13 work.
+
+## Remaining production closure work
+
+These are explicit operational migrations or product decisions, not hidden
+automatic behavior:
+
+1. **Legacy reconciliation:** report and repair old manual generations,
+   lineage-node gaps, unanchored household links, and old portrait approvals
+   that lack the new consent attestations. Old files must not be grandfathered
+   into public/cinematic display without evidence.
+2. **Divorce, death, and succession:** the PDF specifies household split and
+   owner -> co-owner/designated-heir transfer. Tomb of Light still needs a
+   governed case workflow with both authorization and immutable evidence; it
+   must not be implemented as a silent role edit or automatic NFT transfer.
+3. **Invitation delivery and reminders:** a family member can now be marked as
+   account-required with an expected email and viewer/contributor role, and
+   reunion readiness matches that expectation to active project membership.
+   Automated email/SMS delivery and reunion reminders still need their own
+   consented communications design and provider integration.
+4. **Production acceptance:** after merge/deploy, run a controlled smoke test
+   with two non-production households, reciprocal keys, inverse generation
+   placement, one clean portrait approval, one rejected portrait, one verified
+   evidence record, reunion status, and a testnet mint. Do not test by reminting
+   an existing customer's canonical NFT.
+
+These remaining items should stay visible in operational readiness until their
+workflow and migration evidence are complete.

--- a/backend/tests/contracts/test_phase13_family_operating_machine.py
+++ b/backend/tests/contracts/test_phase13_family_operating_machine.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_relationships_are_guided_and_automatically_placed():
+    catalog = _read("backend/app/core/relationship_catalog.py")
+    placement = _read("backend/app/services/family_placement_service.py")
+    route = _read("backend/app/routes/family_members.py")
+    assert "step_parent" in catalog
+    assert "chosen_parent" in catalog
+    assert "step_child" in catalog
+    assert "Relationship placement conflict" in placement
+    assert "cannot be supplied when creating a family member" in route
+
+
+def test_household_links_are_anchored_aligned_and_privacy_filtered():
+    request_service = _read("backend/app/services/link_request_service.py")
+    network = _read("backend/app/services/linked_network_service.py")
+    tree_route = _read("backend/app/routes/tree.py")
+    assert "source_anchor_member_id" in request_service
+    assert "target_generation_offset" in request_service
+    assert "_reserve_key_use" in request_service
+    assert "alignment_conflicts" in network
+    assert "Death never overrides" in network
+    assert "get_authorized_linked_family_tree" in tree_route
+
+
+def test_portrait_pipeline_is_clean_consented_and_master_approved():
+    uploads = _read("backend/app/routes/uploads.py")
+    viewer = _read("backend/app/services/viewer_manifest_service.py")
+    portrait_page = _read("portrait-upload.html")
+    assert "consent_attested: bool = Form(...)" in uploads
+    assert "authority_attested: bool = Form(...)" in uploads
+    assert 'require_permission("uploads.admin.review")' in uploads
+    assert '"/{upload_id}/verification-review"' in uploads
+    assert 'bool(upload.get("consent_attested"))' in viewer
+    assert "data-portrait-member-dropboxes" in portrait_page
+
+
+def test_reunion_status_does_not_return_private_secrets():
+    service = _read("backend/app/services/family_reunion_service.py")
+    assert "incomplete_reasons" in service
+    assert "passwords" in service
+    assert "wallet secrets" in service
+
+
+def test_mint_persists_exact_transaction_before_broadcast_and_requires_customer_owner():
+    blockchain = _read("backend/app/services/blockchain_mint_service.py")
+    jobs = _read("backend/app/services/mint_job_service.py")
+    routes = _read("backend/app/routes/mint_records.py")
+    prepared_at = blockchain.index("on_transaction_prepared")
+    broadcast_at = blockchain.index("send_raw_transaction", prepared_at)
+    assert prepared_at < broadcast_at
+    assert "signed_transaction" in jobs
+    assert "_acquire_signer_lease" in jobs
+    assert "Internal administrators cannot create customer mint consent" in routes

--- a/backend/tests/contracts/test_phase13_family_operating_machine.py
+++ b/backend/tests/contracts/test_phase13_family_operating_machine.py
@@ -21,6 +21,8 @@ def test_relationships_are_guided_and_automatically_placed():
 
 def test_household_links_are_anchored_aligned_and_privacy_filtered():
     request_service = _read("backend/app/services/link_request_service.py")
+    key_routes = _read("backend/app/routes/link_keys.py")
+    request_routes = _read("backend/app/routes/link_requests.py")
     network = _read("backend/app/services/linked_network_service.py")
     tree_route = _read("backend/app/routes/tree.py")
     assert "source_anchor_member_id" in request_service
@@ -29,6 +31,8 @@ def test_household_links_are_anchored_aligned_and_privacy_filtered():
     assert "alignment_conflicts" in network
     assert "Death never overrides" in network
     assert "get_authorized_linked_family_tree" in tree_route
+    assert '"admin.intake.write" in permissions' in key_routes
+    assert 'require_permission("admin.intake.write")' in request_routes
 
 
 def test_portrait_pipeline_is_clean_consented_and_master_approved():

--- a/backend/tests/test_family_placement_service.py
+++ b/backend/tests/test_family_placement_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+
+from bson import ObjectId
+
+from app.core.relationship_catalog import relationship_generation_delta
+from app.services.family_placement_service import (
+    FamilyPlacementError,
+    calculate_family_placement,
+)
+
+
+class _Collection:
+    def __init__(self, documents):
+        self.documents = list(documents)
+
+    def find(self, query):
+        family_values = set((query.get("family_id") or {}).get("$in") or [])
+        if not family_values:
+            return list(self.documents)
+        return [
+            item
+            for item in self.documents
+            if item.get("family_id") in family_values
+        ]
+
+
+class _Database:
+    def __init__(self, members, relationships):
+        self.collections = {
+            "family_members": _Collection(members),
+            "relationships": _Collection(relationships),
+        }
+
+    def __getitem__(self, name):
+        return self.collections[name]
+
+
+class FamilyPlacementServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.family_id = str(ObjectId())
+        self.parent_id = str(ObjectId())
+        self.child_id = str(ObjectId())
+
+    def test_parent_child_is_placed_one_generation_apart(self):
+        db = _Database(
+            [
+                {"_id": ObjectId(self.parent_id), "family_id": self.family_id},
+                {"_id": ObjectId(self.child_id), "family_id": self.family_id},
+            ],
+            [
+                {
+                    "family_id": self.family_id,
+                    "source_member_id": self.parent_id,
+                    "target_member_id": self.child_id,
+                    "relationship_type": "step_parent",
+                }
+            ],
+        )
+        placement = calculate_family_placement(db, self.family_id)
+        self.assertEqual(placement["assignments"][self.parent_id], 0)
+        self.assertEqual(placement["assignments"][self.child_id], 1)
+
+    def test_conflicting_peer_and_parent_edges_are_rejected(self):
+        db = _Database(
+            [
+                {"_id": ObjectId(self.parent_id), "family_id": self.family_id},
+                {"_id": ObjectId(self.child_id), "family_id": self.family_id},
+            ],
+            [
+                {
+                    "family_id": self.family_id,
+                    "source_member_id": self.parent_id,
+                    "target_member_id": self.child_id,
+                    "relationship_type": "biological_parent",
+                },
+                {
+                    "family_id": self.family_id,
+                    "source_member_id": self.parent_id,
+                    "target_member_id": self.child_id,
+                    "relationship_type": "spouse",
+                },
+            ],
+        )
+        with self.assertRaises(FamilyPlacementError):
+            calculate_family_placement(db, self.family_id)
+
+    def test_unrelated_people_are_not_silently_guessed_into_tree(self):
+        other_id = str(ObjectId())
+        db = _Database(
+            [
+                {"_id": ObjectId(self.parent_id), "family_id": self.family_id},
+                {"_id": ObjectId(other_id), "family_id": self.family_id},
+            ],
+            [],
+        )
+        placement = calculate_family_placement(db, self.family_id)
+        self.assertEqual(placement["placement_status"][self.parent_id], "unplaced")
+        self.assertEqual(placement["placement_status"][other_id], "unplaced")
+
+    def test_inverse_household_bridge_deltas_are_explicit(self):
+        self.assertEqual(relationship_generation_delta("step_child"), -1)
+        self.assertEqual(relationship_generation_delta("grandchild"), -2)
+        self.assertEqual(relationship_generation_delta("identity_bridge"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -708,8 +708,8 @@ class LinkKeyHardeningTests(unittest.TestCase):
         db = FakeDatabase({"project_link_keys": []})
         with (
             patch.object(link_key_service, "get_database", return_value=db),
-            patch.object(link_key_service, "user_can_access_project", return_value=True),
-            patch.object(link_key_service, "project_supports_link_keys", return_value=True),
+            patch.object(link_key_service, "user_can_manage_project", return_value=True),
+            patch.object(link_key_service, "project_supports_household_links", return_value=True),
             patch.object(
                 link_key_service,
                 "get_project_summary",
@@ -800,3 +800,4 @@ class RootDisclosureTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/create-relationship.html
+++ b/create-relationship.html
@@ -61,32 +61,113 @@
                 Relationship Type
                 <select name="relationship_type" required>
                   <option value="">Select relationship type</option>
-                  <option value="spouse">spouse</option>
-                  <option value="parent_child">parent_child</option>
-                  <option value="sibling">sibling</option>
-                  <option value="guardian">guardian</option>
-                  <option value="adoptive_parent_child">adoptive_parent_child</option>
-                  <option value="step_parent_child">step_parent_child</option>
+                  <optgroup label="Source is parent or elder of target">
+                    <option value="parent_unspecified">Parent → child (type not specified)</option>
+                    <option value="biological_parent">Biological parent → child</option>
+                    <option value="gestational_parent">Gestational parent → child</option>
+                    <option value="donor_parent">Donor parent → child</option>
+                    <option value="intended_parent">Intended parent → child</option>
+                    <option value="adoptive_parent">Adoptive parent → child</option>
+                    <option value="foster_parent">Foster parent → child</option>
+                    <option value="step_parent">Step-parent → stepchild</option>
+                    <option value="guardian">Guardian → ward</option>
+                    <option value="chosen_parent">Chosen parent → child</option>
+                    <option value="community_parent">Community parent → child</option>
+                    <option value="spiritual_parent">Spiritual parent → child</option>
+                    <option value="grandparent">Grandparent → grandchild</option>
+                    <option value="aunt_uncle">Aunt/uncle → niece/nephew</option>
+                  </optgroup>
+                  <optgroup label="Partners and peers">
+                    <option value="spouse">Spouse</option>
+                    <option value="former_spouse">Former spouse</option>
+                    <option value="domestic_partner">Domestic partner</option>
+                    <option value="former_partner">Former partner</option>
+                    <option value="co_parent">Co-parent</option>
+                    <option value="sibling">Sibling</option>
+                    <option value="half_sibling">Half-sibling</option>
+                    <option value="step_sibling">Step-sibling</option>
+                    <option value="adoptive_sibling">Adoptive sibling</option>
+                    <option value="chosen_sibling">Chosen sibling</option>
+                    <option value="cousin">Cousin</option>
+                  </optgroup>
+                  <optgroup label="Narrative, cultural, and household">
+                    <option value="godparent">Godparent</option>
+                    <option value="mentor">Mentor</option>
+                    <option value="clan_elder">Clan/cultural elder</option>
+                    <option value="spiritual_elder">Spiritual elder</option>
+                    <option value="in_law">In-law</option>
+                    <option value="other_relative">Other relative</option>
+                    <option value="family_friend">Family friend</option>
+                    <option value="household_member">Household member</option>
+                  </optgroup>
                 </select>
               </label>
 
               <label>
-                Source Member ID
-                <input
-                  type="text"
+                Source Family Member
+                <select
                   name="source_member_id"
-                  placeholder="Example: 69b8c44898aa11f9a41fc1ca"
                   required
-                />
+                >
+                  <option value="">Select a family first</option>
+                </select>
               </label>
 
               <label>
-                Target Member ID
+                Target Family Member
+                <select
+                  name="target_member_id"
+                  required
+                >
+                  <option value="">Select a family first</option>
+                </select>
+              </label>
+
+              <div class="form-grid two-col">
+                <label>
+                  Truth Layer
+                  <select name="relationship_mode" required>
+                    <option value="narrative">Narrative / family-held</option>
+                    <option value="verified">Verified by approved records</option>
+                  </select>
+                </label>
+
+                <label>
+                  Privacy
+                  <select name="privacy_scope" required>
+                    <option value="household_private">Household private</option>
+                    <option value="private_to_owner">Owner only</option>
+                    <option value="private_to_owner_and_co_owner">Owner and co-owner</option>
+                    <option value="branch_shared">Branch shared</option>
+                    <option value="linked_family_shared">Linked-family shared</option>
+                    <option value="public_memorial">Public memorial</option>
+                    <option value="minor_protected">Minor protected</option>
+                  </select>
+                </label>
+              </div>
+
+              <label>
+                Approved Verification Evidence
+                <select
+                  name="evidence_record_ids"
+                  multiple
+                  size="5"
+                >
+                  <option value="">Select a family to load approved evidence</option>
+                </select>
+                <span class="helper">
+                  Required only for Verified. Choose one or more approved records;
+                  no database IDs need to be typed.
+                </span>
+              </label>
+
+              <label>
+                Family or Cultural Label
                 <input
                   type="text"
-                  name="target_member_id"
-                  placeholder="Example: 69b8c48b98aa11f9a41fc1cc"
-                  required
+                  name="relationship_label"
+                  maxlength="100"
+                  placeholder="Optional, for example Big Mama, clan elder, or chosen aunt"
                 />
               </label>
 
@@ -138,7 +219,9 @@
                 <div class="card-number">2</div>
                 <h3>Parent-child links</h3>
                 <p class="card-copy">
-                  Use <strong>parent_child</strong> when connecting a parent to a child.
+                  Choose the parent as the <strong>source</strong> and the child
+                  as the <strong>target</strong>. Step-parent → stepchild and
+                  every other parent type use the same clear direction.
                 </p>
               </div>
               <div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -41,6 +41,7 @@
             <a href="link-keys.html" style="display: none">Link Keys</a>
             <a href="household-access.html" style="display: none">Members &amp; Access</a>
             <a href="tree-view.html" style="display: none">Family Tree</a>
+            <a href="family-reunion.html">Family Reunion</a>
             <a href="lineage-certificate.html" style="display: none">Lineage Certificate</a>
             <a href="portal-help.html" data-dashboard-tool="help_center">Help Center</a>
           </nav>
@@ -452,6 +453,12 @@
                   <p>Create protected keys for controlled family or workspace handshakes.</p>
                   <span class="portal-action-status">Check access</span>
                   <span class="portal-action-cta">Manage Keys</span>
+                </a>
+                <a class="portal-action-card" href="family-reunion.html">
+                  <strong>Family Reunion Readiness</strong>
+                  <p>See which visible family members are placed, approved, and ready without exposing private files.</p>
+                  <span class="portal-action-status">Private status view</span>
+                  <span class="portal-action-cta">Check Family Progress</span>
                 </a>
                 <a class="portal-action-card" href="billing.html" data-dashboard-tool="billing">
                   <strong>Billing &amp; Cards</strong>

--- a/family-reunion.html
+++ b/family-reunion.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
+    <title>Family Reunion Readiness | Tomb of Light</title>
+    <meta name="description" content="See which linked family members are ready without exposing private family files." />
+    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+  </head>
+  <body class="portal-dashboard-body">
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html">Tomb of Light<span class="brand-symbol">™</span></a>
+          <nav class="site-nav" aria-label="Portal navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="family-reunion.html" aria-current="page">Family Reunion</a>
+            <a href="portrait-upload.html">Portraits</a>
+            <a href="tree-view.html">Family Tree</a>
+            <a href="link-keys.html">Link Keys</a>
+          </nav>
+          <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
+        </div>
+      </header>
+
+      <main id="main-content" data-family-reunion-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">Family Reunion Command View</span>
+              <h1>See who is ready—and who still needs help.</h1>
+              <p data-reunion-status>Loading linked-family readiness…</p>
+              <div class="notice" style="margin-top: 1rem">
+                This page shows completion states only. It never reveals anyone’s
+                password, private files, wallet secrets, or unshared living-person records.
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Network Progress</span>
+              <div class="grid-3" data-reunion-summary></div>
+            </div>
+            <div data-reunion-households></div>
+            <div class="form-panel" data-reunion-empty style="display: none">
+              <h2>No family members are available yet.</h2>
+              <p class="card-copy">
+                Add family members, place their relationships, and use the named
+                portrait dropboxes to begin reunion readiness.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container"><div class="footer-card"><div class="footer-bottom">
+          <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+        </div></div></div>
+      </footer>
+    </div>
+    <script src="config.js?v=20260328-7"></script>
+    <script src="app.js?v=20260821-phase9"></script>
+    <script src="auth.js?v=20260509-audit"></script>
+    <script src="family-reunion.js?v=20260823-phase13"></script>
+  </body>
+</html>
+

--- a/family-reunion.js
+++ b/family-reunion.js
@@ -1,0 +1,125 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  const authPages = window.TOLAuthPages || {};
+  if (!app || typeof app.apiRequest !== "function") return;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function humanize(value) {
+    return String(value || "unknown")
+      .split("_")
+      .map(function (part) {
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join(" ");
+  }
+
+  function projectIdFromContext(context) {
+    return String(
+      context?.activeProject?.project_id ||
+      context?.activeProject?.projectId ||
+      context?.activeProject?.id ||
+      context?.activeProject?._id ||
+      context?.currentWorkspace?.projectId ||
+      "",
+    ).trim();
+  }
+
+  function statusPill(value, readyValue) {
+    const ready = value === readyValue;
+    return `<span class="eyebrow" data-state="${ready ? "success" : "pending"}">${escapeHtml(humanize(value))}</span>`;
+  }
+
+  function render(payload) {
+    const summaryNode = document.querySelector("[data-reunion-summary]");
+    const householdsNode = document.querySelector("[data-reunion-households]");
+    const emptyNode = document.querySelector("[data-reunion-empty]");
+    const statusNode = document.querySelector("[data-reunion-status]");
+    const summary = payload.summary || {};
+
+    statusNode.textContent = payload.ready
+      ? "Every visible family member is ready for the family reunion."
+      : `${summary.incomplete_member_count || 0} visible family member(s) still need attention.`;
+
+    summaryNode.innerHTML = [
+      ["Households", summary.household_count || 0],
+      ["Members Ready", `${summary.complete_member_count || 0} / ${summary.member_count || 0}`],
+      ["Cinematic Slides Ready", summary.slide_ready_count || 0],
+    ].map(function (item, index) {
+      return `<div class="family-record-card"><div class="card-number">${index + 1}</div><h3>${escapeHtml(item[0])}</h3><p class="card-copy">${escapeHtml(item[1])}</p></div>`;
+    }).join("");
+
+    const households = Array.isArray(payload.households) ? payload.households : [];
+    if (!households.length) {
+      householdsNode.innerHTML = "";
+      emptyNode.style.display = "";
+      return;
+    }
+    emptyNode.style.display = "none";
+
+    householdsNode.innerHTML = households.map(function (household) {
+      const completion = household.completion || {};
+      const members = Array.isArray(household.members) ? household.members : [];
+      const memberCards = members.map(function (member) {
+        const reasons = Array.isArray(member.incomplete_reasons)
+          ? member.incomplete_reasons
+          : [];
+        return `
+          <div class="family-record-card">
+            <span class="eyebrow">Generation ${escapeHtml(member.generation ?? "unplaced")}</span>
+            <h3>${escapeHtml(member.display_name)}</h3>
+            <p class="card-copy"><strong>Portrait:</strong> ${statusPill(member.portrait_status, "approved")}</p>
+            <p class="card-copy"><strong>Tree placement:</strong> ${statusPill(member.placement_status === "root" ? "placed" : member.placement_status, "placed")}</p>
+            <p class="card-copy"><strong>Account:</strong> ${escapeHtml(humanize(member.account_status))}</p>
+            <p class="card-copy"><strong>Verification:</strong> ${escapeHtml(humanize(member.verification_status))}</p>
+            <p class="card-copy"><strong>Automatic slide:</strong> ${member.slide_ready ? "Ready" : "Not ready"}</p>
+            ${reasons.length ? `<p class="card-copy"><strong>Needs:</strong> ${escapeHtml(reasons.map(humanize).join(", "))}</p>` : '<p class="card-copy"><strong>Status:</strong> Complete</p>'}
+          </div>
+        `;
+      }).join("");
+      return `
+        <section class="form-panel" style="margin-top: 1.5rem">
+          <span class="eyebrow">${escapeHtml(household.alignment_status || "unplaced")}</span>
+          <h2>${escapeHtml(household.household_name || "Linked Household")}</h2>
+          <p class="card-copy">${escapeHtml(completion.complete_members || 0)} of ${escapeHtml(completion.total_members || 0)} visible members complete (${escapeHtml(completion.percent || 0)}%).</p>
+          <div class="grid-3" style="margin-top: 1rem">${memberCards}</div>
+        </section>
+      `;
+    }).join("");
+  }
+
+  async function setup() {
+    const page = document.querySelector("[data-family-reunion-page]");
+    if (!page) return;
+    const statusNode = document.querySelector("[data-reunion-status]");
+    try {
+      const me = await app.apiRequest("/auth/me", { method: "GET" });
+      const orders = authPages.fetchOrders ? await authPages.fetchOrders() : [];
+      const context =
+        typeof authPages.getDashboardContextForCurrentPage === "function"
+          ? await authPages.getDashboardContextForCurrentPage(me, orders)
+          : await authPages.getDashboardContext(me, orders);
+      const queryProjectId = new URLSearchParams(window.location.search).get("project_id");
+      const projectId = queryProjectId || projectIdFromContext(context);
+      if (!projectId) throw new Error("No active project is attached to this account.");
+      const payload = await app.apiRequest(
+        `/projects/${encodeURIComponent(projectId)}/family-reunion-readiness`,
+        { method: "GET" },
+      );
+      render(payload);
+    } catch (error) {
+      statusNode.textContent = error.message || "Unable to load family reunion readiness.";
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", setup);
+})();

--- a/link-keys.html
+++ b/link-keys.html
@@ -106,6 +106,8 @@
                 this key with the other person or branch you want to connect.
                 A link is only completed when both sides present active keys and
                 the receiving side accepts the handshake by choice.
+                A raw key is shown once. Copy it when generated; Tomb of Light
+                stores only its cryptographic hash.
               </div>
 
               <label>
@@ -160,6 +162,59 @@
               </div>
 
               <form class="form-grid" data-link-request-form novalidate>
+                <label>
+                  Your Connecting Family Member
+                  <select name="source_anchor_member_id" required>
+                    <option value="">Loading family members...</option>
+                  </select>
+                </label>
+
+                <label>
+                  Your Selected Member Is…
+                  <select name="bridge_relationship_type" required>
+                    <option value="identity_bridge">The same person as their selected member</option>
+                    <option value="parent_unspecified">Parent of their selected member (type not specified)</option>
+                    <option value="biological_parent">Biological parent of their selected member</option>
+                    <option value="gestational_parent">Gestational parent of their selected member</option>
+                    <option value="donor_parent">Donor parent of their selected member</option>
+                    <option value="intended_parent">Intended parent of their selected member</option>
+                    <option value="adoptive_parent">Adoptive parent of their selected member</option>
+                    <option value="foster_parent">Foster parent of their selected member</option>
+                    <option value="step_parent">Step-parent of their selected member</option>
+                    <option value="guardian">Guardian of their selected member</option>
+                    <option value="chosen_parent">Chosen parent of their selected member</option>
+                    <option value="community_parent">Community parent of their selected member</option>
+                    <option value="spiritual_parent">Spiritual parent of their selected member</option>
+                    <option value="spouse">Spouse of their selected member</option>
+                    <option value="domestic_partner">Domestic partner of their selected member</option>
+                    <option value="former_spouse">Former spouse of their selected member</option>
+                    <option value="former_partner">Former partner of their selected member</option>
+                    <option value="co_parent">Co-parent of their selected member</option>
+                    <option value="sibling">Sibling of their selected member</option>
+                    <option value="half_sibling">Half-sibling of their selected member</option>
+                    <option value="step_sibling">Step-sibling of their selected member</option>
+                    <option value="adoptive_sibling">Adoptive sibling of their selected member</option>
+                    <option value="chosen_sibling">Chosen sibling of their selected member</option>
+                    <option value="cousin">Cousin of their selected member</option>
+                    <option value="grandparent">Grandparent of their selected member</option>
+                    <option value="aunt_uncle">Aunt/uncle of their selected member</option>
+                    <option value="child">Child of their selected member (type not specified)</option>
+                    <option value="biological_child">Biological child of their selected member</option>
+                    <option value="gestational_child">Gestational child of their selected member</option>
+                    <option value="donor_conceived_child">Donor-conceived child of their selected member</option>
+                    <option value="intended_child">Intended child of their selected member</option>
+                    <option value="adopted_child">Adopted child of their selected member</option>
+                    <option value="foster_child">Foster child of their selected member</option>
+                    <option value="step_child">Stepchild of their selected member</option>
+                    <option value="ward">Ward of their selected member</option>
+                    <option value="chosen_child">Chosen child of their selected member</option>
+                    <option value="community_child">Community child of their selected member</option>
+                    <option value="spiritual_child">Spiritual child of their selected member</option>
+                    <option value="grandchild">Grandchild of their selected member</option>
+                    <option value="niece_nephew">Niece/nephew of their selected member</option>
+                  </select>
+                </label>
+
                 <label>
                   Target Link Key
                   <input

--- a/link-keys.js
+++ b/link-keys.js
@@ -14,6 +14,7 @@
   let currentProjectId = "";
   let currentKey = null;
   let currentRequests = [];
+  let currentMembers = [];
 
   function normalizeValue(value) {
     return String(value || "")
@@ -51,6 +52,58 @@
     if (normalized === "revoked") return "Handshake Revoked";
     if (normalized === "rejected") return "Handshake Rejected";
     return "Handshake Pending";
+  }
+
+  function memberDisplayName(member) {
+    return String(
+      member?.full_name ||
+      member?.display_name ||
+      `${member?.first_name || ""} ${member?.last_name || ""}`,
+    ).trim() || "Unnamed family member";
+  }
+
+  function memberOptions(placeholder) {
+    return `<option value="">${escapeHtml(placeholder)}</option>${currentMembers
+      .slice()
+      .sort(function (a, b) {
+        const generationA = Number.isFinite(Number(a.generation)) ? Number(a.generation) : 999;
+        const generationB = Number.isFinite(Number(b.generation)) ? Number(b.generation) : 999;
+        if (generationA !== generationB) return generationA - generationB;
+        return memberDisplayName(a).localeCompare(memberDisplayName(b));
+      })
+      .map(function (member) {
+        return `<option value="${escapeHtml(member.id)}">${escapeHtml(memberDisplayName(member))} — generation ${escapeHtml(member.generation ?? "unplaced")}</option>`;
+      })
+      .join("")}`;
+  }
+
+  async function loadCurrentMembers() {
+    const familyId = getFamilyIdFromContext(currentContext);
+    if (!familyId) {
+      throw new Error("This workspace has no family record for link placement.");
+    }
+    const graph = await app.apiRequest(
+      `/families/${encodeURIComponent(familyId)}/graph`,
+      { method: "GET" },
+    );
+    currentMembers = Array.isArray(graph.members)
+      ? graph.members.filter(function (member) {
+          return ["placed", "root"].includes(
+            normalizeValue(member.placement_status),
+          );
+        })
+      : [];
+    const sourceSelect = document.querySelector(
+      '[data-link-request-form] [name="source_anchor_member_id"]',
+    );
+    if (sourceSelect) {
+      sourceSelect.innerHTML = memberOptions("Select your connecting family member");
+    }
+    if (!currentMembers.length) {
+      throw new Error(
+        "Place at least one family member through validated relationships before linking households.",
+      );
+    }
   }
 
   function setStatus(node, message, type) {
@@ -124,7 +177,7 @@
   }
 
   function canUseLinkKeyTools(resolved) {
-    return Boolean(resolved?.can_use_link_keys || resolved?.can_manage_link_keys);
+    return Boolean(resolved?.can_link_households);
   }
 
   function updateNav(context) {
@@ -209,7 +262,9 @@
 
     if (keyInput) {
       keyInput.value = currentKey?.key_value || "";
-      keyInput.placeholder = currentKey ? "" : "No active key yet";
+      keyInput.placeholder = currentKey
+        ? "Active key is stored securely; raw value was shown once"
+        : "No active key yet";
     }
 
     if (generateBtn) {
@@ -250,6 +305,8 @@
       `<p class="card-copy"><strong>Trust Handshake:</strong> ${escapeHtml(handshakeLabel(item))}</p>`,
       `<p class="card-copy"><strong>Requested By:</strong> ${escapeHtml(item.requested_by || "—")}</p>`,
       `<p class="card-copy"><strong>Created:</strong> ${escapeHtml(item.created_at || "—")}</p>`,
+      `<p class="card-copy"><strong>Tree Connection:</strong> ${escapeHtml(humanizeStatus(item.bridge_relationship_type || "unplaced legacy link"))}</p>`,
+      `<p class="card-copy"><strong>Alignment:</strong> ${escapeHtml(humanizeStatus(item.alignment_status || "pending"))}</p>`,
     ];
 
     if (item.source_handshake_at) {
@@ -326,6 +383,12 @@
             <div class="card-number">${index + 1}</div>
             <h3>Incoming Request</h3>
             ${requestMeta(item)}
+            <label>
+              Their Connecting Family Member
+              <select data-link-target-anchor-for="${escapeHtml(item.id)}">
+                ${memberOptions("Select the receiving family member")}
+              </select>
+            </label>
             <div class="inline-actions" style="margin-top: 1rem">
               <button class="btn btn-primary" type="button" data-link-action="approve" data-request-id="${escapeHtml(item.id)}">
                 Approve
@@ -403,6 +466,13 @@
     }
 
     renderCurrentKey();
+    if (currentKey && !currentKey.key_value) {
+      setStatus(
+        statusNode,
+        "An active link key exists. Its raw value was shown only when generated; regenerate if you need to copy and share it again.",
+        "info",
+      );
+    }
   }
 
   async function loadRequests() {
@@ -482,7 +552,7 @@
 
   async function copyCurrentKey() {
     const statusNode = document.querySelector("[data-link-key-status]");
-    if (!currentKey?.key_value) {
+    if (!currentKey) {
       setStatus(statusNode, "Generate a link key first.", "error");
       return;
     }
@@ -516,10 +586,20 @@
     }
 
     const targetKey = String(form.target_key.value || "").trim();
+    const sourceAnchorMemberId = String(
+      form.source_anchor_member_id.value || "",
+    ).trim();
+    const bridgeRelationshipType = String(
+      form.bridge_relationship_type.value || "",
+    ).trim();
     const notes = String(form.notes.value || "").trim();
 
-    if (!targetKey) {
-      setStatus(statusNode, "Target link key is required.", "error");
+    if (!targetKey || !sourceAnchorMemberId || !bridgeRelationshipType) {
+      setStatus(
+        statusNode,
+        "Choose your connecting family member, the relationship, and the target key.",
+        "error",
+      );
       return;
     }
 
@@ -530,6 +610,8 @@
         method: "POST",
         body: JSON.stringify({
           source_project_id: currentProjectId,
+          source_anchor_member_id: sourceAnchorMemberId,
+          bridge_relationship_type: bridgeRelationshipType,
           target_key: targetKey,
           notes: notes || null,
         }),
@@ -558,6 +640,20 @@
     } else if (action === "approve") {
       notes = window.prompt("Optional approval note:", "") || "";
     }
+    const targetAnchorSelect = document.querySelector(
+      `[data-link-target-anchor-for="${CSS.escape(requestId)}"]`,
+    );
+    const targetAnchorMemberId = String(
+      targetAnchorSelect?.value || "",
+    ).trim();
+    if (action === "approve" && !targetAnchorMemberId) {
+      setStatus(
+        statusNode,
+        "Select the receiving family member before approving this link.",
+        "error",
+      );
+      return;
+    }
 
     setStatus(statusNode, "Updating link request...", "info");
 
@@ -566,7 +662,11 @@
         `/link-requests/${encodeURIComponent(requestId)}/${action}`,
         {
           method: "POST",
-          body: JSON.stringify({ notes: notes || null }),
+          body: JSON.stringify({
+            notes: notes || null,
+            target_anchor_member_id:
+              action === "approve" ? targetAnchorMemberId : null,
+          }),
         },
       );
 
@@ -709,6 +809,7 @@
       });
 
       await loadCurrentKey();
+      await loadCurrentMembers();
       await loadRequests();
       bindActions();
     } catch (error) {

--- a/member.js
+++ b/member.js
@@ -24,6 +24,9 @@
     }
 
     await loadFamiliesIntoSelect(familySelect, statusNode);
+    familySelect.addEventListener('change', function () {
+      loadExistingMembers(form, familySelect.value, statusNode);
+    });
 
     form.addEventListener('submit', async function (event) {
       event.preventDefault();
@@ -40,17 +43,24 @@
       const formData = new FormData(form);
 
       const birthYearRaw = String(formData.get('birth_year') || '').trim();
-      const generationRaw = String(formData.get('generation') || '').trim();
-
       const payload = {
         family_id: String(formData.get('family_id') || '').trim(),
         first_name: String(formData.get('first_name') || '').trim(),
         last_name: String(formData.get('last_name') || '').trim(),
         birth_year: birthYearRaw ? Number(birthYearRaw) : null,
-        generation: generationRaw ? Number(generationRaw) : 0,
+        generation: null,
         father_id: String(formData.get('father_id') || '').trim() || null,
         mother_id: String(formData.get('mother_id') || '').trim() || null,
         spouse_id: String(formData.get('spouse_id') || '').trim() || null,
+        father_relationship_type: String(formData.get('father_relationship_type') || 'biological_parent').trim(),
+        mother_relationship_type: String(formData.get('mother_relationship_type') || 'biological_parent').trim(),
+        partner_relationship_type: String(formData.get('partner_relationship_type') || 'spouse').trim(),
+        relationship_mode: 'narrative',
+        privacy_scope: 'household_private',
+        identity_matching_consent: Boolean(formData.get('identity_matching_consent')),
+        account_required: Boolean(formData.get('account_required')),
+        invite_email: String(formData.get('invite_email') || '').trim().toLowerCase() || null,
+        account_member_role: String(formData.get('account_member_role') || 'viewer').trim(),
         bio: String(formData.get('bio') || '').trim() || null
       };
 
@@ -59,13 +69,13 @@
         return;
       }
 
-      if (!Number.isInteger(payload.generation) || payload.generation < 0) {
-        showStatus(statusNode, 'Generation must be 0 or greater.', 'error');
+      if (payload.birth_year !== null && !Number.isInteger(payload.birth_year)) {
+        showStatus(statusNode, 'Birth year must be a valid number.', 'error');
         return;
       }
 
-      if (payload.birth_year !== null && !Number.isInteger(payload.birth_year)) {
-        showStatus(statusNode, 'Birth year must be a valid number.', 'error');
+      if (payload.account_required && !payload.invite_email) {
+        showStatus(statusNode, 'Enter the email for the family member who needs an account.', 'error');
         return;
       }
 
@@ -97,6 +107,66 @@
         submitBtn.textContent = 'Add Family Member';
       }
     });
+  }
+
+  async function loadExistingMembers(form, familyId, statusNode) {
+    const selects = [
+      form.querySelector('[name="father_id"]'),
+      form.querySelector('[name="mother_id"]'),
+      form.querySelector('[name="spouse_id"]')
+    ].filter(Boolean);
+    const placeholder = familyId
+      ? '<option value="">Loading family members...</option>'
+      : '<option value="">Select a family first</option>';
+    selects.forEach(function (select) {
+      select.innerHTML = placeholder;
+    });
+    if (!familyId) return;
+
+    try {
+      const graph = await window.TOLAuth.apiRequest(
+        `/families/${encodeURIComponent(familyId)}/graph`,
+        { method: 'GET' }
+      );
+      const members = Array.isArray(graph.members) ? graph.members : [];
+      const options = members
+        .slice()
+        .sort(function (a, b) {
+          const generationA = Number.isFinite(Number(a.generation)) ? Number(a.generation) : 999;
+          const generationB = Number.isFinite(Number(b.generation)) ? Number(b.generation) : 999;
+          if (generationA !== generationB) return generationA - generationB;
+          return displayName(a).localeCompare(displayName(b));
+        })
+        .map(function (member) {
+          return `<option value="${escapeHtml(member.id)}">${escapeHtml(displayName(member))} — generation ${escapeHtml(member.generation ?? 'unplaced')}</option>`;
+        })
+        .join('');
+      selects.forEach(function (select) {
+        select.innerHTML = `<option value="">None / not yet known</option>${options}`;
+      });
+    } catch (error) {
+      selects.forEach(function (select) {
+        select.innerHTML = '<option value="">Unable to load members</option>';
+      });
+      showStatus(statusNode, error.message || 'Unable to load existing family members.', 'error');
+    }
+  }
+
+  function displayName(member) {
+    return String(
+      member.full_name ||
+      member.display_name ||
+      `${member.first_name || ''} ${member.last_name || ''}`
+    ).trim() || 'Unnamed family member';
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
   }
 
   async function loadFamiliesIntoSelect(selectNode, statusNode, preservePlaceholder) {

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -136,6 +136,21 @@
               <span class="eyebrow">Step 2 - Upload Portrait</span>
 
               <form class="form-grid" data-portrait-upload-form novalidate>
+                <div>
+                  <div class="helper" style="margin-bottom: 0.85rem">
+                    Each named box belongs to one family member. Choose the photo
+                    in that person’s box so Tomb of Light can keep placement aligned.
+                  </div>
+                  <div class="grid-3" data-portrait-member-dropboxes>
+                    <div class="family-record-card">
+                      Load a portrait record to create the named family dropboxes.
+                    </div>
+                  </div>
+                </div>
+
+                <div class="helper">
+                  The selector below is an accessible fallback for the same named dropboxes.
+                </div>
                 <div class="form-grid two-col">
                   <label>
                     Portrait Subject
@@ -166,6 +181,7 @@
                   >
                     <input
                       type="checkbox"
+                      name="authority_attested"
                       required
                       style="margin-top: 0.2rem"
                     />
@@ -182,6 +198,7 @@
                   >
                     <input
                       type="checkbox"
+                      name="consent_attested"
                       required
                       style="margin-top: 0.2rem"
                     />

--- a/portrait-upload.js
+++ b/portrait-upload.js
@@ -378,6 +378,101 @@
       members,
       "Select subject",
     );
+    renderMemberDropboxes(members);
+  }
+
+  function renderMemberDropboxes(members) {
+    const container = document.querySelector("[data-portrait-member-dropboxes]");
+    if (!container) return;
+    if (!Array.isArray(members) || !members.length) {
+      container.innerHTML =
+        '<div class="family-record-card">No family members are available for portrait upload yet.</div>';
+      return;
+    }
+
+    container.innerHTML = sortMembers(members)
+      .map(function (member) {
+        const memberId = String(member.id || "").trim();
+        const generation = Number.isFinite(Number(member.generation))
+          ? `Generation ${Number(member.generation)}`
+          : "Placement pending";
+        return `
+          <div class="family-record-card" data-portrait-dropbox-card="${escapeHtml(memberId)}">
+            <span class="eyebrow">${escapeHtml(generation)}</span>
+            <h3>${escapeHtml(getDisplayName(member))}</h3>
+            <p class="card-copy">Portrait dropbox for this family member only.</p>
+            <label>
+              Choose ${escapeHtml(getDisplayName(member))}’s portrait
+              <input
+                type="file"
+                data-portrait-dropbox-file="${escapeHtml(memberId)}"
+                accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
+              />
+            </label>
+            <button
+              class="btn btn-primary"
+              type="button"
+              data-portrait-dropbox-upload="${escapeHtml(memberId)}"
+            >
+              Upload for ${escapeHtml(getDisplayName(member))}
+            </button>
+          </div>
+        `;
+      })
+      .join("");
+  }
+
+  async function uploadFromNamedDropBox(button, form) {
+    const actionStatus = document.querySelector("[data-portrait-action-status]");
+    const memberId = String(
+      button.getAttribute("data-portrait-dropbox-upload") || "",
+    ).trim();
+    const card = button.closest("[data-portrait-dropbox-card]");
+    const input = card?.querySelector("[data-portrait-dropbox-file]");
+    const file = input?.files?.[0] || null;
+    const authorityAttested = Boolean(form.elements.authority_attested?.checked);
+    const consentAttested = Boolean(form.elements.consent_attested?.checked);
+
+    if (!currentFamilyId || !memberId || !file) {
+      setStatus(actionStatus, "Choose a portrait inside the named family-member dropbox.", "error");
+      return;
+    }
+    if (!authorityAttested || !consentAttested) {
+      setStatus(actionStatus, "Complete both consent confirmations before uploading.", "error");
+      return;
+    }
+    if (!validateFileType(file)) {
+      setStatus(actionStatus, "Invalid file type. Allowed portrait formats are JPG, PNG, and WEBP.", "error");
+      return;
+    }
+
+    const body = new FormData();
+    body.append("family_id", currentFamilyId);
+    body.append("member_id", memberId);
+    body.append("authority_attested", "true");
+    body.append("consent_attested", "true");
+    body.append("file", file);
+
+    button.disabled = true;
+    try {
+      setStatus(actionStatus, "Uploading portrait for the named family member...", "info");
+      await app.apiRequest("/uploads/member-photo", { method: "POST", body });
+      input.value = "";
+      const memberSelect = document.querySelector("[data-portrait-member-select]");
+      const listMember = document.querySelector("[data-portrait-list-member]");
+      if (memberSelect) memberSelect.value = memberId;
+      if (listMember) listMember.value = memberId;
+      setStatus(
+        actionStatus,
+        "Portrait uploaded and sent for security scanning and master review. Approved portraits are placed automatically.",
+        "success",
+      );
+      await loadUploads();
+    } catch (error) {
+      setStatus(actionStatus, error.message || "Unable to upload portrait.", "error");
+    } finally {
+      button.disabled = false;
+    }
   }
 
   function renderFamilies(preferredFamilyId) {
@@ -641,6 +736,14 @@
     const body = new FormData();
     body.append("family_id", currentFamilyId);
     body.append("member_id", memberId);
+    body.append(
+      "authority_attested",
+      form.elements.authority_attested.checked ? "true" : "false",
+    );
+    body.append(
+      "consent_attested",
+      form.elements.consent_attested.checked ? "true" : "false",
+    );
     body.append("file", file);
 
     try {
@@ -660,7 +763,7 @@
 
       setStatus(
         actionStatus,
-        "Portrait uploaded successfully. You can return to the dashboard or add another portrait.",
+        "Portrait uploaded and sent for security scanning and master review. It will appear in the family tree and cinematic viewer only after approval.",
         "success",
       );
       await loadUploads();
@@ -854,6 +957,11 @@
 
       if (uploadForm) {
         uploadForm.addEventListener("submit", handlePortraitUploadSubmit);
+        uploadForm.addEventListener("click", function (event) {
+          const button = event.target.closest("[data-portrait-dropbox-upload]");
+          if (!button) return;
+          uploadFromNamedDropBox(button, uploadForm);
+        });
       }
 
       if (loadUploadsButton) {

--- a/relationship.js
+++ b/relationship.js
@@ -9,6 +9,10 @@
     const sourceInput = form.querySelector('[name="source_member_id"]');
     const targetInput = form.querySelector('[name="target_member_id"]');
     const typeSelect = form.querySelector('[name="relationship_type"]');
+    const modeSelect = form.querySelector('[name="relationship_mode"]');
+    const privacySelect = form.querySelector('[name="privacy_scope"]');
+    const evidenceSelect = form.querySelector('[name="evidence_record_ids"]');
+    const relationshipLabelInput = form.querySelector('[name="relationship_label"]');
     const notesInput = form.querySelector('[name="notes"]');
     const createdByInput = form.querySelector('[name="created_by"]');
     const statusNode = document.querySelector('[data-relationship-status]');
@@ -34,6 +38,11 @@
       return;
     }
 
+    familySelect.addEventListener('change', function () {
+      loadFamilyMembers(familySelect.value, sourceInput, targetInput, statusNode);
+      loadApprovedEvidence(familySelect.value, evidenceSelect, statusNode);
+    });
+
     form.addEventListener('submit', async function (event) {
       event.preventDefault();
       hideStatus(statusNode);
@@ -47,6 +56,16 @@
         source_member_id: String(sourceInput.value || '').trim(),
         target_member_id: String(targetInput.value || '').trim(),
         relationship_type: String(typeSelect.value || '').trim(),
+        relationship_mode: String(modeSelect.value || 'narrative').trim(),
+        status_marker:
+          String(modeSelect.value || 'narrative').trim() === 'verified'
+            ? 'verified'
+            : 'narrative',
+        privacy_scope: String(privacySelect.value || 'household_private').trim(),
+        evidence_record_ids: Array.from(evidenceSelect.selectedOptions || [])
+          .map(function (option) { return String(option.value || '').trim(); })
+          .filter(Boolean),
+        relationship_label: String(relationshipLabelInput.value || '').trim() || null,
         notes: String(notesInput.value || '').trim() || null,
         created_by: String(createdByInput.value || '').trim() || null
       };
@@ -57,7 +76,19 @@
       }
 
       if (payload.source_member_id === payload.target_member_id) {
-        showStatus(statusNode, 'Source and target member IDs must be different.', 'error');
+        showStatus(statusNode, 'Source and target family members must be different.', 'error');
+        return;
+      }
+
+      if (
+        payload.relationship_mode === 'verified' &&
+        payload.evidence_record_ids.length === 0
+      ) {
+        showStatus(
+          statusNode,
+          'Verified relationships require at least one clean, approved verification record.',
+          'error'
+        );
         return;
       }
 
@@ -71,7 +102,11 @@
         });
 
         showStatus(statusNode, 'Relationship created successfully.', 'success');
+        const selectedFamilyId = payload.family_id;
         form.reset();
+        familySelect.value = selectedFamilyId;
+        await loadFamilyMembers(selectedFamilyId, sourceInput, targetInput, statusNode);
+        await loadApprovedEvidence(selectedFamilyId, evidenceSelect, statusNode);
 
         try {
           const me = await window.TOLAuth.apiRequest('/auth/me', { method: 'GET' });
@@ -105,6 +140,94 @@
       option.textContent = `${family.family_name} (${family.created_by})`;
       selectNode.appendChild(option);
     });
+  }
+
+  async function loadFamilyMembers(familyId, sourceSelect, targetSelect, statusNode) {
+    const placeholder = familyId
+      ? '<option value="">Loading family members...</option>'
+      : '<option value="">Select a family first</option>';
+    sourceSelect.innerHTML = placeholder;
+    targetSelect.innerHTML = placeholder;
+    if (!familyId) return;
+
+    try {
+      const graph = await window.TOLAuth.apiRequest(
+        `/families/${encodeURIComponent(familyId)}/graph`,
+        { method: 'GET' }
+      );
+      const members = Array.isArray(graph.members) ? graph.members : [];
+      const options = members
+        .slice()
+        .sort(function (a, b) {
+          const generationA = Number.isFinite(Number(a.generation)) ? Number(a.generation) : 999;
+          const generationB = Number.isFinite(Number(b.generation)) ? Number(b.generation) : 999;
+          if (generationA !== generationB) return generationA - generationB;
+          return String(a.full_name || '').localeCompare(String(b.full_name || ''));
+        })
+        .map(function (member) {
+          const name = String(
+            member.full_name ||
+            `${member.first_name || ''} ${member.last_name || ''}`
+          ).trim() || 'Unnamed family member';
+          return `<option value="${escapeHtml(member.id)}">${escapeHtml(name)} — generation ${escapeHtml(member.generation ?? 'unplaced')}</option>`;
+        })
+        .join('');
+      sourceSelect.innerHTML = `<option value="">Select source family member</option>${options}`;
+      targetSelect.innerHTML = `<option value="">Select target family member</option>${options}`;
+      if (!members.length) {
+        showStatus(statusNode, 'Add family members before creating relationships.', 'error');
+      }
+    } catch (error) {
+      sourceSelect.innerHTML = '<option value="">Unable to load members</option>';
+      targetSelect.innerHTML = '<option value="">Unable to load members</option>';
+      showStatus(statusNode, error.message || 'Unable to load family members.', 'error');
+    }
+  }
+
+  async function loadApprovedEvidence(familyId, selectNode, statusNode) {
+    if (!selectNode) return;
+    selectNode.innerHTML = familyId
+      ? '<option value="">Loading approved verification evidence...</option>'
+      : '<option value="">Select a family to load approved evidence</option>';
+    if (!familyId) return;
+
+    try {
+      const payload = await window.TOLAuth.apiRequest(
+        `/uploads/family/${encodeURIComponent(familyId)}?category=verification_evidence`,
+        { method: 'GET' }
+      );
+      const uploads = (Array.isArray(payload.uploads) ? payload.uploads : [])
+        .filter(function (upload) {
+          return (
+            String(upload.scan_status || '').toLowerCase() === 'clean' &&
+            !upload.quarantined &&
+            String(upload.verification_status || '').toLowerCase() === 'approved'
+          );
+        });
+      if (!uploads.length) {
+        selectNode.innerHTML = '<option value="">No approved evidence yet — use Verification Uploads first</option>';
+        return;
+      }
+      selectNode.innerHTML = uploads.map(function (upload) {
+        const label = [
+          upload.verification_type || upload.evidence_kind || 'Verification record',
+          upload.original_filename || 'approved file'
+        ].join(' — ');
+        return `<option value="${escapeHtml(upload.id)}">${escapeHtml(label)}</option>`;
+      }).join('');
+    } catch (error) {
+      selectNode.innerHTML = '<option value="">Unable to load approved evidence</option>';
+      showStatus(statusNode, error.message || 'Unable to load verification evidence.', 'error');
+    }
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
   }
 
   function showStatus(node, message, type) {

--- a/tree-view.js
+++ b/tree-view.js
@@ -3,19 +3,45 @@
 
   const authPages = window.TOLAuthPages || {};
   const ANCESTRY_TYPES = new Set([
+    "parent_unspecified",
     "biological_parent",
+    "gestational_parent",
+    "donor_parent",
+    "intended_parent",
     "adoptive_parent",
+    "foster_parent",
     "step_parent",
     "guardian",
+    "chosen_parent",
+    "community_parent",
+    "spiritual_parent",
   ]);
 
   const PRIMARY_ANCESTRY_TYPES = new Set([
+    "parent_unspecified",
     "biological_parent",
+    "gestational_parent",
+    "donor_parent",
+    "intended_parent",
     "adoptive_parent",
-    "guardian",
   ]);
 
-  const SECONDARY_ANCESTRY_TYPES = new Set(["step_parent"]);
+  const SECONDARY_ANCESTRY_TYPES = new Set([
+    "foster_parent",
+    "step_parent",
+    "guardian",
+    "chosen_parent",
+    "community_parent",
+    "spiritual_parent",
+  ]);
+  const PARTNER_TYPES = new Set([
+    "spouse",
+    "former_spouse",
+    "domestic_partner",
+    "former_partner",
+    "co_parent",
+    "co_parent",
+  ]);
   const RELATIONSHIP_TYPE_ALIASES = {
     "parent-child": "biological_parent",
     parent_child: "biological_parent",
@@ -156,23 +182,42 @@
     const rel = normalizeRelationshipType(relationshipType);
 
     if (context === "parents") {
+      if (rel === "parent_unspecified") return "Parent";
       if (rel === "biological_parent") return "Biological parent";
+      if (rel === "gestational_parent") return "Gestational parent";
+      if (rel === "donor_parent") return "Donor parent";
+      if (rel === "intended_parent") return "Intended parent";
       if (rel === "step_parent") return "Step-parent";
       if (rel === "adoptive_parent") return "Adoptive parent";
+      if (rel === "foster_parent") return "Foster parent";
       if (rel === "guardian") return "Guardian";
+      if (rel === "chosen_parent") return "Chosen parent";
+      if (rel === "community_parent") return "Community parent";
+      if (rel === "spiritual_parent") return "Spiritual parent";
       return rel.replaceAll("_", " ");
     }
 
     if (context === "children") {
+      if (rel === "parent_unspecified") return "Child";
       if (rel === "biological_parent") return "Biological child";
+      if (rel === "gestational_parent") return "Gestational child";
+      if (rel === "donor_parent") return "Donor-conceived child";
+      if (rel === "intended_parent") return "Intended child";
       if (rel === "step_parent") return "Step-child";
       if (rel === "adoptive_parent") return "Adopted child";
+      if (rel === "foster_parent") return "Foster child";
       if (rel === "guardian") return "Ward";
+      if (rel === "chosen_parent") return "Chosen child";
+      if (rel === "community_parent") return "Community child";
+      if (rel === "spiritual_parent") return "Spiritual child";
       return rel.replaceAll("_", " ");
     }
 
     if (context === "spouses") {
       if (rel === "former_spouse") return "Former spouse";
+      if (rel === "domestic_partner") return "Domestic partner";
+      if (rel === "former_partner") return "Former partner";
+      if (rel === "co_parent") return "Co-parent";
       return "Spouse";
     }
 
@@ -861,7 +906,7 @@
     );
 
     const nodeWidth = 190;
-    const nodeHeight = 104;
+    const nodeHeight = 165;
     const coupleGap = 28;
     const itemGap = 80;
     const rowGap = 200;
@@ -1406,8 +1451,19 @@
 
     const name = getDisplayName(member);
     const birth = getBirthYear(member);
+    const portraitUrl = String(member.portrait_url || "").trim();
+    const portrait = portraitUrl
+      ? `<img
+          class="tree-node-portrait"
+          src="${escapeHtml(apiAssetUrl(portraitUrl))}"
+          alt="${escapeHtml(name)} approved portrait"
+          loading="lazy"
+          style="width: 52px; height: 52px; border-radius: 50%; object-fit: cover; margin: 0 auto 0.55rem; display: block;"
+        />`
+      : "";
 
     card.innerHTML = `
+      ${portrait}
       <div class="tree-node-name">${escapeHtml(name)}</div>
       <div class="tree-node-meta">Born: ${escapeHtml(birth)}</div>
     `;
@@ -1430,6 +1486,16 @@
     wrapper.appendChild(card);
   }
 
+  function apiAssetUrl(path) {
+    if (!path) return "";
+    if (/^https?:\/\//i.test(path)) return path;
+    const base =
+      window.TOLAuth && typeof window.TOLAuth.getApiBaseUrl === "function"
+        ? window.TOLAuth.getApiBaseUrl()
+        : "";
+    return `${base}${path.startsWith("/") ? "" : "/"}${path}`;
+  }
+
   function renderDetailPanel(
     member,
     memberMap,
@@ -1448,8 +1514,7 @@
     const spouses = relationships
       .filter(
         (rel) =>
-          (rel.relationship_type === "spouse" ||
-            rel.relationship_type === "former_spouse") &&
+          PARTNER_TYPES.has(rel.relationship_type) &&
           (rel.source_member_id === member.id ||
             rel.target_member_id === member.id),
       )
@@ -1688,8 +1753,8 @@
     const memberById = new Map();
     members.forEach((member) => memberById.set(member.id, member));
 
-    const spouseLinks = relationships.filter(
-      (rel) => rel.relationship_type === "spouse",
+    const spouseLinks = relationships.filter((rel) =>
+      PARTNER_TYPES.has(rel.relationship_type),
     );
     const spouseGraph = new Map();
 
@@ -1764,8 +1829,7 @@
     relationships
       .filter(
         (rel) =>
-          rel.relationship_type === "spouse" ||
-          rel.relationship_type === "former_spouse",
+          PARTNER_TYPES.has(rel.relationship_type),
       )
       .forEach((rel) => {
         const source = memberMap.get(rel.source_member_id);


### PR DESCRIPTION
## Phase 13 — Family Operating Machine

This PR turns the Verified/Narrative/Privacy design in `verified and narrative breakdown-3.pdf` into one explicit operating contract and closes the family-workflow gaps found in the backend audit.

### What this completes

- expands the relationship catalog across biological, reproductive, legal, step, guardian, foster, adoptive, chosen, cultural, partner, sibling, extended-family, and household relationships
- makes source → target direction explicit and adds inverse cross-household choices such as child, stepchild, ward, grandchild, and niece/nephew
- removes customer-entered generation values and solves generation/lineage-node placement from relationships, rejecting cycles and conflicting constraints
- adds Verified/Narrative truth fields, approved-evidence requirements, privacy scopes, validity dates, and guided evidence selection
- limits Family Key management to billing owners/co-owners (or internal family-operations permission), prevents unrelated officer roles from using the admin bypass, enforces household-link entitlements, displays raw keys once, hashes stored keys, atomically reserves key uses, and anchors both sides to selected people
- computes cross-household generation offsets, flags alignment conflicts, and makes the linked tree use the privacy-filtered aligned network
- prevents death from overriding privacy and requires external relationship facts/portraits to have their own cross-branch sharing approval
- adds one named portrait dropbox per family member, recorded authority/consent attestations, working malware scanning against the stored path, and separate pending versus active portraits
- adds master portrait and verification-evidence review queues
- automatically places an approved portrait in the tree and dynamically creates its relationship-aware private cinematic slide
- adds Family Reunion readiness grouped by household without exposing passwords, wallet secrets, private files, or unshared living-person records
- makes duplicate-person matching opt-in on both records and confines cross-household matching to approved links
- hardens the mint pipeline with owner/co-owner customer consent, no admin consent override, idempotent jobs, signer leasing, pending nonce selection, pre-broadcast transaction persistence, exact-transaction rebroadcast, stale-job recovery, and receipt synchronization
- documents the full operating model and remaining operational migrations

### Safety

- no production customer/account/database data was changed
- no existing canonical NFT was reminted or altered
- private tree/vault material remains off-chain
- unscanned, quarantined, unattested, or unapproved portraits cannot enter the tree, client review, or cinematic manifest

### Verification completed before push

- Python compilation passed for `backend/app` and `backend/tests`
- JavaScript syntax passed for all changed/new scripts
- Phase 13 contract checks passed
- merge-conflict marker scan passed
- branch contains three focused commits on current `main`
- GitHub Actions passed all four jobs: runtime/security, architecture/contracts, browser execution, and dependency audit

The complete behavior contract and production acceptance checklist are in:
`backend/docs/governance/tomb_of_light_family_operating_model.md`

### Required production follow-through after merge

- verify GitHub Pages and Render advance from the currently observed live revisions (`20260821-phase10-1` frontend / `0f898678e2788579cfbf365c35a0ba09e56308e4` backend); do not certify Phase 12 or Phase 13 while production still reports those older revisions
- reconcile legacy manual generations, missing lineage nodes, unanchored links, and old portrait approvals without attestations
- design governed divorce/death/succession and household-split cases
- add consented invitation delivery/reminders
- run the documented two-household smoke test and a testnet mint; do not use an existing customer canonical NFT for testing
