### PR TITLE
Fix Moreland prototype full-family-tree flow

### DIFF
--- a/browser-tests/moreland-viewer-flow.spec.mjs
+++ b/browser-tests/moreland-viewer-flow.spec.mjs
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+
+test("Moreland autoplay traverses the complete family tree without looping at Malik's parents", async ({ page }) => {
+  await page.addInitScript(() => {
+    let intervalId = 0;
+    const callbacks = [];
+
+    window.setInterval = (callback, delay, ...args) => {
+      intervalId += 1;
+      callbacks.push({ callback, delay, args, intervalId });
+      return intervalId;
+    };
+
+    window.__runMorelandAutoAdvance = () => {
+      const entry = callbacks.find((candidate) => candidate.delay === 5000);
+      if (!entry) throw new Error("Moreland autoplay interval was not registered.");
+      entry.callback(...entry.args);
+    };
+  });
+
+  await page.goto("/viewer/?demo=malik-moreland");
+
+  const expectedTitles = [
+    "Malik Moreland",
+    "Elias Moreland + Clara Moreland",
+    "Malik Moreland",
+    "Malik Descendants",
+    "Imani Benton / Imani Moreland",
+    "Imani Descendants",
+    "Elias Moreland + Clara Moreland",
+    "Selah Carter",
+    "Selah Descendants",
+    "Elias Moreland + Clara Moreland",
+    "Julian Moreland",
+  ];
+
+  for (let index = 0; index < expectedTitles.length; index += 1) {
+    await expect(page.locator("#viewerTitle")).toHaveText(expectedTitles[index]);
+    await expect(page.locator(`[data-path-index="${index}"]`)).toHaveClass(/is-current/);
+    await page.waitForTimeout(200);
+    if (index < expectedTitles.length - 1) {
+      await page.evaluate(() => window.__runMorelandAutoAdvance());
+    }
+  }
+});

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -305,6 +305,6 @@
     <script src="../config.js?v=20260509-visualfix"></script>
     <script src="../app.js?v=20260509-visualfix"></script>
     <script src="js/genesis-prototype-manifest.js?v=20260509-visualfix"></script>
-    <script src="js/script.js?v=20260509-visualfix"></script>
+    <script src="js/script.js?v=20260824-full-tree-flow"></script>
   </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -104,6 +104,7 @@
   let statesById = {};
   let stateOrder = [];
   let state = "";
+  let autoAdvanceIndex = -1;
   let isPlaying = true;
   let narrationInterval = null;
   let narrationFadeTimeout = null;
@@ -325,6 +326,28 @@
       : [];
   }
 
+  function findNextAutoAdvanceIndex(stateId, fromIndex = -1) {
+    const orderedStates = getAutoAdvanceStateIds();
+    if (!orderedStates.length || !stateId) return -1;
+
+    for (let offset = 1; offset <= orderedStates.length; offset += 1) {
+      const index = (fromIndex + offset + orderedStates.length) % orderedStates.length;
+      if (orderedStates[index] === stateId) return index;
+    }
+
+    return -1;
+  }
+
+  function alignAutoAdvanceIndex(stateId) {
+    const orderedStates = getAutoAdvanceStateIds();
+    if (!orderedStates.length) {
+      autoAdvanceIndex = -1;
+      return;
+    }
+    if (orderedStates[autoAdvanceIndex] === stateId) return;
+    autoAdvanceIndex = findNextAutoAdvanceIndex(stateId, autoAdvanceIndex);
+  }
+
   function renderPathList(manifest) {
     if (!pathList) return;
 
@@ -350,6 +373,7 @@
       if (canNavigate) {
         row.type = "button";
         row.setAttribute("data-path-state", targetStateId);
+        row.setAttribute("data-path-index", String(index));
       }
       pathList.appendChild(row);
     });
@@ -443,6 +467,8 @@
     statesById = currentManifest.stateMap;
     stateOrder = currentManifest.stateOrder;
     state = currentManifest.initialStateId || stateOrder[0] || "";
+    autoAdvanceIndex = -1;
+    alignAutoAdvanceIndex(state);
 
     updateHeaderCopy(currentManifest);
     updateNavLabels();
