### PR TITLE
Phase 15 — Paid NFT Add-On Mint Console

### DIFF
--- a/ONCHAIN_ANCHOR_BACKEND_SPEC.md
+++ b/ONCHAIN_ANCHOR_BACKEND_SPEC.md
@@ -1,6 +1,6 @@
 # Tomb of Light On-Chain Anchor Backend Spec
 
-Status: Proposed production backend spec
+Status: Implemented architecture; Phase 15 add-on policy below is binding
 
 Purpose: Define the exact backend architecture for public-safe NFT anchor issuance, metadata generation, poster generation, mint jobs, and dashboard display without exposing private family archive data.
 
@@ -22,34 +22,33 @@ Core rule:
 
 This means the live operational flow is:
 
-1. payment confirmed
-2. workspace provisioned
-3. intake completed
-4. uploads and build completed
-5. admin final approval
-6. customer public-safe approval when required
-7. metadata and poster generated
-8. mint job executed
-9. mint record stored
-10. dashboard updated
+1. base package payment confirmed and workspace provisioned
+2. intake, uploads, profile build, and delivery completed
+3. customer purchases the exact NFT add-on valid for the current mint state
+4. Stripe verifies a project-scoped paid credit without creating a mint
+5. Tomb of Light prepares an approval record and atomically claims one credit
+6. customer records their public Base wallet and approves public-safe metadata
+7. CEO master account gives separate final approval
+8. CEO master account queues the approved record
+9. controlled worker generates metadata/poster, mints, and syncs the receipt
+10. dashboard updates from the canonical on-chain result
 
 ## 2. Package mint policy
 
-Launch v1 policy:
+Phase 15 policy:
 
-- `legacy_snapshot`: no automatic mint
-- `legacy_portrait_intro`: no automatic mint
-- `digital_legacy_portrait`: automatic `portrait_anchor`
-- `household_foundation`: automatic `household_anchor`
-- `heirloom_legacy_tree`: automatic `household_anchor`
-- `legacy_plus`: automatic `household_anchor`
-- `family_estate_concierge`: automatic `branch_anchor`, up to 3 included
-- `command_structure_network`: opt-in only for launch, `organization_anchor`
+- No base package includes an NFT or an automatic mint.
+- The completed-profile gate applies to every package.
+- The first mint requires `nft_lineage_record` ($499).
+- Every later mint requires `additional_nft_copy_mint` ($399).
+- `nft_metadata_revision` ($149) can revise public-safe metadata but never authorizes a new mint.
+- Checkout creates a paid credit only. It cannot prepare, approve, queue, or execute minting.
+- Customer wallet/public-safe consent and CEO final approval are always separate authenticated acts.
 
 Policy rules:
 
-- Lowest two portrait packages stay off-chain by default.
-- Organization minting is disabled by default until public-title and privacy handling is finalized.
+- Every package stays off-chain unless the customer later purchases the correct NFT add-on.
+- Organization mint execution also requires the organization runtime flag.
 - Customer opt-in is required before using an approved portrait as public poster art.
 - Public title is opt-in only.
 
@@ -360,7 +359,8 @@ Add these backend services under `backend/app/services/`:
 
 Responsibilities:
 
-- decide whether a package auto-mints
+- expose the add-on-only policy and token type for each package
+- require a completed profile and paid project-scoped mint credit
 - decide token type from package
 - enforce launch toggles
 - enforce org opt-in behavior
@@ -517,12 +517,21 @@ Response:
   "package_code": "digital_legacy_portrait",
   "package_lane": "portrait",
   "mint_policy": {
-    "auto_mint_enabled": true,
+    "product_includes_onchain_anchor": false,
+    "onchain_anchor_available_as_addon": true,
+    "requires_paid_nft_addon": true,
+    "auto_mint_enabled": false,
     "token_type": "portrait_anchor",
     "requires_customer_public_safe_approval": true
   },
