### PR TITLE
Phase 14 — Private upload storage and production readiness closure

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -53,7 +53,11 @@ def get_database() -> Database:
 def get_service_state(*, include_operational_details: bool = False) -> dict[str, Any]:
     # Import lazily so the services package can import get_database during
     # application startup without creating a database/services import cycle.
-    from app.services.upload_scan_service import get_upload_scanner_configuration
+    from app.services.r2_storage_service import get_private_storage_health
+    from app.services.upload_scan_service import (
+        get_upload_scanner_configuration,
+        get_upload_scanner_health,
+    )
 
     database_connected = db is not None
     degraded_reasons = [] if database_connected else ["database_unavailable"]
@@ -93,6 +97,37 @@ def get_service_state(*, include_operational_details: bool = False) -> dict[str,
     )
     scanner_configuration = get_upload_scanner_configuration()
     scanner_configured = scanner_configuration.configured
+    if include_operational_details:
+        scanner_health = get_upload_scanner_health()
+        private_object_storage = get_private_storage_health(check_provider=True)
+    else:
+        scanner_health = {
+            "configured": scanner_configured,
+            "available": scanner_configured,
+            "detail": scanner_configuration.detail,
+        }
+        private_object_storage = get_private_storage_health(check_provider=False)
+    scanner_available = bool(scanner_health.get("available"))
+    private_object_storage_configured = bool(
+        private_object_storage.get("configured")
+    )
+    private_object_storage_available = bool(
+        private_object_storage.get("available")
+    )
+    legacy_clean_local_uploads: int | None = None
+    if include_operational_details and database_connected:
+        try:
+            legacy_clean_local_uploads = int(
+                db["uploaded_files"].count_documents(
+                    {
+                        "scan_status": "clean",
+                        "quarantined": {"$ne": True},
+                        "storage_provider": {"$ne": "r2"},
+                    }
+                )
+            )
+        except Exception:
+            legacy_clean_local_uploads = None
     mount_path_value = str(settings.render_disk_mount_path or "").strip()
     mount_path = Path(mount_path_value) if mount_path_value else None
     persistent_private_storage = bool(
@@ -125,10 +160,23 @@ def get_service_state(*, include_operational_details: bool = False) -> dict[str,
             operational_degraded_reasons.append("stripe_configuration_incomplete")
         if not postmark_configured:
             operational_degraded_reasons.append("postmark_configuration_incomplete")
-        if not scanner_configured:
+        if not scanner_configured or not scanner_available:
             operational_degraded_reasons.append("upload_scanner_unavailable_quarantine_only")
         if not persistent_private_storage:
             operational_degraded_reasons.append("private_upload_storage_not_persistent")
+        if not private_object_storage_configured:
+            operational_degraded_reasons.append("private_object_storage_not_configured")
+        elif not private_object_storage_available:
+            operational_degraded_reasons.append("private_object_storage_unavailable")
+        if include_operational_details:
+            if legacy_clean_local_uploads is None:
+                operational_degraded_reasons.append(
+                    "legacy_private_upload_inventory_unavailable"
+                )
+            elif legacy_clean_local_uploads:
+                operational_degraded_reasons.append(
+                    "legacy_private_uploads_pending_r2_migration"
+                )
         if not release_sha:
             operational_degraded_reasons.append("deployment_revision_unavailable")
         if not continuity_execution_enabled:
@@ -161,16 +209,25 @@ def get_service_state(*, include_operational_details: bool = False) -> dict[str,
             "transactional_email": {"configured": postmark_configured},
             "upload_scanner": {
                 "configured": scanner_configured,
+                "available": scanner_available,
                 "fail_closed": bool(settings.upload_scan_fail_closed),
-                "mode": "active" if scanner_configured else "quarantine_only",
+                "mode": "active" if scanner_available else "quarantine_only",
                 "configuration_detail": scanner_configuration.detail,
+                "health_detail": str(scanner_health.get("detail") or ""),
                 "legacy_command_ignored": bool(
                     str(settings.upload_scan_command or "").strip()
                 ),
             },
             "private_upload_storage": {
                 "persistent": persistent_private_storage,
-                "mode": "persistent_disk" if persistent_private_storage else "local_runtime",
+                "mode": "staging_disk" if persistent_private_storage else "local_runtime",
+            },
+            "private_object_storage": {
+                "configured": private_object_storage_configured,
+                "available": private_object_storage_available,
+                "mode": "private_r2" if private_object_storage_available else "unavailable",
+                "health_detail": str(private_object_storage.get("detail") or ""),
+                "legacy_clean_local_uploads": legacy_clean_local_uploads,
             },
             "continuity_kernel": {
                 "execution_enabled": continuity_execution_enabled,

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -36,7 +36,12 @@ from app.services.upload_service import (
     store_private_media_upload,
     store_verification_evidence_upload,
 )
-from app.services.r2_storage_service import generate_private_download_url
+from app.services.r2_storage_service import (
+    delete_private_object,
+    generate_private_download_url,
+    private_storage_is_configured,
+    upload_private_file,
+)
 from app.services.upload_scan_service import scan_uploaded_file
 from app.services.audit_log_service import create_audit_log
 from app.services.privacy_access_service import (
@@ -497,6 +502,8 @@ def _public_upload_record(record: dict[str, Any]) -> dict[str, Any]:
     serialized.pop("master_review_notes", None)
     serialized.pop("verification_review_notes", None)
     serialized.pop("verified_by", None)
+    serialized.pop("scan_detail", None)
+    serialized.pop("quarantine_reason", None)
     return serialized
 
 
@@ -588,41 +595,296 @@ def _quarantine_path_for_upload(relative_path: str) -> Path:
     return candidate
 
 
+def _absolute_quarantine_path(quarantine_path: str) -> Path:
+    quarantine_root = Path(settings.upload_quarantine_root_path).resolve()
+    candidate = Path(quarantine_path).resolve()
+    try:
+        candidate.relative_to(quarantine_root)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Stored quarantine path is invalid.",
+        )
+    return candidate
+
+
+def _safe_storage_token(value: Any, *, fallback: str) -> str:
+    token = "".join(
+        character
+        for character in _normalize_value(value)
+        if character.isalnum() or character in {"-", "_"}
+    ).strip("_-")
+    return token or fallback
+
+
+def _private_storage_key(upload_record: dict[str, Any], upload_id: str) -> str:
+    category = _safe_storage_token(upload_record.get("category"), fallback="upload")
+    family_id = _safe_storage_token(upload_record.get("family_id"), fallback="family")
+    member_id = _safe_storage_token(upload_record.get("member_id"), fallback="member")
+    stored_filename = _safe_storage_token(
+        upload_record.get("stored_filename"),
+        fallback="private-object",
+    )
+    upload_token = _safe_storage_token(upload_id, fallback=secrets.token_hex(12))
+    return (
+        f"private-uploads/v1/{category}/{family_id}/{member_id}/"
+        f"{upload_token}/{stored_filename}"
+    )
+
+
+def _update_member_photo_scan_status(
+    *,
+    db: Any,
+    upload_record: dict[str, Any],
+    upload_id: str,
+    photo_submission_status: str,
+) -> None:
+    if _normalize_value(upload_record.get("category")) != "member_photo":
+        return
+    member_id = _normalize_value(upload_record.get("member_id"))
+    if not ObjectId.is_valid(member_id):
+        return
+    try:
+        db["family_members"].update_one(
+            {
+                "_id": ObjectId(member_id),
+                "pending_photo_upload_id": upload_id,
+            },
+            {
+                "$set": {
+                    "photo_submission_status": photo_submission_status,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            },
+        )
+    except Exception:
+        # The upload record remains authoritative if auxiliary member-state
+        # bookkeeping needs reconciliation.
+        pass
+
+
+def _quarantine_upload(
+    *,
+    db: Any,
+    upload_record: dict[str, Any],
+    upload_id: str,
+    absolute_path: Path,
+    status_value: str,
+    detail: str,
+) -> None:
+    relative_path = _normalize_value(upload_record.get("relative_path"))
+    quarantine_path = _quarantine_path_for_upload(relative_path)
+    quarantined = False
+    quarantine_detail = detail[:500] or status_value
+    if absolute_path.exists():
+        try:
+            quarantine_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(absolute_path), str(quarantine_path))
+            quarantined = True
+        except OSError:
+            quarantine_detail = f"{quarantine_detail}; move_failed"
+    now = datetime.now(UTC).isoformat()
+    db["uploaded_files"].update_one(
+        {"_id": ObjectId(upload_id)},
+        {
+            "$set": {
+                "scan_status": status_value,
+                "scan_detail": quarantine_detail,
+                "quarantined": quarantined,
+                "quarantine_reason": quarantine_detail,
+                "quarantine_path": str(quarantine_path) if quarantined else "",
+                "storage_promotion_status": "blocked",
+                "updated_at": now,
+            }
+        },
+    )
+    _update_member_photo_scan_status(
+        db=db,
+        upload_record=upload_record,
+        upload_id=upload_id,
+        photo_submission_status="quarantined",
+    )
+
+
+def _promote_clean_upload_to_private_storage(
+    *,
+    db: Any,
+    upload_record: dict[str, Any],
+    upload_id: str,
+    absolute_path: Path,
+    scan_detail: str,
+) -> None:
+    storage_key = _private_storage_key(upload_record, upload_id)
+    started_at = datetime.now(UTC).isoformat()
+    start_result = db["uploaded_files"].update_one(
+        {"_id": ObjectId(upload_id)},
+        {
+            "$set": {
+                "storage_promotion_status": "in_progress",
+                "storage_key_candidate": storage_key,
+                "storage_promotion_started_at": started_at,
+                "updated_at": started_at,
+            }
+        },
+    )
+    if getattr(start_result, "matched_count", 1) != 1:
+        raise RuntimeError("Upload record disappeared before storage promotion.")
+    try:
+        storage_result = upload_private_file(
+            key=storage_key,
+            path=absolute_path,
+            content_type=_normalize_value(upload_record.get("content_type"))
+            or "application/octet-stream",
+            metadata={
+                "upload-id": upload_id,
+                "category": _safe_storage_token(
+                    upload_record.get("category"),
+                    fallback="upload",
+                ),
+            },
+        )
+    except Exception:
+        # The provider may have accepted the object before a connection error.
+        # A deterministic key makes this cleanup safe and idempotent.
+        try:
+            delete_private_object(key=storage_key)
+        except Exception:
+            pass
+        raise
+    now = datetime.now(UTC).isoformat()
+    try:
+        update_result = db["uploaded_files"].update_one(
+            {"_id": ObjectId(upload_id)},
+            {
+                "$set": {
+                    "scan_status": "clean",
+                    "scan_detail": scan_detail[:500],
+                    "quarantined": False,
+                    "quarantine_reason": "",
+                    "quarantine_path": "",
+                    "storage_provider": "r2",
+                    "storage_bucket": storage_result.get("bucket"),
+                    "storage_key": storage_key,
+                    "storage_key_candidate": "",
+                    "storage_promotion_status": "complete",
+                    "storage_promoted_at": now,
+                    "local_staging_deleted": False,
+                    "updated_at": now,
+                }
+            },
+        )
+        if getattr(update_result, "matched_count", 1) != 1:
+            raise RuntimeError("Upload record disappeared during storage promotion.")
+    except Exception:
+        try:
+            delete_private_object(key=storage_key)
+        except Exception:
+            pass
+        raise
+
+    local_staging_deleted = False
+    try:
+        absolute_path.unlink(missing_ok=True)
+        local_staging_deleted = True
+    except OSError:
+        local_staging_deleted = False
+    try:
+        db["uploaded_files"].update_one(
+            {"_id": ObjectId(upload_id)},
+            {
+                "$set": {
+                    "local_staging_deleted": local_staging_deleted,
+                    "local_staging_cleanup_pending": not local_staging_deleted,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            },
+        )
+    except Exception:
+        # R2 and the first database update are already authoritative. A later
+        # maintenance pass can reconcile any leftover staging file.
+        pass
+    _update_member_photo_scan_status(
+        db=db,
+        upload_record=upload_record,
+        upload_id=upload_id,
+        photo_submission_status="pending_master_review",
+    )
+
+
 def _scan_and_quarantine_upload(*, db: Any, upload_record: dict[str, Any]) -> dict[str, Any]:
     upload_id = str(upload_record.get("id") or upload_record.get("_id") or "")
     relative_path = _normalize_value(upload_record.get("relative_path"))
     if not upload_id or not relative_path:
         return upload_record
+    stored_record = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
+    if stored_record:
+        upload_record = stored_record
+        relative_path = _normalize_value(upload_record.get("relative_path"))
     absolute_path = _absolute_upload_path(relative_path)
     result = scan_uploaded_file(str(absolute_path))
-    if result.status in {"infected", "error"}:
-        quarantine_path = _quarantine_path_for_upload(relative_path)
-        quarantined = False
-        quarantine_detail = result.detail[:500] or result.status
-        if absolute_path.exists():
-            try:
-                quarantine_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(absolute_path), str(quarantine_path))
-                quarantined = True
-            except OSError as exc:
-                del exc
-                quarantine_detail = f"{quarantine_detail}; move_failed"
+    if result.status in {"infected", "error", "skipped"}:
+        _quarantine_upload(
+            db=db,
+            upload_record=upload_record,
+            upload_id=upload_id,
+            absolute_path=absolute_path,
+            status_value=result.status,
+            detail=result.detail,
+        )
+    elif result.status == "clean" and private_storage_is_configured():
+        try:
+            _promote_clean_upload_to_private_storage(
+                db=db,
+                upload_record=upload_record,
+                upload_id=upload_id,
+                absolute_path=absolute_path,
+                scan_detail=result.detail,
+            )
+        except Exception as exc:
+            _quarantine_upload(
+                db=db,
+                upload_record=upload_record,
+                upload_id=upload_id,
+                absolute_path=absolute_path,
+                status_value="error",
+                detail=f"private_storage_promotion_failed:{type(exc).__name__}",
+            )
+    elif result.status == "clean" and settings.is_production_environment:
+        _quarantine_upload(
+            db=db,
+            upload_record=upload_record,
+            upload_id=upload_id,
+            absolute_path=absolute_path,
+            status_value="error",
+            detail="private_storage_not_configured",
+        )
+    elif result.status == "clean":
         db["uploaded_files"].update_one(
             {"_id": ObjectId(upload_id)},
             {
                 "$set": {
                     "scan_status": result.status,
-                    "scan_detail": quarantine_detail,
-                    "quarantined": quarantined,
-                    "quarantine_reason": quarantine_detail,
-                    "quarantine_path": str(quarantine_path) if quarantined else "",
+                    "scan_detail": result.detail[:500],
+                    "quarantined": False,
+                    "storage_promotion_status": "local_development_only",
+                    "updated_at": datetime.now(UTC).isoformat(),
                 }
             },
         )
+        _update_member_photo_scan_status(
+            db=db,
+            upload_record=upload_record,
+            upload_id=upload_id,
+            photo_submission_status="pending_master_review",
+        )
     else:
-        db["uploaded_files"].update_one(
-            {"_id": ObjectId(upload_id)},
-            {"$set": {"scan_status": result.status, "scan_detail": result.detail[:500], "quarantined": False}},
+        _quarantine_upload(
+            db=db,
+            upload_record=upload_record,
+            upload_id=upload_id,
+            absolute_path=absolute_path,
+            status_value="error",
+            detail="scanner_returned_non_clean_verdict",
         )
     refreshed = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
     return refreshed or upload_record
@@ -630,12 +892,99 @@ def _scan_and_quarantine_upload(*, db: Any, upload_record: dict[str, Any]) -> di
 
 def _upload_scan_blocks_download(upload_record: dict[str, Any]) -> bool:
     scan_status = _normalize_value(upload_record.get("scan_status")).lower()
-    return bool(upload_record.get("quarantined")) or scan_status in {
+    deletion_status = _normalize_value(upload_record.get("deletion_status")).lower()
+    return deletion_status in {"pending", "failed"} or bool(
+        upload_record.get("quarantined")
+    ) or scan_status in {
         "infected",
         "error",
         "skipped",
         "pending",
     }
+
+
+def _upload_has_durable_private_storage(upload_record: dict[str, Any]) -> bool:
+    if not settings.is_production_environment:
+        return True
+    return bool(
+        _normalize_value(upload_record.get("storage_provider")).lower() == "r2"
+        and _normalize_value(upload_record.get("storage_key"))
+    )
+
+
+def _clear_deleted_member_photo_references(
+    *,
+    db: Any,
+    upload_record: dict[str, Any],
+    upload_id: str,
+    current_user: dict[str, Any],
+) -> None:
+    if _normalize_value(upload_record.get("category")) != "member_photo":
+        return
+    member_id = _normalize_value(upload_record.get("member_id"))
+    if not ObjectId.is_valid(member_id):
+        return
+
+    member = db["family_members"].find_one({"_id": ObjectId(member_id)})
+    if not member:
+        return
+
+    pending_matches = (
+        _normalize_value(member.get("pending_photo_upload_id")) == upload_id
+    )
+    approved_matches = (
+        _normalize_value(member.get("approved_photo_upload_id")) == upload_id
+    )
+    active_matches = _normalize_value(member.get("photo_upload_id")) == upload_id
+    if not (pending_matches or approved_matches or active_matches):
+        return
+
+    member_update: dict[str, Any] = {
+        "updated_at": datetime.now(UTC).isoformat(),
+        "updated_by": _actor_label(current_user),
+        "updated_by_user_id": _current_user_id(current_user),
+    }
+    if pending_matches:
+        member_update["pending_photo_upload_id"] = None
+    if approved_matches:
+        member_update["approved_photo_upload_id"] = None
+        member_update["portrait_approved_at"] = None
+    if active_matches:
+        member_update.update(
+            {
+                "photo_upload_id": None,
+                "photo_path": None,
+                "photo_original_filename": None,
+                "photo_content_type": None,
+                "photo_size_bytes": 0,
+            }
+        )
+
+    other_active = bool(
+        (
+            _normalize_value(member.get("approved_photo_upload_id"))
+            and not approved_matches
+        )
+        or (
+            _normalize_value(member.get("photo_upload_id"))
+            and not active_matches
+        )
+    )
+    other_pending = bool(
+        _normalize_value(member.get("pending_photo_upload_id"))
+        and not pending_matches
+    )
+    if other_active:
+        member_update["photo_submission_status"] = "approved"
+    elif not other_pending:
+        member_update["photo_submission_status"] = "not_submitted"
+
+    result = db["family_members"].update_one(
+        {"_id": ObjectId(member_id)},
+        {"$set": member_update},
+    )
+    if getattr(result, "matched_count", 1) != 1:
+        raise RuntimeError("Family member disappeared during upload deletion.")
 
 
 def _file_extension(filename: str) -> str:
@@ -1452,6 +1801,19 @@ def update_upload_cinematic_approval(
             status_code=status.HTTP_409_CONFLICT,
             detail="Portrait must pass malware scanning before master approval.",
         )
+    if approving and not _upload_has_durable_private_storage(upload_record):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Portrait must be stored in durable private storage before master approval.",
+        )
+    if approving and _normalize_value(upload_record.get("deletion_status")).lower() in {
+        "pending",
+        "failed",
+    }:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Portrait deletion is pending and cannot be approved.",
+        )
     if approving and not (
         bool(upload_record.get("consent_attested"))
         and bool(upload_record.get("authority_attested"))
@@ -1562,6 +1924,21 @@ def update_upload_verification_review(
             status_code=status.HTTP_409_CONFLICT,
             detail="Verification evidence must pass malware scanning before approval.",
         )
+    if decision == "approved" and not _upload_has_durable_private_storage(upload_record):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Verification evidence must be stored in durable private storage "
+                "before approval."
+            ),
+        )
+    if decision == "approved" and _normalize_value(
+        upload_record.get("deletion_status")
+    ).lower() in {"pending", "failed"}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Verification evidence deletion is pending and cannot be approved.",
+        )
 
     now = datetime.now(UTC).isoformat()
     db["uploaded_files"].update_one(
@@ -1639,6 +2016,17 @@ def download_upload(
         current_user,
         detail="Your active package does not include upload access.",
     )
+    deletion_status = _normalize_value(upload_record.get("deletion_status")).lower()
+    if deletion_status in {"pending", "failed"}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This file is unavailable while deletion is pending reconciliation.",
+        )
+    if not _upload_has_durable_private_storage(upload_record):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="This file is unavailable until private storage migration completes.",
+        )
     if _upload_scan_blocks_download(upload_record):
         is_admin = _is_admin(current_user)
         if not (
@@ -1665,11 +2053,22 @@ def download_upload(
             )
 
     if _normalize_value(upload_record.get("storage_provider")).lower() == "r2":
-        storage_key = _normalize_value(upload_record.get("storage_key") or upload_record.get("relative_path"))
-        signed_url = generate_private_download_url(key=storage_key, expires_seconds=120)
+        storage_key = _normalize_value(upload_record.get("storage_key"))
+        if not storage_key:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Private object storage key is missing for this upload.",
+            )
+        try:
+            signed_url = generate_private_download_url(
+                key=storage_key,
+                expires_seconds=120,
+            )
+        except Exception:
+            signed_url = None
         if not signed_url:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Private object storage is unavailable for this upload.",
             )
         response = RedirectResponse(url=signed_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
@@ -1715,33 +2114,113 @@ def delete_upload(
     )
 
     relative_path = _normalize_value(upload_record.get("relative_path"))
-    if relative_path:
-        absolute_path = _absolute_upload_path(relative_path)
-        if absolute_path.exists():
-            absolute_path.unlink()
+    absolute_path = _absolute_upload_path(relative_path) if relative_path else None
+    quarantine_path = _normalize_value(upload_record.get("quarantine_path"))
+    absolute_quarantine_path = (
+        _absolute_quarantine_path(quarantine_path) if quarantine_path else None
+    )
 
-    db["uploaded_files"].delete_one({"_id": ObjectId(upload_id)})
+    now = datetime.now(UTC).isoformat()
+    db["uploaded_files"].update_one(
+        {"_id": ObjectId(upload_id)},
+        {
+            "$set": {
+                "deletion_status": "pending",
+                "deletion_requested_at": now,
+                "deletion_requested_by_user_id": _current_user_id(current_user),
+                "updated_at": now,
+            }
+        },
+    )
 
-    if _normalize_value(upload_record.get("category")) == "member_photo":
-        member_id = _normalize_value(upload_record.get("member_id"))
-        if ObjectId.is_valid(member_id):
-            db["family_members"].update_one(
-                {
-                    "_id": ObjectId(member_id),
-                    "photo_upload_id": upload_id,
-                },
+    if _normalize_value(upload_record.get("storage_provider")).lower() == "r2":
+        storage_key = _normalize_value(upload_record.get("storage_key"))
+        if not storage_key:
+            db["uploaded_files"].update_one(
+                {"_id": ObjectId(upload_id)},
                 {
                     "$set": {
-                        "photo_upload_id": "",
-                        "photo_path": "",
-                        "photo_original_filename": "",
-                        "photo_content_type": "",
-                        "photo_size_bytes": 0,
-                        "updated_by": _actor_label(current_user),
-                        "updated_by_user_id": _current_user_id(current_user),
+                        "deletion_status": "failed",
+                        "deletion_detail": "private_storage_key_missing",
+                        "updated_at": datetime.now(UTC).isoformat(),
                     }
                 },
             )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Private object storage key is missing; deletion was stopped safely.",
+            )
+        try:
+            delete_private_object(key=storage_key)
+        except Exception as exc:
+            db["uploaded_files"].update_one(
+                {"_id": ObjectId(upload_id)},
+                {
+                    "$set": {
+                        "deletion_status": "failed",
+                        "deletion_detail": (
+                            f"private_storage_delete_failed:{type(exc).__name__}"
+                        ),
+                        "updated_at": datetime.now(UTC).isoformat(),
+                    }
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Private object storage deletion failed; the record was retained for retry.",
+            )
+
+    try:
+        if absolute_path:
+            absolute_path.unlink(missing_ok=True)
+
+        if absolute_quarantine_path:
+            absolute_quarantine_path.unlink(missing_ok=True)
+    except OSError as exc:
+        db["uploaded_files"].update_one(
+            {"_id": ObjectId(upload_id)},
+            {
+                "$set": {
+                    "deletion_status": "failed",
+                    "deletion_detail": f"local_cleanup_failed:{type(exc).__name__}",
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Upload cleanup failed; the record was retained for retry.",
+        )
+
+    try:
+        _clear_deleted_member_photo_references(
+            db=db,
+            upload_record=upload_record,
+            upload_id=upload_id,
+            current_user=current_user,
+        )
+    except Exception as exc:
+        db["uploaded_files"].update_one(
+            {"_id": ObjectId(upload_id)},
+            {
+                "$set": {
+                    "deletion_status": "failed",
+                    "deletion_detail": (
+                        f"member_reference_cleanup_failed:{type(exc).__name__}"
+                    ),
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "Member portrait references could not be cleared; "
+                "the upload record was retained for retry."
+            ),
+        )
+
+    db["uploaded_files"].delete_one({"_id": ObjectId(upload_id)})
 
     return {
         "status": "deleted",

--- a/backend/app/services/poster_asset_service.py
+++ b/backend/app/services/poster_asset_service.py
@@ -7,7 +7,11 @@ from pymongo.collection import Collection
 
 from app.config import settings
 from app.database import get_database
-from app.services.r2_storage_service import ZONE_POSTER, upload_bytes
+from app.services.r2_storage_service import (
+    ZONE_POSTER,
+    download_private_bytes,
+    upload_bytes,
+)
 
 ALLOWED_POSTER_STYLES = {
     "abstract_cover",
@@ -192,6 +196,33 @@ def _read_local_upload_bytes(upload_record: dict[str, Any]) -> tuple[bytes, str,
     return absolute_path.read_bytes(), content_type, suffix
 
 
+def _read_approved_upload_bytes(
+    upload_record: dict[str, Any],
+) -> tuple[bytes, str, str] | None:
+    storage_provider = _normalize(upload_record.get("storage_provider")).lower()
+    if storage_provider != "r2":
+        if settings.is_production_environment:
+            return None
+        return _read_local_upload_bytes(upload_record)
+
+    storage_key = _normalize(upload_record.get("storage_key"))
+    if not storage_key:
+        return None
+    try:
+        body = download_private_bytes(
+            key=storage_key,
+            max_bytes=settings.upload_max_image_bytes,
+        )
+    except Exception:
+        return None
+
+    content_type = _normalize(upload_record.get("content_type"))
+    if content_type not in set(settings.upload_image_content_types_list):
+        return None
+    suffix = Path(_normalize(upload_record.get("stored_filename"))).suffix or ".bin"
+    return body, content_type, suffix
+
+
 def export_approved_public_poster(
     project_id: str,
     version_number: int,
@@ -201,20 +232,14 @@ def export_approved_public_poster(
 ) -> dict[str, Any]:
     upload_record = _best_uploaded_portrait(project_id)
     if upload_record is None:
-        return generate_abstract_cover(
-            project_id,
-            version_number,
-            public_token_id,
-            publish=publish,
+        raise RuntimeError(
+            "Approved poster was requested, but no eligible approved portrait exists."
         )
 
-    source = _read_local_upload_bytes(upload_record)
+    source = _read_approved_upload_bytes(upload_record)
     if source is None:
-        return generate_abstract_cover(
-            project_id,
-            version_number,
-            public_token_id,
-            publish=publish,
+        raise RuntimeError(
+            "Approved poster was requested, but its private source is unavailable."
         )
 
     body, content_type, suffix = source

--- a/backend/app/services/r2_storage_service.py
+++ b/backend/app/services/r2_storage_service.py
@@ -68,6 +68,21 @@ def r2_is_configured() -> bool:
     )
 
 
+def private_storage_is_configured() -> bool:
+    """Return whether the dedicated private-object-storage zone is usable."""
+
+    return all(
+        (
+            _normalize(settings.r2_access_key_id),
+            _normalize(settings.r2_secret_access_key),
+            _normalize(settings.r2_resolved_endpoint_url),
+            # Private customer files must never silently share the generic or
+            # public metadata/poster bucket. Require the dedicated setting.
+            _normalize(settings.r2_private_bucket),
+        )
+    )
+
+
 def _allow_local_fallback() -> bool:
     environment = _normalize(settings.environment).lower()
     if _has_any_r2_config():
@@ -86,7 +101,7 @@ def _bucket_for_zone(zone: str) -> str:
     return _normalize(settings.r2_bucket)
 
 
-def _lazy_s3_client():
+def _lazy_s3_client(*, healthcheck: bool = False):
     try:
         import boto3 # type: ignore
         from botocore.config import Config # type: ignore
@@ -109,8 +124,47 @@ def _lazy_s3_client():
         config=Config(
             signature_version="s3v4",
             s3={"addressing_style": "path" if settings.r2_force_path_style else "virtual"},
+            connect_timeout=3 if healthcheck else 5,
+            read_timeout=5 if healthcheck else 30,
+            retries={
+                "max_attempts": 1 if healthcheck else 3,
+                "mode": "standard",
+            },
         ),
     )
+
+
+def get_private_storage_health(*, check_provider: bool = False) -> dict[str, Any]:
+    """Return minimized private R2 configuration and provider availability."""
+
+    configured = private_storage_is_configured()
+    if not configured:
+        return {
+            "configured": False,
+            "available": False,
+            "detail": "private_object_storage_not_configured",
+        }
+    if not check_provider:
+        return {
+            "configured": True,
+            "available": True,
+            "detail": "private_object_storage_configured",
+        }
+
+    try:
+        client = _lazy_s3_client(healthcheck=True)
+        client.head_bucket(Bucket=_private_bucket())
+    except Exception as exc:
+        return {
+            "configured": True,
+            "available": False,
+            "detail": f"private_object_storage_unavailable:{type(exc).__name__}",
+        }
+    return {
+        "configured": True,
+        "available": True,
+        "detail": "private_object_storage_ready",
+    }
 
 
 def _local_fallback_write(
@@ -174,6 +228,90 @@ def upload_bytes(
     }
 
 
+def upload_private_file(
+    *,
+    key: str,
+    path: str | Path,
+    content_type: str,
+    metadata: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Stream one malware-clean private file into the dedicated R2 bucket."""
+
+    source = Path(path)
+    if not source.is_file():
+        raise RuntimeError("Private upload source file is unavailable.")
+    if not private_storage_is_configured():
+        raise RuntimeError("Private object storage is not fully configured.")
+
+    storage_key = key.lstrip("/")
+    if not storage_key:
+        raise RuntimeError("Private object key is missing.")
+    bucket = _private_bucket()
+    size_bytes = source.stat().st_size
+    client = _lazy_s3_client()
+    with source.open("rb") as file_handle:
+        client.put_object(
+            Bucket=bucket,
+            Key=storage_key,
+            Body=file_handle,
+            ContentLength=size_bytes,
+            ContentType=content_type or "application/octet-stream",
+            CacheControl="private, no-store",
+            Metadata=metadata or {},
+        )
+
+    return {
+        "storage_provider": "r2",
+        "bucket": bucket,
+        "key": storage_key,
+        "size_bytes": size_bytes,
+        "content_type": content_type or "application/octet-stream",
+    }
+
+
+def delete_private_object(*, key: str) -> None:
+    """Idempotently remove one object from the dedicated private R2 bucket."""
+
+    storage_key = key.lstrip("/")
+    if not storage_key:
+        raise RuntimeError("Private object key is missing.")
+    if not private_storage_is_configured():
+        raise RuntimeError("Private object storage is not fully configured.")
+    client = _lazy_s3_client()
+    client.delete_object(Bucket=_private_bucket(), Key=storage_key)
+
+
+def download_private_bytes(*, key: str, max_bytes: int) -> bytes:
+    """Read a bounded private object for an authorized server-side derivative."""
+
+    storage_key = key.lstrip("/")
+    if not storage_key:
+        raise RuntimeError("Private object key is missing.")
+    if max_bytes < 1:
+        raise RuntimeError("Private object read limit must be positive.")
+    if not private_storage_is_configured():
+        raise RuntimeError("Private object storage is not fully configured.")
+
+    client = _lazy_s3_client()
+    response = client.get_object(Bucket=_private_bucket(), Key=storage_key)
+    content_length = int(response.get("ContentLength") or 0)
+    if content_length and content_length > max_bytes:
+        raise RuntimeError("Private object exceeds the authorized read limit.")
+
+    body = response.get("Body")
+    if body is None or not hasattr(body, "read"):
+        raise RuntimeError("Private object response body is unavailable.")
+    try:
+        payload = body.read(max_bytes + 1)
+    finally:
+        close = getattr(body, "close", None)
+        if callable(close):
+            close()
+    if len(payload) > max_bytes:
+        raise RuntimeError("Private object exceeds the authorized read limit.")
+    return bytes(payload)
+
+
 def upload_json(
     *,
     zone: str,
@@ -212,7 +350,7 @@ def upload_text(
 
 def generate_private_download_url(*, key: str, expires_seconds: int = 120) -> str | None:
     bucket = _private_bucket()
-    if not r2_is_configured() or not bucket:
+    if not private_storage_is_configured() or not bucket:
         return None
     client = _lazy_s3_client()
     return str(

--- a/backend/app/services/upload_scan_service.py
+++ b/backend/app/services/upload_scan_service.py
@@ -95,6 +95,71 @@ def get_upload_scanner_configuration() -> UploadScannerConfiguration:
     )
 
 
+def get_upload_scanner_health() -> dict[str, Any]:
+    """Return minimized configuration and live-provider availability details."""
+
+    configuration = get_upload_scanner_configuration()
+    if not configuration.configured:
+        return {
+            "configured": False,
+            "available": False,
+            "detail": configuration.detail or "scanner_not_configured",
+        }
+
+    hook_path = str(settings.upload_scan_hook or "").strip()
+    module_name, separator, _function_name = hook_path.partition(":")
+    if not separator or not module_name.strip():
+        return {
+            "configured": False,
+            "available": False,
+            "detail": "scanner_hook_format_invalid",
+        }
+
+    try:
+        module = importlib.import_module(module_name.strip())
+        healthcheck = getattr(module, "healthcheck")
+    except Exception:
+        return {
+            "configured": True,
+            "available": False,
+            "detail": "scanner_healthcheck_unavailable",
+        }
+    if not callable(healthcheck):
+        return {
+            "configured": True,
+            "available": False,
+            "detail": "scanner_healthcheck_not_callable",
+        }
+
+    try:
+        result: Any = healthcheck()
+    except Exception as exc:
+        return {
+            "configured": True,
+            "available": False,
+            "detail": f"scanner_healthcheck_error:{type(exc).__name__}",
+        }
+
+    if isinstance(result, dict):
+        configured = bool(result.get("configured", True))
+        available = bool(result.get("available") or result.get("ready"))
+        detail = str(result.get("detail") or "")
+    elif isinstance(result, tuple):
+        available = bool(result[0]) if result else False
+        configured = True
+        detail = str(result[1] if len(result) > 1 else "")
+    else:
+        configured = True
+        available = bool(result)
+        detail = ""
+
+    return {
+        "configured": configured,
+        "available": available,
+        "detail": detail or ("scanner_ready" if available else "scanner_unavailable"),
+    }
+
+
 def _coerce_result(result: object) -> UploadScanResult:
     if isinstance(result, UploadScanResult):
         return result
@@ -137,9 +202,10 @@ def scan_uploaded_file(path: str) -> UploadScanResult:
     try:
         result = _coerce_result(hook(file_path))
     except Exception as exc:
+        detail = f"scanner_error:{type(exc).__name__}"
         if _must_fail_closed():
-            return UploadScanResult(status="error", detail=f"scanner_error:{exc}")
-        return UploadScanResult(status="skipped", detail=f"scanner_error:{exc}")
+            return UploadScanResult(status="error", detail=detail)
+        return UploadScanResult(status="skipped", detail=detail)
 
     normalized_status = str(result.status or "").strip().lower()
     if normalized_status == "skipped" and _must_fail_closed():

--- a/backend/docs/governance/continuity_kernel_phase14_private_upload_storage_closure.md
+++ b/backend/docs/governance/continuity_kernel_phase14_private_upload_storage_closure.md
@@ -1,0 +1,84 @@
+# Continuity Kernel Phase 14 — Private Upload Storage Closure
+
+Date: 2026-08-24
+
+## Outcome
+
+Phase 14 makes the private-upload pipeline use Render's persistent disk only for
+staging and quarantine. A file must receive a clean malware verdict before it is
+streamed into the dedicated private Cloudflare R2 bucket. The database becomes
+authoritative for the R2 object only after that object write succeeds, and the
+local staging copy is then removed.
+
+The engineering verification in this phase does not upload, download, migrate,
+or delete production customer files.
+
+## Governed storage states
+
+| State | Local disk | Private R2 | Download allowed |
+| --- | --- | --- | --- |
+| Pending scan | Staging copy | No object | No |
+| Malware clean, promotion complete | Removed after promotion | Private object | Yes, after normal authorization |
+| Malware detected | Quarantine copy | No object | No |
+| Scanner or R2 error | Quarantine copy when possible | No newly authoritative object | No |
+| Deletion pending or failed | Cleanup may be pending | Deletion unconfirmed | No |
+
+Development environments without R2 may retain clean files locally. Production
+never treats that fallback as successful: missing or failed private object
+storage moves the upload into the blocked/quarantine path.
+
+## Object confidentiality
+
+- Private objects use keys rooted at `private-uploads/v1/` and contain system
+  identifiers plus the generated stored filename, not the customer's original
+  filename.
+- The dedicated `R2_PRIVATE_BUCKET` setting is mandatory; the system will not
+  silently place customer files in a generic metadata or poster bucket.
+- Uploads set `Cache-Control: private, no-store`.
+- Downloads require the existing workspace and privacy authorization checks,
+  then redirect to a signed R2 URL with a two-minute lifetime.
+- An explicitly selected approved NFT poster is read from private R2 through a
+  bounded server-side path. If that approved source is unavailable, manifest
+  preparation fails closed instead of silently minting an abstract substitute.
+- Public serialization does not expose the staging path, R2 bucket, or R2 key.
+- Infected, skipped, errored, quarantined, deletion-pending, and deletion-failed
+  records cannot produce a download.
+
+## Failure and deletion behavior
+
+- If an R2 write fails, production keeps the file blocked and moves the staging
+  copy into quarantine when possible.
+- If the R2 write succeeds but the database authority update fails, the new R2
+  object is deleted best-effort before the upload is quarantined.
+- Deletion first validates every local path, marks the record pending, and then
+  requests idempotent R2 deletion.
+- If R2 deletion fails, the database record is retained with a failed status so
+  the operation can be retried and audited; downloads remain blocked.
+- Confirmed deletions also remove any residual staging file and the actual
+  quarantine file, closing the earlier quarantine-orphan defect.
+- Deleting an active or pending portrait clears its member-level pending,
+  approved, and active-photo references before the upload record is removed.
+
+## Protected readiness
+
+Public liveness remains low-latency and does not disclose control details. The
+CEO-only operational readiness surface now performs live, minimized checks for:
+
+1. a writable Render disk mounted for staging and quarantine;
+2. a configured and reachable scanner health check;
+3. a configured and reachable dedicated private R2 bucket.
+
+The protected gate also fails closed if it cannot count legacy clean local
+uploads; an unknown migration inventory is not treated as zero.
+
+Provider errors are reduced to control-state codes and exception types. Endpoint
+URLs, bucket names, access-key identifiers, and secrets are not included in the
+readiness response.
+
+## Deployment boundary
+
+New uploads begin using this lifecycle only after Phase 14 is merged and its
+backend deployment is live. Existing clean local records are not silently moved
+by engineering tests or application startup. Any legacy-file migration must be
+counted first, verified against actual disk availability, and executed through a
+separate governed, resumable operation that preserves authorization and evidence.

--- a/backend/tests/test_health_and_db_unavailable.py
+++ b/backend/tests/test_health_and_db_unavailable.py
@@ -50,6 +50,24 @@ def _upload_workspace_context():
     }
 
 
+class ReadinessUploadCollection:
+    def __init__(self, legacy_clean_local_uploads=0):
+        self.legacy_clean_local_uploads = legacy_clean_local_uploads
+
+    def count_documents(self, _query):
+        return self.legacy_clean_local_uploads
+
+
+class ReadinessDatabase:
+    def __init__(self, legacy_clean_local_uploads=0):
+        self.uploaded_files = ReadinessUploadCollection(legacy_clean_local_uploads)
+
+    def __getitem__(self, name):
+        if name != "uploaded_files":
+            raise KeyError(name)
+        return self.uploaded_files
+
+
 class HealthAndDbUnavailableTests(unittest.TestCase):
     def _request(self, path: str, method: str = "GET") -> Request:
         return Request(
@@ -107,25 +125,45 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
 
     def test_production_operational_readiness_reports_controls_only_to_ceo_surface(self):
         with tempfile.TemporaryDirectory() as mount_path:
+            readiness_db = ReadinessDatabase()
             with (
-                patch.object(database_module, "db", object()),
-                patch.object(database_module.settings, "environment", "production"),
-                patch.object(database_module.settings, "secret_key", "s" * 48),
-                patch.object(database_module.settings, "stripe_secret_key", "sk_live_configured"),
-                patch.object(database_module.settings, "stripe_publishable_key", "pk_live_configured"),
-                patch.object(database_module.settings, "stripe_webhook_secret", "whsec_configured"),
-                patch.object(database_module.settings, "postmark_server_token", "postmark-configured"),
-                patch.object(database_module.settings, "postmark_server_token_file", ""),
-                patch.object(database_module.settings, "postmark_from_email", "security@tomboflight.com"),
-                patch.object(
+                patch.object(database_module, "db", readiness_db),
+                patch.multiple(
                     database_module.settings,
-                    "upload_scan_hook",
-                    "app.services.clamav_upload_scanner:scan",
+                    environment="production",
+                    secret_key="s" * 48,
+                    stripe_secret_key="sk_live_configured",
+                    stripe_publishable_key="pk_live_configured",
+                    stripe_webhook_secret="whsec_configured",
+                    postmark_server_token="postmark-configured",
+                    postmark_server_token_file="",
+                    postmark_from_email="security@tomboflight.com",
+                    upload_scan_hook="app.services.clamav_upload_scanner:scan",
+                    upload_clamav_host="127.0.0.1",
+                    upload_scan_command="",
+                    upload_scan_fail_closed=True,
+                    render_disk_mount_path=mount_path,
+                    r2_access_key_id="configured-access-key",
+                    r2_secret_access_key="configured-secret-key",
+                    r2_endpoint_url="https://account.r2.cloudflarestorage.com",
+                    r2_private_bucket="private-bucket",
                 ),
-                patch.object(database_module.settings, "upload_clamav_host", "127.0.0.1"),
-                patch.object(database_module.settings, "upload_scan_command", ""),
-                patch.object(database_module.settings, "upload_scan_fail_closed", True),
-                patch.object(database_module.settings, "render_disk_mount_path", mount_path),
+                patch(
+                    "app.services.upload_scan_service.get_upload_scanner_health",
+                    return_value={
+                        "configured": True,
+                        "available": True,
+                        "detail": "clamav_ready",
+                    },
+                ),
+                patch(
+                    "app.services.r2_storage_service.get_private_storage_health",
+                    return_value={
+                        "configured": True,
+                        "available": True,
+                        "detail": "private_object_storage_ready",
+                    },
+                ),
                 patch.dict(
                     database_module.os.environ,
                     {
@@ -136,6 +174,14 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
             ):
                 public_state = database_module.get_service_state()
                 detailed_state = database_module.get_service_state(
+                    include_operational_details=True
+                )
+                readiness_db.uploaded_files.legacy_clean_local_uploads = 2
+                migration_state = database_module.get_service_state(
+                    include_operational_details=True
+                )
+                readiness_db.uploaded_files.legacy_clean_local_uploads = None
+                inventory_unavailable_state = database_module.get_service_state(
                     include_operational_details=True
                 )
 
@@ -150,6 +196,23 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
         self.assertTrue(detailed_state["components"]["stripe_webhooks"]["configured"])
         self.assertEqual(detailed_state["components"]["upload_scanner"]["mode"], "active")
         self.assertTrue(detailed_state["components"]["private_upload_storage"]["persistent"])
+        self.assertTrue(detailed_state["components"]["private_object_storage"]["available"])
+        self.assertEqual(
+            detailed_state["components"]["private_object_storage"][
+                "legacy_clean_local_uploads"
+            ],
+            0,
+        )
+        self.assertFalse(migration_state["operational_ready"])
+        self.assertIn(
+            "legacy_private_uploads_pending_r2_migration",
+            migration_state["operational_degraded_reasons"],
+        )
+        self.assertFalse(inventory_unavailable_state["operational_ready"])
+        self.assertIn(
+            "legacy_private_upload_inventory_unavailable",
+            inventory_unavailable_state["operational_degraded_reasons"],
+        )
 
     def test_production_operational_readiness_fails_closed_on_missing_controls(self):
         release_env = {
@@ -187,6 +250,7 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
                 "postmark_configuration_incomplete",
                 "upload_scanner_unavailable_quarantine_only",
                 "private_upload_storage_not_persistent",
+                "private_object_storage_not_configured",
                 "deployment_revision_unavailable",
                 "continuity_execution_disabled",
             }.issubset(reasons)

--- a/backend/tests/test_private_upload_r2_storage.py
+++ b/backend/tests/test_private_upload_r2_storage.py
@@ -1,0 +1,750 @@
+import io
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from app.routes import uploads as upload_routes
+from app.services import poster_asset_service, r2_storage_service, upload_scan_service
+
+
+class FakeUpdateResult:
+    def __init__(self, matched_count=0):
+        self.matched_count = matched_count
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    def find_one(self, query):
+        for document in self.documents:
+            if all(document.get(key) == value for key, value in query.items()):
+                return document
+        return None
+
+    def update_one(self, query, update):
+        document = self.find_one(query)
+        if document is None:
+            return FakeUpdateResult()
+        document.update(update.get("$set", {}))
+        return FakeUpdateResult(matched_count=1)
+
+    def delete_one(self, query):
+        document = self.find_one(query)
+        if document is not None:
+            self.documents.remove(document)
+
+
+class FakeDatabase:
+    def __init__(self, collections=None):
+        self.collections = {
+            name: FakeCollection(documents)
+            for name, documents in (collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        if name not in self.collections:
+            self.collections[name] = FakeCollection()
+        return self.collections[name]
+
+
+class FakeS3Client:
+    def __init__(self):
+        self.put_request = None
+        self.deleted = None
+        self.head_bucket_name = None
+
+    def put_object(self, **kwargs):
+        self.put_request = {
+            **kwargs,
+            "Body": kwargs["Body"].read(),
+        }
+
+    def delete_object(self, **kwargs):
+        self.deleted = kwargs
+
+    def head_bucket(self, **kwargs):
+        self.head_bucket_name = kwargs["Bucket"]
+
+    def get_object(self, **_kwargs):
+        return {
+            "ContentLength": len(b"private-pdf"),
+            "Body": io.BytesIO(b"private-pdf"),
+        }
+
+    def generate_presigned_url(self, *_args, **_kwargs):
+        return "https://private-download.example/signed"
+
+
+class PrivateUploadPromotionTests(unittest.TestCase):
+    def _upload_fixture(self, upload_root: Path):
+        upload_id = ObjectId()
+        relative_path = "member_photos/family-1/member-1/photo.jpg"
+        source = upload_root / relative_path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(b"clean-photo")
+        record = {
+            "_id": upload_id,
+            "id": str(upload_id),
+            "project_id": "project-1",
+            "family_id": "family-1",
+            "member_id": "member-1",
+            "category": "member_photo",
+            "stored_filename": "photo.jpg",
+            "relative_path": relative_path,
+            "content_type": "image/jpeg",
+            "storage_provider": "local_disk",
+            "scan_status": "pending",
+            "quarantined": False,
+        }
+        return upload_id, source, record
+
+    def _enter_settings(
+        self,
+        stack: ExitStack,
+        upload_root: Path,
+        quarantine_root: Path,
+    ) -> None:
+        patches = (
+            patch.object(upload_routes.settings, "render_disk_mount_path", ""),
+            patch.object(upload_routes.settings, "upload_storage_dir", str(upload_root)),
+            patch.object(
+                upload_routes.settings,
+                "upload_quarantine_dir",
+                str(quarantine_root),
+            ),
+        )
+        for settings_patch in patches:
+            stack.enter_context(settings_patch)
+
+    def test_clean_upload_promotes_to_private_r2_and_removes_staging_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_root = Path(tmpdir) / "uploads"
+            quarantine_root = Path(tmpdir) / "quarantine"
+            upload_id, source, record = self._upload_fixture(upload_root)
+            db = FakeDatabase({"uploaded_files": [record]})
+            upload_result = {
+                "storage_provider": "r2",
+                "bucket": "private-bucket",
+            }
+            with ExitStack() as stack:
+                self._enter_settings(stack, upload_root, quarantine_root)
+                scan_file = stack.enter_context(
+                    patch.object(upload_routes, "scan_uploaded_file")
+                )
+                stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "private_storage_is_configured",
+                        return_value=True,
+                    )
+                )
+                upload_private = stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "upload_private_file",
+                        return_value=upload_result,
+                    )
+                )
+                scan_file.return_value = SimpleNamespace(
+                    status="clean",
+                    detail="clamav_clean",
+                )
+                updated = upload_routes._scan_and_quarantine_upload(
+                    db=db,
+                    upload_record={
+                        "id": str(upload_id),
+                        "relative_path": record["relative_path"],
+                    },
+                )
+
+            self.assertEqual(updated["storage_provider"], "r2")
+            self.assertEqual(updated["scan_status"], "clean")
+            self.assertEqual(updated["storage_promotion_status"], "complete")
+            self.assertTrue(updated["storage_key"].startswith("private-uploads/v1/"))
+            self.assertFalse(source.exists())
+            upload_private.assert_called_once()
+
+    def test_infected_upload_is_quarantined_and_never_sent_to_r2(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_root = Path(tmpdir) / "uploads"
+            quarantine_root = Path(tmpdir) / "quarantine"
+            upload_id, source, record = self._upload_fixture(upload_root)
+            db = FakeDatabase({"uploaded_files": [record]})
+            with ExitStack() as stack:
+                self._enter_settings(stack, upload_root, quarantine_root)
+                scan_file = stack.enter_context(
+                    patch.object(upload_routes, "scan_uploaded_file")
+                )
+                stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "private_storage_is_configured",
+                        return_value=True,
+                    )
+                )
+                upload_private = stack.enter_context(
+                    patch.object(upload_routes, "upload_private_file")
+                )
+                scan_file.return_value = SimpleNamespace(
+                    status="infected",
+                    detail="clamav_detected:test-signature",
+                )
+                updated = upload_routes._scan_and_quarantine_upload(
+                    db=db,
+                    upload_record={
+                        "id": str(upload_id),
+                        "relative_path": record["relative_path"],
+                    },
+                )
+
+            self.assertEqual(updated["scan_status"], "infected")
+            self.assertTrue(updated["quarantined"])
+            self.assertFalse(source.exists())
+            self.assertTrue(Path(updated["quarantine_path"]).is_file())
+            upload_private.assert_not_called()
+
+    def test_skipped_scan_is_quarantined_and_never_promoted_to_r2(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_root = Path(tmpdir) / "uploads"
+            quarantine_root = Path(tmpdir) / "quarantine"
+            upload_id, source, record = self._upload_fixture(upload_root)
+            db = FakeDatabase({"uploaded_files": [record]})
+            with ExitStack() as stack:
+                self._enter_settings(stack, upload_root, quarantine_root)
+                scan_file = stack.enter_context(
+                    patch.object(upload_routes, "scan_uploaded_file")
+                )
+                stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "private_storage_is_configured",
+                        return_value=True,
+                    )
+                )
+                upload_private = stack.enter_context(
+                    patch.object(upload_routes, "upload_private_file")
+                )
+                scan_file.return_value = SimpleNamespace(
+                    status="skipped",
+                    detail="scanner_unavailable",
+                )
+                updated = upload_routes._scan_and_quarantine_upload(
+                    db=db,
+                    upload_record={
+                        "id": str(upload_id),
+                        "relative_path": record["relative_path"],
+                    },
+                )
+
+            self.assertEqual(updated["scan_status"], "skipped")
+            self.assertTrue(updated["quarantined"])
+            self.assertFalse(source.exists())
+            upload_private.assert_not_called()
+
+    def test_r2_promotion_failure_is_quarantined_and_blocks_access(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_root = Path(tmpdir) / "uploads"
+            quarantine_root = Path(tmpdir) / "quarantine"
+            upload_id, source, record = self._upload_fixture(upload_root)
+            db = FakeDatabase({"uploaded_files": [record]})
+            with ExitStack() as stack:
+                self._enter_settings(stack, upload_root, quarantine_root)
+                scan_file = stack.enter_context(
+                    patch.object(upload_routes, "scan_uploaded_file")
+                )
+                stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "private_storage_is_configured",
+                        return_value=True,
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        upload_routes,
+                        "upload_private_file",
+                        side_effect=RuntimeError("provider unavailable"),
+                    )
+                )
+                delete_partial = stack.enter_context(
+                    patch.object(upload_routes, "delete_private_object")
+                )
+                scan_file.return_value = SimpleNamespace(
+                    status="clean",
+                    detail="clamav_clean",
+                )
+                updated = upload_routes._scan_and_quarantine_upload(
+                    db=db,
+                    upload_record={
+                        "id": str(upload_id),
+                        "relative_path": record["relative_path"],
+                    },
+                )
+
+            self.assertEqual(updated["scan_status"], "error")
+            self.assertTrue(updated["quarantined"])
+            self.assertTrue(upload_routes._upload_scan_blocks_download(updated))
+            self.assertFalse(source.exists())
+            self.assertTrue(
+                delete_partial.call_args.kwargs["key"].startswith(
+                    "private-uploads/v1/"
+                )
+            )
+
+
+class PrivateUploadAccessTests(unittest.TestCase):
+    def _record(self):
+        upload_id = ObjectId()
+        return {
+            "_id": upload_id,
+            "id": str(upload_id),
+            "category": "private_media",
+            "storage_provider": "r2",
+            "storage_key": (
+                "private-uploads/v1/private_media/family/member/"
+                f"{upload_id}/filemp4"
+            ),
+            "relative_path": "private_media/family/member/file.mp4",
+            "scan_status": "clean",
+            "quarantined": False,
+            "content_type": "video/mp4",
+            "original_filename": "message.mp4",
+        }
+
+    def test_production_approval_requires_durable_private_r2_key(self):
+        with patch.object(upload_routes.settings, "environment", "production"):
+            self.assertFalse(
+                upload_routes._upload_has_durable_private_storage(
+                    {"storage_provider": "local_disk"}
+                )
+            )
+            self.assertFalse(
+                upload_routes._upload_has_durable_private_storage(
+                    {"storage_provider": "r2", "storage_key": ""}
+                )
+            )
+            self.assertTrue(
+                upload_routes._upload_has_durable_private_storage(
+                    {
+                        "storage_provider": "r2",
+                        "storage_key": "private-uploads/v1/member/id/photo",
+                    }
+                )
+            )
+
+    def test_r2_download_uses_short_lived_redirect(self):
+        record = self._record()
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_access",
+                return_value=(record, {}),
+            ),
+            patch.object(
+                upload_routes,
+                "generate_private_download_url",
+                return_value="https://private-download.example/signed",
+            ) as signed_url,
+        ):
+            response = upload_routes.download_upload(
+                str(record["_id"]),
+                current_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(
+            response.headers["location"],
+            "https://private-download.example/signed",
+        )
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        signed_url.assert_called_once_with(
+            key=record["storage_key"],
+            expires_seconds=120,
+        )
+
+    def test_r2_download_with_missing_key_fails_closed(self):
+        record = self._record()
+        record["storage_key"] = ""
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_access",
+                return_value=(record, {}),
+            ),
+            patch.object(upload_routes, "generate_private_download_url") as signed_url,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                upload_routes.download_upload(
+                    str(record["_id"]),
+                    current_user={"id": "owner-1", "email": "owner@example.com"},
+                )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        signed_url.assert_not_called()
+
+    def test_production_download_blocks_legacy_local_upload_pending_migration(self):
+        record = self._record()
+        record["storage_provider"] = "local_disk"
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes.settings, "environment", "production"),
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_access",
+                return_value=(record, {}),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                upload_routes.download_upload(
+                    str(record["_id"]),
+                    current_user={"id": "owner-1", "email": "owner@example.com"},
+                )
+
+        self.assertEqual(raised.exception.status_code, 503)
+
+    def test_deletion_pending_cannot_be_bypassed_by_admin_override(self):
+        record = self._record()
+        record["deletion_status"] = "pending"
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes.settings, "upload_allow_admin_quarantine_override", True),
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_access",
+                return_value=(record, {}),
+            ),
+            patch.object(upload_routes, "_is_admin", return_value=True),
+            patch.object(upload_routes, "generate_private_download_url") as signed_url,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                upload_routes.download_upload(
+                    str(record["_id"]),
+                    admin_override=True,
+                    current_user={"id": "admin-1", "email": "admin@example.com"},
+                )
+
+        self.assertEqual(raised.exception.status_code, 403)
+        signed_url.assert_not_called()
+
+    def test_r2_deletion_removes_object_before_database_record(self):
+        record = self._record()
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_management_access",
+                return_value=(record, {}),
+            ),
+            patch.object(upload_routes, "delete_private_object") as delete_private,
+        ):
+            result = upload_routes.delete_upload(
+                str(record["_id"]),
+                current_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+
+        self.assertEqual(result["status"], "deleted")
+        self.assertEqual(db["uploaded_files"].documents, [])
+        delete_private.assert_called_once_with(key=record["storage_key"])
+
+    def test_r2_deletion_failure_retains_blocked_record_for_retry(self):
+        record = self._record()
+        db = FakeDatabase({"uploaded_files": [record]})
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_management_access",
+                return_value=(record, {}),
+            ),
+            patch.object(
+                upload_routes,
+                "delete_private_object",
+                side_effect=RuntimeError("provider unavailable"),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                upload_routes.delete_upload(
+                    str(record["_id"]),
+                    current_user={"id": "owner-1", "email": "owner@example.com"},
+                )
+
+        self.assertEqual(raised.exception.status_code, 503)
+        self.assertEqual(len(db["uploaded_files"].documents), 1)
+        self.assertEqual(record["deletion_status"], "failed")
+        self.assertTrue(upload_routes._upload_scan_blocks_download(record))
+
+    def test_deleting_quarantined_upload_removes_quarantine_file(self):
+        record = self._record()
+        record["storage_provider"] = "local_disk"
+        record["scan_status"] = "infected"
+        record["quarantined"] = True
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_root = Path(tmpdir) / "uploads"
+            quarantine_root = Path(tmpdir) / "quarantine"
+            quarantine_root.mkdir(parents=True)
+            quarantine_file = quarantine_root / "infected-item"
+            quarantine_file.write_bytes(b"infected")
+            record["quarantine_path"] = str(quarantine_file)
+            db = FakeDatabase({"uploaded_files": [record]})
+            with (
+                patch.object(upload_routes.settings, "render_disk_mount_path", ""),
+                patch.object(upload_routes.settings, "upload_storage_dir", str(upload_root)),
+                patch.object(
+                    upload_routes.settings,
+                    "upload_quarantine_dir",
+                    str(quarantine_root),
+                ),
+                patch.object(upload_routes, "get_database", return_value=db),
+                patch.object(
+                    upload_routes,
+                    "_require_upload_management_access",
+                    return_value=(record, {}),
+                ),
+            ):
+                upload_routes.delete_upload(
+                    str(record["_id"]),
+                    current_user={"id": "owner-1", "email": "owner@example.com"},
+                )
+
+            self.assertFalse(quarantine_file.exists())
+            self.assertEqual(db["uploaded_files"].documents, [])
+
+    def test_deleting_active_portrait_clears_all_member_references(self):
+        record = self._record()
+        record["category"] = "member_photo"
+        member_id = ObjectId()
+        record["member_id"] = str(member_id)
+        upload_id = str(record["_id"])
+        member = {
+            "_id": member_id,
+            "pending_photo_upload_id": upload_id,
+            "approved_photo_upload_id": upload_id,
+            "photo_upload_id": upload_id,
+            "photo_path": "old/path.jpg",
+            "photo_submission_status": "approved",
+        }
+        db = FakeDatabase(
+            {"uploaded_files": [record], "family_members": [member]}
+        )
+        with (
+            patch.object(upload_routes, "get_database", return_value=db),
+            patch.object(
+                upload_routes,
+                "_require_upload_management_access",
+                return_value=(record, {}),
+            ),
+            patch.object(upload_routes, "delete_private_object"),
+        ):
+            upload_routes.delete_upload(
+                upload_id,
+                current_user={"id": "owner-1", "email": "owner@example.com"},
+            )
+
+        self.assertIsNone(member["pending_photo_upload_id"])
+        self.assertIsNone(member["approved_photo_upload_id"])
+        self.assertIsNone(member["photo_upload_id"])
+        self.assertIsNone(member["photo_path"])
+        self.assertEqual(member["photo_submission_status"], "not_submitted")
+
+
+class PrivateR2ServiceTests(unittest.TestCase):
+    def _enter_configuration(self, stack: ExitStack) -> None:
+        patches = (
+            patch.object(r2_storage_service.settings, "r2_access_key_id", "access-key"),
+            patch.object(
+                r2_storage_service.settings,
+                "r2_secret_access_key",
+                "secret-key",
+            ),
+            patch.object(
+                r2_storage_service.settings,
+                "r2_endpoint_url",
+                "https://account.r2.cloudflarestorage.com",
+            ),
+            patch.object(
+                r2_storage_service.settings,
+                "r2_private_bucket",
+                "private-bucket",
+            ),
+        )
+        for configuration_patch in patches:
+            stack.enter_context(configuration_patch)
+
+    def test_private_file_stream_health_download_and_delete(self):
+        client = FakeS3Client()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "upload.pdf"
+            source.write_bytes(b"private-pdf")
+            with ExitStack() as stack:
+                self._enter_configuration(stack)
+                stack.enter_context(
+                    patch.object(
+                        r2_storage_service,
+                        "_lazy_s3_client",
+                        return_value=client,
+                    )
+                )
+                result = r2_storage_service.upload_private_file(
+                    key="private-uploads/v1/evidence/family/member/upload/file.pdf",
+                    path=source,
+                    content_type="application/pdf",
+                )
+                health = r2_storage_service.get_private_storage_health(
+                    check_provider=True
+                )
+                signed_url = r2_storage_service.generate_private_download_url(
+                    key=result["key"]
+                )
+                downloaded = r2_storage_service.download_private_bytes(
+                    key=result["key"],
+                    max_bytes=100,
+                )
+                r2_storage_service.delete_private_object(key=result["key"])
+
+        self.assertEqual(client.put_request["Body"], b"private-pdf")
+        self.assertEqual(client.put_request["CacheControl"], "private, no-store")
+        self.assertEqual(client.head_bucket_name, "private-bucket")
+        self.assertTrue(health["available"])
+        self.assertEqual(signed_url, "https://private-download.example/signed")
+        self.assertEqual(downloaded, b"private-pdf")
+        self.assertEqual(client.deleted["Key"], result["key"])
+
+    def test_generic_bucket_does_not_satisfy_private_bucket_requirement(self):
+        with (
+            patch.object(r2_storage_service.settings, "r2_access_key_id", "access-key"),
+            patch.object(r2_storage_service.settings, "r2_secret_access_key", "secret-key"),
+            patch.object(
+                r2_storage_service.settings,
+                "r2_endpoint_url",
+                "https://account.r2.cloudflarestorage.com",
+            ),
+            patch.object(r2_storage_service.settings, "r2_bucket", "public-bucket"),
+            patch.object(r2_storage_service.settings, "r2_private_bucket", ""),
+        ):
+            self.assertFalse(r2_storage_service.private_storage_is_configured())
+
+    def test_approved_r2_portrait_can_be_exported_as_public_poster(self):
+        portrait = {
+            "storage_provider": "r2",
+            "storage_key": "private-uploads/v1/member_photo/family/member/id/photojpg",
+            "content_type": "image/jpeg",
+            "stored_filename": "photo.jpg",
+        }
+        with (
+            patch.object(
+                poster_asset_service,
+                "_best_uploaded_portrait",
+                return_value=portrait,
+            ),
+            patch.object(
+                poster_asset_service,
+                "download_private_bytes",
+                return_value=b"approved-photo",
+            ) as download_private,
+            patch.object(
+                poster_asset_service,
+                "upload_bytes",
+                return_value={
+                    "storage_provider": "r2",
+                    "bucket": "poster-bucket",
+                    "key": "v1/token-approved-poster.jpg",
+                },
+            ) as upload_poster,
+        ):
+            result = poster_asset_service.export_approved_public_poster(
+                "project-1",
+                1,
+                "token",
+            )
+
+        download_private.assert_called_once_with(
+            key=portrait["storage_key"],
+            max_bytes=poster_asset_service.settings.upload_max_image_bytes,
+        )
+        self.assertEqual(upload_poster.call_args.kwargs["body"], b"approved-photo")
+        self.assertEqual(result["poster_storage_provider"], "r2")
+
+    def test_approved_poster_never_silently_substitutes_abstract_art(self):
+        with patch.object(
+            poster_asset_service,
+            "_best_uploaded_portrait",
+            return_value=None,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "no eligible approved portrait"):
+                poster_asset_service.export_approved_public_poster(
+                    "project-1",
+                    1,
+                    "token",
+                )
+
+    def test_production_approved_poster_rejects_legacy_local_source(self):
+        with (
+            patch.object(
+                poster_asset_service.settings,
+                "environment",
+                "production",
+            ),
+            patch.object(
+                poster_asset_service,
+                "_read_local_upload_bytes",
+                return_value=(b"local-photo", "image/jpeg", ".jpg"),
+            ) as read_local,
+        ):
+            source = poster_asset_service._read_approved_upload_bytes(
+                {"storage_provider": "local_disk"}
+            )
+
+        self.assertIsNone(source)
+        read_local.assert_not_called()
+
+    def test_scanner_health_uses_provider_healthcheck(self):
+        configuration = upload_scan_service.UploadScannerConfiguration(
+            configured=True,
+            detail="clamav_configured",
+        )
+        module = SimpleNamespace(
+            healthcheck=lambda: {
+                "configured": True,
+                "available": True,
+                "detail": "clamav_ready",
+            }
+        )
+        with (
+            patch.object(
+                upload_scan_service,
+                "get_upload_scanner_configuration",
+                return_value=configuration,
+            ),
+            patch.object(
+                upload_scan_service.settings,
+                "upload_scan_hook",
+                "scanner.module:scan",
+            ),
+            patch.object(
+                upload_scan_service.importlib,
+                "import_module",
+                return_value=module,
+            ),
+        ):
+            health = upload_scan_service.get_upload_scanner_health()
+
+        self.assertTrue(health["available"])
+        self.assertEqual(health["detail"], "clamav_ready")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 14 closes the private-upload storage lifecycle for Tomb of Light:

- uses Render persistent disk only for staging and quarantine;
- requires a clean malware verdict before promotion;
- streams clean private files into the dedicated Cloudflare R2 private bucket;
- removes local staging copies after database authority switches to R2;
- serves authorized downloads through two-minute signed URLs;
- makes R2 deletion retryable and blocks deletion-pending/failed downloads;
- clears pending, approved, and active member-photo references during deletion;
- reads approved NFT poster sources from bounded private R2 storage and fails closed when the selected source is unavailable;
- adds live, minimized ClamAV and private-R2 checks to the protected readiness surface;
- fails readiness closed when legacy local-upload inventory is unknown or nonzero.

## Security closure

- Skipped, infected, errored, quarantined, and incompletely stored uploads are never promoted.
- Production approval and download require durable private R2 storage.
- A missing R2 key cannot fall back to an old local path.
- `R2_PRIVATE_BUCKET` is mandatory; customer files cannot silently use a generic public bucket.
- Provider errors expose only minimized status codes and exception types.
- Public upload serialization excludes local paths, quarantine reasons, scan details, bucket names, and object keys.
- Existing clean local records are counted but are not silently migrated.

## Verification

- Full backend: **1,854 passed, 2 skipped; 91 subtests passed**
- Contract guardrails: **1,289 passed, 4 skipped**
- Architecture guardrails: **9 passed**
- Focused Phase 14 suite: **26 passed**
- Python compilation, dependency consistency, and diff checks passed
- Remote Git tree `b306c227cd3fbdd78281a3f1bdfe90c7215dcd1e` exactly matches locally tested commit `76eb9ee`
- Production infrastructure checks passed for writable persistent disk, private R2 reachability, ClamAV PING, and standard harmless malware-signature detection
- GitHub Actions remains authoritative for Chromium browser execution because the local sandbox did not contain a browser binary

## Production boundary

This PR does not migrate, download, alter, or delete production customer files. The only external configuration correction was replacing a literal placeholder in `UPLOAD_CLAMAV_HOST` with the Render private-service hostname; the redeployed API then passed scanner, disk, and R2 checks.

After merge and deployment, the protected CEO readiness endpoint must be checked again. Any reported legacy clean local uploads require a separate governed, resumable migration.