@@ -539,11 +565,13 @@
   function getNextAutoAdvanceStateId() {
     const orderedStates = getAutoAdvanceStateIds();
     if (orderedStates.length > 0) {
-      const currentIndex = orderedStates.indexOf(state);
-      if (currentIndex !== -1) {
-        return orderedStates[(currentIndex + 1) % orderedStates.length] || "";
-      }
-      return orderedStates[0] || "";
+      alignAutoAdvanceIndex(state);
+      const nextIndex =
+        autoAdvanceIndex === -1
+          ? 0
+          : (autoAdvanceIndex + 1) % orderedStates.length;
+      autoAdvanceIndex = nextIndex;
+      return orderedStates[nextIndex] || "";
     }
 
     const currentState = statesById[state];
@@ -899,6 +927,7 @@
 
     transitionLock = true;
     state = nextState;
+    alignAutoAdvanceIndex(state);
     setZoom(1, false);
 
     const imageLoaded = await swapViewerImage(config.image, config.node);
@@ -1014,7 +1043,12 @@
   function syncPathListState() {
     if (!pathList) return;
     pathList.querySelectorAll("[data-path-state]").forEach(function (item) {
-      const isCurrent = item.getAttribute("data-path-state") === state;
+      const itemIndex = Number(item.getAttribute("data-path-index"));
+      const isCurrent =
+        item.getAttribute("data-path-state") === state &&
+        (!Number.isInteger(autoAdvanceIndex) ||
+          autoAdvanceIndex < 0 ||
+          itemIndex === autoAdvanceIndex);
       item.classList.toggle("is-current", isCurrent);
       if (isCurrent) {
         item.setAttribute("aria-current", "true");
@@ -1024,7 +1058,7 @@
     });
   }
 
-  function navigatePathState(targetStateId) {
+  function navigatePathState(targetStateId, targetPathIndex = null) {
     if (EMBED_MODE) return;
     const resolved = String(targetStateId || "").trim();
     if (!resolved || !statesById[resolved]) {
@@ -1032,6 +1066,14 @@
         "That demo step is unavailable. Use Parents, Descendants, Zoom In, or Zoom Out to continue.",
       );
       return;
+    }
+    const resolvedPathIndex = Number(targetPathIndex);
+    const orderedStates = getAutoAdvanceStateIds();
+    if (
+      Number.isInteger(resolvedPathIndex) &&
+      orderedStates[resolvedPathIndex] === resolved
+    ) {
+      autoAdvanceIndex = resolvedPathIndex;
     }
     markInteraction();
     pauseNarrationForManualControl();
@@ -1163,7 +1205,10 @@
       pathList.addEventListener("click", function (event) {
         const button = event.target.closest("[data-path-state]");
         if (!button) return;
-        navigatePathState(button.getAttribute("data-path-state"));
+        navigatePathState(
+          button.getAttribute("data-path-state"),
+          button.getAttribute("data-path-index"),
+        );
       });
     }
 


### PR DESCRIPTION
## Frontend prototype — complete Moreland family-tree flow

Fixes the homepage/public Moreland viewer autoplay getting trapped between Malik Moreland and Elias + Clara Moreland.

### Root cause

The canonical demo path contains intentional repeated routing states. Malik appears twice and the parent household appears three times as the tour moves between branches. Autoplay used Array.indexOf(currentState), which always selected the first occurrence and restarted the Malik/parents loop.

### Correction

- Track the exact autoplay sequence position instead of searching for the first matching state.
- Preserve the correct position across repeated routing nodes.
- Align manual graph and path-list navigation with the nearest valid sequence step.
- Highlight only the active occurrence in the guided path.
- Cache-bust the viewer script so the frontend receives the correction after deployment.
- Add a Chromium regression that verifies the complete 11-step tour:
  1. Malik
  2. Elias + Clara
  3. Malik
  4. Malik descendants
  5. Imani
  6. Imani descendants
  7. Elias + Clara
  8. Selah
  9. Selah descendants
  10. Elias + Clara
  11. Julian

### Verification

- JavaScript syntax passed.
- Git diff integrity passed.
- 21 existing viewer/frontend contracts passed.
- New full-tree Playwright regression is discovered.
- GitHub tree exactly matches the locally tested tree: 08ed096f10b74faaf4c4d8a230d0b6440580a1b7.
- No production accounts, customer data, billing records, or blockchain state changed.