-  "eligible": true,
-  "reasons": [],
+  "profile_complete": true,
+  "nft_addon": {
+    "required_mint_addon_code": "nft_lineage_record",
+    "mint_credit_satisfied": false,
+    "checkout_never_triggers_mint": true
+  },
+  "eligible": false,
+  "reasons": ["nft_addon_not_purchased"],
   "latest_mint_record_id": "string|null"
 }
 ```
@@ -633,8 +642,9 @@ Suggested front-end API source:
 
 UI states:
 
-- `not_included`
-- `eligible_waiting_for_build`
+- `profile_not_complete`
+- `nft_addon_not_purchased`
+- `paid_waiting_for_preparation`
 - `waiting_for_approval`
 - `queued`
 - `minting`
@@ -654,7 +664,8 @@ Use these version rules:
 
 Required rules:
 
-- admin final approval required before queueing mint
+- no package inclusion, manual fee flag, or waiver can satisfy the paid add-on gate
+- CEO master-account final approval and queue action are required
 - customer public-safe approval required when public title, poster opt-in, or wallet assignment is involved
 - customer cannot mint without an entitled project
 - customer cannot mint another customer’s project
@@ -698,7 +709,8 @@ Build order:
 This spec is complete when:
 
 - metadata generation is public-safe by allowlist
-- approved packages mint only according to policy
+- only a verified paid NFT add-on credit can create a mint approval record
+- checkout cannot invoke preparation, approval, queueing, or execution
 - no private archive fields appear in public metadata
 - minting is versioned and auditable
 - dashboard shows mint state and history correctly

--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -183,7 +183,10 @@
                         <span>Primary</span>
                         <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="sync_package">Sync Package</button>
                         <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="repair_record">Repair Record</button>
-                        <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="queue_for_mint_review">Queue for Mint Review</button>
+                        <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="queue_for_mint_review">Open Mint Review</button>
+                        <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="prepare_legacy_anchor">Prepare NFT Approval</button>
+                        <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="approve_legacy_anchor">CEO Final Approve</button>
+                        <button class="btn btn-primary admin-action-tier--primary" type="button" data-admin-case-action="queue_approved_legacy_anchor">Queue Approved NFT</button>
                       </div>
                       <div class="admin-action-group admin-action-group--secondary">
                         <span>Restricted Administrative Actions</span>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -202,6 +202,9 @@
     refresh_entitlement: ["project_id"],
     run_readiness_check: ["project_id"],
     queue_for_mint_review: ["project_id"],
+    prepare_legacy_anchor: ["project_id"],
+    approve_legacy_anchor: ["project_id"],
+    queue_approved_legacy_anchor: ["project_id"],
     repair_record: ["project_id"],
     refresh_case_data: [],
   };
@@ -210,6 +213,9 @@
     sync_package: "primary",
     repair_record: "primary",
     queue_for_mint_review: "primary",
+    prepare_legacy_anchor: "primary",
+    approve_legacy_anchor: "primary",
+    queue_approved_legacy_anchor: "primary",
     normalize_package: "secondary",
     assign_lane: "secondary",
     link_order_to_project: "secondary",
@@ -1856,6 +1862,10 @@
           <div class="admin-card-header"><span class="admin-card-badge">R</span><h3 class="admin-card-title">Readiness Gates</h3></div>
           ${renderFieldGrid([
             { label: "Eligibility", value: tabData.eligibility, chip: true },
+            { label: "Profile Complete", value: tabData.profile_complete, chip: true },
+            { label: "Required NFT Add-On", value: tabData.required_nft_addon_code, chip: true },
+            { label: "Paid NFT Credit", value: tabData.paid_nft_credit, chip: true },
+            { label: "NFT Add-On Order", value: tabData.nft_addon_order_id, mono: true },
             { label: "Runtime", value: tabData.runtime, chip: true },
             { label: "Review Ready", value: tabData.approvals && tabData.approvals.mint_review_ready, chip: true },
             { label: "Public Approval Required", value: tabData.approvals && tabData.approvals.customer_public_safe_approval_required, chip: true },

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,15 +51,26 @@ STRIPE_PUBLISHABLE_KEY=""
 STRIPE_WEBHOOK_SECRET=""
 STRIPE_BILLING_PORTAL_CONFIGURATION_ID=""
 STRIPE_BILLING_PORTAL_RETURN_URL="https://tomboflight.com/billing.html"
+# Optional but recommended. If blank, authenticated checkout resolves one
+# exact active Stripe price by product name and USD amount.
+STRIPE_NFT_LINEAGE_RECORD_PRICE_ID=""
+STRIPE_ADDITIONAL_NFT_MINT_PRICE_ID=""
+STRIPE_NFT_METADATA_REVISION_PRICE_ID=""
 
 # Mint runtime flags + chain config
 NFT_MINT_ENABLED="false"
 NFT_ORG_MINT_ENABLED="false"
 NFT_AUTO_MINT_ON_REVIEW_ENABLED="false"
+NFT_MINT_WORKER_ENABLED="false"
+NFT_MINT_WORKER_POLL_SECONDS="15"
+# Set true only after the three old public NFT Payment Links are deactivated
+# in Stripe. Authenticated server-created Checkout Sessions replace them.
+NFT_LEGACY_PAYMENT_LINKS_DISABLED="false"
 NFT_CHAIN="base-mainnet"
 NFT_RPC_URL=""
 NFT_CONTRACT_ADDRESS=""
 NFT_CONTRACT_ABI_JSON=""
+NFT_MINT_FUNCTION_NAME="safeMint"
 NFT_MINTER_PRIVATE_KEY=""
 NFT_DEFAULT_RECIPIENT_WALLET=""
 HASH_SALT=""

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,7 @@
    - **Auth/JWT**: `SECRET_KEY`, `ALGORITHM`, token expiry values
    - **R2/storage** (if using object storage): `R2_*` variables
    - **Stripe** (billing/webhooks): `STRIPE_*` variables
-   - **Mint runtime flags/config**: `NFT_MINT_ENABLED`, `NFT_ORG_MINT_ENABLED`, `NFT_AUTO_MINT_ON_REVIEW_ENABLED`, and NFT chain/contract fields
+   - **Mint runtime flags/config**: `NFT_MINT_ENABLED`, `NFT_ORG_MINT_ENABLED`, `NFT_MINT_WORKER_ENABLED`, `NFT_MINT_WORKER_POLL_SECONDS`, optional exact Stripe NFT Price IDs, and NFT chain/contract fields. `NFT_AUTO_MINT_ON_REVIEW_ENABLED` must remain `false`.
    - **Email/Postmark** (if enabled): `POSTMARK_*` variables
 
 ## 2) Local setup
@@ -26,6 +26,7 @@ uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 Notes:
 - If Mongo is unavailable, startup continues in degraded mode; liveness remains up while readiness fails, and DB-backed routes return structured `503 database_unavailable` responses until connectivity is restored.
 - Keep `NFT_MINT_ENABLED=false` for local development unless all mint dependencies are configured.
+- No base package includes an NFT. The delivered-profile, paid add-on, customer wallet consent, CEO approval, and controlled queue contract is documented in `docs/governance/continuity_kernel_phase15_nft_addon_mint_console.md`.
 
 ## 4) Test command
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -165,6 +165,18 @@ class Settings(BaseSettings):
         default=3,
         validation_alias=AliasChoices("STRIPE_PAYMENT_METHOD_MAX_CARDS"),
     )
+    stripe_nft_lineage_record_price_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("STRIPE_NFT_LINEAGE_RECORD_PRICE_ID"),
+    )
+    stripe_additional_nft_mint_price_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("STRIPE_ADDITIONAL_NFT_MINT_PRICE_ID"),
+    )
+    stripe_nft_metadata_revision_price_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("STRIPE_NFT_METADATA_REVISION_PRICE_ID"),
+    )
     manual_fulfillment_mode: bool = Field(
         default=True,
         validation_alias=AliasChoices("MANUAL_FULFILLMENT_MODE"),
@@ -198,7 +210,7 @@ class Settings(BaseSettings):
         ),
     )
     nft_mint_function_name: str = Field(
-        default="mintAnchor",
+        default="safeMint",
         validation_alias=AliasChoices("NFT_MINT_FUNCTION_NAME"),
     )
     nft_minter_private_key: str = Field(
@@ -224,6 +236,20 @@ class Settings(BaseSettings):
     nft_auto_mint_on_review_enabled: bool = Field(
         default=False,
         validation_alias=AliasChoices("NFT_AUTO_MINT_ON_REVIEW_ENABLED"),
+    )
+    nft_mint_worker_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("NFT_MINT_WORKER_ENABLED"),
+    )
+    nft_mint_worker_poll_seconds: int = Field(
+        default=15,
+        ge=2,
+        le=300,
+        validation_alias=AliasChoices("NFT_MINT_WORKER_POLL_SECONDS"),
+    )
+    nft_legacy_payment_links_disabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("NFT_LEGACY_PAYMENT_LINKS_DISABLED"),
     )
     nft_token_name_prefix: str = Field(
         default="Tomb of Light Legacy Anchor",

--- a/backend/app/core/package_catalog.py
+++ b/backend/app/core/package_catalog.py
@@ -37,6 +37,16 @@ PACKAGE_CODE_ALIASES: dict[str, str] = {
 }
 
 ADDON_CODE_ALIASES: dict[str, str] = {
+    "nft-lineage-record": "nft_lineage_record",
+    "nft_lineage_record": "nft_lineage_record",
+    "nft lineage record": "nft_lineage_record",
+    "additional-nft-copy-mint": "additional_nft_copy_mint",
+    "additional_nft_copy_mint": "additional_nft_copy_mint",
+    "additional nft copy / mint": "additional_nft_copy_mint",
+    "additional nft copy mint": "additional_nft_copy_mint",
+    "nft-metadata-revision": "nft_metadata_revision",
+    "nft_metadata_revision": "nft_metadata_revision",
+    "nft metadata revision": "nft_metadata_revision",
     "extra-upload-pack": "extra_upload_pack",
     "extra_upload_pack": "extra_upload_pack",
     "extra-storage": "extra_storage",
@@ -571,9 +581,34 @@ PACKAGE_CATALOG: dict[str, dict[str, Any]] = {
     },
 }
 
-PACKAGE_CONTROL_POLICY: dict[str, dict[str, Any]] = {
-    "legacy_snapshot": {
-        "anchor_type": None,
+NFT_ADDON_CODES = (
+    "nft_lineage_record",
+    "additional_nft_copy_mint",
+    "nft_metadata_revision",
+)
+
+PACKAGE_ANCHOR_TYPES: dict[str, str] = {
+    "legacy_snapshot": "portrait_anchor",
+    "legacy_portrait_intro": "portrait_anchor",
+    "digital_legacy_portrait": "portrait_anchor",
+    "household_foundation": "household_anchor",
+    "heirloom_legacy_tree": "household_anchor",
+    "legacy_plus": "household_anchor",
+    "family_estate_concierge": "branch_anchor",
+    "command_structure_network": "organization_anchor",
+}
+
+
+def _addon_only_mint_control(anchor_type: str) -> dict[str, Any]:
+    """Return the single canonical NFT rule shared by every base package.
+
+    A base package never includes or automatically creates an NFT.  A completed
+    profile can purchase a verified NFT add-on, after which customer wallet
+    consent and the controlled approval queue still have to complete.
+    """
+
+    return {
+        "anchor_type": anchor_type,
         "launch_policy": {
             "allows_automatic_anchor": False,
             "requires_runtime_flag_for_auto_mint": True,
@@ -581,184 +616,69 @@ PACKAGE_CONTROL_POLICY: dict[str, dict[str, Any]] = {
         "maintenance_default": "monthly",
         "mint_policy": {
             "product_includes_onchain_anchor": False,
-            "auto_mint_enabled": False,
-            "opt_in_only": False,
-            "token_type": None,
-            "included_anchor_count": 0,
-            "requires_customer_public_safe_approval": False,
-            "mint_fee_model": "service_plus_network",
-            "minting_included": False,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "legacy_portrait_intro": {
-        "anchor_type": None,
-        "launch_policy": {
-            "allows_automatic_anchor": False,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": False,
-            "auto_mint_enabled": False,
-            "opt_in_only": False,
-            "token_type": None,
-            "included_anchor_count": 0,
-            "requires_customer_public_safe_approval": False,
-            "mint_fee_model": "service_plus_network",
-            "minting_included": False,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "digital_legacy_portrait": {
-        "anchor_type": "portrait_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
-            "auto_mint_enabled": True,
-            "opt_in_only": False,
-            "token_type": "portrait_anchor",
-            "included_anchor_count": 1,
-            "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "flat_included",
-            "minting_included": True,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "household_foundation": {
-        "anchor_type": "household_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
-            "auto_mint_enabled": True,
-            "opt_in_only": False,
-            "token_type": "household_anchor",
-            "included_anchor_count": 1,
-            "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "flat_included",
-            "minting_included": True,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "heirloom_legacy_tree": {
-        "anchor_type": "household_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
-            "auto_mint_enabled": True,
-            "opt_in_only": False,
-            "token_type": "household_anchor",
-            "included_anchor_count": 1,
-            "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "flat_included",
-            "minting_included": True,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "legacy_plus": {
-        "anchor_type": "household_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
-            "auto_mint_enabled": True,
-            "opt_in_only": False,
-            "token_type": "household_anchor",
-            "included_anchor_count": 1,
-            "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "flat_included",
-            "minting_included": True,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "family_estate_concierge": {
-        "anchor_type": "branch_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
-            "auto_mint_enabled": True,
-            "opt_in_only": False,
-            "token_type": "branch_anchor",
-            "included_anchor_count": 3,
-            "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "flat_included",
-            "minting_included": True,
-            "minting_service_fee_usd": 199,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
-            "remint_service_fee_usd": 149,
-            "network_fee_quote_usd": 0,
-        },
-    },
-    "command_structure_network": {
-        "anchor_type": "organization_anchor",
-        "launch_policy": {
-            "allows_automatic_anchor": True,
-            "requires_runtime_flag_for_auto_mint": True,
-        },
-        "maintenance_default": "monthly",
-        "mint_policy": {
-            "product_includes_onchain_anchor": True,
+            "onchain_anchor_available_as_addon": True,
+            "requires_paid_nft_addon": True,
+            "profile_completion_required_before_purchase": True,
+            "checkout_never_triggers_mint": True,
             "auto_mint_enabled": False,
             "opt_in_only": True,
-            "token_type": "organization_anchor",
-            "included_anchor_count": 1,
+            "token_type": anchor_type,
+            "included_anchor_count": 0,
             "requires_customer_public_safe_approval": True,
-            "mint_fee_model": "service_plus_network",
+            "requires_admin_final_approval": True,
+            "mint_fee_model": "verified_addon_purchase",
             "minting_included": False,
-            "minting_service_fee_usd": 299,
-            "default_network_fee_policy": "quoted_variable",
-            "additional_mint_service_fee_usd": 199,
+            "minting_service_fee_usd": 499,
+            "default_network_fee_policy": "included_in_addon",
+            "additional_mint_service_fee_usd": 399,
             "remint_service_fee_usd": 149,
             "network_fee_quote_usd": 0,
+            "initial_mint_addon_code": "nft_lineage_record",
+            "additional_mint_addon_code": "additional_nft_copy_mint",
+            "metadata_revision_addon_code": "nft_metadata_revision",
         },
-    },
+    }
+
+
+PACKAGE_CONTROL_POLICY: dict[str, dict[str, Any]] = {
+    package_code: _addon_only_mint_control(anchor_type)
+    for package_code, anchor_type in PACKAGE_ANCHOR_TYPES.items()
 }
 
 ADDON_CATALOG: dict[str, dict[str, Any]] = {
+    "nft_lineage_record": {
+        "addon_code": "nft_lineage_record",
+        "display_name": "NFT Lineage Record",
+        "price_usd": 499,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "fulfillment_type": "initial_nft_mint_credit",
+        "requires_completed_profile": True,
+        "status": "active",
+    },
+    "additional_nft_copy_mint": {
+        "addon_code": "additional_nft_copy_mint",
+        "display_name": "Additional NFT Copy / Mint",
+        "price_usd": 399,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "fulfillment_type": "additional_nft_mint_credit",
+        "requires_completed_profile": True,
+        "requires_existing_mint": True,
+        "status": "active",
+    },
+    "nft_metadata_revision": {
+        "addon_code": "nft_metadata_revision",
+        "display_name": "NFT Metadata Revision",
+        "price_usd": 149,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "fulfillment_type": "metadata_revision_credit",
+        "requires_completed_profile": True,
+        "requires_existing_mint": True,
+        "authorizes_new_mint": False,
+        "status": "active",
+    },
     "extra_upload_pack": {
         "addon_code": "extra_upload_pack",
         "display_name": "Extra Upload Pack",
@@ -893,6 +813,9 @@ ADDON_CATALOG: dict[str, dict[str, Any]] = {
 def _copy_package(value: dict[str, Any]) -> dict[str, Any]:
     package = deepcopy(value)
     package["package_lane"] = normalize_package_type(package.get("package_lane"))
+    package["allowed_addons"] = list(
+        dict.fromkeys([*(package.get("allowed_addons") or []), *NFT_ADDON_CODES])
+    )
     package_code = str(package.get("package_code") or "").strip()
     return _with_vault_entitlements(package_code, package)
 
@@ -999,12 +922,25 @@ def get_package_control_profile(package_code: str) -> dict[str, Any] | None:
             "product_includes_onchain_anchor": bool(
                 mint_policy.get("product_includes_onchain_anchor")
             ),
+            "onchain_anchor_available_as_addon": bool(
+                mint_policy.get("onchain_anchor_available_as_addon")
+            ),
+            "requires_paid_nft_addon": bool(mint_policy.get("requires_paid_nft_addon")),
+            "profile_completion_required_before_purchase": bool(
+                mint_policy.get("profile_completion_required_before_purchase")
+            ),
+            "checkout_never_triggers_mint": bool(
+                mint_policy.get("checkout_never_triggers_mint", True)
+            ),
             "auto_mint_enabled": bool(mint_policy.get("auto_mint_enabled")),
             "opt_in_only": bool(mint_policy.get("opt_in_only")),
             "token_type": mint_policy.get("token_type"),
             "included_anchor_count": int(mint_policy.get("included_anchor_count") or 0),
             "requires_customer_public_safe_approval": bool(
                 mint_policy.get("requires_customer_public_safe_approval")
+            ),
+            "requires_admin_final_approval": bool(
+                mint_policy.get("requires_admin_final_approval")
             ),
             "mint_fee_model": str(mint_policy.get("mint_fee_model") or "service_plus_network"),
             "minting_included": bool(mint_policy.get("minting_included", int(mint_policy.get("included_anchor_count") or 0) > 0)),
@@ -1013,6 +949,15 @@ def get_package_control_profile(package_code: str) -> dict[str, Any] | None:
             "additional_mint_service_fee_usd": float(mint_policy.get("additional_mint_service_fee_usd") or 0),
             "remint_service_fee_usd": float(mint_policy.get("remint_service_fee_usd") or 0),
             "network_fee_quote_usd": float(mint_policy.get("network_fee_quote_usd") or 0),
+            "initial_mint_addon_code": str(
+                mint_policy.get("initial_mint_addon_code") or ""
+            ),
+            "additional_mint_addon_code": str(
+                mint_policy.get("additional_mint_addon_code") or ""
+            ),
+            "metadata_revision_addon_code": str(
+                mint_policy.get("metadata_revision_addon_code") or ""
+            ),
         },
     }
 
@@ -1071,7 +1016,10 @@ def get_public_package_catalog() -> list[dict[str, Any]]:
             ],
         }
         package["verification_meaning"] = "Verification is a private evidence and review path used to support trusted lineage records."
-        package["minting_available"] = bool(mint_policy.get("product_includes_onchain_anchor"))
+        package["minting_available"] = bool(
+            mint_policy.get("onchain_anchor_available_as_addon")
+        )
+        package["minting_requires_addon"] = bool(mint_policy.get("requires_paid_nft_addon"))
         package["minting_included"] = bool(mint_policy.get("minting_included", False))
         package["included_anchor_count"] = int(mint_policy.get("included_anchor_count") or 0)
         package["mint_fee_model"] = str(mint_policy.get("mint_fee_model") or "service_plus_network")
@@ -1080,8 +1028,9 @@ def get_public_package_catalog() -> list[dict[str, Any]]:
         package["remint_service_fee_usd"] = float(mint_policy.get("remint_service_fee_usd") or 0)
         package["default_network_fee_policy"] = str(mint_policy.get("default_network_fee_policy") or "quoted_variable")
         package["minting_copy"] = (
-            "Blockchain / NFT minting is a separate one-time production step unless explicitly included in your package. "
-            "This fee covers collectible preparation, metadata creation, mint execution, and applicable blockchain network costs. "
+            "No base package includes an NFT. After the profile is complete, the customer may purchase the required NFT add-on. "
+            "That purchase covers collectible preparation, metadata creation, mint execution, and applicable blockchain network costs, but never starts minting automatically. "
+            "Customer wallet consent and Tomb of Light final approval are still required. "
             "Private vault materials are not minted by default. "
             "Only approved delivery-safe collectible assets are eligible for blockchain minting."
         )

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -181,6 +181,14 @@ def get_service_state(*, include_operational_details: bool = False) -> dict[str,
             operational_degraded_reasons.append("deployment_revision_unavailable")
         if not continuity_execution_enabled:
             operational_degraded_reasons.append("continuity_execution_disabled")
+        if not settings.nft_mint_enabled:
+            operational_degraded_reasons.append("nft_mint_runtime_disabled")
+        elif not settings.nft_mint_worker_enabled:
+            operational_degraded_reasons.append("nft_controlled_worker_disabled")
+        if settings.nft_auto_mint_on_review_enabled:
+            operational_degraded_reasons.append("unsafe_nft_auto_mint_on_review_enabled")
+        if not settings.nft_legacy_payment_links_disabled:
+            operational_degraded_reasons.append("legacy_nft_payment_links_not_confirmed_disabled")
 
     operational_ready = ready and not operational_degraded_reasons
     service_state: dict[str, Any] = {
@@ -234,6 +242,22 @@ def get_service_state(*, include_operational_details: bool = False) -> dict[str,
             },
             "nft_runtime": {
                 "enabled": bool(settings.nft_mint_enabled),
+                "controlled_worker_enabled": bool(settings.nft_mint_worker_enabled),
+                "checkout_auto_mint_disabled": not bool(
+                    settings.nft_auto_mint_on_review_enabled
+                ),
+                "legacy_payment_links_confirmed_disabled": bool(
+                    settings.nft_legacy_payment_links_disabled
+                ),
+                "purchase_accepting": bool(
+                    settings.nft_mint_enabled
+                    and settings.nft_mint_worker_enabled
+                    and not settings.nft_auto_mint_on_review_enabled
+                    and (
+                        not settings.is_production_environment
+                        or settings.nft_legacy_payment_links_disabled
+                    )
+                ),
             },
         },
     })

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
-from contextlib import asynccontextmanager
+import asyncio
+from contextlib import asynccontextmanager, suppress
 import logging
 
 from fastapi import FastAPI, Request, status
@@ -106,6 +107,10 @@ from app.routes.workspace_access import (
 from app.services.nft_runtime_validation_service import (
     validate_nft_runtime_configuration_on_startup,
 )
+from app.services.mint_worker_service import (
+    mint_worker_enabled,
+    run_controlled_mint_worker,
+)
 from app.services.auth_service import ensure_auth_indexes
 from app.services.rate_limit_service import ensure_rate_limit_indexes
 
@@ -159,6 +164,8 @@ async def lifespan(app: FastAPI):
     validate_nft_runtime_configuration_on_startup()
     db = connect_to_mongo()
     app.state.db = db
+    mint_worker_stop = asyncio.Event()
+    mint_worker_task: asyncio.Task | None = None
     if db is not None:
         ensure_auth_indexes()
         ensure_rate_limit_indexes()
@@ -178,9 +185,18 @@ async def lifespan(app: FastAPI):
                 raise
             logger.warning("Admin access bootstrap sync skipped outside production: %s", exc)
         logger.info("Connected to MongoDB database.")
+        if mint_worker_enabled():
+            mint_worker_task = asyncio.create_task(
+                run_controlled_mint_worker(mint_worker_stop),
+                name="controlled-nft-mint-worker",
+            )
     else:
         logger.warning("MongoDB unavailable at startup; running in degraded mode.")
     yield
+    if mint_worker_task is not None:
+        mint_worker_stop.set()
+        with suppress(asyncio.CancelledError):
+            await mint_worker_task
     close_mongo_connection()
     logger.info("MongoDB connection closed.")
 

--- a/backend/app/routes/mint_records.py
+++ b/backend/app/routes/mint_records.py
@@ -15,6 +15,7 @@ from app.schemas.mint_record import (
 from app.services.mint_job_service import queue_mint_pipeline, sync_receipt_for_mint_record
 from app.services.mint_maintenance_service import run_mint_maintenance
 from app.services.mint_fee_service import get_project_mint_readiness
+from app.services.nft_checkout_service import create_nft_addon_checkout_session
 from app.services.mint_policy_service import describe_project_mint_eligibility
 from app.services.mint_record_service import (
     approve_admin_mint_record,
@@ -111,7 +112,7 @@ def _require_mint_fee_ready(project_id: str) -> None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                "Mint fee and readiness requirements are not satisfied: "
+                "Paid NFT add-on and readiness requirements are not satisfied: "
                 + ", ".join(readiness.get("blocking_reasons") or ["mint_not_ready"])
             ),
         )
@@ -170,6 +171,30 @@ def get_project_mint_eligibility(
     return eligibility
 
 
+@router.post("/projects/{project_id}/nft-addons/{addon_code}/checkout-session")
+def create_project_nft_addon_checkout(
+    project_id: str,
+    addon_code: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    try:
+        return create_nft_addon_checkout_session(
+            user=current_user,
+            project_id=project_id,
+            addon_code=addon_code,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+
 @router.get("/admin/mint-records/overview")
 def list_admin_mint_overview(
     limit: int = 100,
@@ -213,7 +238,11 @@ def list_admin_mint_overview(
         if normalized_status and latest_status != normalized_status:
             continue
 
-        if mintable_only and not bool((item.get("eligibility") or {}).get("mint_policy", {}).get("product_includes_onchain_anchor")):
+        if mintable_only and not bool(
+            (item.get("eligibility") or {})
+            .get("mint_policy", {})
+            .get("onchain_anchor_available_as_addon")
+        ):
             continue
 
         items.append(item)

--- a/backend/app/schemas/mint_record.py
+++ b/backend/app/schemas/mint_record.py
@@ -11,10 +11,17 @@ class MintPolicyItem(BaseModel):
     package_lane: str
     token_type: str | None = None
     product_includes_onchain_anchor: bool
+    onchain_anchor_available_as_addon: bool = False
+    requires_paid_nft_addon: bool = True
+    profile_completion_required_before_purchase: bool = True
+    checkout_never_triggers_mint: bool = True
     auto_mint_enabled: bool
     opt_in_only: bool = False
     requires_customer_public_safe_approval: bool = False
     included_anchor_count: int = 0
+    initial_mint_addon_code: str = "nft_lineage_record"
+    additional_mint_addon_code: str = "additional_nft_copy_mint"
+    metadata_revision_addon_code: str = "nft_metadata_revision"
     runtime_enabled: bool = False
 
 
@@ -27,6 +34,10 @@ class MintEligibilityResponse(BaseModel):
     reasons: list[str] = Field(default_factory=list)
     latest_mint_record_id: str | None = None
     missing_approvals: list[str] = Field(default_factory=list)
+    profile_complete: bool = False
+    purchase_eligible: bool = False
+    ready_for_mint_preparation: bool = False
+    nft_addon: dict = Field(default_factory=dict)
 
 
 class PrepareMintRecordPayload(BaseModel):
@@ -67,6 +78,8 @@ class MintRecordResponse(BaseModel):
     package_code: str
     package_lane: str
     token_type: str | None = None
+    nft_addon_order_id: str | None = None
+    nft_addon_code: str | None = None
     chain: str
     contract_address: str
     token_id: str | None = None

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -43,6 +43,8 @@ class OrderResponse(BaseModel):
     package_code: str
     package_slug: str
     package_name: str
+    addon_code: Optional[str] = None
+    purchase_code: Optional[str] = None
     price_label: str
     item_type: str
     billing_plan: str
@@ -52,6 +54,8 @@ class OrderResponse(BaseModel):
     stripe_session_id: Optional[str] = None
     stripe_payment_link_id: Optional[str] = None
     fulfillment_status: Optional[str] = None
+    nft_credit_status: Optional[str] = None
+    nft_credit_slot: Optional[str] = None
     created_at: datetime
 
 

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -36,9 +36,13 @@ from app.core.role_catalog import (
 from app.core.relationship_catalog import normalize_relationship_type
 from app.database import get_database, get_service_state
 from app.services.audit_log_service import write_audit_log
-from app.services.mint_job_service import sync_receipt_for_mint_record
+from app.services.mint_fee_service import get_project_mint_readiness
+from app.services.mint_job_service import queue_mint_pipeline, sync_receipt_for_mint_record
 from app.services.mint_policy_service import describe_project_mint_eligibility
 from app.services.mint_record_service import (
+    approve_admin_mint_record,
+    create_mint_record,
+    get_latest_mint_record,
     rebuild_mint_summary_for_project,
     resolve_canonical_mint_status,
 )
@@ -142,6 +146,9 @@ CASE_ACTION_PERMISSIONS: dict[str, set[str]] = {
     "run_readiness_check": {"admin.control.view"},
     "refresh_case_data": {"admin.control.view"},
     "queue_for_mint_review": {"admin.control.mint.readiness"},
+    "prepare_legacy_anchor": {"admin.control.mint"},
+    "approve_legacy_anchor": {"admin.control.mint"},
+    "queue_approved_legacy_anchor": {"admin.control.mint"},
     "repair_mint_status": {"admin.control.mint"},
     "rebuild_mint_summary": {"admin.control.mint"},
     "resync_mint_receipt": {"admin.control.mint"},
@@ -282,6 +289,9 @@ OPERATIONS_ACTION_ALLOWLIST = [
     "repair_record",
     "run_readiness_check",
     "queue_for_mint_review",
+    "prepare_legacy_anchor",
+    "approve_legacy_anchor",
+    "queue_approved_legacy_anchor",
     "refresh_case_data",
 ]
 OPERATIONS_BULK_ACTION_ALLOWLIST = [
@@ -408,9 +418,30 @@ OPERATOR_GUIDANCE_RULES = {
     },
     "mint_runtime_disabled": {
         "title": "Mint runtime is disabled",
-        "rule": "The runtime flag is off, so this case can be prepared but cannot execute automatic minting.",
-        "next_action": "Queue for Mint Review",
-        "recommended_action": "queue_for_mint_review",
+        "rule": "The runtime flag is off, so an approved case cannot execute its controlled mint queue.",
+        "next_action": "Keep the approved NFT unqueued until runtime is configured",
+        "recommended_action": "run_readiness_check",
+        "severity": "warning",
+    },
+    "controlled_mint_worker_disabled": {
+        "title": "Controlled mint worker is disabled",
+        "rule": "Approved NFT jobs cannot execute until the controlled worker is enabled.",
+        "next_action": "Keep the approved NFT unqueued until the worker is ready",
+        "recommended_action": "run_readiness_check",
+        "severity": "warning",
+    },
+    "profile_not_complete": {
+        "title": "Customer profile is not complete",
+        "rule": "NFT add-on checkout is locked until the customer profile is delivered.",
+        "next_action": "Complete and deliver the customer profile",
+        "recommended_action": "run_readiness_check",
+        "severity": "warning",
+    },
+    "nft_addon_not_purchased": {
+        "title": "Paid NFT add-on is required",
+        "rule": "No package includes an NFT. The customer must purchase the correct add-on after profile completion.",
+        "next_action": "Customer purchases the required NFT add-on",
+        "recommended_action": "run_readiness_check",
         "severity": "warning",
     },
     "project_not_build_ready": {
@@ -2637,13 +2668,18 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
     phase_ready = _normalize(project.get("phase")).lower() in INTAKE_APPROVED_PHASES
     mint_eligibility = describe_project_mint_eligibility(project)
     canonical_mint = resolve_canonical_mint_status(project_id_str, include_history=False)
-    mint_already_completed = bool(canonical_mint.get("is_minted"))
-
-    control_profile = get_package_control_profile(package_fields["package_code"]) or {}
-    launch_policy = dict(control_profile.get("launch_policy") or {})
-    allows_automatic_anchor = bool(launch_policy.get("allows_automatic_anchor"))
+    addon_status = dict(mint_eligibility.get("nft_addon") or {})
+    additional_mint_requested = bool(
+        canonical_mint.get("is_minted")
+        and addon_status.get("required_mint_addon_code") == "additional_nft_copy_mint"
+        and addon_status.get("available_mint_credit_count", 0)
+    )
+    mint_already_completed = bool(
+        canonical_mint.get("is_minted") and not additional_mint_requested
+    )
     mint_review_ready = bool(
-        allows_automatic_anchor
+        addon_status.get("profile_complete")
+        and addon_status.get("mint_credit_satisfied")
         and status_ready
         and phase_ready
         and package_synced
@@ -2704,6 +2740,7 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
             "canonical_mint_status": canonical_mint.get("current_status") or "none",
         },
         "mint_policy": mint_eligibility.get("mint_policy"),
+        "nft_addon": addon_status,
         "mint_reasons": mint_eligibility.get("reasons") or [],
         "blocking_reasons": blocking_reasons,
         "package": package_fields,
@@ -2722,6 +2759,7 @@ def enable_mint_review(*, project_id: str, order_id: str = "", actor: dict[str, 
             "auto_mint_executed": False,
             "skipped_reason": "canonical_mint_already_minted",
             "canonical_mint": readiness.get("canonical_mint"),
+            "nft_addon": readiness.get("nft_addon") or {},
         }
     if not readiness.get("mint_review_ready"):
         raise ValueError("Project is not ready for mint review.")
@@ -2737,11 +2775,15 @@ def enable_mint_review(*, project_id: str, order_id: str = "", actor: dict[str, 
                 "mint_review_ready": True,
                 "mint_review_ready_at": _now(),
                 "mint_review_state": "ready",
+                "mint_collectible_preparing": True,
+                "mint_preparation_started": True,
+                "mint_preparation_started_at": _now(),
             }
         },
     )
 
-    auto_mint_allowed = bool(settings.nft_auto_mint_on_review_enabled)
+    # Checkout and review never auto-mint. A separate CEO queue action is required.
+    auto_mint_allowed = False
     _write_admin_action_audit(
         actor=actor,
         action="mint_readiness.enable_mint_review",
@@ -2756,6 +2798,91 @@ def enable_mint_review(*, project_id: str, order_id: str = "", actor: dict[str, 
         "mint_review_ready": True,
         "auto_mint_allowed": auto_mint_allowed,
         "auto_mint_executed": False,
+        "nft_addon": readiness.get("nft_addon") or {},
+    }
+
+
+def prepare_legacy_anchor(
+    *,
+    project_id: str,
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    readiness = enable_mint_review(project_id=project_id, actor=actor)
+    addon_status = dict((readiness or {}).get("nft_addon") or {})
+    version_strategy = (
+        "new_version"
+        if (
+            readiness.get("skipped_reason") == "canonical_mint_already_minted"
+            or addon_status.get("required_mint_addon_code")
+            == "additional_nft_copy_mint"
+        )
+        else "new_version_if_needed"
+    )
+    record = create_mint_record(project_id, version_strategy=version_strategy)
+    return {
+        "project_id": _normalize(project_id),
+        "checkout_triggered_mint": False,
+        "mint_record": record,
+        "next_step": "customer_wallet_and_public_safe_consent",
+    }
+
+
+def _require_ceo_mint_actor(actor: dict[str, Any] | None) -> str:
+    email = _normalize_email((actor or {}).get("email"))
+    if not email or not is_canonical_ceo_email(email):
+        raise ValueError(
+            "Only the CEO master account can give final NFT approval or queue minting."
+        )
+    return email
+
+
+def approve_legacy_anchor(
+    *,
+    project_id: str,
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    approved_by_email = _require_ceo_mint_actor(actor)
+    record = get_latest_mint_record(project_id)
+    if not record:
+        raise ValueError("Prepare the NFT approval record before final CEO approval.")
+    approved = approve_admin_mint_record(
+        record["id"],
+        approved_by_email=approved_by_email,
+        notes="CEO final approval from the governed Admin Control Center.",
+    )
+    return {
+        "project_id": _normalize(project_id),
+        "mint_record": approved,
+        "next_step": (
+            "queue_approved_legacy_anchor"
+            if approved.get("mint_status") == "approved"
+            else "customer_wallet_and_public_safe_consent"
+        ),
+    }
+
+
+def queue_approved_legacy_anchor(
+    *,
+    project_id: str,
+    actor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    queued_by = _require_ceo_mint_actor(actor)
+    record = get_latest_mint_record(project_id)
+    if not record:
+        raise ValueError("Prepare the NFT approval record before queueing.")
+    readiness = get_project_mint_readiness(project_id)
+    if not readiness.get("ready_for_mint_execution"):
+        raise ValueError(
+            "NFT is not ready to queue: "
+            + ", ".join(readiness.get("blocking_reasons") or ["unknown_reason"])
+        )
+    jobs = queue_mint_pipeline(project_id, record["id"], queued_by=queued_by)
+    return {
+        "project_id": _normalize(project_id),
+        "mint_record_id": record["id"],
+        "jobs": jobs,
+        "checkout_triggered_mint": False,
+        "next_step": "controlled_mint_worker",
     }
 
 
@@ -4239,7 +4366,7 @@ def _operator_guidance_items(
         codes.extend([_normalize(value) for value in readiness.get("blocking_reasons") or []])
         if readiness.get("mint_review_ready") and not readiness.get("mint_eligible"):
             codes.append("mint_blocked")
-        if include_mint_runtime and not settings.nft_auto_mint_on_review_enabled and not readiness.get("mint_already_completed"):
+        if include_mint_runtime and not settings.nft_mint_enabled and not readiness.get("mint_already_completed"):
             codes.append("mint_runtime_disabled")
 
     codes.extend([_normalize(value) for value in alerts or []])
@@ -8097,6 +8224,9 @@ def _mint_record_snapshot(project_id: str) -> dict[str, Any]:
         "error_state": canonical.get("error_message") if canonical.get("is_current_failed") else None,
         "error_code": canonical.get("error_code") if canonical.get("is_current_failed") else None,
         "mint_queue_status": canonical.get("current_status") or "not_queued",
+        "pending_approvals": current.get("pending_approvals") or [],
+        "nft_addon_code": current.get("nft_addon_code"),
+        "nft_addon_order_id": current.get("nft_addon_order_id"),
         "historical_attempt_count": canonical.get("historical_attempt_count", 0),
         "historical_attempts": [
             {
@@ -8606,6 +8736,9 @@ def list_customer_cases(
                     "refresh_entitlement",
                     "run_readiness_check",
                     "queue_for_mint_review",
+                    "prepare_legacy_anchor",
+                    "approve_legacy_anchor",
+                    "queue_approved_legacy_anchor",
                     "repair_record",
                     "refresh_case_data",
                 ],
@@ -8763,15 +8896,31 @@ def _build_case_workspace_payload(
         warnings=package_fields.get("warnings") or [],
         include_mint_runtime=True,
     )
-    next_mint_action = (
-        "No mint action required"
-        if readiness.get("mint_already_completed")
-        else (
-        "Queue for Mint Review"
-        if readiness.get("mint_review_ready")
-        else ((mint_guidance[0] or {}).get("next_action") if mint_guidance else "Run Readiness Check")
+    addon_status = dict(readiness.get("nft_addon") or {})
+    current_mint_state = _normalize(mint_record.get("current_status")).lower()
+    pending_mint_approvals = set(mint_record.get("pending_approvals") or [])
+    if readiness.get("mint_already_completed"):
+        next_mint_action = "No mint action required"
+    elif not addon_status.get("profile_complete"):
+        next_mint_action = "Complete and deliver the customer profile"
+    elif not addon_status.get("mint_credit_satisfied"):
+        next_mint_action = "Customer purchases the required NFT add-on"
+    elif current_mint_state in {"", "none"}:
+        next_mint_action = "Prepare Legacy Anchor"
+    elif "customer_public_safe" in pending_mint_approvals:
+        next_mint_action = "Customer records wallet and public-safe consent"
+    elif "admin_final" in pending_mint_approvals:
+        next_mint_action = "CEO Final Approve"
+    elif current_mint_state == "approved":
+        next_mint_action = "Queue Approved Legacy Anchor"
+    elif current_mint_state in {"queued", "processing"}:
+        next_mint_action = "Controlled mint worker in progress"
+    else:
+        next_mint_action = (
+            (mint_guidance[0] or {}).get("next_action")
+            if mint_guidance
+            else "Run Readiness Check"
         )
-    )
 
     display_name = (
         identity.get("full_name")
@@ -8819,6 +8968,8 @@ def _build_case_workspace_payload(
                     "anchor_type": control_profile.get("anchor_type"),
                     "allows_automatic_anchor": (control_profile.get("launch_policy") or {}).get("allows_automatic_anchor"),
                     "auto_mint_enabled": (control_profile.get("mint_policy") or {}).get("auto_mint_enabled"),
+                    "requires_paid_nft_addon": (control_profile.get("mint_policy") or {}).get("requires_paid_nft_addon"),
+                    "checkout_never_triggers_mint": (control_profile.get("mint_policy") or {}).get("checkout_never_triggers_mint"),
                 },
                 "maintenance_defaults": control_profile.get("maintenance_default"),
                 "package_normalization_status": package_fields.get("normalization_status"),
@@ -8883,8 +9034,13 @@ def _build_case_workspace_payload(
             },
             "mint_readiness": {
                 "package_mint_policy": readiness.get("mint_policy") or (control_profile.get("mint_policy") or {}),
+                "nft_addon": readiness.get("nft_addon") or {},
+                "profile_complete": (readiness.get("nft_addon") or {}).get("profile_complete"),
+                "required_nft_addon_code": (readiness.get("nft_addon") or {}).get("required_mint_addon_code"),
+                "paid_nft_credit": (readiness.get("nft_addon") or {}).get("mint_credit_satisfied"),
+                "nft_addon_order_id": mint_record.get("nft_addon_order_id"),
                 "eligibility": "minted" if readiness.get("mint_already_completed") else "eligible" if readiness.get("mint_eligible") else "blocked",
-                "runtime": "enabled" if settings.nft_auto_mint_on_review_enabled else "disabled",
+                "runtime": "enabled" if settings.nft_mint_enabled else "disabled",
                 "current_state": mint_record.get("current_status") or ("mint_ready" if readiness.get("mint_eligible") else "blocked"),
                 "decision": "Minted successfully" if readiness.get("mint_already_completed") else "Ready for mint review" if readiness.get("mint_review_ready") else "Readiness gates are still blocking mint review",
                 "next_admin_action": next_mint_action,
@@ -9192,6 +9348,9 @@ def execute_case_action(
         "refresh_entitlement": lambda: generate_entitlement(project_id=project_id, order_id=order_id, force=True),
         "run_readiness_check": lambda: run_readiness_check(project_id=project_id, order_id=order_id),
         "queue_for_mint_review": lambda: enable_mint_review(project_id=project_id, order_id=order_id),
+        "prepare_legacy_anchor": lambda: prepare_legacy_anchor(project_id=project_id, actor=actor),
+        "approve_legacy_anchor": lambda: approve_legacy_anchor(project_id=project_id, actor=actor),
+        "queue_approved_legacy_anchor": lambda: queue_approved_legacy_anchor(project_id=project_id, actor=actor),
         "repair_record": lambda: repair_record(project_id=project_id, order_id=order_id),
         "repair_mint_status": lambda: repair_project_mint_status(project_id=project_id),
         "rebuild_mint_summary": lambda: repair_project_mint_status(project_id=project_id),

--- a/backend/app/services/continuity_runtime_service.py
+++ b/backend/app/services/continuity_runtime_service.py
@@ -68,6 +68,9 @@ CASE_ACTION_SPECS: dict[str, ActionSpec] = {
         "admin_repair_safety", "low", "customer_case", ("case_id",), mutates_business_data=False
     ),
     "queue_for_mint_review": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "prepare_legacy_anchor": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "approve_legacy_anchor": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
+    "queue_approved_legacy_anchor": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
     "repair_record": ActionSpec("admin_repair_safety", "high", "customer_case", ("case_id",)),
     "repair_mint_status": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),
     "rebuild_mint_summary": ActionSpec("mint_readiness_repair", "high", "customer_case", ("case_id",)),

--- a/backend/app/services/mint_fee_service.py
+++ b/backend/app/services/mint_fee_service.py
@@ -1,27 +1,18 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from bson import ObjectId
 from pymongo.database import Database
 
 from app.database import get_database
-from app.services.audit_log_service import write_audit_log
 from app.services.mint_policy_service import (
     READINESS_REASON_DETAILS,
     describe_project_mint_eligibility,
 )
 
-TERMINAL_STATUSES = {"paid", "waived", "included", "executed"}
-
-
 def _normalize(value: Any) -> str:
     return str(value or "").strip()
-
-
-def _now() -> datetime:
-    return datetime.now(UTC)
 
 
 def _db() -> Database:
@@ -57,6 +48,7 @@ def _as_int(value: Any, default: int = 0) -> int:
 def _base_mint_fee_state(project: dict[str, Any]) -> dict[str, Any]:
     eligibility = describe_project_mint_eligibility(project)
     policy = dict(eligibility.get("mint_policy") or {})
+    addon_status = dict(eligibility.get("nft_addon") or {})
     included_anchor_count = _as_int(policy.get("included_anchor_count"), 0)
     minting_included = bool(policy.get("minting_included", included_anchor_count > 0))
     mint_fee_model = _normalize(policy.get("mint_fee_model") or ("flat_included" if minting_included else "service_plus_network"))
@@ -73,7 +65,16 @@ def _base_mint_fee_state(project: dict[str, Any]) -> dict[str, Any]:
         "remint_service_fee_usd": _as_float(policy.get("remint_service_fee_usd"), 0.0),
         "network_fee_quote_usd": _as_float(project.get("network_fee_quote_usd") or policy.get("network_fee_quote_usd"), 0.0),
         "network_fee_quote_expires_at": project.get("network_fee_quote_expires_at"),
-        "mint_fee_status": _normalize(project.get("mint_fee_status")) or "not_required",
+        "mint_fee_status": (
+            "paid_addon_claimed"
+            if addon_status.get("active_mint_credit")
+            else "paid_addon_available"
+            if addon_status.get("mint_credit_satisfied")
+            else "nft_addon_required"
+        ),
+        "required_nft_addon_code": addon_status.get("required_mint_addon_code"),
+        "verified_paid_addon_credit": bool(addon_status.get("mint_credit_satisfied")),
+        "checkout_never_triggers_mint": True,
         "mint_fee_paid_at": project.get("mint_fee_paid_at"),
         "network_fee_locked_at": project.get("network_fee_locked_at"),
         "mint_fee_notes": _normalize(project.get("mint_fee_notes")),
@@ -82,177 +83,42 @@ def _base_mint_fee_state(project: dict[str, Any]) -> dict[str, Any]:
 
 def get_project_mint_fee(project_id: str) -> dict[str, Any]:
     project = _project(project_id)
-    state = _base_mint_fee_state(project)
-
-    if not bool(describe_project_mint_eligibility(project).get("mint_policy", {}).get("product_includes_onchain_anchor")):
-        state["mint_fee_status"] = "not_required"
-
-    return state
-
-
-def _create_order_line_item(
-    *,
-    project_id: str,
-    package_code: str,
-    item_type: str,
-    amount_usd: float,
-    status: str,
-    quote_expires_at: datetime | None,
-    notes: str,
-) -> None:
-    _db()["order_line_items"].insert_one(
-        {
-            "project_id": project_id,
-            "package_code": package_code,
-            "item_type": item_type,
-            "amount_usd": amount_usd,
-            "status": status,
-            "quote_expires_at": quote_expires_at,
-            "mint_fee_notes": notes,
-            "created_at": _now(),
-            "updated_at": _now(),
-        }
-    )
-
-
-def _write_fee_audit(action: str, project_id: str, actor: dict[str, Any], before: dict[str, Any], after: dict[str, Any]) -> None:
-    write_audit_log(
-        actor_user_id=_normalize(actor.get("id") or actor.get("_id") or actor.get("user_id")) or None,
-        actor_email=_normalize(actor.get("email")).lower() or None,
-        actor_name=_normalize(actor.get("name") or actor.get("full_name")) or None,
-        action=action,
-        target_type="project",
-        target_id=project_id,
-        before=before,
-        after=after,
-        details={"mint_fee_billing": True},
-    )
+    return _base_mint_fee_state(project)
 
 
 def quote_mint_fee(project_id: str, actor: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    project = _project(project_id)
-    before = _base_mint_fee_state(project)
-    fee_notes = _normalize(payload.get("mint_fee_notes"))
-    expires_at = _now() + timedelta(minutes=max(5, int(payload.get("quote_ttl_minutes") or 60)))
-
-    update = {
-        "minting_service_fee_usd": _as_float(payload.get("minting_service_fee_usd"), before["minting_service_fee_usd"]),
-        "blockchain_network_fee_usd": _as_float(payload.get("blockchain_network_fee_usd"), before["blockchain_network_fee_usd"]),
-        "network_fee_quote_usd": _as_float(payload.get("network_fee_quote_usd"), before["network_fee_quote_usd"]),
-        "network_fee_quote_expires_at": expires_at,
-        "mint_fee_status": "quoted",
-        "mint_fee_notes": fee_notes,
-        "updated_at": _now(),
-    }
-    _db()["projects"].update_one({"_id": project["_id"]}, {"$set": update})
-
-    package_code = _normalize(project.get("package_code") or project.get("package_slug"))
-    _create_order_line_item(
-        project_id=project_id,
-        package_code=package_code,
-        item_type="minting_service_fee",
-        amount_usd=update["minting_service_fee_usd"],
-        status="quoted",
-        quote_expires_at=expires_at,
-        notes=fee_notes,
+    del project_id, actor, payload
+    raise ValueError(
+        "Separate mint-fee quotes are disabled. Use the exact verified NFT add-on price."
     )
-    _create_order_line_item(
-        project_id=project_id,
-        package_code=package_code,
-        item_type="blockchain_network_fee",
-        amount_usd=update["blockchain_network_fee_usd"],
-        status="quoted",
-        quote_expires_at=expires_at,
-        notes=fee_notes,
-    )
-
-    after = get_project_mint_fee(project_id)
-    _write_fee_audit("project_mint_fee_quoted", project_id, actor, before, after)
-    return after
 
 
 def mark_mint_fee_paid(project_id: str, actor: dict[str, Any], notes: str = "") -> dict[str, Any]:
-    project = _project(project_id)
-    before = _base_mint_fee_state(project)
-    now = _now()
-    _db()["projects"].update_one(
-        {"_id": project["_id"]},
-        {
-            "$set": {
-                "mint_fee_status": "paid",
-                "mint_fee_paid_at": now,
-                "network_fee_locked_at": now,
-                "mint_fee_notes": _normalize(notes) or before.get("mint_fee_notes") or "",
-                "updated_at": now,
-            }
-        },
+    del project_id, actor, notes
+    raise ValueError(
+        "Manual fee status cannot authorize minting. The customer must purchase the verified NFT add-on."
     )
-    _db()["order_line_items"].update_many(
-        {"project_id": project_id, "item_type": {"$in": ["minting_service_fee", "blockchain_network_fee", "remint_fee"]}},
-        {"$set": {"status": "paid", "updated_at": now}},
-    )
-    after = get_project_mint_fee(project_id)
-    _write_fee_audit("project_mint_fee_marked_paid", project_id, actor, before, after)
-    return after
 
 
 def waive_mint_fee(project_id: str, actor: dict[str, Any], notes: str = "") -> dict[str, Any]:
-    project = _project(project_id)
-    before = _base_mint_fee_state(project)
-    now = _now()
-    _db()["projects"].update_one(
-        {"_id": project["_id"]},
-        {
-            "$set": {
-                "mint_fee_status": "waived",
-                "mint_fee_notes": _normalize(notes) or "Admin waived mint fee.",
-                "updated_at": now,
-            }
-        },
+    del project_id, actor, notes
+    raise ValueError(
+        "NFT add-on purchases cannot be waived into existence. A verified paid add-on is required."
     )
-    _db()["order_line_items"].update_many(
-        {"project_id": project_id, "item_type": {"$in": ["minting_service_fee", "blockchain_network_fee", "remint_fee"]}},
-        {"$set": {"status": "waived", "updated_at": now}},
-    )
-    after = get_project_mint_fee(project_id)
-    _write_fee_audit("project_mint_fee_waived", project_id, actor, before, after)
-    return after
 
 
 def refresh_network_quote(project_id: str, actor: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
-    project = _project(project_id)
-    before = _base_mint_fee_state(project)
-    expires_at = _now() + timedelta(minutes=max(5, int(payload.get("quote_ttl_minutes") or 60)))
-    _db()["projects"].update_one(
-        {"_id": project["_id"]},
-        {
-            "$set": {
-                "network_fee_quote_usd": _as_float(payload.get("network_fee_quote_usd"), before["network_fee_quote_usd"]),
-                "network_fee_quote_expires_at": expires_at,
-                "mint_fee_status": "quoted",
-                "mint_fee_notes": _normalize(payload.get("mint_fee_notes")) or before.get("mint_fee_notes") or "",
-                "updated_at": _now(),
-            }
-        },
+    del project_id, actor, payload
+    raise ValueError(
+        "Separate network-fee quotes are disabled. Network execution is fulfilled through the verified NFT add-on."
     )
-    after = get_project_mint_fee(project_id)
-    _write_fee_audit("project_mint_fee_network_quote_refreshed", project_id, actor, before, after)
-    return after
 
 
 def mint_fee_satisfied(project: dict[str, Any]) -> tuple[bool, str | None]:
     state = _base_mint_fee_state(project)
-    status = _normalize(state.get("mint_fee_status")).lower()
-    included = bool(state.get("minting_included")) and _as_int(state.get("mints_used_count"), 0) < _as_int(state.get("included_anchor_count"), 0)
-    model = _normalize(state.get("mint_fee_model"))
-
-    if model == "flat_included" and included:
+    if bool(state.get("verified_paid_addon_credit")):
         return True, None
-    if status in TERMINAL_STATUSES:
-        return True, None
-    if included and model in {"flat_included", "flat_fee"}:
-        return True, None
-    return False, "mint_fee_unpaid_or_unwaived"
+    return False, "nft_addon_not_purchased"
 
 
 def get_project_mint_readiness(project_id: str) -> dict[str, Any]:
@@ -261,8 +127,13 @@ def get_project_mint_readiness(project_id: str) -> dict[str, Any]:
     fee_ok, fee_reason = mint_fee_satisfied(project)
     reasons = list(eligibility.get("reasons") or [])
     blocking_details = list(eligibility.get("blocking_details") or [])
-    if not fee_ok and fee_reason:
+    if not fee_ok and fee_reason and fee_reason not in reasons:
         reasons.append(fee_reason)
+    if (
+        not fee_ok
+        and fee_reason
+        and not any(detail.get("code") == fee_reason for detail in blocking_details)
+    ):
         blocking_details.append(
             {
                 "code": fee_reason,
@@ -276,7 +147,9 @@ def get_project_mint_readiness(project_id: str) -> dict[str, Any]:
         "mint_eligible": bool(eligibility.get("eligible")),
         "mint_policy": eligibility.get("mint_policy") or {},
         "mint_fee": _base_mint_fee_state(project),
-        "ready_for_mint_preparation": bool(eligibility.get("eligible")),
+        "ready_for_mint_preparation": bool(
+            eligibility.get("ready_for_mint_preparation")
+        ),
         "ready_for_mint_execution": bool(eligibility.get("eligible")) and fee_ok,
         "blocking_reasons": reasons,
         "blocking_details": blocking_details,

--- a/backend/app/services/mint_job_service.py
+++ b/backend/app/services/mint_job_service.py
@@ -10,6 +10,7 @@ from pymongo import ReturnDocument
 from pymongo.collection import Collection
 from pymongo.errors import DuplicateKeyError, OperationFailure
 
+from app.core.admin_permission_registry import is_canonical_ceo_email
 from app.database import get_database
 from app.services.blockchain_mint_service import (
     mint_anchor,
@@ -330,7 +331,11 @@ def queue_mint_pipeline(
     *,
     queued_by: str = "system",
 ) -> list[dict[str, Any]]:
-    del queued_by
+    normalized_queued_by = _normalize(queued_by).lower()
+    if not is_canonical_ceo_email(normalized_queued_by):
+        raise ValueError(
+            "Only the CEO master account can queue an approved NFT."
+        )
     now = _now()
 
     record = get_mint_record(mint_record_id)

--- a/backend/app/services/mint_policy_service.py
+++ b/backend/app/services/mint_policy_service.py
@@ -12,37 +12,27 @@ from app.core.package_catalog import (
 from app.core.package_mapping import resolve_package_identity
 from app.database import get_database
 
-BUILD_READY_STATUSES = {
-    "build_ready",
-    "in_production",
-    "qa_review",
-    "client_review",
-    "delivered",
-    "archived",
-}
-BUILD_READY_PHASES = {
-    "intake_approved",
-    "in_production",
-    "qa_review",
-    "client_review",
-    "delivered",
-    "archived",
-}
+COMPLETE_PROFILE_STATUSES = {"delivered", "archived"}
+COMPLETE_PROFILE_PHASES = {"delivery_complete", "delivered", "archived"}
 
 MINT_FEE_STATUS_READY = {"paid", "waived", "included", "executed"}
 
 READINESS_REASON_DETAILS: dict[str, dict[str, str]] = {
-    "package_not_included": {
-        "message": "This package does not include on-chain minting.",
-        "flag": "product_includes_onchain_anchor",
+    "nft_addon_not_purchased": {
+        "message": "A verified paid NFT mint add-on is required.",
+        "flag": "paid_nft_addon_credit",
     },
-    "build_not_ready": {
-        "message": "Project workflow state is not build-ready.",
-        "flag": "build_ready_state",
+    "profile_not_complete": {
+        "message": "The customer profile must be delivered before an NFT add-on can be purchased or prepared.",
+        "flag": "profile_complete",
     },
     "mint_runtime_disabled": {
         "message": "Mint runtime flags are disabled for this token type.",
         "flag": "runtime_enabled",
+    },
+    "controlled_mint_worker_disabled": {
+        "message": "The controlled mint worker is disabled.",
+        "flag": "nft_mint_worker_enabled",
     },
     "public_safe_approval_incomplete": {
         "message": "Public-safe approval is incomplete.",
@@ -55,10 +45,6 @@ READINESS_REASON_DETAILS: dict[str, dict[str, str]] = {
     "collectible_not_preparing": {
         "message": "Collectible preparation has not started.",
         "flag": "mint_collectible_preparing",
-    },
-    "mint_fee_unpaid_or_unwaived": {
-        "message": "Mint fee requirements are not yet satisfied.",
-        "flag": "mint_fee_satisfied",
     },
 }
 
@@ -104,9 +90,7 @@ def _runtime_enabled(token_type: str | None) -> bool:
 def _project_has_build_state(project: dict[str, Any]) -> bool:
     status_value = _normalize(project.get("status")).lower()
     phase_value = _normalize(project.get("phase")).lower()
-    return (
-        status_value in BUILD_READY_STATUSES or phase_value in BUILD_READY_PHASES
-    )
+    return status_value in COMPLETE_PROFILE_STATUSES or phase_value in COMPLETE_PROFILE_PHASES
 
 
 
@@ -150,10 +134,23 @@ def get_package_mint_policy(package_code: str) -> dict[str, Any]:
         "product_includes_onchain_anchor": bool(
             base_policy.get("product_includes_onchain_anchor")
         ),
+        "onchain_anchor_available_as_addon": bool(
+            base_policy.get("onchain_anchor_available_as_addon")
+        ),
+        "requires_paid_nft_addon": bool(base_policy.get("requires_paid_nft_addon")),
+        "profile_completion_required_before_purchase": bool(
+            base_policy.get("profile_completion_required_before_purchase")
+        ),
+        "checkout_never_triggers_mint": bool(
+            base_policy.get("checkout_never_triggers_mint", True)
+        ),
         "auto_mint_enabled": bool(base_policy.get("auto_mint_enabled")),
         "opt_in_only": bool(base_policy.get("opt_in_only")),
         "requires_customer_public_safe_approval": bool(
             base_policy.get("requires_customer_public_safe_approval")
+        ),
+        "requires_admin_final_approval": bool(
+            base_policy.get("requires_admin_final_approval")
         ),
         "included_anchor_count": int(base_policy.get("included_anchor_count") or 0),
         "mint_fee_model": str(base_policy.get("mint_fee_model") or "service_plus_network"),
@@ -163,6 +160,9 @@ def get_package_mint_policy(package_code: str) -> dict[str, Any]:
         "remint_service_fee_usd": float(base_policy.get("remint_service_fee_usd") or 0),
         "network_fee_quote_usd": float(base_policy.get("network_fee_quote_usd") or 0),
         "default_network_fee_policy": str(base_policy.get("default_network_fee_policy") or "quoted_variable"),
+        "initial_mint_addon_code": str(base_policy.get("initial_mint_addon_code") or ""),
+        "additional_mint_addon_code": str(base_policy.get("additional_mint_addon_code") or ""),
+        "metadata_revision_addon_code": str(base_policy.get("metadata_revision_addon_code") or ""),
         "runtime_enabled": _runtime_enabled(token_type),
     }
 
@@ -185,25 +185,40 @@ def describe_project_mint_eligibility(project: dict[str, Any]) -> dict[str, Any]
     policy = get_package_mint_policy(package_code)
     reasons: list[str] = []
 
-    if not policy.get("product_includes_onchain_anchor"):
-        reasons.append("package_not_included")
+    profile_complete = _project_has_build_state(project)
+    if not profile_complete:
+        reasons.append("profile_not_complete")
 
-    if not _project_has_build_state(project):
-        reasons.append("build_not_ready")
+    project_id = _normalize(project.get("_id") or project.get("id"))
+    try:
+        from app.services.nft_addon_service import get_nft_addon_status
 
-    if (
-        policy.get("product_includes_onchain_anchor")
-        and not policy.get("runtime_enabled")
-    ):
+        addon_status = get_nft_addon_status(project_id, project=project)
+    except (RuntimeError, ValueError):
+        addon_status = {
+            "project_id": project_id,
+            "profile_complete": profile_complete,
+            "required_mint_addon_code": policy.get("initial_mint_addon_code"),
+            "mint_credit_satisfied": False,
+            "checkout_never_triggers_mint": True,
+            "purchase_options": {},
+        }
+
+    if policy.get("requires_paid_nft_addon") and not addon_status.get("mint_credit_satisfied"):
+        reasons.append("nft_addon_not_purchased")
+
+    if not policy.get("runtime_enabled"):
         reasons.append("mint_runtime_disabled")
+    elif not settings.nft_mint_worker_enabled:
+        reasons.append("controlled_mint_worker_disabled")
 
-    if policy.get("product_includes_onchain_anchor") and not _project_public_safe_approved(project):
+    if not _project_public_safe_approved(project):
         reasons.append("public_safe_approval_incomplete")
 
-    if policy.get("product_includes_onchain_anchor") and not _delivery_manifest_finalized(project):
+    if not _delivery_manifest_finalized(project):
         reasons.append("delivery_manifest_not_finalized")
 
-    if policy.get("product_includes_onchain_anchor") and not bool(project.get("mint_collectible_preparing") or project.get("mint_preparation_started")):
+    if not bool(project.get("mint_collectible_preparing") or project.get("mint_preparation_started")):
         reasons.append("collectible_not_preparing")
 
     blocking_details = [
@@ -216,10 +231,23 @@ def describe_project_mint_eligibility(project: dict[str, Any]) -> dict[str, Any]
         for reason in reasons
     ]
     return {
-        "project_id": _normalize(project.get("_id") or project.get("id")),
+        "project_id": project_id,
         "package_code": package_code,
         "package_lane": package_lane,
         "mint_policy": policy,
+        "nft_addon": addon_status,
+        "profile_complete": profile_complete,
+        "purchase_eligible": bool(
+            profile_complete
+            and addon_status.get("purchase_runtime_ready")
+            and any(
+                bool((option or {}).get("eligible"))
+                for option in (addon_status.get("purchase_options") or {}).values()
+            )
+        ),
+        "ready_for_mint_preparation": bool(
+            profile_complete and addon_status.get("mint_credit_satisfied")
+        ),
         "eligible": len(reasons) == 0,
         "reasons": reasons,
         "blocking_details": blocking_details,

--- a/backend/app/services/mint_record_service.py
+++ b/backend/app/services/mint_record_service.py
@@ -9,9 +9,16 @@ from pymongo.collection import Collection
 from pymongo.errors import OperationFailure
 
 from app.config import settings
+from app.core.admin_permission_registry import is_canonical_ceo_email
 from app.core.package_catalog import get_package
 from app.database import get_database
 from app.services.mint_policy_service import get_package_mint_policy
+from app.services.nft_addon_service import (
+    finalize_mint_addon_reservation,
+    get_nft_addon_status,
+    release_mint_addon_reservation,
+    reserve_paid_mint_addon,
+)
 from app.services.public_manifest_service import (
     build_public_manifest,
     compute_build_hash,
@@ -180,6 +187,7 @@ def ensure_mint_record_indexes() -> None:
         ([("mint_status", 1), ("created_at", -1)], "mint_status_1_created_at_-1"),
         ([("tx_hash", 1)], "tx_hash_1"),
         ([("token_id", 1), ("contract_address", 1)], "token_id_1_contract_address_1"),
+        ([("nft_addon_order_id", 1)], "nft_addon_order_id_1"),
     ]
     approval_definitions = [
         ([("project_id", 1), ("approval_type", 1), ("status", 1)], "project_id_1_approval_type_1_status_1"),
@@ -259,6 +267,8 @@ def _serialize_record(document: dict[str, Any]) -> dict[str, Any]:
         "user_id": _normalize(document.get("user_id")),
         "package_code": _normalize(document.get("package_code")),
         "package_lane": _normalize(document.get("package_lane")),
+        "nft_addon_order_id": _normalize(document.get("nft_addon_order_id")) or None,
+        "nft_addon_code": _normalize(document.get("nft_addon_code")) or None,
         "token_type": _normalize(document.get("token_type")) or None,
         "chain": _normalize(document.get("chain")) or settings.nft_chain,
         "contract_address": _normalize(document.get("contract_address"))
@@ -761,8 +771,8 @@ def create_mint_record(
     package_code, package_lane = _package_fields(project)
     policy = get_package_mint_policy(package_code)
 
-    if not policy.get("product_includes_onchain_anchor"):
-        raise ValueError("This package does not include an on-chain legacy anchor.")
+    if not policy.get("onchain_anchor_available_as_addon"):
+        raise ValueError("This project does not support the NFT add-on workflow.")
 
     existing_summary = resolve_canonical_mint_status(project_id, include_history=False)
     existing = existing_summary.get("current_record")
@@ -782,6 +792,15 @@ def create_mint_record(
             raise ValueError("Canonical mint summary is missing the current mint record.")
         return existing
 
+    addon_status = get_nft_addon_status(project_id, project=project)
+    if not addon_status.get("profile_complete"):
+        raise ValueError("The customer profile must be complete before NFT preparation.")
+    required_addon_code = _normalize(addon_status.get("required_mint_addon_code"))
+    reservation = reserve_paid_mint_addon(
+        project_id,
+        required_addon_code=required_addon_code,
+    )
+
     version_number = _next_version_number(project_id)
     project_doc_id = _normalize(project.get("_id"))
     now = _now()
@@ -793,6 +812,9 @@ def create_mint_record(
         "user_id": _object_id_or_text(project.get("owner_user_id")),
         "package_code": package_code,
         "package_lane": package_lane,
+        "nft_addon_order_id": _object_id_or_text(reservation["order_id"]),
+        "nft_addon_code": reservation["addon_code"],
+        "checkout_triggered_mint": False,
         "token_type": _normalize(policy.get("token_type")) or None,
         "chain": settings.nft_chain,
         "contract_address": settings.nft_contract_address,
@@ -821,8 +843,18 @@ def create_mint_record(
         "updated_at": now,
     }
 
-    result = _records_collection().insert_one(document)
-    mint_record_id = _normalize(result.inserted_id)
+    try:
+        result = _records_collection().insert_one(document)
+        mint_record_id = _normalize(result.inserted_id)
+        finalize_mint_addon_reservation(
+            reservation,
+            mint_record_id=mint_record_id,
+        )
+    except Exception:
+        release_mint_addon_reservation(reservation)
+        if "result" in locals():
+            _records_collection().delete_one({"_id": result.inserted_id})
+        raise
     _supersede_active_records(
         project_doc_id,
         keep_mint_record_id=mint_record_id,
@@ -898,6 +930,11 @@ def approve_admin_mint_record(
     approved_by_email: str,
     notes: str = "",
 ) -> dict[str, Any]:
+    normalized_approver = _normalize(approved_by_email).lower()
+    if not is_canonical_ceo_email(normalized_approver):
+        raise ValueError(
+            "Only the CEO master account can give final NFT approval."
+        )
     record = get_mint_record(mint_record_id)
     if record is None:
         raise ValueError("Mint record not found.")
@@ -907,7 +944,7 @@ def approve_admin_mint_record(
         mint_record_id=mint_record_id,
         approval_type=ADMIN_APPROVAL_TYPE,
         status="approved",
-        approved_by_email=approved_by_email,
+        approved_by_email=normalized_approver,
         notes=notes,
     )
     return _recompute_mint_approval_state(mint_record_id)
@@ -971,6 +1008,10 @@ def mark_mint_queued(mint_record_id: str) -> dict[str, Any]:
         raise ValueError("Mint record not found.")
     if record["mint_status"] not in {"approved", "queued"}:
         raise ValueError("Mint record must be approved before queueing.")
+    if not record.get("nft_addon_order_id") or not record.get("nft_addon_code"):
+        raise ValueError("A verified paid NFT add-on must be attached before queueing.")
+    if not record.get("customer_wallet"):
+        raise ValueError("Customer wallet consent is required before queueing.")
     canonical = resolve_canonical_mint_status(record["project_id"], include_history=False)
     if canonical.get("is_minted"):
         mark_obsolete_mint_jobs_for_project(
@@ -1092,7 +1133,9 @@ def build_mint_status(project_id: str) -> dict[str, Any]:
 
     return {
         "project_id": _normalize(project_id),
-        "mint_enabled": bool(mint_policy.get("product_includes_onchain_anchor")),
+        "mint_enabled": bool(mint_policy.get("onchain_anchor_available_as_addon")),
+        "minting_included_in_package": False,
+        "nft_addon": get_nft_addon_status(project_id, project=project),
         "current_status": canonical["current_status"],
         "canonical_status": canonical["canonical_status"],
         "current_mint_record_id": canonical["current_mint_record_id"],

--- a/backend/app/services/mint_worker_service.py
+++ b/backend/app/services/mint_worker_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from app.config import settings
+from app.services.mint_job_service import run_next_job
+
+
+logger = logging.getLogger(__name__)
+
+
+def mint_worker_enabled() -> bool:
+    return bool(settings.nft_mint_enabled and settings.nft_mint_worker_enabled)
+
+
+async def run_controlled_mint_worker(stop_event: asyncio.Event) -> None:
+    """Execute only jobs that a CEO has explicitly placed in the mint queue."""
+
+    if not mint_worker_enabled():
+        return
+
+    worker_id = f"mint-worker-{os.getpid()}"
+    idle_delay = max(2, int(settings.nft_mint_worker_poll_seconds))
+    logger.info("Controlled NFT mint worker started as %s.", worker_id)
+
+    while not stop_event.is_set():
+        delay = idle_delay
+        try:
+            result: dict[str, Any] = await asyncio.to_thread(run_next_job, worker_id)
+            if result.get("status") != "idle":
+                delay = 1
+        except Exception:
+            logger.exception("Controlled NFT mint worker iteration failed.")
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=delay)
+        except TimeoutError:
+            continue
+
+    logger.info("Controlled NFT mint worker stopped.")

--- a/backend/app/services/nft_addon_service.py
+++ b/backend/app/services/nft_addon_service.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from bson import ObjectId
+from pymongo import ReturnDocument
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from app.config import settings
+from app.core.package_catalog import (
+    get_addon,
+    get_package_control_profile,
+    normalize_addon_code,
+)
+from app.database import get_database
+
+
+INITIAL_MINT_ADDON_CODE = "nft_lineage_record"
+ADDITIONAL_MINT_ADDON_CODE = "additional_nft_copy_mint"
+METADATA_REVISION_ADDON_CODE = "nft_metadata_revision"
+NFT_ADDON_CODES = frozenset(
+    {
+        INITIAL_MINT_ADDON_CODE,
+        ADDITIONAL_MINT_ADDON_CODE,
+        METADATA_REVISION_ADDON_CODE,
+    }
+)
+MINT_ADDON_CODES = frozenset({INITIAL_MINT_ADDON_CODE, ADDITIONAL_MINT_ADDON_CODE})
+AUTHORITATIVE_ORDER_SOURCES = frozenset(
+    {"stripe_webhook", "stripe_verified"}
+)
+PAID_ORDER_STATUSES = frozenset({"paid", "complete", "completed", "succeeded"})
+COMPLETE_PROJECT_STATUSES = frozenset({"delivered", "archived"})
+COMPLETE_PROJECT_PHASES = frozenset({"delivery_complete", "delivered", "archived"})
+ACTIVE_MINT_RECORD_STATUSES = frozenset(
+    {
+        "draft",
+        "pending_approval",
+        "approved",
+        "queued",
+        "processing",
+        "minting",
+        # A technical failure does not consume the customer's right to retry
+        # the same paid mint. Keep the credit bound to the failed record so a
+        # second checkout cannot be sold as the recovery mechanism.
+        "failed",
+    }
+)
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _db() -> Database:
+    db = cast(Database | None, get_database())
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    return db
+
+
+def _id_candidates(value: Any) -> list[Any]:
+    normalized = _normalize(value)
+    candidates: list[Any] = []
+    if normalized:
+        candidates.append(normalized)
+    if ObjectId.is_valid(normalized):
+        candidates.append(ObjectId(normalized))
+    return list(dict.fromkeys(candidates))
+
+
+def _project(project_id: str) -> dict[str, Any]:
+    candidates = _id_candidates(project_id)
+    if not candidates:
+        raise ValueError("Project not found.")
+    project = _db()["projects"].find_one({"_id": {"$in": candidates}})
+    if not isinstance(project, dict):
+        raise ValueError("Project not found.")
+    return project
+
+
+def profile_is_complete(project: dict[str, Any]) -> bool:
+    status = _normalize(project.get("status")).lower()
+    phase = _normalize(project.get("phase")).lower()
+    return status in COMPLETE_PROJECT_STATUSES or phase in COMPLETE_PROJECT_PHASES
+
+
+def purchase_runtime_is_ready(project: dict[str, Any]) -> bool:
+    if not (
+        settings.nft_mint_enabled
+        and settings.nft_mint_worker_enabled
+        and not settings.nft_auto_mint_on_review_enabled
+    ):
+        return False
+    if (
+        settings.is_production_environment
+        and not settings.nft_legacy_payment_links_disabled
+    ):
+        return False
+    package_code = _normalize(
+        project.get("package_code")
+        or project.get("package_slug")
+        or project.get("package_type")
+    )
+    control_profile = get_package_control_profile(package_code) or {}
+    token_type = _normalize((control_profile.get("mint_policy") or {}).get("token_type"))
+    if token_type == "organization_anchor" and not settings.nft_org_mint_enabled:
+        return False
+    return True
+
+
+def project_mint_count(project_id: str, project: dict[str, Any] | None = None) -> int:
+    source = project or _project(project_id)
+    token_ids = {
+        _normalize(record.get("token_id"))
+        for record in _db()["mint_records"].find(
+            {
+                "project_id": {"$in": _id_candidates(project_id)},
+                "token_id": {"$exists": True, "$nin": [None, ""]},
+            }
+        )
+        if _normalize(record.get("token_id"))
+    }
+    legacy_token_id = _normalize(source.get("mint_token_id"))
+    if legacy_token_id:
+        token_ids.add(legacy_token_id)
+    if token_ids:
+        return len(token_ids)
+    # A legacy project may retain the transaction before its token id was
+    # backfilled. Count it as one completed mint so it can never buy the first
+    # mint product again.
+    return 1 if _normalize(source.get("mint_tx_hash")) else 0
+
+
+def project_has_existing_mint(project_id: str, project: dict[str, Any] | None = None) -> bool:
+    return project_mint_count(project_id, project) > 0
+
+
+def _credit_slot(project_id: str, addon_code: str, *, mint_count: int) -> tuple[str, str]:
+    code = normalize_addon_code(addon_code)
+    if code == INITIAL_MINT_ADDON_CODE:
+        slot = "mint:1"
+    elif code == ADDITIONAL_MINT_ADDON_CODE:
+        slot = f"mint:{mint_count + 1}"
+    else:
+        return "", ""
+    return slot, f"{_normalize(project_id)}:{slot}"
+
+
+def _record_for_paid_credit(project_id: str) -> dict[str, Any] | None:
+    record = _db()["mint_records"].find_one(
+        {
+            "project_id": {"$in": _id_candidates(project_id)},
+            "mint_status": {"$in": list(ACTIVE_MINT_RECORD_STATUSES)},
+            "nft_addon_order_id": {"$nin": [None, ""]},
+        },
+        sort=[("version_number", -1), ("updated_at", -1)],
+    )
+    return record if isinstance(record, dict) else None
+
+
+def _active_mint_record(project_id: str) -> dict[str, Any] | None:
+    return _record_for_paid_credit(project_id)
+
+
+def _order_addon_code(order: dict[str, Any]) -> str:
+    return normalize_addon_code(
+        order.get("addon_code") or order.get("purchase_code") or order.get("package_code")
+    )
+
+
+def _paid_nft_addon_orders(project_id: str) -> list[dict[str, Any]]:
+    orders = _db()["orders"].find(
+        {
+            "project_id": {"$in": _id_candidates(project_id)},
+            "item_type": "addon",
+            "source": {"$in": list(AUTHORITATIVE_ORDER_SOURCES)},
+            "status": {"$in": list(PAID_ORDER_STATUSES)},
+            "nft_addon_verified": True,
+            "$or": [
+                {"addon_code": {"$in": list(NFT_ADDON_CODES)}},
+                {"package_code": {"$in": list(NFT_ADDON_CODES)}},
+            ],
+        }
+    )
+    return [order for order in orders if _order_addon_code(order) in NFT_ADDON_CODES]
+
+
+def _credit_is_available(order: dict[str, Any]) -> bool:
+    return _normalize(order.get("nft_credit_status")).lower() in {"", "available"}
+
+
+def get_nft_addon_status(
+    project_id: str,
+    *,
+    project: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    source = project or _project(project_id)
+    normalized_project_id = _normalize(source.get("_id") or source.get("id") or project_id)
+    complete = profile_is_complete(source)
+    purchase_runtime_ready = purchase_runtime_is_ready(source)
+    mint_count = project_mint_count(normalized_project_id, source)
+    existing_mint = mint_count > 0
+    active_record = _active_mint_record(normalized_project_id)
+    orders = _paid_nft_addon_orders(normalized_project_id)
+    paid_order_ids = {_normalize(order.get("_id")) for order in orders}
+
+    counts = {code: 0 for code in NFT_ADDON_CODES}
+    available = {code: 0 for code in NFT_ADDON_CODES}
+    consumed = {code: 0 for code in NFT_ADDON_CODES}
+    for order in orders:
+        code = _order_addon_code(order)
+        counts[code] += 1
+        if _credit_is_available(order):
+            available[code] += 1
+        else:
+            consumed[code] += 1
+
+    required_code = (
+        ADDITIONAL_MINT_ADDON_CODE if existing_mint else INITIAL_MINT_ADDON_CODE
+    )
+    required_credit_slot, required_credit_slot_key = _credit_slot(
+        normalized_project_id,
+        required_code,
+        mint_count=mint_count,
+    )
+    active_code = normalize_addon_code((active_record or {}).get("nft_addon_code"))
+    active_order_id = _normalize((active_record or {}).get("nft_addon_order_id"))
+    active_credit = bool(
+        active_record
+        and active_code in MINT_ADDON_CODES
+        and active_order_id in paid_order_ids
+    )
+    available_required_credit = available.get(required_code, 0) > 0
+
+    return {
+        "project_id": normalized_project_id,
+        "profile_complete": complete,
+        "profile_completion_required": True,
+        "purchase_runtime_ready": purchase_runtime_ready,
+        "has_existing_mint": existing_mint,
+        "mint_count": mint_count,
+        "active_mint_record_id": _normalize((active_record or {}).get("_id")) or None,
+        "active_mint_addon_code": active_code or None,
+        "active_mint_credit": active_credit,
+        "required_mint_addon_code": required_code,
+        "required_mint_addon": get_addon(required_code),
+        "required_mint_credit_slot": required_credit_slot,
+        "required_mint_credit_slot_key": required_credit_slot_key,
+        "mint_credit_satisfied": bool(active_credit or available_required_credit),
+        "available_mint_credit_count": int(available.get(required_code, 0)),
+        "purchased_counts": counts,
+        "available_counts": available,
+        "consumed_counts": consumed,
+        "purchase_options": {
+            INITIAL_MINT_ADDON_CODE: {
+                "eligible": bool(
+                    complete
+                    and purchase_runtime_ready
+                    and not existing_mint
+                    and not active_credit
+                    and available[INITIAL_MINT_ADDON_CODE] == 0
+                ),
+                "reason": (
+                    None
+                    if (
+                        complete
+                        and purchase_runtime_ready
+                        and not existing_mint
+                        and not active_credit
+                        and available[INITIAL_MINT_ADDON_CODE] == 0
+                    )
+                    else "profile_not_complete"
+                    if not complete
+                    else "mint_runtime_unavailable"
+                    if not purchase_runtime_ready
+                    else "mint_credit_already_purchased"
+                    if available[INITIAL_MINT_ADDON_CODE] > 0
+                    else "initial_mint_already_exists_or_is_in_progress"
+                ),
+            },
+            ADDITIONAL_MINT_ADDON_CODE: {
+                "eligible": bool(
+                    complete
+                    and purchase_runtime_ready
+                    and existing_mint
+                    and not active_credit
+                    and available[ADDITIONAL_MINT_ADDON_CODE] == 0
+                ),
+                "reason": (
+                    None
+                    if (
+                        complete
+                        and purchase_runtime_ready
+                        and existing_mint
+                        and not active_credit
+                        and available[ADDITIONAL_MINT_ADDON_CODE] == 0
+                    )
+                    else "profile_not_complete"
+                    if not complete
+                    else "mint_runtime_unavailable"
+                    if not purchase_runtime_ready
+                    else "existing_mint_required"
+                    if not existing_mint
+                    else "mint_credit_already_purchased"
+                    if available[ADDITIONAL_MINT_ADDON_CODE] > 0
+                    else "mint_already_in_progress"
+                ),
+            },
+            METADATA_REVISION_ADDON_CODE: {
+                "eligible": bool(complete and purchase_runtime_ready and existing_mint),
+                "reason": (
+                    None
+                    if complete and purchase_runtime_ready and existing_mint
+                    else "profile_not_complete"
+                    if not complete
+                    else "mint_runtime_unavailable"
+                    if not purchase_runtime_ready
+                    else "existing_mint_required"
+                ),
+                "authorizes_new_mint": False,
+            },
+        },
+        "checkout_never_triggers_mint": True,
+    }
+
+
+def _user_can_purchase_for_project(user: dict[str, Any], project: dict[str, Any]) -> bool:
+    user_ids = _id_candidates(user.get("_id") or user.get("id") or user.get("user_id"))
+    owner_ids = _id_candidates(project.get("owner_user_id"))
+    if set(user_ids).intersection(owner_ids):
+        return True
+
+    user_email = _normalize(user.get("email")).lower()
+    owner_email = _normalize(project.get("owner_email")).lower()
+    if user_email and owner_email and user_email == owner_email:
+        return True
+
+    member = _db()["project_members"].find_one(
+        {
+            "project_id": {"$in": _id_candidates(project.get("_id"))},
+            "user_id": {"$in": user_ids},
+            "status": {"$in": ["active", "accepted"]},
+            "role": {"$in": ["billing_owner", "co_owner"]},
+        }
+    )
+    return isinstance(member, dict)
+
+
+def validate_nft_addon_purchase_target(
+    *,
+    user: dict[str, Any],
+    project_id: str,
+    addon_code: str,
+) -> dict[str, Any]:
+    code = normalize_addon_code(addon_code)
+    if code not in NFT_ADDON_CODES:
+        raise ValueError("Checkout product is not a recognized NFT add-on.")
+    project = _project(project_id)
+    if not _user_can_purchase_for_project(user, project):
+        raise ValueError("NFT add-on checkout does not belong to this customer workspace.")
+    if not profile_is_complete(project):
+        raise ValueError("Complete the customer profile before purchasing an NFT add-on.")
+    if not purchase_runtime_is_ready(project):
+        raise ValueError("NFT add-on checkout is temporarily unavailable until mint operations are ready.")
+
+    status = get_nft_addon_status(project_id, project=project)
+    option = dict((status.get("purchase_options") or {}).get(code) or {})
+    if not option.get("eligible"):
+        reason = _normalize(option.get("reason")) or "nft_addon_not_available"
+        messages = {
+            "mint_credit_already_purchased": (
+                "The required NFT mint add-on is already paid for this mint."
+            ),
+            "initial_mint_already_exists_or_is_in_progress": (
+                "Use Additional NFT Copy / Mint after the first NFT has been minted."
+            ),
+            "existing_mint_required": (
+                "The first NFT must be minted before purchasing this add-on."
+            ),
+            "mint_already_in_progress": (
+                "The current paid NFT mint must finish or be reconciled before another purchase."
+            ),
+        }
+        raise ValueError(messages.get(reason, "This NFT add-on is not available for the current project state."))
+
+    validated = dict(project)
+    if code in MINT_ADDON_CODES:
+        slot, slot_key = _credit_slot(
+            _normalize(project.get("_id") or project_id),
+            code,
+            mint_count=int(status.get("mint_count") or 0),
+        )
+        validated["_nft_credit_slot"] = slot
+        validated["_nft_credit_slot_key"] = slot_key
+    else:
+        purchased_count = int(
+            ((status.get("purchased_counts") or {}).get(code)) or 0
+        )
+        validated["_nft_checkout_sequence"] = f"revision:{purchased_count + 1}"
+    return validated
+
+
+def reserve_paid_mint_addon(
+    project_id: str,
+    *,
+    required_addon_code: str,
+) -> dict[str, Any]:
+    code = normalize_addon_code(required_addon_code)
+    if code not in MINT_ADDON_CODES:
+        raise ValueError("A mint-authorizing NFT add-on is required.")
+
+    claim_token = secrets.token_urlsafe(24)
+    orders: Collection[dict[str, Any]] = _db()["orders"]
+    order = orders.find_one_and_update(
+        {
+            "project_id": {"$in": _id_candidates(project_id)},
+            "item_type": "addon",
+            "source": {"$in": list(AUTHORITATIVE_ORDER_SOURCES)},
+            "status": {"$in": list(PAID_ORDER_STATUSES)},
+            "nft_addon_verified": True,
+            "$or": [{"addon_code": code}, {"package_code": code}],
+            "nft_credit_status": {"$in": [None, "", "available"]},
+        },
+        {
+            "$set": {
+                "nft_credit_status": "reserved",
+                "nft_credit_claim_token": claim_token,
+                "nft_credit_reserved_at": _now(),
+                "updated_at": _now(),
+            }
+        },
+        sort=[("created_at", 1)],
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(order, dict):
+        raise ValueError(f"A paid {code.replace('_', ' ')} add-on is required before preparation.")
+    return {
+        "order_id": _normalize(order.get("_id")),
+        "addon_code": code,
+        "claim_token": claim_token,
+    }
+
+
+def finalize_mint_addon_reservation(
+    reservation: dict[str, Any],
+    *,
+    mint_record_id: str,
+) -> None:
+    order_id = _normalize(reservation.get("order_id"))
+    claim_token = _normalize(reservation.get("claim_token"))
+    if not ObjectId.is_valid(order_id) or not claim_token:
+        raise ValueError("NFT add-on reservation is invalid.")
+    result = _db()["orders"].update_one(
+        {"_id": ObjectId(order_id), "nft_credit_claim_token": claim_token},
+        {
+            "$set": {
+                "nft_credit_status": "claimed",
+                "nft_credit_mint_record_id": (
+                    ObjectId(mint_record_id)
+                    if ObjectId.is_valid(mint_record_id)
+                    else mint_record_id
+                ),
+                "nft_credit_claimed_at": _now(),
+                "updated_at": _now(),
+            },
+            "$unset": {"nft_credit_claim_token": ""},
+        },
+    )
+    if not result.modified_count:
+        raise RuntimeError("NFT add-on reservation could not be finalized.")
+
+
+def release_mint_addon_reservation(reservation: dict[str, Any]) -> None:
+    order_id = _normalize(reservation.get("order_id"))
+    claim_token = _normalize(reservation.get("claim_token"))
+    if not ObjectId.is_valid(order_id) or not claim_token:
+        return
+    _db()["orders"].update_one(
+        {"_id": ObjectId(order_id), "nft_credit_claim_token": claim_token},
+        {
+            "$set": {"nft_credit_status": "available", "updated_at": _now()},
+            "$unset": {
+                "nft_credit_claim_token": "",
+                "nft_credit_reserved_at": "",
+            },
+        },
+    )

--- a/backend/app/services/nft_checkout_service.py
+++ b/backend/app/services/nft_checkout_service.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Iterable
+from urllib.parse import urlencode, urlparse
+
+import stripe
+
+from app.config import settings
+from app.core.package_catalog import get_addon, normalize_addon_code
+from app.services.nft_addon_service import (
+    ADDITIONAL_MINT_ADDON_CODE,
+    INITIAL_MINT_ADDON_CODE,
+    METADATA_REVISION_ADDON_CODE,
+    NFT_ADDON_CODES,
+    validate_nft_addon_purchase_target,
+)
+
+
+PRICE_SETTING_BY_ADDON = {
+    INITIAL_MINT_ADDON_CODE: "stripe_nft_lineage_record_price_id",
+    ADDITIONAL_MINT_ADDON_CODE: "stripe_additional_nft_mint_price_id",
+    METADATA_REVISION_ADDON_CODE: "stripe_nft_metadata_revision_price_id",
+}
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _stripe_to_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "to_dict_recursive"):
+        return dict(value.to_dict_recursive())
+    if isinstance(value, dict):
+        return value
+    return dict(value)
+
+
+def _normalized_product_name(value: Any) -> str:
+    normalized = _normalize(value).lower().replace("—", "-").replace("–", "-")
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"^add\s*-?\s*on\s*-\s*", "", normalized)
+    return normalized.strip()
+
+
+def _require_stripe() -> None:
+    secret = _normalize(settings.stripe_secret_key)
+    if not secret:
+        raise RuntimeError("STRIPE_SECRET_KEY is not configured.")
+    stripe.api_key = secret
+
+
+def _expected_price(addon_code: str) -> tuple[dict[str, Any], int]:
+    addon = get_addon(addon_code) or {}
+    if not addon or addon_code not in NFT_ADDON_CODES:
+        raise ValueError("NFT add-on is not in the approved server catalog.")
+    cents = int(round(float(addon.get("price_usd") or 0) * 100))
+    if cents <= 0:
+        raise RuntimeError("NFT add-on price is not configured.")
+    return addon, cents
+
+
+def _price_matches(
+    price: dict[str, Any],
+    *,
+    addon: dict[str, Any],
+    expected_cents: int,
+) -> bool:
+    product = price.get("product") or {}
+    if not isinstance(product, dict):
+        return False
+    return bool(
+        _normalize(price.get("id"))
+        and price.get("active") is not False
+        and product.get("active") is not False
+        and price.get("recurring") in (None, {})
+        and _normalize(price.get("currency")).lower() == "usd"
+        and price.get("unit_amount") == expected_cents
+        and _normalized_product_name(product.get("name"))
+        == _normalized_product_name(addon.get("display_name"))
+    )
+
+
+def _iter_stripe_prices(response: Any) -> Iterable[dict[str, Any]]:
+    if hasattr(response, "auto_paging_iter"):
+        for value in response.auto_paging_iter():
+            yield _stripe_to_dict(value)
+        return
+    payload = _stripe_to_dict(response)
+    for value in payload.get("data") or []:
+        yield _stripe_to_dict(value)
+
+
+def resolve_nft_addon_price_id(addon_code: str) -> str:
+    code = normalize_addon_code(addon_code)
+    addon, expected_cents = _expected_price(code)
+    _require_stripe()
+
+    configured_field = PRICE_SETTING_BY_ADDON[code]
+    configured_price_id = _normalize(getattr(settings, configured_field, ""))
+    if configured_price_id:
+        price = _stripe_to_dict(
+            stripe.Price.retrieve(configured_price_id, expand=["product"])
+        )
+        if not _price_matches(price, addon=addon, expected_cents=expected_cents):
+            raise RuntimeError(
+                f"Configured Stripe price for {code} does not match the approved product and USD amount."
+            )
+        return configured_price_id
+
+    response = stripe.Price.list(
+        active=True,
+        currency="usd",
+        type="one_time",
+        limit=100,
+        expand=["data.product"],
+    )
+    matches = [
+        price
+        for price in _iter_stripe_prices(response)
+        if _price_matches(price, addon=addon, expected_cents=expected_cents)
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Stripe must contain exactly one active {code} price matching the approved product and amount; found {len(matches)}. "
+            f"Set {configured_field.upper()} to select the intended price."
+        )
+    return _normalize(matches[0].get("id"))
+
+
+def _public_app_base_url() -> str:
+    raw = _normalize(settings.nft_default_external_url).rstrip("/")
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RuntimeError("NFT_DEFAULT_EXTERNAL_URL must be a valid public app URL.")
+    if settings.is_production_environment and parsed.scheme != "https":
+        raise RuntimeError("NFT_DEFAULT_EXTERNAL_URL must use HTTPS in production.")
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _user_id(user: dict[str, Any]) -> str:
+    value = _normalize(user.get("_id") or user.get("id") or user.get("user_id"))
+    if not value:
+        raise ValueError("Authenticated customer id is missing.")
+    return value
+
+
+def _user_email(user: dict[str, Any]) -> str:
+    value = _normalize(user.get("email")).lower()
+    if not value or "@" not in value:
+        raise ValueError("Authenticated customer email is missing.")
+    return value
+
+
+def create_nft_addon_checkout_session(
+    *,
+    user: dict[str, Any],
+    project_id: str,
+    addon_code: str,
+) -> dict[str, Any]:
+    code = normalize_addon_code(addon_code)
+    validated_project = validate_nft_addon_purchase_target(
+        user=user,
+        project_id=project_id,
+        addon_code=code,
+    )
+    addon, expected_cents = _expected_price(code)
+    price_id = resolve_nft_addon_price_id(code)
+    customer_id = _user_id(user)
+    customer_email = _user_email(user)
+    normalized_project_id = _normalize(validated_project.get("_id") or project_id)
+    checkout_sequence = _normalize(
+        validated_project.get("_nft_credit_slot")
+        or validated_project.get("_nft_checkout_sequence")
+        or code
+    )
+    reference = "tol:" + urlencode(
+        {
+            "v": "1",
+            "u": customer_id,
+            "p": normalized_project_id,
+            "k": code,
+            "t": "addon",
+            "b": "one_time",
+        }
+    )
+    metadata = {
+        "item_type": "addon",
+        "addon_code": code,
+        "project_id": normalized_project_id,
+        "user_id": customer_id,
+        "checkout_never_triggers_mint": "true",
+    }
+    app_base = _public_app_base_url()
+    session_params: dict[str, Any] = {
+        "mode": "payment",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "client_reference_id": reference,
+        "metadata": metadata,
+        "payment_intent_data": {"metadata": metadata},
+        "success_url": (
+            f"{app_base}/thank-you.html?session_id={{CHECKOUT_SESSION_ID}}"
+            f"&type=addon&package={code}"
+        ),
+        "cancel_url": f"{app_base}/dashboard.html#legacy-anchor",
+        "allow_promotion_codes": False,
+        "billing_address_collection": "auto",
+        "idempotency_key": "tol-nft-checkout-"
+        + hashlib.sha256(
+            f"{customer_id}:{normalized_project_id}:{code}:{checkout_sequence}".encode(
+                "utf-8"
+            )
+        ).hexdigest(),
+    }
+    stripe_customer_id = _normalize(user.get("stripe_customer_id"))
+    if stripe_customer_id.startswith("cus_"):
+        session_params["customer"] = stripe_customer_id
+    else:
+        session_params["customer_email"] = customer_email
+        session_params["customer_creation"] = "always"
+
+    _require_stripe()
+    session = _stripe_to_dict(stripe.checkout.Session.create(**session_params))
+    checkout_url = _normalize(session.get("url"))
+    parsed_checkout = urlparse(checkout_url)
+    if parsed_checkout.scheme != "https" or parsed_checkout.netloc != "checkout.stripe.com":
+        raise RuntimeError("Stripe did not return a valid hosted Checkout URL.")
+    return {
+        "session_id": _normalize(session.get("id")),
+        "checkout_url": checkout_url,
+        "project_id": normalized_project_id,
+        "addon_code": code,
+        "amount_cents": expected_cents,
+        "currency": "usd",
+        "checkout_creates_credit_only": True,
+        "checkout_never_triggers_mint": True,
+        "expires_at": session.get("expires_at"),
+    }

--- a/backend/app/services/nft_runtime_validation_service.py
+++ b/backend/app/services/nft_runtime_validation_service.py
@@ -56,6 +56,19 @@ def _validate_contract_abi() -> None:
         raise RuntimeError("NFT_CONTRACT_ABI_JSON is not valid JSON.") from exc
     if not isinstance(parsed, list):
         raise RuntimeError("NFT_CONTRACT_ABI_JSON must be a JSON array.")
+    preferred = _normalize(settings.nft_mint_function_name)
+    allowed_names = [name for name in (preferred, "mintAnchor", "safeMint") if name]
+    supported = []
+    for item in parsed:
+        if item.get("type") != "function" or item.get("name") not in allowed_names:
+            continue
+        input_types = [_normalize(value.get("type")).lower() for value in item.get("inputs", [])]
+        if "address" in input_types and "string" in input_types:
+            supported.append(item.get("name"))
+    if not supported:
+        raise RuntimeError(
+            "NFT_CONTRACT_ABI_JSON must expose mintAnchor or safeMint with recipient address and metadata URI inputs."
+        )
 
 
 def _validate_r2_configuration() -> None:
@@ -79,6 +92,14 @@ def _validate_r2_configuration() -> None:
 
 
 def validate_nft_runtime_configuration_on_startup() -> None:
+    if settings.nft_auto_mint_on_review_enabled:
+        raise RuntimeError(
+            "NFT_AUTO_MINT_ON_REVIEW_ENABLED is not supported. Checkout and review must never auto-mint."
+        )
+    if settings.nft_mint_worker_enabled and not settings.nft_mint_enabled:
+        raise RuntimeError(
+            "NFT_MINT_WORKER_ENABLED requires NFT_MINT_ENABLED and the complete validated mint configuration."
+        )
     if not settings.nft_mint_enabled:
         return
 

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -8,10 +8,10 @@ import stripe
 from bson import ObjectId
 from pymongo.collection import Collection
 from pymongo.database import Database
-from pymongo.errors import OperationFailure
+from pymongo.errors import DuplicateKeyError, OperationFailure
 
 from app.config import settings
-from app.core.package_catalog import get_package
+from app.core.package_catalog import get_addon, get_package, normalize_addon_code
 from app.core.package_mapping import normalize_package_code as normalize_mapped_package_code
 from app.database import get_database
 from app.services.auth_service import create_pending_checkout_user
@@ -25,6 +25,10 @@ from app.services.project_entitlement_service import (
     update_project_entitlement_maintenance,
 )
 from app.services.project_entitlement_service import MAINTENANCE_START_DELAY_DAYS
+from app.services.nft_addon_service import (
+    NFT_ADDON_CODES,
+    validate_nft_addon_purchase_target,
+)
 
 AUTHORITATIVE_ORDER_SOURCES = {
     "stripe_webhook",
@@ -353,6 +357,8 @@ def _serialize_order(order: dict[str, Any]) -> dict[str, Any]:
         "lane": order.get("lane") or order.get("package_lane") or _package_lane_for_code(package_code),
         "package_lane": order.get("package_lane") or order.get("lane") or _package_lane_for_code(package_code),
         "package_name": order.get("package_name", ""),
+        "addon_code": order.get("addon_code"),
+        "purchase_code": order.get("purchase_code"),
         "price_label": order.get("price_label", ""),
         "item_type": order.get("item_type", "package"),
         "billing_plan": order.get("billing_plan", "one_time"),
@@ -362,6 +368,8 @@ def _serialize_order(order: dict[str, Any]) -> dict[str, Any]:
         "stripe_session_id": order.get("stripe_session_id"),
         "stripe_payment_link_id": order.get("stripe_payment_link_id"),
         "fulfillment_status": order.get("fulfillment_status"),
+        "nft_credit_status": order.get("nft_credit_status"),
+        "nft_credit_slot": order.get("nft_credit_slot"),
         "created_at": order["created_at"],
     }
 
@@ -732,11 +740,25 @@ def ensure_order_indexes() -> None:
     _ensure_index([("package_code", 1)], name="package_code_1")
     _ensure_index([("package_slug", 1)], name="package_slug_1")
     _ensure_index([("item_type", 1)], name="item_type_1")
+    _ensure_index([("addon_code", 1)], name="addon_code_1")
     _ensure_index([("billing_plan", 1)], name="billing_plan_1")
     _ensure_index([("created_at", -1)], name="created_at_-1")
     # project_id is queried on every workspace access check; index is required to
     # avoid full collection scans that cause request timeouts.
     _ensure_index([("project_id", 1)], name="project_id_1")
+    _ensure_index(
+        [("project_id", 1), ("addon_code", 1), ("nft_credit_status", 1)],
+        name="project_id_1_addon_code_1_nft_credit_status_1",
+    )
+    # The value combines project id and mint sequence (for example mint:1).
+    # A sparse unique index closes concurrent duplicate-checkout races without
+    # constraining metadata-revision purchases.
+    _ensure_index(
+        [("nft_credit_slot_key", 1)],
+        name="nft_credit_slot_key_1",
+        unique=True,
+        sparse=True,
+    )
     _ensure_index(
         [("stripe_session_id", 1)],
         name="stripe_session_id_1",
@@ -873,10 +895,15 @@ def _extract_checkout_context(session: dict[str, Any]) -> dict[str, str]:
         context["user_id"] = _normalize(parsed.get("u"))
     if parsed.get("p"):
         context["project_id"] = _normalize(parsed.get("p"))
-    if parsed.get("k"):
-        context["package_code"] = _normalize_package_code(parsed.get("k"))
     if parsed.get("t"):
         context["item_type"] = _normalize(parsed.get("t")).lower()
+    if parsed.get("k"):
+        raw_code = _normalize(parsed.get("k")).lower().replace("-", "_").replace(" ", "_")
+        context["package_code"] = (
+            normalize_addon_code(raw_code)
+            if context.get("item_type") == "addon"
+            else _normalize_package_code(raw_code)
+        )
     if parsed.get("b"):
         context["billing_interval"] = _normalize(parsed.get("b")).lower()
     if parsed.get("c"):
@@ -1006,6 +1033,108 @@ def _extract_verified_package_purchase_from_session(session: dict[str, Any]) -> 
     }
 
 
+def _normalized_catalog_product_name(value: Any) -> str:
+    normalized = _normalize(value).lower().replace("—", "-").replace("–", "-")
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"^add\s*-?\s*on\s*-\s*", "", normalized)
+    return normalized.strip()
+
+
+def _match_nft_addon_code_from_product(
+    *,
+    raw_code: str,
+    product_name: str,
+) -> str:
+    candidate = normalize_addon_code(raw_code)
+    if candidate not in NFT_ADDON_CODES:
+        candidate = ""
+
+    normalized_name = _normalized_catalog_product_name(product_name)
+    name_matches = [
+        code
+        for code in NFT_ADDON_CODES
+        if normalized_name
+        == _normalized_catalog_product_name((get_addon(code) or {}).get("display_name"))
+    ]
+    if len(name_matches) != 1:
+        return ""
+    if candidate and candidate != name_matches[0]:
+        return ""
+    return candidate or name_matches[0]
+
+
+def _extract_verified_catalog_purchase_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    """Verify a base-package or NFT add-on purchase against the server catalog."""
+
+    metadata = session.get("metadata") or {}
+    context = _extract_checkout_context(session)
+    requested_type = _normalize(metadata.get("item_type") or context.get("item_type")).lower()
+
+    line_items = ((session.get("line_items") or {}).get("data")) or []
+    first_item = line_items[0] if line_items else {}
+    price_obj = (first_item or {}).get("price") or {}
+    product_obj = price_obj.get("product") or {}
+    product_name = _normalize(
+        product_obj.get("name")
+        or (first_item or {}).get("description")
+        or metadata.get("package_name")
+    )
+    raw_code = _normalize(
+        metadata.get("addon_code")
+        or metadata.get("package_code")
+        or metadata.get("package_slug")
+        or (product_obj.get("metadata") or {}).get("addon_code")
+        or (product_obj.get("metadata") or {}).get("package_code")
+        or context.get("package_code")
+    )
+    addon_code = _match_nft_addon_code_from_product(
+        raw_code=raw_code,
+        product_name=product_name,
+    )
+    if requested_type == "addon" or addon_code:
+        session_status = _normalize(session.get("status")).lower()
+        if session_status == "expired":
+            raise ValueError("Checkout session has expired.")
+        if _normalize(session.get("payment_status")).lower() != "paid":
+            raise ValueError("Checkout session is not paid.")
+        if not line_items or not price_obj or not product_obj:
+            raise ValueError("Checkout session is missing expanded product and price data.")
+        if len(line_items) != 1 or int((first_item or {}).get("quantity") or 1) != 1:
+            raise ValueError("NFT add-on checkout must contain exactly one item.")
+        if not addon_code:
+            raise ValueError("Checkout product is not an approved Tomb of Light NFT add-on.")
+
+        addon = get_addon(addon_code) or {}
+        amount_cents = price_obj.get("unit_amount")
+        expected_cents = int(round(float(addon.get("price_usd") or 0) * 100))
+        currency = _normalize_currency(price_obj.get("currency") or session.get("currency"))
+        if expected_cents <= 0 or currency != "usd" or amount_cents != expected_cents:
+            raise ValueError("Checkout product and price do not match the approved NFT add-on catalog.")
+        amount_total = session.get("amount_total")
+        if isinstance(amount_total, int) and amount_total != expected_cents:
+            raise ValueError("Checkout session amount does not match expected NFT add-on total.")
+
+        price_id = _normalize(price_obj.get("id"))
+        product_id = _normalize(product_obj.get("id"))
+        if not price_id or not product_id:
+            raise ValueError("Checkout session NFT add-on has unknown Stripe catalog identifiers.")
+        return {
+            "package_code": addon_code,
+            "addon_code": addon_code,
+            "package_name": _normalize(addon.get("display_name")),
+            "price_label": _format_price_label(expected_cents, "one_time"),
+            "item_type": "addon",
+            "billing_plan": "one_time",
+            "currency": currency,
+            "amount_cents": expected_cents,
+            "stripe_payment_link_id": _normalize(session.get("payment_link")) or None,
+            "price_id": price_id,
+            "product_id": product_id,
+        }
+
+    return _extract_verified_package_purchase_from_session(session)
+
+
 def _ensure_session_belongs_to_user(
     *,
     user: dict[str, Any],
@@ -1017,7 +1146,8 @@ def _ensure_session_belongs_to_user(
         raise ValueError("Checkout session email does not match authenticated customer.")
 
     metadata = session.get("metadata") or {}
-    metadata_user_id = _normalize(metadata.get("user_id"))
+    context = _extract_checkout_context(session)
+    metadata_user_id = _normalize(metadata.get("user_id") or context.get("user_id"))
     current_user_id = _normalize(str(user.get("_id") or user.get("id") or user.get("user_id") or ""))
     if metadata_user_id and current_user_id and metadata_user_id != current_user_id:
         raise ValueError("Checkout session user association mismatch.")
@@ -1246,6 +1376,66 @@ def _get_email_from_event(event: dict[str, Any]) -> Optional[str]:
     return _normalize_email(email)
 
 
+def _record_escalated_nft_addon_payment(
+    *,
+    user: dict[str, Any],
+    email: str,
+    session: dict[str, Any],
+    purchase: dict[str, Any],
+    reason: str,
+    project_id: str = "",
+) -> dict[str, Any]:
+    """Preserve a paid but ineligible add-on without granting a mint credit."""
+
+    orders = _get_orders_collection()
+    session_id = _normalize(session.get("id"))
+    existing = orders.find_one({"stripe_session_id": session_id})
+    if existing:
+        return {
+            "order_id": str(existing["_id"]),
+            "existing": True,
+            "reason": "nft_addon_payment_escalated",
+            "error": reason,
+            "session_id": session_id,
+        }
+
+    addon_code = normalize_addon_code(purchase.get("addon_code"))
+    document: dict[str, Any] = {
+        "user_id": ObjectId(str(user["_id"])),
+        "email": email,
+        "package_code": addon_code,
+        "package_slug": addon_code,
+        "addon_code": addon_code,
+        "purchase_code": addon_code,
+        "package_name": purchase.get("package_name"),
+        "price_label": purchase.get("price_label"),
+        "item_type": "addon",
+        "billing_plan": "one_time",
+        "source": "stripe_webhook",
+        "status": "paid",
+        "fulfillment_status": FULFILLMENT_ESCALATED,
+        "fulfillment_error": reason,
+        "nft_addon_verified": False,
+        "nft_credit_status": "blocked",
+        "nft_addon_checkout_does_not_auto_mint": True,
+        "stripe_session_id": session_id,
+        "stripe_payment_link_id": _normalize(session.get("payment_link")) or None,
+        "created_at": datetime.now(UTC),
+    }
+    project_oid = _to_object_id(project_id)
+    if project_oid is not None:
+        document["project_id"] = project_oid
+    result = orders.insert_one(document)
+    return {
+        "order_id": str(result.inserted_id),
+        "existing": False,
+        "reason": "nft_addon_payment_escalated",
+        "error": reason,
+        "session_id": session_id,
+        "project_id": str(project_oid) if project_oid is not None else None,
+    }
+
+
 def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
     event_type = event.get("type", "")
     data = _event_object(event)
@@ -1274,7 +1464,7 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         }
 
     try:
-        purchase = _extract_verified_package_purchase_from_session(session)
+        purchase = _extract_verified_catalog_purchase_from_session(session)
     except ValueError as exc:
         return {
             "order_id": None,
@@ -1318,6 +1508,92 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "email": email,
         }
 
+    item_type = purchase["item_type"]
+    addon_code = normalize_addon_code(purchase.get("addon_code"))
+    orders = _get_orders_collection()
+    existing_session_order = orders.find_one({"stripe_session_id": session_id})
+    if item_type == "addon" and existing_session_order:
+        existing_user_id = _normalize(str(existing_session_order.get("user_id") or ""))
+        incoming_user_id = _normalize(
+            str(user.get("_id") or user.get("id") or user.get("user_id") or "")
+        )
+        existing_email = _normalize_email(existing_session_order.get("email"))
+        if (
+            (existing_user_id and incoming_user_id and existing_user_id != incoming_user_id)
+            or (existing_email and existing_email != email)
+        ):
+            return {
+                "order_id": None,
+                "reason": "session_already_associated_with_another_customer",
+                "type": event_type,
+                "session_id": session_id,
+                "email": email,
+            }
+        existing_addon_code = normalize_addon_code(
+            existing_session_order.get("addon_code")
+            or existing_session_order.get("purchase_code")
+        )
+        if existing_addon_code != addon_code:
+            return {
+                "order_id": None,
+                "reason": "session_already_associated_with_another_product",
+                "type": event_type,
+                "session_id": session_id,
+                "email": email,
+            }
+        return {
+            "order_id": str(existing_session_order["_id"]),
+            "existing": True,
+            "type": event_type,
+            "session_id": session_id,
+            "email": email,
+            "package_code": existing_session_order.get("package_code"),
+            "addon_code": existing_addon_code,
+            "item_type": "addon",
+            "billing_plan": existing_session_order.get("billing_plan") or "one_time",
+            "project_id": (
+                str(existing_session_order["project_id"])
+                if existing_session_order.get("project_id")
+                else None
+            ),
+            "nft_credit_status": existing_session_order.get("nft_credit_status"),
+        }
+
+    target_project_id = _extract_target_project_id(session)
+    target_project: dict[str, Any] | None = None
+    if item_type == "addon":
+        if addon_code not in NFT_ADDON_CODES:
+            return _record_escalated_nft_addon_payment(
+                user=user,
+                email=email,
+                session=session,
+                purchase=purchase,
+                reason="Checkout did not resolve to an approved NFT add-on.",
+            )
+        if not target_project_id:
+            return _record_escalated_nft_addon_payment(
+                user=user,
+                email=email,
+                session=session,
+                purchase=purchase,
+                reason="NFT add-on payment is missing required customer project context.",
+            )
+        try:
+            target_project = validate_nft_addon_purchase_target(
+                user=user,
+                project_id=target_project_id,
+                addon_code=addon_code,
+            )
+        except ValueError as exc:
+            return _record_escalated_nft_addon_payment(
+                user=user,
+                email=email,
+                session=session,
+                purchase=purchase,
+                reason=str(exc),
+                project_id=target_project_id,
+            )
+
     customer_id = _normalize(session.get("customer"))
     if customer_id:
         try:
@@ -1329,12 +1605,17 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         except Exception:
             pass
 
-    orders = _get_orders_collection()
     checkout_context = _extract_checkout_context(session)
     campaign = _normalize((session.get("metadata") or {}).get("campaign") or checkout_context.get("campaign")).upper()
 
-    item_type = purchase["item_type"]
-    package_code = purchase["package_code"]
+    purchase_code = purchase["package_code"]
+    package_code = purchase_code
+    if target_project is not None:
+        package_code = _normalize_package_code(
+            target_project.get("package_code")
+            or target_project.get("package_slug")
+            or target_project.get("package_type")
+        )
     package_name = purchase["package_name"]
     price_label = purchase["price_label"]
     billing_plan = purchase["billing_plan"]
@@ -1370,6 +1651,28 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
             "status": "paid",
             "stripe_session_id": session_id,
         }
+        if item_type == "addon" and target_project is not None:
+            update_fields.update(
+                {
+                    "project_id": target_project["_id"],
+                    "addon_code": addon_code,
+                    "purchase_code": purchase_code,
+                    "nft_addon_verified": True,
+                    "nft_addon_checkout_does_not_auto_mint": True,
+                }
+            )
+            _set_if_present(
+                update_fields,
+                "nft_credit_slot",
+                target_project.get("_nft_credit_slot"),
+            )
+            _set_if_present(
+                update_fields,
+                "nft_credit_slot_key",
+                target_project.get("_nft_credit_slot_key"),
+            )
+            if not _normalize(existing.get("nft_credit_status")):
+                update_fields["nft_credit_status"] = "available"
         _set_if_present(update_fields, "stripe_payment_link_id", stripe_payment_link_id)
         _set_if_present(update_fields, "campaign", campaign)
         _set_if_present(update_fields, "stripe_payment_intent_id", _normalize(session.get("payment_intent")) or None)
@@ -1429,6 +1732,27 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
         "stripe_session_id": session_id,
         "created_at": datetime.now(UTC),
     }
+    if item_type == "addon" and target_project is not None:
+        order_doc.update(
+            {
+                "project_id": target_project["_id"],
+                "addon_code": addon_code,
+                "purchase_code": purchase_code,
+                "nft_addon_verified": True,
+                "nft_addon_checkout_does_not_auto_mint": True,
+                "nft_credit_status": "available",
+            }
+        )
+        _set_if_present(
+            order_doc,
+            "nft_credit_slot",
+            target_project.get("_nft_credit_slot"),
+        )
+        _set_if_present(
+            order_doc,
+            "nft_credit_slot_key",
+            target_project.get("_nft_credit_slot_key"),
+        )
     manual_mode = manual_fulfillment_mode_enabled()
     if manual_mode and item_type == "package":
         order_doc["fulfillment_status"] = FULFILLMENT_PENDING
@@ -1436,7 +1760,52 @@ def upsert_order_from_stripe_event(event: dict[str, Any]) -> dict[str, Any]:
     _set_if_present(order_doc, "campaign", campaign)
     _set_if_present(order_doc, "stripe_payment_intent_id", _normalize(session.get("payment_intent")) or None)
 
-    result = orders.insert_one(order_doc)
+    try:
+        result = orders.insert_one(order_doc)
+    except DuplicateKeyError:
+        raced = orders.find_one({"stripe_session_id": session_id})
+        if raced is not None:
+            return {
+                "order_id": str(raced["_id"]),
+                "existing": True,
+                "type": event_type,
+                "session_id": session_id,
+                "email": email,
+                "package_code": raced.get("package_code"),
+                "item_type": raced.get("item_type"),
+                "billing_plan": raced.get("billing_plan"),
+                "project_id": str(raced["project_id"]) if raced.get("project_id") else None,
+            }
+        if item_type != "addon":
+            raise
+        order_doc.pop("nft_credit_slot", None)
+        order_doc.pop("nft_credit_slot_key", None)
+        order_doc.update(
+            {
+                "nft_addon_verified": False,
+                "nft_credit_status": "blocked",
+                "fulfillment_status": FULFILLMENT_ESCALATED,
+                "fulfillment_error": (
+                    "A paid NFT mint credit already exists for this project and mint sequence."
+                ),
+            }
+        )
+        result = orders.insert_one(order_doc)
+        order_doc["_id"] = result.inserted_id
+        return {
+            "order_id": str(result.inserted_id),
+            "existing": False,
+            "reason": "duplicate_nft_mint_credit_payment_escalated",
+            "error": order_doc["fulfillment_error"],
+            "type": event_type,
+            "session_id": session_id,
+            "email": email,
+            "package_code": package_code,
+            "addon_code": addon_code,
+            "item_type": item_type,
+            "billing_plan": billing_plan,
+            "project_id": str(order_doc["project_id"]),
+        }
     order_doc["_id"] = result.inserted_id
 
     if item_type == "package" and not manual_mode:

--- a/backend/docs/governance/continuity_kernel_phase15_nft_addon_mint_console.md
+++ b/backend/docs/governance/continuity_kernel_phase15_nft_addon_mint_console.md
@@ -1,0 +1,69 @@
+# Continuity Kernel Phase 15 — NFT Add-On Mint Console
+
+## Binding business rule
+
+- No Tomb of Light base package includes an NFT.
+- A customer profile must be complete and delivered before NFT checkout unlocks.
+- The first mint requires **NFT Lineage Record** (`nft_lineage_record`, $499).
+- Every later mint requires **Additional NFT Copy / Mint** (`additional_nft_copy_mint`, $399).
+- **NFT Metadata Revision** (`nft_metadata_revision`, $149) is a revision credit and cannot authorize a mint.
+- A paid Stripe checkout creates only a verified project-scoped credit. It never prepares, approves, queues, or executes a mint.
+- Customer wallet/public-safe consent and CEO final approval are separate authenticated acts.
+- Private vault files and private family information stay off-chain.
+
+## Customer sequence
+
+1. Tomb of Light completes and delivers the profile.
+2. The dashboard unlocks only the add-on valid for the current NFT state.
+3. The authenticated backend validates the customer, delivered project, mint sequence, and runtime before it creates a hosted Stripe Checkout Session. Raw NFT payment links are not published in the frontend.
+4. Stripe confirms the exact catalog product and price against the signed-in customer and project context.
+5. Tomb of Light records a verified project-and-sequence-scoped credit. No mint job is created. A sparse unique credit key closes concurrent duplicate-checkout races.
+6. After Tomb of Light prepares the approval record, the billing owner or co-owner signs in and supplies the public Base recipient wallet.
+7. The customer explicitly approves the public-safe metadata. Private keys and recovery phrases are rejected.
+
+## CEO sequence
+
+Use the selected customer case in Admin Control Center:
+
+1. **Open Mint Review** — confirms profile completion, verified payment, project linkage, entitlement, and uploads; sets preparation state only.
+2. **Prepare NFT Approval** — atomically claims exactly one valid paid mint credit and creates the approval record.
+3. Wait for the customer wallet/public-safe consent shown in the customer dashboard.
+4. **CEO Final Approve** — records the CEO approval independently of customer consent.
+5. **Queue Approved NFT** — creates the four controlled jobs only when both approvals and all readiness gates pass.
+6. The controlled worker prepares metadata, creates the poster, submits `safeMint`, and syncs the receipt.
+
+All three mutating Admin Control Center actions run through the Continuity Kernel. Checkout is never an execution path.
+
+## Production activation
+
+Keep execution disabled until the contract owner wallet, Base ETH balance, R2 public artifact paths, and runtime configuration have been verified. Then set these Render secrets/settings:
+
+```text
+NFT_AUTO_MINT_ON_REVIEW_ENABLED=false
+NFT_MINT_ENABLED=true
+NFT_MINT_WORKER_ENABLED=true
+NFT_MINT_WORKER_POLL_SECONDS=15
+NFT_MINT_FUNCTION_NAME=safeMint
+NFT_LEGACY_PAYMENT_LINKS_DISABLED=true
+```
+
+The existing validated settings are also required: `NFT_CHAIN`, `NFT_RPC_URL`, `NFT_CONTRACT_ADDRESS`, `NFT_CONTRACT_ABI_JSON`, `NFT_MINTER_PRIVATE_KEY`, `HASH_SALT`, `METADATA_BASE_URL`, `POSTER_BASE_URL`, `PUBLIC_TOKEN_EXTERNAL_BASE_URL`, and the R2 credentials/buckets.
+
+The authenticated checkout resolver can locate the exact active Stripe price from the existing product name and amount. For an unambiguous fail-closed deployment, set the optional Price IDs `STRIPE_NFT_LINEAGE_RECORD_PRICE_ID`, `STRIPE_ADDITIONAL_NFT_MINT_PRICE_ID`, and `STRIPE_NFT_METADATA_REVISION_PRICE_ID`. A configured Price ID is revalidated against the server catalog before every Checkout Session is created.
+
+Before setting `NFT_LEGACY_PAYMENT_LINKS_DISABLED=true`, deactivate the three former public NFT Payment Links in Stripe. Production readiness and new NFT checkout stay blocked until that operator confirmation is present. Do not set the flag merely to clear readiness; it records a completed Stripe-side control.
+
+`NFT_MINTER_PRIVATE_KEY` must be stored only as a secret in Render. It must belong to the wallet that owns the configured contract and must never be pasted into source code, a pull request, logs, screenshots, or customer forms. The wallet needs enough Base ETH for network fees.
+
+Startup fails closed when the worker is enabled without minting, when legacy auto-mint-on-review is enabled, or when the ABI does not expose a supported recipient-and-metadata mint function.
+
+## Recovery and rollback
+
+- Set `NFT_MINT_WORKER_ENABLED=false` to stop new queued job execution while preserving approvals and queued evidence.
+- Set `NFT_MINT_ENABLED=false` to disable blockchain execution entirely.
+- A failed or ambiguous blockchain submission must be reviewed from its existing mint record and transaction hash. Do not sell or consume a second credit merely to retry a technical failure.
+- A paid checkout without valid delivered-project context is preserved as an escalated paid order with a blocked credit so staff can reconcile or refund it without minting.
+
+## Verification contract
+
+Phase 15 tests assert that every base package has zero included anchors, public raw NFT payment links are absent, authenticated Checkout Sessions enforce the delivered-profile gate, exact Stripe prices are verified, duplicate mint-sequence credits fail closed, metadata revisions cannot authorize mints, manual fee overrides cannot unlock execution, customer and CEO approvals stay separate, and the worker processes only previously queued jobs.

--- a/backend/tests/test_continuity_runtime_service.py
+++ b/backend/tests/test_continuity_runtime_service.py
@@ -464,9 +464,12 @@ class TestContinuityRuntimeControlSurfaceAdapters(unittest.TestCase):
             "impersonation_stop",
             "legacy_admin_remediation",
             "orphan_identity_reconciliation",
+            "prepare_legacy_anchor",
+            "approve_legacy_anchor",
+            "queue_approved_legacy_anchor",
         }
         self.assertEqual(runtime.RUNTIME_VERSION, "12.0.0")
-        self.assertEqual(len(runtime.ACTION_SPECS), 38)
+        self.assertEqual(len(runtime.ACTION_SPECS), 41)
         self.assertTrue(expected.issubset(runtime.ACTION_SPECS))
 
     def test_permanent_deletion_adapter_passes_both_irreversible_confirmations(self) -> None:

--- a/backend/tests/test_health_and_db_unavailable.py
+++ b/backend/tests/test_health_and_db_unavailable.py
@@ -147,6 +147,10 @@ class HealthAndDbUnavailableTests(unittest.TestCase):
                     r2_secret_access_key="configured-secret-key",
                     r2_endpoint_url="https://account.r2.cloudflarestorage.com",
                     r2_private_bucket="private-bucket",
+                    nft_mint_enabled=True,
+                    nft_mint_worker_enabled=True,
+                    nft_auto_mint_on_review_enabled=False,
+                    nft_legacy_payment_links_disabled=True,
                 ),
                 patch(
                     "app.services.upload_scan_service.get_upload_scanner_health",

--- a/backend/tests/test_legacy_snapshot_package_contract.py
+++ b/backend/tests/test_legacy_snapshot_package_contract.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from fastapi import HTTPException
 
-from app.core.package_catalog import get_package, get_package_control_profile
+from app.core.package_catalog import NFT_ADDON_CODES, get_package, get_package_control_profile
 from app.routes import family_graph, workspace_access
 from app.services.entitlement_service import can_purchase_addon, resolve_project_entitlements
 
@@ -159,7 +159,7 @@ class HouseholdFoundationPackageContractTests(unittest.TestCase):
         self.assertFalse(bool(package.get("maintenance_starts_on_delivery")))
         self.assertCountEqual(
             list(package.get("allowed_addons") or []),
-            ["rush_delivery", "on_site_photo_scanning"],
+            ["rush_delivery", "on_site_photo_scanning", *NFT_ADDON_CODES],
         )
 
     def test_household_foundation_maintenance_default_is_monthly(self):
@@ -200,7 +200,7 @@ class HeirloomLegacyTreePackageContractTests(unittest.TestCase):
         self.assertFalse(bool(package.get("maintenance_starts_on_delivery")))
         self.assertCountEqual(
             list(package.get("allowed_addons") or []),
-            ["rush_delivery", "on_site_photo_scanning"],
+            ["rush_delivery", "on_site_photo_scanning", *NFT_ADDON_CODES],
         )
 
     def test_heirloom_legacy_tree_maintenance_default_is_monthly(self):
@@ -242,7 +242,7 @@ class LegacyPlusPackageContractTests(unittest.TestCase):
         self.assertFalse(bool(package.get("maintenance_starts_on_delivery")))
         self.assertCountEqual(
             list(package.get("allowed_addons") or []),
-            ["rush_delivery", "on_site_photo_scanning", "additional_narration_minute"],
+            ["rush_delivery", "on_site_photo_scanning", "additional_narration_minute", *NFT_ADDON_CODES],
         )
 
     def test_legacy_plus_maintenance_default_is_monthly(self):
@@ -302,6 +302,7 @@ class FamilyEstateConciergePackageContractTests(unittest.TestCase):
                 "on_site_photo_scanning",
                 "additional_narration_minute",
                 "white_glove_archive_support",
+                *NFT_ADDON_CODES,
             ],
         )
 
@@ -371,6 +372,7 @@ class CommandStructureNetworkPackageContractTests(unittest.TestCase):
                 "extra_storage",
                 "rush_delivery",
                 "command_report_addon",
+                *NFT_ADDON_CODES,
             ],
         )
         self.assertNotIn("family_estate_concierge", list(package.get("upgrade_targets") or []))

--- a/backend/tests/test_mint_fee_and_policy.py
+++ b/backend/tests/test_mint_fee_and_policy.py
@@ -24,7 +24,8 @@ class MintFeeCatalogTests(unittest.TestCase):
         packages = {item["package_code"]: item for item in get_public_package_catalog()}
         sample = packages["digital_legacy_portrait"]
         self.assertIn("minting_copy", sample)
-        self.assertIn("separate one-time production step", sample["minting_copy"])
+        self.assertIn("No base package includes an NFT", sample["minting_copy"])
+        self.assertIn("never starts minting automatically", sample["minting_copy"])
         self.assertIn("Private vault materials are not minted by default", sample["minting_copy"])
 
 
@@ -49,7 +50,7 @@ class MintReadinessTests(unittest.TestCase):
         self.assertTrue(any(item["code"] == "public_safe_approval_incomplete" for item in payload["blocking_details"]))
         self.assertIn("public_safe_approved", payload["missing_readiness_flags"])
 
-    def test_mint_fee_satisfied_for_included_credit(self):
+    def test_package_inclusion_cannot_satisfy_nft_addon_gate(self):
         project = {
             "_id": "p1",
             "package_code": "digital_legacy_portrait",
@@ -58,8 +59,8 @@ class MintReadinessTests(unittest.TestCase):
         }
         with patch.object(mint_fee_service, "describe_project_mint_eligibility", return_value={"mint_policy": {"included_anchor_count": 1, "minting_included": True, "mint_fee_model": "flat_included"}}):
             ok, reason = mint_fee_service.mint_fee_satisfied(project)
-        self.assertTrue(ok)
-        self.assertIsNone(reason)
+        self.assertFalse(ok)
+        self.assertEqual(reason, "nft_addon_not_purchased")
 
 
 class MintQueueFeeGateTests(unittest.TestCase):
@@ -71,13 +72,13 @@ class MintQueueFeeGateTests(unittest.TestCase):
         ), patch.object(
             mint_records, "describe_project_mint_eligibility", return_value={"eligible": True, "reasons": []}
         ), patch.object(
-            mint_records, "get_project_mint_readiness", return_value={"ready_for_mint_execution": False, "blocking_reasons": ["mint_fee_unpaid_or_unwaived"]}
+            mint_records, "get_project_mint_readiness", return_value={"ready_for_mint_execution": False, "blocking_reasons": ["nft_addon_not_purchased"]}
         ):
             with self.assertRaises(HTTPException) as ctx:
                 mint_records.queue_project_mint_record("p1", "m1", {"email": "admin@test.com"})
 
         self.assertEqual(ctx.exception.status_code, 409)
-        self.assertIn("mint_fee_unpaid_or_unwaived", str(ctx.exception.detail))
+        self.assertIn("nft_addon_not_purchased", str(ctx.exception.detail))
 
     def test_mint_readiness_returns_human_blocking_details(self):
         project = {
@@ -103,14 +104,14 @@ class MintQueueFeeGateTests(unittest.TestCase):
                 },
             ),
             patch.object(mint_fee_service, "_base_mint_fee_state", return_value={"mint_fee_status": "quoted"}),
-            patch.object(mint_fee_service, "mint_fee_satisfied", return_value=(False, "mint_fee_unpaid_or_unwaived")),
+            patch.object(mint_fee_service, "mint_fee_satisfied", return_value=(False, "nft_addon_not_purchased")),
         ):
             readiness = mint_fee_service.get_project_mint_readiness("p1")
 
         self.assertFalse(readiness["ready_for_mint_execution"])
-        self.assertIn("mint_fee_unpaid_or_unwaived", readiness["blocking_reasons"])
-        self.assertTrue(any(item["code"] == "mint_fee_unpaid_or_unwaived" for item in readiness["blocking_details"]))
-        self.assertIn("mint_fee_satisfied", readiness["missing_readiness_flags"])
+        self.assertIn("nft_addon_not_purchased", readiness["blocking_reasons"])
+        self.assertTrue(any(item["code"] == "nft_addon_not_purchased" for item in readiness["blocking_details"]))
+        self.assertIn("paid_nft_addon_credit", readiness["missing_readiness_flags"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_phase15_nft_addon_mint_flow.py
+++ b/backend/tests/test_phase15_nft_addon_mint_flow.py
@@ -1,0 +1,514 @@
+import asyncio
+import re
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from bson import ObjectId
+
+from app.core.admin_permission_registry import CEO_MASTER_ADMIN_EMAIL
+from app.core.package_catalog import (
+    NFT_ADDON_CODES,
+    get_addon,
+    get_package_catalog,
+    get_package_control_profile,
+)
+from app.services import (
+    mint_fee_service,
+    mint_job_service,
+    mint_policy_service,
+    mint_record_service,
+    mint_worker_service,
+    nft_addon_service,
+    nft_checkout_service,
+    order_service,
+)
+from app.services.nft_addon_service import (
+    ACTIVE_MINT_RECORD_STATUSES,
+    ADDITIONAL_MINT_ADDON_CODE,
+    INITIAL_MINT_ADDON_CODE,
+    METADATA_REVISION_ADDON_CODE,
+    MINT_ADDON_CODES,
+    profile_is_complete,
+    purchase_runtime_is_ready,
+    reserve_paid_mint_addon,
+    validate_nft_addon_purchase_target,
+)
+
+
+def checkout_session(*, code: str, name: str, cents: int) -> dict:
+    return {
+        "id": "cs_phase15",
+        "status": "complete",
+        "payment_status": "paid",
+        "amount_total": cents,
+        "currency": "usd",
+        "customer_details": {"email": "customer@example.com"},
+        "client_reference_id": f"tol:v=1&u=507f1f77bcf86cd799439011&p=507f1f77bcf86cd799439012&k={code}&t=addon&b=one_time",
+        "line_items": {
+            "data": [
+                {
+                    "quantity": 1,
+                    "description": name,
+                    "price": {
+                        "id": "price_phase15",
+                        "unit_amount": cents,
+                        "currency": "usd",
+                        "product": {
+                            "id": "prod_phase15",
+                            "name": name,
+                            "metadata": {"addon_code": code},
+                        },
+                    },
+                }
+            ]
+        },
+    }
+
+
+class Phase15CatalogPolicyTests(unittest.TestCase):
+    def test_every_base_package_is_addon_only(self):
+        for package_code in get_package_catalog():
+            with self.subTest(package_code=package_code):
+                policy = get_package_control_profile(package_code)["mint_policy"]
+                self.assertFalse(policy["product_includes_onchain_anchor"])
+                self.assertFalse(policy["minting_included"])
+                self.assertFalse(policy["auto_mint_enabled"])
+                self.assertEqual(policy["included_anchor_count"], 0)
+                self.assertTrue(policy["requires_paid_nft_addon"])
+                self.assertTrue(policy["checkout_never_triggers_mint"])
+
+    def test_nft_addon_catalog_matches_live_prices(self):
+        self.assertEqual(get_addon(INITIAL_MINT_ADDON_CODE)["price_usd"], 499)
+        self.assertEqual(get_addon(ADDITIONAL_MINT_ADDON_CODE)["price_usd"], 399)
+        self.assertEqual(get_addon(METADATA_REVISION_ADDON_CODE)["price_usd"], 149)
+        self.assertEqual(set(NFT_ADDON_CODES), {
+            INITIAL_MINT_ADDON_CODE,
+            ADDITIONAL_MINT_ADDON_CODE,
+            METADATA_REVISION_ADDON_CODE,
+        })
+        self.assertNotIn(METADATA_REVISION_ADDON_CODE, MINT_ADDON_CODES)
+
+    def test_profile_must_be_delivered_not_merely_build_ready(self):
+        self.assertFalse(profile_is_complete({"status": "build_ready", "phase": "client_review"}))
+        self.assertTrue(profile_is_complete({"status": "delivered"}))
+        self.assertTrue(profile_is_complete({"phase": "delivery_complete"}))
+
+    def test_organization_checkout_requires_organization_mint_runtime(self):
+        project = {
+            "package_code": "command_structure_network",
+            "status": "delivered",
+        }
+        with (
+            patch.object(nft_addon_service.settings, "nft_mint_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_mint_worker_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_auto_mint_on_review_enabled", False),
+            patch.object(nft_addon_service.settings, "nft_org_mint_enabled", False),
+        ):
+            self.assertFalse(purchase_runtime_is_ready(project))
+
+    def test_production_checkout_requires_legacy_links_disabled_confirmation(self):
+        project = {
+            "package_code": "digital_legacy_portrait",
+            "status": "delivered",
+        }
+        with (
+            patch.object(nft_addon_service.settings, "environment", "production"),
+            patch.object(nft_addon_service.settings, "nft_mint_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_mint_worker_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_auto_mint_on_review_enabled", False),
+            patch.object(
+                nft_addon_service.settings,
+                "nft_legacy_payment_links_disabled",
+                False,
+            ),
+        ):
+            self.assertFalse(purchase_runtime_is_ready(project))
+
+
+class Phase15StripeVerificationTests(unittest.TestCase):
+    def test_exact_first_mint_addon_is_verified(self):
+        purchase = order_service._extract_verified_catalog_purchase_from_session(
+            checkout_session(
+                code=INITIAL_MINT_ADDON_CODE,
+                name="Add-On — NFT Lineage Record",
+                cents=49900,
+            )
+        )
+        self.assertEqual(purchase["item_type"], "addon")
+        self.assertEqual(purchase["addon_code"], INITIAL_MINT_ADDON_CODE)
+        self.assertEqual(purchase["amount_cents"], 49900)
+
+    def test_wrong_nft_addon_price_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "do not match"):
+            order_service._extract_verified_catalog_purchase_from_session(
+                checkout_session(
+                    code=INITIAL_MINT_ADDON_CODE,
+                    name="Add-On — NFT Lineage Record",
+                    cents=39900,
+                )
+            )
+
+    def test_metadata_revision_never_becomes_mint_credit(self):
+        purchase = order_service._extract_verified_catalog_purchase_from_session(
+            checkout_session(
+                code=METADATA_REVISION_ADDON_CODE,
+                name="Add-On — NFT Metadata Revision",
+                cents=14900,
+            )
+        )
+        self.assertEqual(purchase["addon_code"], METADATA_REVISION_ADDON_CODE)
+        self.assertNotIn(purchase["addon_code"], MINT_ADDON_CODES)
+
+    def test_product_name_and_requested_code_must_agree(self):
+        with self.assertRaisesRegex(ValueError, "not an approved"):
+            order_service._extract_verified_catalog_purchase_from_session(
+                checkout_session(
+                    code=INITIAL_MINT_ADDON_CODE,
+                    name="Add-On — Additional NFT Copy / Mint",
+                    cents=49900,
+                )
+            )
+
+    def test_checkout_must_contain_exactly_one_addon(self):
+        session = checkout_session(
+            code=INITIAL_MINT_ADDON_CODE,
+            name="Add-On — NFT Lineage Record",
+            cents=49900,
+        )
+        session["line_items"]["data"].append(session["line_items"]["data"][0])
+        with self.assertRaisesRegex(ValueError, "exactly one item"):
+            order_service._extract_verified_catalog_purchase_from_session(session)
+
+
+class Phase15AuthenticatedCheckoutTests(unittest.TestCase):
+    def test_price_resolver_requires_one_exact_active_product_and_amount(self):
+        stripe_price = {
+            "id": "price_nft_lineage",
+            "active": True,
+            "unit_amount": 49900,
+            "currency": "usd",
+            "recurring": None,
+            "product": {
+                "id": "prod_nft_lineage",
+                "name": "Add-On — NFT Lineage Record",
+                "active": True,
+            },
+        }
+        with (
+            patch.object(nft_checkout_service.settings, "stripe_secret_key", "sk_test_phase15"),
+            patch.object(
+                nft_checkout_service.settings,
+                "stripe_nft_lineage_record_price_id",
+                "",
+            ),
+            patch.object(
+                nft_checkout_service.stripe.Price,
+                "list",
+                return_value={"data": [stripe_price]},
+            ),
+        ):
+            price_id = nft_checkout_service.resolve_nft_addon_price_id(
+                INITIAL_MINT_ADDON_CODE
+            )
+        self.assertEqual(price_id, "price_nft_lineage")
+
+    def test_server_creates_checkout_only_after_authenticated_validation(self):
+        user_id = ObjectId("507f1f77bcf86cd799439011")
+        project_id = ObjectId("507f1f77bcf86cd799439012")
+        user = {"_id": user_id, "email": "customer@example.com"}
+        validated_project = {
+            "_id": project_id,
+            "_nft_credit_slot": "mint:1",
+        }
+        with (
+            patch.object(
+                nft_checkout_service,
+                "validate_nft_addon_purchase_target",
+                return_value=validated_project,
+            ) as validate_target,
+            patch.object(
+                nft_checkout_service,
+                "resolve_nft_addon_price_id",
+                return_value="price_nft_lineage",
+            ),
+            patch.object(nft_checkout_service.settings, "stripe_secret_key", "sk_test_phase15"),
+            patch.object(
+                nft_checkout_service.settings,
+                "nft_default_external_url",
+                "https://tomboflight.com",
+            ),
+            patch.object(
+                nft_checkout_service.stripe.checkout.Session,
+                "create",
+                return_value={
+                    "id": "cs_phase15_server",
+                    "url": "https://checkout.stripe.com/c/pay/cs_phase15_server",
+                    "expires_at": 123456789,
+                },
+            ) as create_session,
+        ):
+            payload = nft_checkout_service.create_nft_addon_checkout_session(
+                user=user,
+                project_id=str(project_id),
+                addon_code=INITIAL_MINT_ADDON_CODE,
+            )
+
+        validate_target.assert_called_once()
+        params = create_session.call_args.kwargs
+        self.assertEqual(params["line_items"], [{"price": "price_nft_lineage", "quantity": 1}])
+        self.assertEqual(params["metadata"]["project_id"], str(project_id))
+        self.assertEqual(params["metadata"]["checkout_never_triggers_mint"], "true")
+        self.assertIn("idempotency_key", params)
+        self.assertNotIn("payment_link", params)
+        self.assertTrue(payload["checkout_creates_credit_only"])
+        self.assertTrue(payload["checkout_never_triggers_mint"])
+
+    def test_public_frontend_contains_no_nft_payment_link_bypass(self):
+        root = Path(__file__).resolve().parents[2]
+        config_source = (root / "config.js").read_text(encoding="utf-8")
+        dashboard_source = (root / "dashboard-intake.js").read_text(encoding="utf-8")
+        for addon_code in (
+            INITIAL_MINT_ADDON_CODE,
+            ADDITIONAL_MINT_ADDON_CODE,
+            METADATA_REVISION_ADDON_CODE,
+        ):
+            self.assertRegex(
+                config_source,
+                re.compile(
+                    rf'slug:\s*"{addon_code}"[\s\S]{{0,180}}checkoutUrl:\s*""'
+                ),
+            )
+        self.assertIn(
+            "/nft-addons/${encodeURIComponent(code)}/checkout-session",
+            dashboard_source,
+        )
+
+
+class _InsertResult:
+    def __init__(self, inserted_id):
+        self.inserted_id = inserted_id
+
+
+class _OrdersCollection:
+    def __init__(self):
+        self.documents = []
+
+    def find_one(self, query):
+        for document in self.documents:
+            if all(document.get(key) == value for key, value in query.items()):
+                return document
+        return None
+
+    def insert_one(self, document):
+        saved = dict(document)
+        saved.setdefault("_id", ObjectId())
+        self.documents.append(saved)
+        return _InsertResult(saved["_id"])
+
+
+class Phase15StripeOrderTests(unittest.TestCase):
+    def test_paid_checkout_creates_credit_only_and_replay_is_idempotent(self):
+        user_id = ObjectId("507f1f77bcf86cd799439011")
+        project_id = ObjectId("507f1f77bcf86cd799439012")
+        session = checkout_session(
+            code=INITIAL_MINT_ADDON_CODE,
+            name="Add-On — NFT Lineage Record",
+            cents=49900,
+        )
+        orders = _OrdersCollection()
+        validated_project = {
+            "_id": project_id,
+            "package_code": "digital_legacy_portrait",
+            "_nft_credit_slot": "mint:1",
+            "_nft_credit_slot_key": f"{project_id}:mint:1",
+        }
+        event = {
+            "type": "checkout.session.completed",
+            "data": {"object": {"id": session["id"]}},
+        }
+        with (
+            patch.object(order_service, "_retrieve_checkout_session", return_value=session),
+            patch.object(
+                order_service,
+                "_get_user_by_email",
+                return_value={"_id": user_id, "email": "customer@example.com"},
+            ),
+            patch.object(order_service, "_get_orders_collection", return_value=orders),
+            patch.object(
+                order_service,
+                "validate_nft_addon_purchase_target",
+                return_value=validated_project,
+            ) as validate_target,
+            patch.object(order_service, "_trigger_package_provisioning") as provision,
+        ):
+            first = order_service.upsert_order_from_stripe_event(event)
+            second = order_service.upsert_order_from_stripe_event(event)
+
+        self.assertFalse(first["existing"])
+        self.assertTrue(second["existing"])
+        self.assertEqual(validate_target.call_count, 1)
+        provision.assert_not_called()
+        self.assertEqual(len(orders.documents), 1)
+        saved = orders.documents[0]
+        self.assertTrue(saved["nft_addon_verified"])
+        self.assertEqual(saved["nft_credit_status"], "available")
+        self.assertEqual(saved["nft_credit_slot"], "mint:1")
+        self.assertTrue(saved["nft_addon_checkout_does_not_auto_mint"])
+        self.assertNotIn("mint_status", saved)
+        self.assertNotIn("mint_record_id", saved)
+
+
+class _ReserveOrdersCollection:
+    def __init__(self):
+        self.query = None
+        self.update = None
+
+    def find_one_and_update(self, query, update, **_kwargs):
+        self.query = query
+        self.update = update
+        return {"_id": ObjectId(), "addon_code": INITIAL_MINT_ADDON_CODE}
+
+
+class Phase15CreditTests(unittest.TestCase):
+    def test_reservation_is_atomic_and_accepts_only_verified_stripe_credit(self):
+        orders = _ReserveOrdersCollection()
+        with patch.object(nft_addon_service, "_db", return_value={"orders": orders}):
+            reservation = reserve_paid_mint_addon(
+                "507f1f77bcf86cd799439012",
+                required_addon_code=INITIAL_MINT_ADDON_CODE,
+            )
+        self.assertEqual(reservation["addon_code"], INITIAL_MINT_ADDON_CODE)
+        self.assertTrue(orders.query["nft_addon_verified"])
+        self.assertNotIn("admin_manual", orders.query["source"]["$in"])
+        self.assertEqual(orders.update["$set"]["nft_credit_status"], "reserved")
+
+    def test_metadata_revision_can_never_be_reserved_for_mint(self):
+        with self.assertRaisesRegex(ValueError, "mint-authorizing"):
+            reserve_paid_mint_addon(
+                "507f1f77bcf86cd799439012",
+                required_addon_code=METADATA_REVISION_ADDON_CODE,
+            )
+
+    def test_failed_record_keeps_paid_credit_bound_for_recovery(self):
+        self.assertIn("failed", ACTIVE_MINT_RECORD_STATUSES)
+
+    def test_duplicate_credit_state_blocks_another_checkout(self):
+        project_id = "507f1f77bcf86cd799439012"
+        project = {
+            "_id": ObjectId(project_id),
+            "owner_user_id": ObjectId("507f1f77bcf86cd799439011"),
+            "status": "delivered",
+        }
+        status = {
+            "mint_count": 0,
+            "purchase_options": {
+                INITIAL_MINT_ADDON_CODE: {
+                    "eligible": False,
+                    "reason": "mint_credit_already_purchased",
+                }
+            },
+        }
+        with (
+            patch.object(nft_addon_service, "_project", return_value=project),
+            patch.object(nft_addon_service, "_user_can_purchase_for_project", return_value=True),
+            patch.object(nft_addon_service, "get_nft_addon_status", return_value=status),
+            patch.object(nft_addon_service.settings, "nft_mint_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_mint_worker_enabled", True),
+            patch.object(nft_addon_service.settings, "nft_auto_mint_on_review_enabled", False),
+        ):
+            with self.assertRaisesRegex(ValueError, "already paid"):
+                validate_nft_addon_purchase_target(
+                    user={"_id": ObjectId("507f1f77bcf86cd799439011")},
+                    project_id=project_id,
+                    addon_code=INITIAL_MINT_ADDON_CODE,
+                )
+
+
+class Phase15ApprovalBoundaryTests(unittest.TestCase):
+    def test_manual_paid_or_waived_flags_cannot_replace_checkout(self):
+        with self.assertRaisesRegex(ValueError, "exact verified NFT add-on price"):
+            mint_fee_service.quote_mint_fee(
+                "project",
+                {"email": CEO_MASTER_ADMIN_EMAIL},
+                {},
+            )
+        with self.assertRaisesRegex(ValueError, "verified NFT add-on"):
+            mint_fee_service.mark_mint_fee_paid("project", {"email": CEO_MASTER_ADMIN_EMAIL})
+        with self.assertRaisesRegex(ValueError, "cannot be waived"):
+            mint_fee_service.waive_mint_fee("project", {"email": CEO_MASTER_ADMIN_EMAIL})
+        with self.assertRaisesRegex(ValueError, "Network execution"):
+            mint_fee_service.refresh_network_quote(
+                "project",
+                {"email": CEO_MASTER_ADMIN_EMAIL},
+                {},
+            )
+
+    def test_non_ceo_cannot_final_approve_or_queue_through_legacy_services(self):
+        with self.assertRaisesRegex(ValueError, "CEO master account"):
+            mint_record_service.approve_admin_mint_record(
+                "mint-record",
+                approved_by_email="operations@tomboflight.com",
+            )
+        with self.assertRaisesRegex(ValueError, "CEO master account"):
+            mint_job_service.queue_mint_pipeline(
+                "project",
+                "mint-record",
+                queued_by="operations@tomboflight.com",
+            )
+
+
+class Phase15EligibilityTests(unittest.TestCase):
+    def test_paid_addon_and_delivered_profile_are_both_required(self):
+        project = {
+            "_id": "project-15",
+            "package_code": "digital_legacy_portrait",
+            "status": "delivered",
+            "public_safe_approved": True,
+            "delivery_manifest_finalized": True,
+            "mint_collectible_preparing": True,
+        }
+        addon_status = {
+            "profile_complete": True,
+            "mint_credit_satisfied": True,
+            "required_mint_addon_code": INITIAL_MINT_ADDON_CODE,
+            "purchase_options": {},
+        }
+        with (
+            patch.object(mint_policy_service, "_runtime_enabled", return_value=True),
+            patch.object(mint_policy_service.settings, "nft_mint_worker_enabled", True),
+            patch(
+                "app.services.nft_addon_service.get_nft_addon_status",
+                return_value=addon_status,
+            ),
+        ):
+            payload = mint_policy_service.describe_project_mint_eligibility(project)
+        self.assertTrue(payload["eligible"])
+        self.assertTrue(payload["ready_for_mint_preparation"])
+
+
+class Phase15WorkerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_worker_runs_only_when_explicitly_enabled(self):
+        stop = asyncio.Event()
+        with patch.object(mint_worker_service, "mint_worker_enabled", return_value=False), patch.object(
+            mint_worker_service, "run_next_job"
+        ) as run_next:
+            await mint_worker_service.run_controlled_mint_worker(stop)
+        run_next.assert_not_called()
+
+    async def test_worker_processes_prequeued_jobs_not_checkout_events(self):
+        stop = asyncio.Event()
+
+        async def stop_after_one(_fn, _worker_id):
+            stop.set()
+            return {"status": "completed"}
+
+        with patch.object(mint_worker_service, "mint_worker_enabled", return_value=True), patch.object(
+            asyncio, "to_thread", new=AsyncMock(side_effect=stop_after_one)
+        ) as to_thread:
+            await mint_worker_service.run_controlled_mint_worker(stop)
+        self.assertEqual(to_thread.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser-tests/phase15-nft-addon-mint.spec.mjs
+++ b/browser-tests/phase15-nft-addon-mint.spec.mjs
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+
+test.describe("Phase 15 NFT add-on mint flow", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("public pricing cannot bypass delivered-profile checkout gate", async ({ page }) => {
+    await page.goto("/pricing.html");
+
+    const nftLinks = page.locator("[data-nft-addon-catalog-link]");
+    await expect(nftLinks).toHaveCount(3);
+    for (const link of await nftLinks.all()) {
+      await expect(link).toHaveAttribute("href", /dashboard\.html#legacy-anchor$/);
+      await expect(link).not.toHaveAttribute("href", /buy\.stripe\.com/);
+    }
+    await expect(page.locator("[data-nft-addon-catalog-link='nft_lineage_record']").locator("xpath=..")).toContainText("$499 one-time");
+    await expect(page.locator("[data-nft-addon-catalog-link='additional_nft_copy_mint']").locator("xpath=..")).toContainText("$399 one-time");
+    await expect(page.locator("[data-nft-addon-catalog-link='nft_metadata_revision']").locator("xpath=..")).toContainText("$149 one-time");
+  });
+
+  test("customer dashboard contains gated purchase and own-wallet consent controls", async ({ page }) => {
+    await page.goto("/dashboard.html#legacy-anchor");
+
+    await expect(page.locator("[data-nft-addon-checkout='nft_lineage_record']")).toHaveCount(1);
+    await expect(page.locator("[data-nft-addon-checkout='additional_nft_copy_mint']")).toHaveCount(1);
+    await expect(page.locator("[data-nft-addon-checkout='nft_metadata_revision']")).toHaveCount(1);
+    await expect(page.locator("[data-nft-customer-wallet]")).toHaveAttribute("placeholder", "0x...");
+    await expect(page.locator("[data-nft-public-safe-consent]")).toHaveCount(1);
+    await expect(page.getByText("No base package includes an NFT.", { exact: false })).toBeVisible();
+  });
+
+  test("CEO console exposes separate governed preparation approval and queue steps", async ({ page }) => {
+    await page.goto("/admin-control-center.html");
+
+    await expect(page.locator("[data-admin-case-action='queue_for_mint_review']")).toHaveText("Open Mint Review");
+    await expect(page.locator("[data-admin-case-action='prepare_legacy_anchor']")).toHaveText("Prepare NFT Approval");
+    await expect(page.locator("[data-admin-case-action='approve_legacy_anchor']")).toHaveText("CEO Final Approve");
+    await expect(page.locator("[data-admin-case-action='queue_approved_legacy_anchor']")).toHaveText("Queue Approved NFT");
+  });
+});

--- a/config.js
+++ b/config.js
@@ -324,7 +324,7 @@
         slug: "nft_lineage_record",
         type: "addon",
         priceLabel: "$499 one-time",
-        checkoutUrl: "https://buy.stripe.com/28E5kDgUSbIzcTs8xnbEA1N",
+        checkoutUrl: "",
         successUrl:
           "/thank-you.html?session_id={CHECKOUT_SESSION_ID}&type=addon&package=nft_lineage_record",
       },
@@ -334,7 +334,7 @@
         slug: "additional_nft_copy_mint",
         type: "addon",
         priceLabel: "$399 one-time",
-        checkoutUrl: "https://buy.stripe.com/dRm14n5ca7sjf1AbJzbEA1O",
+        checkoutUrl: "",
         successUrl:
           "/thank-you.html?session_id={CHECKOUT_SESSION_ID}&type=addon&package=additional_nft_copy_mint",
       },
@@ -344,7 +344,7 @@
         slug: "nft_metadata_revision",
         type: "addon",
         priceLabel: "$149 one-time",
-        checkoutUrl: "https://buy.stripe.com/cNiaEX1ZYaEvaLkfZPbEA1P",
+        checkoutUrl: "",
         successUrl:
           "/thank-you.html?session_id={CHECKOUT_SESSION_ID}&type=addon&package=nft_metadata_revision",
       },

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -932,9 +932,10 @@
 
   function reasonLabel(reason) {
     const normalized = normalizeValue(reason);
-    if (normalized === "build_not_ready") return "Build completion is still pending.";
-    if (normalized === "package_not_included") return "This package does not include on-chain minting.";
+    if (normalized === "profile_not_complete") return "Profile completion and delivery are still pending.";
+    if (normalized === "nft_addon_not_purchased") return "The required NFT add-on has not been purchased.";
     if (normalized === "mint_runtime_disabled") return "Minting is temporarily offline.";
+    if (normalized === "controlled_mint_worker_disabled") return "The controlled mint worker is temporarily offline.";
     return humanizeStatus(normalized || "unavailable");
   }
 
@@ -1007,6 +1008,128 @@
     }
   }
 
+  function configureNftAddonCheckout(projectId, eligibility) {
+    const addonStatus = eligibility && eligibility.nft_addon ? eligibility.nft_addon : {};
+    const options = addonStatus.purchase_options || {};
+    const statusNode = document.querySelector("[data-nft-addon-status]");
+
+    if (!addonStatus.profile_complete) {
+      text(
+        statusNode,
+        "NFT add-ons unlock only after Tomb of Light marks the profile delivered. Finish the profile first; no payment is needed yet.",
+      );
+    } else if (!addonStatus.purchase_runtime_ready && !addonStatus.mint_credit_satisfied) {
+      text(
+        statusNode,
+        "Your profile is complete, but NFT checkout is temporarily paused until the controlled Base mint runtime is fully ready.",
+      );
+    } else if (addonStatus.active_mint_credit) {
+      text(
+        statusNode,
+        "Your paid NFT add-on is attached to the controlled approval flow. No second purchase is needed for this mint.",
+      );
+    } else if (addonStatus.mint_credit_satisfied) {
+      text(
+        statusNode,
+        "Payment verified. Tomb of Light can now prepare the NFT approval record; checkout has not started minting.",
+      );
+    } else {
+      const required = humanizeStatus(addonStatus.required_mint_addon_code || "nft_lineage_record");
+      text(statusNode, `Profile complete. Purchase ${required} to begin the separate approval process.`);
+    }
+
+    document.querySelectorAll("[data-nft-addon-checkout]").forEach(function (button) {
+      const code = String(button.dataset.nftAddonCheckout || "").trim();
+      const option = options[code] || {};
+      const enabled = Boolean(projectId && option.eligible);
+      button.dataset.checkoutEnabled = enabled ? "true" : "false";
+      button.setAttribute("aria-disabled", enabled ? "false" : "true");
+      button.classList.toggle("is-disabled", !enabled);
+      if (enabled) {
+        button.href = "dashboard.html#legacy-anchor";
+        button.removeAttribute("target");
+        button.removeAttribute("rel");
+        button.title = "Open authenticated Stripe checkout. Payment does not start minting.";
+      } else {
+        button.href = "dashboard.html#legacy-anchor";
+        button.removeAttribute("target");
+        button.removeAttribute("rel");
+        button.title = option.reason
+          ? humanizeStatus(option.reason)
+          : "This add-on is not available for the current NFT state.";
+      }
+    });
+  }
+
+  function configureNftCustomerConsent(projectId, mintStatus) {
+    const form = document.querySelector("[data-nft-customer-consent-form]");
+    if (!form) return;
+    const latest = mintStatus && mintStatus.latest ? mintStatus.latest : null;
+    const pending = Array.isArray(latest && latest.pending_approvals)
+      ? latest.pending_approvals
+      : [];
+    const needsCustomerConsent = Boolean(
+      projectId && latest && pending.includes("customer_public_safe"),
+    );
+    form.hidden = !needsCustomerConsent;
+    form.dataset.projectId = needsCustomerConsent ? projectId : "";
+    form.dataset.mintRecordId = needsCustomerConsent ? String(latest.id || "") : "";
+  }
+
+  async function submitNftCustomerConsent(form) {
+    const projectId = String(form.dataset.projectId || "").trim();
+    const mintRecordId = String(form.dataset.mintRecordId || "").trim();
+    const wallet = String(form.querySelector("[data-nft-customer-wallet]")?.value || "").trim();
+    const publicSafeConsent = Boolean(
+      form.querySelector("[data-nft-public-safe-consent]")?.checked,
+    );
+    const publicTitleOptIn = Boolean(
+      form.querySelector("[data-nft-public-title-opt-in]")?.checked,
+    );
+    const publicTitle = String(
+      form.querySelector("[data-nft-public-title]")?.value || "",
+    ).trim();
+    const statusNode = form.querySelector("[data-nft-consent-status]");
+    const submitButton = form.querySelector("[data-nft-consent-submit]");
+
+    if (!projectId || !mintRecordId || !/^0x[a-fA-F0-9]{40}$/.test(wallet)) {
+      text(statusNode, "Enter a valid public Base wallet address beginning with 0x.");
+      return;
+    }
+    if (!publicSafeConsent) {
+      text(statusNode, "Confirm the public-safe metadata consent before continuing.");
+      return;
+    }
+
+    if (submitButton) submitButton.disabled = true;
+    text(statusNode, "Recording your wallet and public-safe consent...");
+    try {
+      await app.apiRequest(
+        `/projects/${encodeURIComponent(projectId)}/mint-records/${encodeURIComponent(mintRecordId)}/approve-customer`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            wallet_address: wallet,
+            approved_poster_opt_in: false,
+            public_title_opt_in: publicTitleOptIn,
+            public_title: publicTitleOptIn ? publicTitle : null,
+            public_title_kind: publicTitleOptIn ? "approved_title" : "none",
+            notes: "Customer approved the recipient wallet and public-safe NFT metadata from the dashboard.",
+          }),
+        },
+      );
+      text(statusNode, "Consent recorded. Tomb of Light final approval is still required before queueing.");
+      await updateLegacyAnchorPanel({ activeProject: { id: projectId } });
+    } catch (error) {
+      text(
+        statusNode,
+        `Consent was not recorded: ${String(error && error.message ? error.message : error)}`,
+      );
+    } finally {
+      if (submitButton) submitButton.disabled = false;
+    }
+  }
+
   function resolveAnchorPresentation(hasProject, eligibility, mintStatus) {
     const latest = mintStatus && mintStatus.latest ? mintStatus.latest : null;
     const latestStatus = normalizeValue(latest && latest.mint_status);
@@ -1024,14 +1147,6 @@
         badge: "Awaiting setup",
         copy: "A provisioned workspace is required before Tomb of Light can prepare your Legacy Anchor.",
         note: "Once your project is provisioned, this panel will show live mint status, public proof links, and wallet verification.",
-      };
-    }
-
-    if (!policy.product_includes_onchain_anchor) {
-      return {
-        badge: "Package-gated",
-        copy: "This package does not include an on-chain Legacy Anchor.",
-        note: "Upgrade into an eligible package to unlock Base Mainnet anchor minting and public-safe proof records.",
       };
     }
 
@@ -1091,11 +1206,19 @@
       };
     }
 
-    if (reasons.includes("build_not_ready")) {
+    if (reasons.includes("profile_not_complete")) {
       return {
-        badge: "Waiting for Build",
-        copy: "Your package is eligible, but the build is not complete enough to mint yet.",
+        badge: "Finish Profile First",
+        copy: "NFT add-on checkout unlocks only after your Tomb of Light profile is complete and delivered.",
         note: reasons.map(reasonLabel).join(" "),
+      };
+    }
+
+    if (reasons.includes("nft_addon_not_purchased")) {
+      return {
+        badge: "Add-On Required",
+        copy: "Your profile is complete. Purchase the required NFT add-on below to start the separate approval process.",
+        note: "No base package includes an NFT, and payment never starts minting automatically.",
       };
     }
 
@@ -1151,6 +1274,20 @@
     setAnchorCopyButton("[data-anchor-copy-public-token]", "", "public token id");
     const verifyButton = document.querySelector("[data-anchor-verify-wallet]");
     if (verifyButton) verifyButton.disabled = true;
+    text(
+      document.querySelector("[data-nft-addon-status]"),
+      "A delivered customer profile is required before any NFT add-on purchase.",
+    );
+    document.querySelectorAll("[data-nft-addon-checkout]").forEach(function (button) {
+      button.dataset.checkoutEnabled = "false";
+      button.setAttribute("aria-disabled", "true");
+      button.classList.add("is-disabled");
+      button.href = "dashboard.html#legacy-anchor";
+      button.removeAttribute("target");
+      button.removeAttribute("rel");
+    });
+    const consentForm = document.querySelector("[data-nft-customer-consent-form]");
+    if (consentForm) consentForm.hidden = true;
   }
 
   async function copyAnchorValue(button) {
@@ -1248,6 +1385,64 @@
         verifyLegacyAnchorWallet();
       });
     }
+
+    document.querySelectorAll("[data-nft-addon-checkout]").forEach(function (button) {
+      if (button.dataset.bound === "true") return;
+      button.dataset.bound = "true";
+      button.addEventListener("click", async function (event) {
+        event.preventDefault();
+        if (button.dataset.checkoutEnabled !== "true") {
+          return;
+        }
+        const code = String(button.dataset.nftAddonCheckout || "").trim();
+        const projectId = String(
+          (legacyAnchorState && legacyAnchorState.projectId) || "",
+        ).trim();
+        const statusNode = document.querySelector("[data-nft-addon-status]");
+        button.dataset.checkoutEnabled = "false";
+        button.setAttribute("aria-busy", "true");
+        button.setAttribute("aria-disabled", "true");
+        text(statusNode, "Opening authenticated Stripe checkout...");
+        try {
+          const checkout = await app.apiRequest(
+            `/projects/${encodeURIComponent(projectId)}/nft-addons/${encodeURIComponent(code)}/checkout-session`,
+            { method: "POST" },
+          );
+          const checkoutUrl = String(checkout && checkout.checkout_url ? checkout.checkout_url : "").trim();
+          if (!/^https:\/\/checkout\.stripe\.com\//i.test(checkoutUrl)) {
+            throw new Error("Stripe did not return a valid checkout page.");
+          }
+          if (typeof app.savePendingCheckout === "function") {
+            app.savePendingCheckout({
+              packageCode: code,
+              purchaseType: "addon",
+              projectId,
+              paymentLink: checkoutUrl,
+              selectedAt: new Date().toISOString(),
+            });
+          }
+          window.location.assign(checkoutUrl);
+        } catch (error) {
+          button.dataset.checkoutEnabled = "true";
+          button.setAttribute("aria-disabled", "false");
+          text(
+            statusNode,
+            `Checkout could not open: ${String(error && error.message ? error.message : error)}`,
+          );
+        } finally {
+          button.removeAttribute("aria-busy");
+        }
+      });
+    });
+
+    const consentForm = document.querySelector("[data-nft-customer-consent-form]");
+    if (consentForm && consentForm.dataset.bound !== "true") {
+      consentForm.dataset.bound = "true";
+      consentForm.addEventListener("submit", function (event) {
+        event.preventDefault();
+        submitNftCustomerConsent(consentForm);
+      });
+    }
   }
 
   async function getMintEligibility(projectId) {
@@ -1291,6 +1486,7 @@
       });
 
       legacyAnchorState = {
+        projectId,
         chain: latest && latest.chain ? latest.chain : "base-mainnet",
         contractAddress: latest && latest.contract_address ? latest.contract_address : "",
         tokenId: latest && latest.token_id ? latest.token_id : "",
@@ -1304,6 +1500,9 @@
             : "",
         explorerUrl: explorerLink,
       };
+
+      configureNftAddonCheckout(projectId, eligibility);
+      configureNftCustomerConsent(projectId, mintStatus);
 
       text(document.querySelector("[data-anchor-status-badge]"), presentation.badge);
       text(document.querySelector("[data-anchor-status-copy]"), presentation.copy);

--- a/dashboard.html
+++ b/dashboard.html
@@ -568,7 +568,7 @@
               <div class="admin-record-list" data-intake-history-list></div>
             </div>
 
-            <div class="form-panel portal-anchor-panel portal-secondary-panel" data-dashboard-customer-only data-legacy-anchor-proof>
+            <div class="form-panel portal-anchor-panel portal-secondary-panel" id="legacy-anchor" data-dashboard-customer-only data-legacy-anchor-proof>
               <div class="anchor-status-row">
                 <span class="eyebrow">Legacy Anchor</span>
                 <span class="presence-badge anchor-status-badge" data-anchor-status-badge>
@@ -587,6 +587,46 @@
               <p class="card-copy anchor-proof-copy" data-anchor-proof-copy>
                 Public-safe proof confirms the anchor while private family archive details remain protected.
               </p>
+
+              <div class="family-record-card" data-nft-addon-purchase-panel>
+                <div class="card-number">$</div>
+                <h3>NFT add-on purchase</h3>
+                <p class="card-copy" data-nft-addon-status>
+                  Checking profile completion and NFT add-on eligibility.
+                </p>
+                <p class="card-copy">
+                  No base package includes an NFT. Checkout only records a paid credit; it never starts minting.
+                </p>
+                <div class="inline-actions">
+                  <a class="btn btn-primary" href="dashboard.html#legacy-anchor" data-nft-addon-checkout="nft_lineage_record" aria-disabled="true">NFT Lineage Record · $499</a>
+                  <a class="btn btn-secondary" href="dashboard.html#legacy-anchor" data-nft-addon-checkout="additional_nft_copy_mint" aria-disabled="true">Additional NFT Copy / Mint · $399</a>
+                  <a class="btn btn-secondary" href="dashboard.html#legacy-anchor" data-nft-addon-checkout="nft_metadata_revision" aria-disabled="true">NFT Metadata Revision · $149</a>
+                </div>
+              </div>
+
+              <form class="family-record-card" data-nft-customer-consent-form hidden>
+                <div class="card-number">✓</div>
+                <h3>Customer wallet and public-safe consent</h3>
+                <p class="card-copy">
+                  Enter only the public Base wallet that should receive the NFT. Never enter a private key or recovery phrase.
+                </p>
+                <label class="field-label" for="nft-customer-wallet">Recipient Base wallet</label>
+                <input id="nft-customer-wallet" name="wallet_address" type="text" inputmode="text" autocomplete="off" placeholder="0x..." pattern="0x[a-fA-F0-9]{40}" required data-nft-customer-wallet />
+                <label class="checkbox-row">
+                  <input type="checkbox" required data-nft-public-safe-consent />
+                  <span>I approve the public-safe NFT metadata and understand that private vault files stay off-chain.</span>
+                </label>
+                <label class="checkbox-row">
+                  <input type="checkbox" data-nft-public-title-opt-in />
+                  <span>Include the approved public title in NFT metadata.</span>
+                </label>
+                <label class="field-label" for="nft-public-title">Approved public title (optional)</label>
+                <input id="nft-public-title" name="public_title" type="text" maxlength="120" data-nft-public-title />
+                <div class="inline-actions">
+                  <button class="btn btn-primary" type="submit" data-nft-consent-submit>Approve wallet and public-safe mint</button>
+                </div>
+                <p class="card-copy" data-nft-consent-status></p>
+              </form>
 
               <div class="grid-3 anchor-proof-grid">
                 <div class="anchor-proof-item">

--- a/digital-collectible.js
+++ b/digital-collectible.js
@@ -292,7 +292,7 @@
       (mintStatus && mintStatus.mint_enabled) ||
         (mintEligibility &&
           mintEligibility.mint_policy &&
-          mintEligibility.mint_policy.product_includes_onchain_anchor),
+          mintEligibility.mint_policy.onchain_anchor_available_as_addon),
     );
     const isMinted = normalizeValue(mintStatusValue) === "minted";
     const isMintPending =

--- a/pricing.html
+++ b/pricing.html
@@ -681,9 +681,9 @@
               <details class="policy-card pricing-accordion">
                 <summary><span>NFT &amp; Blockchain Legacy Records</span><span class="pricing-accordion-note">On-chain preservation options</span></summary>
                 <div class="service-list">
-                  <div class="service-item"><div class="service-item-header"><strong>NFT Lineage Record</strong><span class="service-price">$499 one-time</span></div><a class="btn btn-secondary" href="https://buy.stripe.com/28E5kDgUSbIzcTs8xnbEA1N" target="_blank" rel="noopener noreferrer" data-payment-link="nft_lineage_record" data-payment-type="addon">Add to Checkout</a></div>
-                  <div class="service-item"><div class="service-item-header"><strong>Additional NFT Copy / Mint</strong><span class="service-price">$399 one-time</span></div><a class="btn btn-secondary" href="https://buy.stripe.com/dRm14n5ca7sjf1AbJzbEA1O" target="_blank" rel="noopener noreferrer" data-payment-link="additional_nft_copy_mint" data-payment-type="addon">Add to Checkout</a></div>
-                  <div class="service-item"><div class="service-item-header"><strong>NFT Metadata Revision</strong><span class="service-price">$149 one-time</span></div><a class="btn btn-secondary" href="https://buy.stripe.com/cNiaEX1ZYaEvaLkfZPbEA1P" target="_blank" rel="noopener noreferrer" data-payment-link="nft_metadata_revision" data-payment-type="addon">Add to Checkout</a></div>
+                  <div class="service-item"><div class="service-item-header"><strong>NFT Lineage Record</strong><span class="service-price">$499 one-time</span></div><a class="btn btn-secondary" href="/dashboard.html#legacy-anchor" data-nft-addon-catalog-link="nft_lineage_record">Available after profile completion</a></div>
+                  <div class="service-item"><div class="service-item-header"><strong>Additional NFT Copy / Mint</strong><span class="service-price">$399 one-time</span></div><a class="btn btn-secondary" href="/dashboard.html#legacy-anchor" data-nft-addon-catalog-link="additional_nft_copy_mint">Available after first mint</a></div>
+                  <div class="service-item"><div class="service-item-header"><strong>NFT Metadata Revision</strong><span class="service-price">$149 one-time</span></div><a class="btn btn-secondary" href="/dashboard.html#legacy-anchor" data-nft-addon-catalog-link="nft_metadata_revision">Available after first mint</a></div>
                 </div>
               </details>
 

--- a/thank-you.js
+++ b/thank-you.js
@@ -72,6 +72,11 @@
     "nft_metadata_revision",
     "rush_delivery_estate_command_minimum",
   ]);
+  const NFT_ADDON_CODES = new Set([
+    "nft_lineage_record",
+    "additional_nft_copy_mint",
+    "nft_metadata_revision",
+  ]);
 
   function getParam(name) {
     const params = new URLSearchParams(window.location.search);
@@ -208,6 +213,9 @@
     }
 
     if (normalizedType === "addon" || normalizedType === "extra") {
+      if (NFT_ADDON_CODES.has(basePackageCode(packageCode))) {
+        return "Your NFT add-on payment was received for verification. Payment does not mint an NFT. Return to your dashboard for the separate wallet-consent and Tomb of Light approval steps.";
+      }
       if (lane === "organization") {
         return "Your organization add-on purchase was received. It will be applied to the correct command structure workspace after payment confirmation.";
       }


### PR DESCRIPTION
## Phase 15 — Paid NFT Add-On Mint Console

This phase makes NFT minting a separately purchased, governed add-on instead of a package entitlement.

### What changed

- Requires the customer profile and delivery record to be complete before NFT checkout.
- Requires the $499 NFT Lineage Record add-on for the first mint.
- Requires the $399 Additional NFT Copy / Mint add-on for each later mint.
- Keeps the $149 NFT Metadata Revision add-on separate; it never authorizes a mint.
- Creates authenticated, server-side Stripe Checkout Sessions and removes raw public NFT payment links from the current customer flow.
- Records one unique mint credit per paid add-on sequence and prevents duplicate webhook crediting.
- Separates customer wallet/public-safe consent from CEO final approval.
- Enforces CEO-only final approval and queueing, including legacy mint routes.
- Adds a controlled mint worker that executes only approved, queued jobs.
- Adds fail-closed NFT runtime and protected readiness validation.
- Adds the Phase 15 CEO mint console and customer delivery flow.

### Verification

- Backend: 1,877 passed, 2 skipped.
- Contract suite: 99 subtests passed.
- Three Phase 15 browser workflow checks added and discovered.
- Python compilation, JavaScript syntax, diff integrity, and secret-pattern checks passed.
- GitHub tree exactly matches the locally tested tree: a5182c85c72fd676f0e78c965d65a29eab01c94f.
- No production accounts, customer records, Stripe objects, or blockchain transactions were changed.

### Required production follow-up after merge

1. Deactivate the three legacy public NFT Payment Links in Stripe.
2. Set NFT_LEGACY_PAYMENT_LINKS_DISABLED=true in Render.
3. Keep NFT_AUTO_MINT_ON_REVIEW_ENABLED=false.
4. Set NFT_MINT_ENABLED=true and NFT_MINT_WORKER_ENABLED=true only after the protected readiness gate is green.
5. Confirm NFT_MINT_FUNCTION_NAME=safeMint.
6. Add exact Stripe Price IDs in Render if automatic product/price resolution is ambiguous.