### PR TITLE
Phase 16 — Universal Lineage Cinema

### DIFF
--- a/PHASE16_UNIVERSAL_LINEAGE_CINEMA.md
+++ b/PHASE16_UNIVERSAL_LINEAGE_CINEMA.md
@@ -1,0 +1,124 @@
+# Phase 16 — Universal Lineage Cinema
+
+Phase 16 turns the Moreland prototype behavior into a private, data-driven
+viewer for every eligible Tomb of Light household and linked family network.
+It does not copy the Moreland people or hard-code a customer sequence.
+
+## Publication contract
+
+A member receives a cinematic slide only when the selected portrait is:
+
+1. a `member_photo` assigned to that exact project, family, and member;
+2. clean from malware scanning and outside quarantine;
+3. backed by consent and authority attestations;
+4. approved for verification, consent, and cinematic use by the master review;
+5. not pending deletion; and
+6. available through authenticated private delivery.
+
+The named member dropbox creates the assignment. Master approval updates the
+member's single approved-photo pointer. The next authenticated viewer request
+then compiles the current approved portraits and relationships into the family
+tour automatically. Rejected, revoked, quarantined, unapproved, deleted, or
+unshared portraits are not compiled.
+
+## Family graph contract
+
+The compiler understands every relationship type in the canonical relationship
+catalog. It groups them without changing their meaning:
+
+- parent and elder types navigate as ancestry;
+- spouses, domestic partners, former partners, and co-parents navigate as partners;
+- sibling types navigate as sibling branches;
+- cousins, aunts/uncles, godparents, mentors, in-laws, friends, household
+  members, identity bridges, and linked-household bridges navigate as extended
+  branches;
+- biological/verified links render solid, adoptive links double, step/foster/
+  guardian/chosen links dashed, narrative links dotted, and former partnerships
+  historical.
+
+Pending, disputed, rejected, revoked, and deleted relationships cannot enter a
+published tour. The family placement service remains the source of generation
+alignment; the compiler reports unplaced states instead of silently changing a
+person's generation.
+
+## Tour contract
+
+One member is one content state. A tour step is one visit to a state. The tour
+may revisit an anchor or ancestor to move between branches, but every visit has
+a unique step id. That distinction prevents the old repeated-state cursor bug.
+
+Every compilation must be:
+
+- deterministic for the same approved graph;
+- anchored on the primary member when that portrait is approved;
+- complete across every approved portrait;
+- bounded to at most four tour steps per eligible state;
+- safe for disconnected/unplaced members without inventing ancestry; and
+- navigable through parent, child, partner, sibling, and extended-branch controls.
+
+The full tour—not the previous six-item preview cap—is returned as
+`auto_advance_state_ids`, `tour_steps`, and `path_items`.
+
+## Linked Family Key contract
+
+The network viewer uses the existing approved household-link graph and its
+generation offsets. Another household contributes a member, relationship, or
+portrait only when that household explicitly exposes it to linked families.
+Private, internal-only, unapproved, or orphan relationship data is filtered
+before compilation.
+
+An external household is not placed from its local generation alone. Linked
+members without a resolved network generation offset are excluded, and any
+alignment conflict blocks linked-branch compilation while leaving the root
+household viewer available. This prevents a Family Key from shifting an entire
+branch into the wrong generation.
+
+Linked portraits use a dedicated viewer authorization path. A caller must be
+authorized for the root network project, the portrait must appear in that
+caller's current privacy-filtered network, and its member/project provenance
+must still match. Guessing an upload id or root project query cannot unlock it.
+
+Family Keys never share passwords, sessions, vault files, billing control, or
+unrelated private records. They connect approved graph projections only.
+
+## Private versioning contract
+
+Each compiled private manifest receives a canonical SHA-256 content hash. The
+immutable version is inserted before a one-document active pointer is swapped.
+If pointer activation fails, the prior active pointer remains unchanged and the
+new manifest is not returned as active.
+
+Unique startup indexes enforce one version key and one active pointer per
+project. Index creation is part of production startup and fails closed with the
+other critical controls.
+
+These versions are private operational records. They are not NFT metadata and
+do not make family portraits or relationships public.
+
+## Viewer behavior
+
+Family slideshow playback is independent of the paid narration entitlement.
+Every complete multi-slide family manifest can autoplay. Narration text remains
+hidden unless the package includes narration. Manual tree navigation pauses the
+slideshow, and the customer can resume it with a clearly labeled control.
+
+The same graph behavior now applies to dynamic customer manifests and the public
+prototype: full-path autoplay, graph-aware zoom controls, branch choices, gaze
+navigation, and duplicate-step-safe path highlighting.
+
+## Verification coverage
+
+Phase 16 includes tests for:
+
+- the full Moreland-style multi-branch topology;
+- all canonical family relationship types;
+- repeated routing states and unique tour steps;
+- hidden-parent sibling derivation;
+- pending/disputed relationship exclusion;
+- deterministic output under reversed database order;
+- 250-member and maximum 999-member lineage depth;
+- immutable manifest versioning and pointer failure behavior;
+- household and linked-network manifest integration;
+- linked portrait privacy and provenance failures;
+- autoplay without narration; and
+- dynamic graph navigation in Chromium.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,6 +113,9 @@ from app.services.mint_worker_service import (
 )
 from app.services.auth_service import ensure_auth_indexes
 from app.services.rate_limit_service import ensure_rate_limit_indexes
+from app.services.cinematic_version_service import (
+    ensure_cinematic_manifest_indexes,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -177,6 +180,7 @@ async def lifespan(app: FastAPI):
         ensure_finance_event_indexes()
         ensure_continuity_runtime_indexes()
         ensure_organization_indexes()
+        ensure_cinematic_manifest_indexes()
         try:
             bootstrap_admin_access_controls()
         except Exception as exc:

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -50,6 +50,7 @@ from app.services.privacy_access_service import (
     normalize_privacy_scope,
 )
 from app.services.tree_service import list_linked_family_ids
+from app.services.linked_network_service import build_linked_network
 from app.services.workspace_access_service import (
     count_workspace_uploads,
     family_is_visible_to_user,
@@ -490,6 +491,62 @@ def _require_upload_management_access(
             detail="Not authorized to manage this upload.",
         )
 
+    return upload_record, context
+
+
+def _require_linked_cinematic_upload_access(
+    upload_id: str,
+    viewer_project_id: str,
+    db: Any,
+    current_user: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Authorize one portrait through the requesting user's linked viewer graph."""
+
+    if not ObjectId.is_valid(upload_id):
+        raise HTTPException(status_code=400, detail="Invalid upload id.")
+    normalized_viewer_project_id = _normalize_value(viewer_project_id)
+    if not normalized_viewer_project_id:
+        raise HTTPException(status_code=400, detail="Viewer project id is required.")
+
+    context = require_workspace_capability(
+        current_user,
+        project_id=normalized_viewer_project_id,
+        capabilities=("can_use_viewer",),
+        detail="Your active package does not include linked family viewer access.",
+    )
+    network = build_linked_network(
+        normalized_viewer_project_id,
+        _current_user_id(current_user),
+        workspace_context=context,
+    )
+    matching_node = next(
+        (
+            node
+            for node in network.get("nodes") or []
+            if _normalize_value(node.get("approved_photo_upload_id")) == upload_id
+        ),
+        None,
+    )
+    if matching_node is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This portrait is not shared with the requested linked family viewer.",
+        )
+
+    upload_record = db["uploaded_files"].find_one({"_id": ObjectId(upload_id)})
+    if upload_record is None:
+        raise HTTPException(status_code=404, detail="Upload not found.")
+    if not (
+        _normalize_value(upload_record.get("category")) == "member_photo"
+        and _normalize_value(upload_record.get("member_id"))
+        == _normalize_value(matching_node.get("id"))
+        and _normalize_value(upload_record.get("project_id"))
+        == _normalize_value(matching_node.get("source_project_id"))
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Linked portrait provenance does not match the approved family graph.",
+        )
     return upload_record, context
 
 
@@ -2004,18 +2061,32 @@ def list_cinematic_assets(
 def download_upload(
     upload_id: str,
     admin_override: bool = Query(default=False),
+    viewer_project_id: str = Query(default=""),
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
 
-    upload_record, _context = _require_upload_access(
-        upload_id,
-        db,
-        current_user,
-        detail="Your active package does not include upload access.",
+    normalized_viewer_project_id = (
+        _normalize_value(viewer_project_id)
+        if isinstance(viewer_project_id, str)
+        else ""
     )
+    if normalized_viewer_project_id:
+        upload_record, _context = _require_linked_cinematic_upload_access(
+            upload_id,
+            normalized_viewer_project_id,
+            db,
+            current_user,
+        )
+    else:
+        upload_record, _context = _require_upload_access(
+            upload_id,
+            db,
+            current_user,
+            detail="Your active package does not include upload access.",
+        )
     deletion_status = _normalize_value(upload_record.get("deletion_status")).lower()
     if deletion_status in {"pending", "failed"}:
         raise HTTPException(

--- a/backend/app/services/cinematic_version_service.py
+++ b/backend/app/services/cinematic_version_service.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+import hashlib
+import json
+from typing import Any
+
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from app.database import get_database
+
+
+CINEMATIC_MANIFEST_SCHEMA_VERSION = "tol-private-cinematic-manifest-1.0"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _serialize(value: Any) -> Any:
+    if isinstance(value, ObjectId):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_serialize(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialize(item) for key, item in value.items()}
+    return value
+
+
+def _manifest_content(manifest: dict[str, Any]) -> dict[str, Any]:
+    content = deepcopy(manifest)
+    content.pop("manifest_version", None)
+    return _serialize(content)
+
+
+def canonical_manifest_hash(manifest: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        _manifest_content(manifest),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def ensure_cinematic_manifest_indexes() -> None:
+    """Create the fail-closed indexes used by immutable private manifests."""
+
+    db = get_database()
+    if db is None:
+        return
+
+    versions = db["cinematic_manifest_versions"]
+    active = db["cinematic_manifest_active"]
+    versions.create_index(
+        [("version_key", 1)],
+        name="cinematic_manifest_version_key_unique",
+        unique=True,
+    )
+    versions.create_index(
+        [("project_id", 1), ("created_at", -1)],
+        name="cinematic_manifest_project_created",
+    )
+    active.create_index(
+        [("project_id", 1)],
+        name="cinematic_manifest_active_project_unique",
+        unique=True,
+    )
+
+
+def _validate_compiled_manifest(manifest: dict[str, Any]) -> None:
+    compiler = manifest.get("cinema_compiler") or {}
+    validation = compiler.get("validation") or {}
+    if not bool(validation.get("complete")):
+        raise RuntimeError(
+            "Cinematic manifest publication failed closed because the family tour is incomplete."
+        )
+    if not bool(validation.get("tour_bounded")):
+        raise RuntimeError(
+            "Cinematic manifest publication failed closed because the family tour is not bounded."
+        )
+    state_ids = {
+        _value(state.get("id"))
+        for state in manifest.get("states") or []
+        if _value(state.get("id")) and _value(state.get("member_id"))
+    }
+    tour_ids = {
+        _value(state_id)
+        for state_id in manifest.get("auto_advance_state_ids") or []
+        if _value(state_id)
+    }
+    if state_ids != tour_ids:
+        raise RuntimeError(
+            "Cinematic manifest publication failed closed because approved portraits are missing from the tour."
+        )
+
+
+def publish_private_cinematic_manifest(
+    manifest: dict[str, Any],
+    *,
+    project_id: str,
+    family_id: str = "",
+) -> dict[str, Any]:
+    """Persist an immutable manifest, then atomically move its active pointer.
+
+    The version insert always happens before the one-document pointer update. If
+    the pointer update fails, MongoDB leaves the prior active pointer untouched.
+    The caller receives the new manifest only after both writes succeed.
+    """
+
+    normalized_project_id = _value(project_id)
+    if not normalized_project_id:
+        raise RuntimeError("Project id is required to publish a cinematic manifest.")
+    _validate_compiled_manifest(manifest)
+
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    content_hash = canonical_manifest_hash(manifest)
+    version_key = f"{normalized_project_id}:{content_hash}"
+    versions = db["cinematic_manifest_versions"]
+    active = db["cinematic_manifest_active"]
+    now = _now()
+    compiler = manifest.get("cinema_compiler") or {}
+    snapshot = _manifest_content(manifest)
+    version_document = {
+        "version_key": version_key,
+        "schema_version": CINEMATIC_MANIFEST_SCHEMA_VERSION,
+        "compiler_version": _value(compiler.get("version")),
+        "project_id": normalized_project_id,
+        "family_id": _value(family_id) or None,
+        "content_hash": content_hash,
+        "publication_scope": "private_authenticated_viewer",
+        "manifest_snapshot": snapshot,
+        "created_at": now,
+    }
+
+    existing = versions.find_one({"version_key": version_key})
+    if existing is None:
+        try:
+            result = versions.insert_one(version_document)
+            version_id = _value(getattr(result, "inserted_id", "")) or version_key
+        except DuplicateKeyError:
+            existing = versions.find_one({"version_key": version_key})
+            if existing is None:
+                raise
+            version_id = _value(existing.get("_id")) or version_key
+    else:
+        version_id = _value(existing.get("_id")) or version_key
+
+    active_document = active.find_one({"project_id": normalized_project_id})
+    if _value((active_document or {}).get("active_version_key")) != version_key:
+        active.update_one(
+            {"project_id": normalized_project_id},
+            {
+                "$set": {
+                    "project_id": normalized_project_id,
+                    "family_id": _value(family_id) or None,
+                    "active_version_id": version_id,
+                    "active_version_key": version_key,
+                    "content_hash": content_hash,
+                    "compiler_version": _value(compiler.get("version")),
+                    "schema_version": CINEMATIC_MANIFEST_SCHEMA_VERSION,
+                    "activated_at": now,
+                },
+                "$setOnInsert": {"created_at": now},
+            },
+            upsert=True,
+        )
+
+    published = deepcopy(manifest)
+    published["manifest_version"] = {
+        "schema_version": CINEMATIC_MANIFEST_SCHEMA_VERSION,
+        "compiler_version": _value(compiler.get("version")),
+        "version_id": version_id,
+        "content_hash": content_hash,
+        "persisted": True,
+    }
+    return published
+
+
+__all__ = [
+    "CINEMATIC_MANIFEST_SCHEMA_VERSION",
+    "canonical_manifest_hash",
+    "ensure_cinematic_manifest_indexes",
+    "publish_private_cinematic_manifest",
+]

--- a/backend/app/services/lineage_cinema_compiler.py
+++ b/backend/app/services/lineage_cinema_compiler.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Any
+
+from app.core.relationship_catalog import (
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    SIBLING_RELATIONSHIP_TYPES,
+    normalize_relationship_type,
+)
+
+
+LINEAGE_CINEMA_COMPILER_VERSION = "tol-lineage-cinema-1.0"
+
+_BLOCKED_RELATIONSHIP_MARKERS = {
+    "pending",
+    "disputed",
+    "rejected",
+    "revoked",
+    "deleted",
+}
+_DIRECT_ANCESTRY_TYPES = {*PARENT_RELATIONSHIP_TYPES, "grandparent"}
+_SIBLING_DERIVATION_PARENT_TYPES = {
+    "parent_unspecified",
+    "biological_parent",
+    "gestational_parent",
+    "donor_parent",
+    "intended_parent",
+    "adoptive_parent",
+    "foster_parent",
+    "step_parent",
+}
+
+
+def _value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _coerce_generation(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _state_sort_key(state: dict[str, Any]) -> tuple[int, str, str]:
+    generation = _coerce_generation(state.get("generation"))
+    return (
+        generation if generation is not None else 999_999,
+        _value(state.get("title") or state.get("node")).lower(),
+        _value(state.get("id")),
+    )
+
+
+def _relationship_is_active(relationship: dict[str, Any]) -> bool:
+    marker = _value(relationship.get("status_marker")).lower()
+    status = _value(relationship.get("status")).lower()
+    return (
+        marker not in _BLOCKED_RELATIONSHIP_MARKERS
+        and status not in _BLOCKED_RELATIONSHIP_MARKERS
+    )
+
+
+def _visual_style(relationship_type: str, relationship: dict[str, Any]) -> str:
+    marker = _value(relationship.get("status_marker")).lower()
+    mode = _value(relationship.get("relationship_mode")).lower()
+    if marker == "unknown":
+        return "unknown"
+    if relationship_type in {
+        "step_parent",
+        "foster_parent",
+        "guardian",
+        "chosen_parent",
+        "community_parent",
+        "spiritual_parent",
+        "step_sibling",
+        "chosen_sibling",
+    }:
+        return "dashed"
+    if relationship_type in {"adoptive_parent", "adoptive_sibling"}:
+        return "double"
+    if relationship_type in {"former_spouse", "former_partner"}:
+        return "historical"
+    if relationship_type in PARTNER_RELATIONSHIP_TYPES:
+        return "partner"
+    if relationship_type in SIBLING_RELATIONSHIP_TYPES or relationship_type == "cousin":
+        return "branch"
+    if mode == "narrative":
+        return "dotted"
+    return "solid"
+
+
+def _relationship_label(relationship_type: str, relationship: dict[str, Any]) -> str:
+    return (
+        _value(relationship.get("relationship_label"))
+        or relationship_type.replace("_", " ").title()
+    )
+
+
+def compile_lineage_cinema(
+    *,
+    states: list[dict[str, Any]],
+    relationships: list[dict[str, Any]],
+    anchor_state_id: str = "",
+) -> dict[str, Any]:
+    """Compile approved member states into one deterministic cinematic tour.
+
+    A member state represents content; a tour step represents one visit to that
+    content. Tour steps may therefore revisit an ancestor or anchor without
+    duplicating the underlying person. This distinction prevents repeated graph
+    states from trapping autoplay at their first sequence occurrence.
+    """
+
+    state_by_id = {
+        _value(state.get("id")): dict(state)
+        for state in states
+        if _value(state.get("id"))
+    }
+    sorted_states = sorted(state_by_id.values(), key=_state_sort_key)
+    state_ids = [_value(state.get("id")) for state in sorted_states]
+    if not state_ids:
+        return {
+            "compiler_version": LINEAGE_CINEMA_COMPILER_VERSION,
+            "ordered_state_ids": [],
+            "tour_steps": [],
+            "auto_advance_state_ids": [],
+            "path_items": [],
+            "branch_options_by_state": {},
+            "navigation_by_state": {},
+            "relationship_edges": [],
+            "validation": {
+                "complete": True,
+                "eligible_state_count": 0,
+                "unique_state_count_in_tour": 0,
+                "tour_step_count": 0,
+                "missing_state_ids": [],
+                "disconnected_state_ids": [],
+                "disconnected_transitions": [],
+                "bounded_transitions": [],
+                "unplaced_state_ids": [],
+                "placement_ready": True,
+                "tour_bounded": True,
+                "max_tour_steps": 0,
+            },
+        }
+
+    resolved_anchor = _value(anchor_state_id)
+    if resolved_anchor not in state_by_id:
+        resolved_anchor = state_ids[0]
+
+    state_id_by_member_id = {
+        _value(state.get("member_id")): state_id
+        for state_id, state in state_by_id.items()
+        if _value(state.get("member_id"))
+    }
+    navigation: dict[str, dict[str, set[str]]] = {
+        state_id: {
+            "parents": set(),
+            "children": set(),
+            "partners": set(),
+            "siblings": set(),
+            "branches": set(),
+        }
+        for state_id in state_ids
+    }
+    adjacency: dict[str, set[str]] = {state_id: set() for state_id in state_ids}
+    relationship_edges: list[dict[str, Any]] = []
+    all_children_by_parent_member: dict[str, set[str]] = defaultdict(set)
+
+    def add_adjacency(source_state_id: str, target_state_id: str) -> None:
+        if source_state_id == target_state_id:
+            return
+        adjacency[source_state_id].add(target_state_id)
+        adjacency[target_state_id].add(source_state_id)
+
+    active_relationships = sorted(
+        (
+            relationship
+            for relationship in relationships
+            if _relationship_is_active(relationship)
+        ),
+        key=lambda relationship: (
+            _value(relationship.get("source_member_id")),
+            _value(relationship.get("target_member_id")),
+            normalize_relationship_type(relationship.get("relationship_type")),
+            _value(relationship.get("relationship_mode")),
+            _value(relationship.get("status_marker")),
+            _value(relationship.get("_id") or relationship.get("id")),
+        ),
+    )
+
+    for relationship in active_relationships:
+        source_member_id = _value(relationship.get("source_member_id"))
+        target_member_id = _value(relationship.get("target_member_id"))
+        relationship_type = normalize_relationship_type(
+            relationship.get("relationship_type")
+        )
+        if not source_member_id or not target_member_id:
+            continue
+
+        if relationship_type in _SIBLING_DERIVATION_PARENT_TYPES:
+            all_children_by_parent_member[source_member_id].add(target_member_id)
+
+        source_state_id = state_id_by_member_id.get(source_member_id, "")
+        target_state_id = state_id_by_member_id.get(target_member_id, "")
+        if not source_state_id or not target_state_id or source_state_id == target_state_id:
+            continue
+
+        add_adjacency(source_state_id, target_state_id)
+        if relationship_type in _DIRECT_ANCESTRY_TYPES:
+            navigation[source_state_id]["children"].add(target_state_id)
+            navigation[target_state_id]["parents"].add(source_state_id)
+        elif relationship_type in PARTNER_RELATIONSHIP_TYPES:
+            navigation[source_state_id]["partners"].add(target_state_id)
+            navigation[target_state_id]["partners"].add(source_state_id)
+        elif relationship_type in SIBLING_RELATIONSHIP_TYPES:
+            navigation[source_state_id]["siblings"].add(target_state_id)
+            navigation[target_state_id]["siblings"].add(source_state_id)
+        else:
+            navigation[source_state_id]["branches"].add(target_state_id)
+            navigation[target_state_id]["branches"].add(source_state_id)
+
+        relationship_edges.append(
+            {
+                "source_state_id": source_state_id,
+                "target_state_id": target_state_id,
+                "relationship_type": relationship_type,
+                "relationship_mode": _value(
+                    relationship.get("relationship_mode")
+                )
+                or "narrative",
+                "status_marker": _value(relationship.get("status_marker"))
+                or "narrative",
+                "privacy_scope": _value(relationship.get("privacy_scope"))
+                or "household_private",
+                "label": _relationship_label(relationship_type, relationship),
+                "visual_style": _visual_style(relationship_type, relationship),
+            }
+        )
+
+    # Two visible children of the same parent are siblings even when the parent
+    # portrait is not approved and therefore has no cinematic state.
+    for child_member_ids in all_children_by_parent_member.values():
+        visible_sibling_states = sorted(
+            {
+                state_id_by_member_id[member_id]
+                for member_id in child_member_ids
+                if member_id in state_id_by_member_id
+            },
+            key=lambda item: _state_sort_key(state_by_id[item]),
+        )
+        for index, source_state_id in enumerate(visible_sibling_states):
+            for target_state_id in visible_sibling_states[index + 1 :]:
+                navigation[source_state_id]["siblings"].add(target_state_id)
+                navigation[target_state_id]["siblings"].add(source_state_id)
+                add_adjacency(source_state_id, target_state_id)
+
+    def sorted_state_ids(values: set[str] | list[str]) -> list[str]:
+        return sorted(
+            {value for value in values if value in state_by_id},
+            key=lambda item: _state_sort_key(state_by_id[item]),
+        )
+
+    ordered_targets: list[str] = []
+    visit_reason: dict[str, str] = {}
+
+    def add_target(state_id: str, reason: str) -> None:
+        if state_id not in state_by_id or state_id in visit_reason:
+            return
+        visit_reason[state_id] = reason
+        ordered_targets.append(state_id)
+
+    add_target(resolved_anchor, "anchor")
+
+    def visit_ancestors(state_id: str) -> None:
+        stack = list(
+            reversed(sorted_state_ids(navigation[state_id]["parents"]))
+        )
+        while stack:
+            parent_state_id = stack.pop()
+            if parent_state_id in visit_reason:
+                continue
+            add_target(parent_state_id, "ancestor")
+            stack.extend(
+                reversed(
+                    sorted_state_ids(navigation[parent_state_id]["parents"])
+                )
+            )
+
+    def visit_descendants(state_id: str, reason: str = "descendant") -> None:
+        stack = list(
+            reversed(sorted_state_ids(navigation[state_id]["children"]))
+        )
+        while stack:
+            child_state_id = stack.pop()
+            if child_state_id in visit_reason:
+                continue
+            add_target(child_state_id, reason)
+            for partner_state_id in sorted_state_ids(
+                navigation[child_state_id]["partners"]
+            ):
+                add_target(partner_state_id, "partner")
+            stack.extend(
+                reversed(
+                    sorted_state_ids(navigation[child_state_id]["children"])
+                )
+            )
+
+    visit_ancestors(resolved_anchor)
+    for partner_state_id in sorted_state_ids(navigation[resolved_anchor]["partners"]):
+        add_target(partner_state_id, "partner")
+    visit_descendants(resolved_anchor)
+
+    for sibling_state_id in sorted_state_ids(navigation[resolved_anchor]["siblings"]):
+        if sibling_state_id in visit_reason:
+            continue
+        add_target(sibling_state_id, "sibling_branch")
+        for partner_state_id in sorted_state_ids(
+            navigation[sibling_state_id]["partners"]
+        ):
+            add_target(partner_state_id, "partner")
+        visit_descendants(sibling_state_id, "sibling_descendant")
+
+    # Narrative, cultural, and other extended branches are visited after the
+    # primary lineage so they remain represented without changing ancestry.
+    branch_scan_index = 0
+    while branch_scan_index < len(ordered_targets):
+        source_state_id = ordered_targets[branch_scan_index]
+        for branch_state_id in sorted_state_ids(
+            navigation[source_state_id]["branches"]
+        ):
+            add_target(branch_state_id, "extended_branch")
+        branch_scan_index += 1
+
+    for state_id in state_ids:
+        add_target(state_id, "additional_family_member")
+
+    def shortest_path(start_state_id: str, end_state_id: str) -> list[str]:
+        if start_state_id == end_state_id:
+            return [start_state_id]
+        queue: deque[str] = deque([start_state_id])
+        previous: dict[str, str | None] = {start_state_id: None}
+        while queue:
+            current_state_id = queue.popleft()
+            for neighbor_state_id in sorted_state_ids(adjacency[current_state_id]):
+                if neighbor_state_id in previous:
+                    continue
+                previous[neighbor_state_id] = current_state_id
+                if neighbor_state_id == end_state_id:
+                    path = [end_state_id]
+                    cursor = current_state_id
+                    while cursor is not None:
+                        path.append(cursor)
+                        cursor = previous[cursor]
+                    return list(reversed(path))
+                queue.append(neighbor_state_id)
+        return []
+
+    max_tour_steps = max(len(state_ids), len(state_ids) * 4)
+    tour_state_ids: list[str] = [ordered_targets[0]]
+    tour_reasons: list[str] = [visit_reason[ordered_targets[0]]]
+    disconnected_transitions: list[dict[str, str]] = []
+    bounded_transitions: list[dict[str, str]] = []
+
+    remaining_targets = ordered_targets[1:]
+    for target_index, target_state_id in enumerate(remaining_targets):
+        if target_state_id in tour_state_ids:
+            continue
+        current_state_id = tour_state_ids[-1]
+        path = shortest_path(current_state_id, target_state_id)
+        additions = path[1:] if path else [target_state_id]
+        if not path:
+            disconnected_transitions.append(
+                {"from_state_id": current_state_id, "to_state_id": target_state_id}
+            )
+
+        future_unseen_targets = {
+            future_target
+            for future_target in remaining_targets[target_index + 1 :]
+            if future_target not in tour_state_ids and future_target != target_state_id
+        }
+        bridge_budget = max(
+            0,
+            max_tour_steps
+            - len(tour_state_ids)
+            - 1
+            - len(future_unseen_targets),
+        )
+        if len(additions) > bridge_budget + 1:
+            bounded_transitions.append(
+                {"from_state_id": current_state_id, "to_state_id": target_state_id}
+            )
+            additions = [*additions[:bridge_budget], target_state_id]
+        for addition in additions:
+            if addition == tour_state_ids[-1]:
+                continue
+            tour_state_ids.append(addition)
+            tour_reasons.append(
+                visit_reason.get(addition, "bridge")
+                if addition == target_state_id
+                else "bridge"
+            )
+
+    seen_states: set[str] = set()
+    tour_steps: list[dict[str, Any]] = []
+    path_items: list[str] = []
+    for index, (state_id, reason) in enumerate(zip(tour_state_ids, tour_reasons)):
+        state = state_by_id[state_id]
+        title = _value(state.get("title") or state.get("node")) or "Family Member"
+        is_return = state_id in seen_states
+        seen_states.add(state_id)
+        step_id = f"tour-{index + 1:04d}-{state_id}"
+        tour_steps.append(
+            {
+                "step_id": step_id,
+                "state_id": state_id,
+                "title": title,
+                "generation": _coerce_generation(state.get("generation")),
+                "reason": "return" if is_return else reason,
+                "is_return": is_return,
+                "previous_step_id": (
+                    f"tour-{index:04d}-{tour_state_ids[index - 1]}"
+                    if index > 0
+                    else None
+                ),
+                "next_step_id": None,
+            }
+        )
+        path_items.append(f"Return to {title}" if is_return else title)
+
+    for index in range(len(tour_steps) - 1):
+        tour_steps[index]["next_step_id"] = tour_steps[index + 1]["step_id"]
+
+    option_prefixes = (
+        ("parents", "Parent / ancestor"),
+        ("children", "Child / descendant"),
+        ("partners", "Partner"),
+        ("siblings", "Sibling branch"),
+        ("branches", "Family branch"),
+    )
+    branch_options_by_state: dict[str, list[dict[str, str]]] = {}
+    navigation_by_state: dict[str, dict[str, list[str]]] = {}
+    for state_id in state_ids:
+        state_navigation = {
+            key: sorted_state_ids(list(values))
+            for key, values in navigation[state_id].items()
+        }
+        navigation_by_state[state_id] = state_navigation
+        options: list[dict[str, str]] = []
+        seen_targets: set[str] = set()
+        for key, prefix in option_prefixes:
+            for target_state_id in state_navigation[key]:
+                if target_state_id in seen_targets:
+                    continue
+                seen_targets.add(target_state_id)
+                target_title = _value(
+                    state_by_id[target_state_id].get("title")
+                    or state_by_id[target_state_id].get("node")
+                )
+                options.append(
+                    {
+                        "label": f"{prefix}: {target_title}",
+                        "target_state_id": target_state_id,
+                        "relationship_group": key,
+                    }
+                )
+        branch_options_by_state[state_id] = options
+
+    reachable: set[str] = set()
+    queue = deque([resolved_anchor])
+    while queue:
+        current_state_id = queue.popleft()
+        if current_state_id in reachable:
+            continue
+        reachable.add(current_state_id)
+        queue.extend(adjacency[current_state_id] - reachable)
+
+    missing_state_ids = sorted(set(state_ids) - set(tour_state_ids))
+    disconnected_state_ids = sorted(set(state_ids) - reachable)
+    unplaced_state_ids = sorted(
+        state_id
+        for state_id, state in state_by_id.items()
+        if _value(state.get("placement_status")).lower()
+        in {"unplaced", "conflict", "unresolved"}
+    )
+    validation = {
+        "complete": not missing_state_ids,
+        "eligible_state_count": len(state_ids),
+        "unique_state_count_in_tour": len(set(tour_state_ids)),
+        "tour_step_count": len(tour_steps),
+        "missing_state_ids": missing_state_ids,
+        "disconnected_state_ids": disconnected_state_ids,
+        "disconnected_transitions": disconnected_transitions,
+        "bounded_transitions": bounded_transitions,
+        "unplaced_state_ids": unplaced_state_ids,
+        "placement_ready": not unplaced_state_ids,
+        "tour_bounded": len(tour_steps) <= max_tour_steps,
+        "max_tour_steps": max_tour_steps,
+    }
+
+    return {
+        "compiler_version": LINEAGE_CINEMA_COMPILER_VERSION,
+        "anchor_state_id": resolved_anchor,
+        "ordered_state_ids": ordered_targets,
+        "tour_steps": tour_steps,
+        "auto_advance_state_ids": tour_state_ids,
+        "path_items": path_items,
+        "branch_options_by_state": branch_options_by_state,
+        "navigation_by_state": navigation_by_state,
+        "relationship_edges": relationship_edges,
+        "validation": validation,
+    }
+
+
+__all__ = [
+    "LINEAGE_CINEMA_COMPILER_VERSION",
+    "compile_lineage_cinema",
+]

--- a/backend/app/services/linked_network_service.py
+++ b/backend/app/services/linked_network_service.py
@@ -65,8 +65,13 @@ def _approved_portrait_for_network(
 
     for upload in candidates:
         ready = bool(
-            _str_id(upload.get("scan_status")).lower() == "clean"
+            _str_id(upload.get("category")).lower() == "member_photo"
+            and _str_id(upload.get("family_id")) == family_id
+            and _str_id(upload.get("member_id")) == member_id
+            and _str_id(upload.get("scan_status")).lower() == "clean"
             and not bool(upload.get("quarantined"))
+            and _str_id(upload.get("deletion_status")).lower()
+            not in {"pending", "failed", "deleted"}
             and bool(upload.get("approved_for_cinematic"))
             and _str_id(upload.get("verification_status")).lower() == "approved"
             and _str_id(upload.get("consent_status")).lower() == "approved"
@@ -76,9 +81,16 @@ def _approved_portrait_for_network(
         if not ready:
             continue
         if not is_own_household and not (
-            bool(upload.get("share_with_linked_families"))
-            or _str_id(upload.get("visibility_scope")).lower()
-            in {"linked_family_shared", "public_memorial"}
+            not bool(upload.get("internal_only"))
+            and bool(upload.get("customer_visible", True))
+            and (
+                bool(upload.get("share_with_linked_families"))
+                or _str_id(
+                    upload.get("privacy_scope")
+                    or upload.get("visibility_scope")
+                ).lower()
+                in {"branch_shared", "linked_family_shared", "public_memorial"}
+            )
         ):
             continue
         return upload

--- a/backend/app/services/viewer_manifest_service.py
+++ b/backend/app/services/viewer_manifest_service.py
@@ -15,8 +15,13 @@ from app.core.relationship_catalog import (
 )
 from app.database import get_database
 from app.dependencies.auth import has_internal_admin_access
+from app.services.cinematic_version_service import (
+    publish_private_cinematic_manifest,
+)
 from app.services.entitlement_service import resolve_project_entitlements
 from app.services.family_placement_service import rebuild_family_placement
+from app.services.lineage_cinema_compiler import compile_lineage_cinema
+from app.services.linked_network_service import build_linked_network
 from app.services.project_entitlement_service import get_project_entitlement
 from app.services.project_service import list_projects
 
@@ -750,6 +755,8 @@ def _upload_is_cinematic_ready(
         and _normalize_value(upload.get("relative_path"))
         and _normalize_value(upload.get("scan_status")).lower() == "clean"
         and not bool(upload.get("quarantined"))
+        and _normalize_value(upload.get("deletion_status")).lower()
+        not in {"pending", "failed", "deleted"}
         and bool(upload.get("approved_for_cinematic"))
         and _normalize_value(upload.get("verification_status")).lower() == "approved"
         and _normalize_value(upload.get("consent_status")).lower() == "approved"
@@ -821,8 +828,13 @@ def build_viewer_manifest(
     resolved_entitlements = _resolve_viewer_entitlements(project)
     max_zoom_layers = _coerce_int(resolved_entitlements.get("max_zoom_layers")) or 0
     can_use_narration = bool(resolved_entitlements.get("can_use_narration"))
-    family_id_value = _normalize_value((family_doc or {}).get("_id") or project.get("family_id"))
+    project_id_value = _normalize_value(project.get("_id") or project.get("id"))
+    family_id_value = _normalize_value(
+        (family_doc or {}).get("_id") or project.get("family_id")
+    )
     members: list[dict[str, Any]] = []
+    linked_network: dict[str, Any] | None = None
+    network_alignment: dict[str, Any] | None = None
     if lane == "organization":
         organization_id = _normalize_value(project.get("organization_id")) or _normalize_value(
             project.get("_id") or project.get("id")
@@ -838,6 +850,91 @@ def build_viewer_manifest(
             ),
         )
 
+    if (
+        lane == "network"
+        and project_id_value
+        and bool(resolved_entitlements.get("can_link_households"))
+    ):
+        candidate_network = build_linked_network(
+            project_id_value,
+            _current_user_id(current_user),
+            workspace_context={
+                "project": project,
+                "resolved_entitlements": resolved_entitlements,
+            },
+        )
+        alignment_conflicts = list(candidate_network.get("alignment_conflicts") or [])
+        candidate_nodes = list(candidate_network.get("nodes") or [])
+        network_nodes = [
+            node
+            for node in candidate_nodes
+            if _normalize_value(node.get("source_project_id")) == project_id_value
+            or node.get("aligned_generation") is not None
+        ]
+        excluded_unaligned_member_count = len(candidate_nodes) - len(network_nodes)
+        if alignment_conflicts:
+            network_alignment = {
+                "status": "blocked_conflict",
+                "conflict_count": len(alignment_conflicts),
+                "excluded_unaligned_member_count": len(candidate_nodes),
+            }
+        elif network_nodes:
+            visible_network_member_ids = {
+                _normalize_value(node.get("id"))
+                for node in network_nodes
+                if _normalize_value(node.get("id"))
+            }
+            linked_network = {
+                **candidate_network,
+                "nodes": network_nodes,
+                "edges": [
+                    edge
+                    for edge in candidate_network.get("edges") or []
+                    if _normalize_value(edge.get("source_member_id"))
+                    in visible_network_member_ids
+                    and _normalize_value(edge.get("target_member_id"))
+                    in visible_network_member_ids
+                ],
+            }
+            network_alignment = {
+                "status": (
+                    "partial_unaligned_excluded"
+                    if excluded_unaligned_member_count
+                    else "aligned"
+                ),
+                "conflict_count": 0,
+                "excluded_unaligned_member_count": excluded_unaligned_member_count,
+            }
+            members = [
+                {
+                    "_id": _normalize_value(node.get("id")),
+                    "first_name": node.get("first_name"),
+                    "last_name": node.get("last_name"),
+                    "display_name": node.get("display_name"),
+                    "generation": (
+                        node.get("aligned_generation")
+                        if node.get("aligned_generation") is not None
+                        else node.get("local_generation")
+                    ),
+                    "placement_status": node.get("placement_status") or "unplaced",
+                    "approved_photo_upload_id": node.get(
+                        "approved_photo_upload_id"
+                    ),
+                    "_cinematic_upload_id": node.get("approved_photo_upload_id"),
+                    "_source_household_id": node.get("source_household_id"),
+                    "_source_household_name": node.get("source_household_name"),
+                    "_source_project_id": node.get("source_project_id"),
+                    "_visibility_scope": node.get("visibility_scope"),
+                }
+                for node in network_nodes
+            ]
+        else:
+            network_alignment = {
+                "status": "empty",
+                "conflict_count": 0,
+                "excluded_unaligned_member_count": excluded_unaligned_member_count,
+            }
+
     ordered_members = _sequence_members_for_viewer(
         lane=lane,
         members=members,
@@ -848,11 +945,19 @@ def build_viewer_manifest(
     anchor_generation = _coerce_int((primary_member or {}).get("generation"))
 
     states: list[dict[str, Any]] = []
+    cinema_compilation: dict[str, Any] | None = None
+    family_relationships: list[dict[str, Any]] = []
     if ordered_members:
-        project_id_value = _normalize_value(project.get("_id") or project.get("id"))
         valid_member_views: list[tuple[dict[str, Any], dict[str, Any]]] = []
         for member in ordered_members:
-            if lane == "organization":
+            if linked_network is not None:
+                approved_upload_id = _normalize_value(
+                    member.get("_cinematic_upload_id")
+                )
+                upload_record = (
+                    {"_id": approved_upload_id} if approved_upload_id else None
+                )
+            elif lane == "organization":
                 upload_record = None
                 upload_id = _normalize_value(member.get("photo_upload_id"))
                 if upload_id and ObjectId.is_valid(upload_id):
@@ -883,11 +988,22 @@ def build_viewer_manifest(
             _normalize_value(member.get("_id"))
             for member, _upload in valid_member_views
         }
-        family_relationships = (
-            list(db["relationships"].find({"family_id": family_id_value}))
-            if family_id_value
-            else []
-        )
+        if linked_network is not None:
+            family_relationships = list(linked_network.get("edges") or [])
+        else:
+            family_relationships = (
+                list(
+                    db["relationships"].find(
+                        {
+                            "family_id": {
+                                "$in": _family_id_candidates(family_id_value)
+                            }
+                        }
+                    )
+                )
+                if family_id_value
+                else []
+            )
         relationship_navigation = _relationship_navigation(
             family_relationships,
             visible_member_ids,
@@ -918,7 +1034,18 @@ def build_viewer_manifest(
                 {
                     "id": f"member-{member_id}",
                     "member_id": member_id,
-                    "image": f"/uploads/{upload_id}/download" if upload_id else "",
+                    "image": (
+                        f"/uploads/{upload_id}/download?viewer_project_id={project_id_value}"
+                        if (
+                            upload_id
+                            and linked_network is not None
+                            and _normalize_value(member.get("_source_project_id"))
+                            != project_id_value
+                        )
+                        else f"/uploads/{upload_id}/download"
+                        if upload_id
+                        else ""
+                    ),
                     "title": title,
                     "status": status,
                     "node": title,
@@ -928,6 +1055,22 @@ def build_viewer_manifest(
                     "placement_status": _normalize_value(
                         member.get("placement_status")
                     ) or "unplaced",
+                    "source_household_id": _normalize_value(
+                        member.get("_source_household_id")
+                    )
+                    or None,
+                    "source_household_name": _normalize_value(
+                        member.get("_source_household_name")
+                    )
+                    or None,
+                    "source_project_id": _normalize_value(
+                        member.get("_source_project_id")
+                    )
+                    or project_id_value,
+                    "privacy_scope": _normalize_value(
+                        member.get("_visibility_scope")
+                    )
+                    or "household",
                     "left_state_id": (
                         f"member-{relationship_navigation.get(member_id, {}).get('parents', [])[0]}"
                         if relationship_navigation.get(member_id, {}).get("parents")
@@ -965,6 +1108,78 @@ def build_viewer_manifest(
                     "eye_targets": DEFAULT_EYE_TARGETS,
                 }
             )
+
+        if lane in {"household", "network"} and states:
+            anchor_state_id = (
+                f"member-{primary_member_id}" if primary_member_id else ""
+            )
+            cinema_compilation = compile_lineage_cinema(
+                states=states,
+                relationships=family_relationships,
+                anchor_state_id=anchor_state_id,
+            )
+            states_by_id = {
+                _normalize_value(state.get("id")): state for state in states
+            }
+            ordered_state_ids = [
+                state_id
+                for state_id in cinema_compilation.get("ordered_state_ids") or []
+                if state_id in states_by_id
+            ]
+            if ordered_state_ids:
+                states = [states_by_id[state_id] for state_id in ordered_state_ids]
+
+            navigation_by_state = (
+                cinema_compilation.get("navigation_by_state") or {}
+            )
+            relationship_edges = cinema_compilation.get("relationship_edges") or []
+            for index, state in enumerate(states):
+                state_id = _normalize_value(state.get("id"))
+                navigation = navigation_by_state.get(state_id) or {}
+                parents = list(navigation.get("parents") or [])
+                children = list(navigation.get("children") or [])
+                partners = list(navigation.get("partners") or [])
+                siblings = list(navigation.get("siblings") or [])
+                branches = list(navigation.get("branches") or [])
+                previous_state_id = (
+                    _normalize_value(states[index - 1].get("id"))
+                    if index > 0
+                    else None
+                )
+                next_state_id = (
+                    _normalize_value(states[index + 1].get("id"))
+                    if index + 1 < len(states)
+                    else None
+                )
+                state["left_state_id"] = parents[0] if parents else previous_state_id
+                state["right_state_id"] = (
+                    children[0]
+                    if children
+                    else siblings[0]
+                    if siblings
+                    else next_state_id
+                )
+                state["parent_state_ids"] = parents
+                state["child_state_ids"] = children
+                state["partner_state_ids"] = partners
+                state["sibling_state_ids"] = siblings
+                state["branch_state_ids"] = [
+                    *siblings,
+                    *[branch for branch in branches if branch not in siblings],
+                ]
+                state["relationship_edges"] = [
+                    edge
+                    for edge in relationship_edges
+                    if state_id
+                    in {edge.get("source_state_id"), edge.get("target_state_id")}
+                ]
+
+    if lane in {"household", "network"} and cinema_compilation is None:
+        cinema_compilation = compile_lineage_cinema(
+            states=[],
+            relationships=[],
+            anchor_state_id="",
+        )
 
     if not states:
         states.append(
@@ -1013,9 +1228,13 @@ def build_viewer_manifest(
             path_title = "Portrait Flow"
             nav_labels = {"left": "Origins", "right": "Forward View"}
 
-    path_items = [
-        f"{state['title']} — {state['status']}"
-        for state in states[:6]
+    compiled_path_items = (
+        list(cinema_compilation.get("path_items") or [])
+        if cinema_compilation
+        else []
+    )
+    path_items = compiled_path_items or [
+        f"{state['title']} — {state['status']}" for state in states
     ]
 
     mode = "secure_share" if secure_share_only else "dynamic"
@@ -1027,6 +1246,11 @@ def build_viewer_manifest(
         "allow_zoom": (not secure_share_only) and max_zoom_layers > 0,
         "allow_branch_navigation": not secure_share_only,
         "allow_gaze_navigation": not secure_share_only,
+        "allow_auto_advance": bool(
+            not secure_share_only
+            and cinema_compilation
+            and len(cinema_compilation.get("auto_advance_state_ids") or []) > 1
+        ),
         "allow_narration_auto_advance": (not secure_share_only) and can_use_narration,
         "max_zoom_layers": max(0, max_zoom_layers),
     }
@@ -1035,13 +1259,23 @@ def build_viewer_manifest(
             "allow_command_navigation": True,
             "allow_zoom": max_zoom_layers > 0,
             "allow_role_navigation": True,
+            "allow_auto_advance": False,
             "allow_narration_auto_advance": False,
             "max_zoom_layers": max(0, max_zoom_layers),
         }
 
     manifest = {
         "mode": mode,
-        "navigation_mode": "sequence",
+        "navigation_mode": (
+            "graph"
+            if cinema_compilation
+            and bool(
+                (cinema_compilation.get("validation") or {}).get(
+                    "eligible_state_count"
+                )
+            )
+            else "sequence"
+        ),
         "hero_kicker": package_name,
         "hero_title": hero_title,
         "hero_body": hero_body,
@@ -1058,12 +1292,30 @@ def build_viewer_manifest(
         "controls": controls,
         "states": states,
         "initial_state_id": states[0]["id"] if states else "",
-        "branch_options_by_state": {},
+        "branch_options_by_state": (
+            cinema_compilation.get("branch_options_by_state") or {}
+            if cinema_compilation
+            else {}
+        ),
         "project": _serialize_project_summary(project),
         "family": _serialize_family_summary(family_doc) if family_doc else None,
         "primary_member_id": primary_member_id or None,
         "has_uploaded_portraits": any(_normalize_value(state.get("image")) for state in states),
     }
+    if network_alignment is not None:
+        manifest["network_alignment"] = network_alignment
+    if cinema_compilation:
+        manifest["auto_advance_state_ids"] = list(
+            cinema_compilation.get("auto_advance_state_ids") or []
+        )
+        manifest["tour_steps"] = list(cinema_compilation.get("tour_steps") or [])
+        manifest["relationship_edges"] = list(
+            cinema_compilation.get("relationship_edges") or []
+        )
+        manifest["cinema_compiler"] = {
+            "version": cinema_compilation.get("compiler_version"),
+            "validation": cinema_compilation.get("validation") or {},
+        }
     if lane == "organization":
         manifest["viewer_modes"] = [
             {"id": "current_command_view", "available": True},
@@ -1077,5 +1329,11 @@ def build_viewer_manifest(
         manifest["instructions"] = (
             "Navigate protected organization command portraits. "
             "Historical command snapshots, succession timeline, and officer wall are available."
+        )
+    if cinema_compilation:
+        manifest = publish_private_cinematic_manifest(
+            manifest,
+            project_id=_normalize_value(project.get("_id") or project.get("id")),
+            family_id=family_id_value,
         )
     return manifest

--- a/backend/tests/contracts/test_phase16_universal_lineage_cinema_contract.py
+++ b/backend/tests/contracts/test_phase16_universal_lineage_cinema_contract.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class Phase16UniversalLineageCinemaContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.compiler = (
+            REPO_ROOT
+            / "backend/app/services/lineage_cinema_compiler.py"
+        ).read_text(encoding="utf-8")
+        cls.viewer = (
+            REPO_ROOT
+            / "backend/app/services/viewer_manifest_service.py"
+        ).read_text(encoding="utf-8")
+        cls.versions = (
+            REPO_ROOT
+            / "backend/app/services/cinematic_version_service.py"
+        ).read_text(encoding="utf-8")
+        cls.uploads = (
+            REPO_ROOT / "backend/app/routes/uploads.py"
+        ).read_text(encoding="utf-8")
+        cls.frontend = (
+            REPO_ROOT / "viewer/js/script.js"
+        ).read_text(encoding="utf-8")
+        cls.main = (REPO_ROOT / "backend/app/main.py").read_text(encoding="utf-8")
+
+    def test_01_compiler_separates_content_states_from_repeatable_tour_steps(self):
+        for marker in (
+            "LINEAGE_CINEMA_COMPILER_VERSION",
+            '"step_id": step_id',
+            '"is_return": is_return',
+            '"auto_advance_state_ids": tour_state_ids',
+            '"complete": not missing_state_ids',
+            '"tour_bounded": len(tour_steps) <= max_tour_steps',
+        ):
+            self.assertIn(marker, self.compiler)
+
+    def test_02_viewer_compiles_the_full_approved_graph_without_preview_cap(self):
+        for marker in (
+            "compile_lineage_cinema(",
+            'cinema_compilation.get("path_items")',
+            'cinema_compilation.get("branch_options_by_state")',
+            'manifest["tour_steps"]',
+            '"navigation_mode": (',
+            'cinema_compilation.get("validation")',
+            '"eligible_state_count"',
+            'else "sequence"',
+        ):
+            self.assertIn(marker, self.viewer)
+        self.assertNotIn("states[:6]", self.viewer)
+
+    def test_03_portrait_gate_requires_scan_consent_authority_and_master_approval(self):
+        for marker in (
+            'upload.get("scan_status")',
+            'upload.get("quarantined")',
+            'upload.get("approved_for_cinematic")',
+            'upload.get("verification_status")',
+            'upload.get("consent_status")',
+            'upload.get("consent_attested")',
+            'upload.get("authority_attested")',
+            'upload.get("deletion_status")',
+        ):
+            self.assertIn(marker, self.viewer)
+
+    def test_04_linked_portraits_require_root_access_graph_membership_and_provenance(self):
+        for marker in (
+            "_require_linked_cinematic_upload_access",
+            'capabilities=("can_use_viewer",)',
+            "build_linked_network(",
+            'node.get("approved_photo_upload_id")',
+            "Linked portrait provenance does not match",
+        ):
+            self.assertIn(marker, self.uploads)
+        self.assertIn("viewer_project_id=", self.viewer)
+
+    def test_05_private_versions_are_immutable_before_atomic_pointer_activation(self):
+        insert_position = self.versions.index("versions.insert_one")
+        pointer_position = self.versions.index("active.update_one")
+        self.assertLess(insert_position, pointer_position)
+        for marker in (
+            "canonical_manifest_hash",
+            '"version_key": version_key',
+            '"manifest_snapshot": snapshot',
+            'unique=True',
+        ):
+            self.assertIn(marker, self.versions)
+        self.assertIn("ensure_cinematic_manifest_indexes()", self.main)
+
+    def test_06_customer_slideshow_is_independent_from_paid_narration(self):
+        for marker in (
+            "function isAutoAdvanceEnabled()",
+            'controls, "allow_auto_advance"',
+            'return hasNarration ? "Narration: ON" : "Slideshow: ON"',
+            "function isGraphNavigationMode()",
+        ):
+            self.assertIn(marker, self.frontend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_legacy_snapshot_viewer_upload_boundaries.py
+++ b/backend/tests/test_legacy_snapshot_viewer_upload_boundaries.py
@@ -162,6 +162,11 @@ class LegacySnapshotViewerBoundariesTests(unittest.TestCase):
                 "load_project_workspace_anchor",
                 return_value=(family, primary_member, project),
             ),
+            patch.object(
+                viewer_manifest_service,
+                "publish_private_cinematic_manifest",
+                side_effect=lambda manifest, **_kwargs: manifest,
+            ),
         ):
             manifest = viewer_manifest_service.build_viewer_manifest(
                 current_user={"id": "user-1", "email": "owner@example.com"},
@@ -204,6 +209,11 @@ class LegacySnapshotViewerBoundariesTests(unittest.TestCase):
                 viewer_manifest_service,
                 "load_project_workspace_anchor",
                 return_value=(family, primary_member, project),
+            ),
+            patch.object(
+                viewer_manifest_service,
+                "publish_private_cinematic_manifest",
+                side_effect=lambda manifest, **_kwargs: manifest,
             ),
         ):
             manifest = viewer_manifest_service.build_viewer_manifest(

--- a/backend/tests/test_phase16_cinematic_manifest_version_service.py
+++ b/backend/tests/test_phase16_cinematic_manifest_version_service.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import unittest
+from unittest.mock import patch
+
+from app.services import cinematic_version_service as service
+
+
+class _InsertResult:
+    def __init__(self, inserted_id):
+        self.inserted_id = inserted_id
+
+
+class _Collection:
+    def __init__(self, name: str, log: list[str], *, fail_update: bool = False):
+        self.name = name
+        self.log = log
+        self.fail_update = fail_update
+        self.docs: list[dict] = []
+        self.indexes: list[tuple] = []
+
+    def find_one(self, query):
+        return next(
+            (
+                deepcopy(document)
+                for document in self.docs
+                if all(document.get(key) == value for key, value in query.items())
+            ),
+            None,
+        )
+
+    def insert_one(self, document):
+        self.log.append(f"insert:{self.name}")
+        stored = deepcopy(document)
+        stored["_id"] = f"version-{len(self.docs) + 1}"
+        self.docs.append(stored)
+        return _InsertResult(stored["_id"])
+
+    def update_one(self, query, update, upsert=False):
+        self.log.append(f"update:{self.name}")
+        if self.fail_update:
+            raise RuntimeError("pointer write failed")
+        existing = next(
+            (
+                document
+                for document in self.docs
+                if all(document.get(key) == value for key, value in query.items())
+            ),
+            None,
+        )
+        if existing is None:
+            if not upsert:
+                return None
+            existing = dict(query)
+            self.docs.append(existing)
+            existing.update(deepcopy(update.get("$setOnInsert") or {}))
+        existing.update(deepcopy(update.get("$set") or {}))
+        return None
+
+    def create_index(self, keys, **options):
+        self.indexes.append((list(keys), dict(options)))
+        return options.get("name")
+
+
+class _Database:
+    def __init__(self, *, fail_active_update: bool = False):
+        self.log: list[str] = []
+        self.collections = {
+            "cinematic_manifest_versions": _Collection(
+                "cinematic_manifest_versions", self.log
+            ),
+            "cinematic_manifest_active": _Collection(
+                "cinematic_manifest_active",
+                self.log,
+                fail_update=fail_active_update,
+            ),
+        }
+
+    def __getitem__(self, name):
+        return self.collections[name]
+
+
+def _manifest() -> dict:
+    return {
+        "mode": "dynamic",
+        "states": [
+            {"id": "member-a", "member_id": "a", "title": "A"},
+            {"id": "member-b", "member_id": "b", "title": "B"},
+        ],
+        "auto_advance_state_ids": ["member-a", "member-b", "member-a"],
+        "cinema_compiler": {
+            "version": "tol-lineage-cinema-1.0",
+            "validation": {"complete": True, "tour_bounded": True},
+        },
+    }
+
+
+class Phase16CinematicManifestVersionTests(unittest.TestCase):
+    def test_hash_is_canonical_and_excludes_runtime_version_metadata(self):
+        first = _manifest()
+        second = {
+            "cinema_compiler": deepcopy(first["cinema_compiler"]),
+            "auto_advance_state_ids": list(first["auto_advance_state_ids"]),
+            "states": deepcopy(first["states"]),
+            "mode": "dynamic",
+            "manifest_version": {"version_id": "old"},
+        }
+
+        self.assertEqual(
+            service.canonical_manifest_hash(first),
+            service.canonical_manifest_hash(second),
+        )
+
+    def test_version_is_inserted_before_atomic_active_pointer_swap(self):
+        db = _Database()
+        with patch.object(service, "get_database", return_value=db):
+            published = service.publish_private_cinematic_manifest(
+                _manifest(), project_id="project-1", family_id="family-1"
+            )
+
+        self.assertEqual(
+            db.log,
+            [
+                "insert:cinematic_manifest_versions",
+                "update:cinematic_manifest_active",
+            ],
+        )
+        self.assertTrue(published["manifest_version"]["persisted"])
+        self.assertEqual(
+            db.collections["cinematic_manifest_active"].docs[0]["active_version_id"],
+            "version-1",
+        )
+
+    def test_identical_manifest_reuses_immutable_version(self):
+        db = _Database()
+        with patch.object(service, "get_database", return_value=db):
+            first = service.publish_private_cinematic_manifest(
+                _manifest(), project_id="project-1"
+            )
+            second = service.publish_private_cinematic_manifest(
+                _manifest(), project_id="project-1"
+            )
+
+        self.assertEqual(
+            len(db.collections["cinematic_manifest_versions"].docs), 1
+        )
+        self.assertEqual(
+            first["manifest_version"]["version_id"],
+            second["manifest_version"]["version_id"],
+        )
+
+    def test_pointer_failure_does_not_return_unactivated_manifest(self):
+        db = _Database(fail_active_update=True)
+        with (
+            patch.object(service, "get_database", return_value=db),
+            self.assertRaisesRegex(RuntimeError, "pointer write failed"),
+        ):
+            service.publish_private_cinematic_manifest(
+                _manifest(), project_id="project-1"
+            )
+
+        self.assertEqual(
+            len(db.collections["cinematic_manifest_versions"].docs), 1
+        )
+        self.assertEqual(db.collections["cinematic_manifest_active"].docs, [])
+
+    def test_incomplete_manifest_fails_before_any_database_write(self):
+        db = _Database()
+        manifest = _manifest()
+        manifest["cinema_compiler"]["validation"]["complete"] = False
+        with (
+            patch.object(service, "get_database", return_value=db),
+            self.assertRaisesRegex(RuntimeError, "incomplete"),
+        ):
+            service.publish_private_cinematic_manifest(
+                manifest, project_id="project-1"
+            )
+
+        self.assertEqual(db.log, [])
+
+    def test_empty_workspace_manifest_can_replace_a_previous_active_version(self):
+        db = _Database()
+        manifest = {
+            "mode": "dynamic",
+            "states": [{"id": "workspace-anchor", "image": ""}],
+            "auto_advance_state_ids": [],
+            "cinema_compiler": {
+                "version": "tol-lineage-cinema-1.0",
+                "validation": {"complete": True, "tour_bounded": True},
+            },
+        }
+        with patch.object(service, "get_database", return_value=db):
+            published = service.publish_private_cinematic_manifest(
+                manifest, project_id="project-1"
+            )
+
+        self.assertTrue(published["manifest_version"]["persisted"])
+        self.assertEqual(
+            db.collections["cinematic_manifest_active"].docs[0]["content_hash"],
+            published["manifest_version"]["content_hash"],
+        )
+
+    def test_startup_indexes_enforce_one_version_key_and_active_pointer(self):
+        db = _Database()
+        with patch.object(service, "get_database", return_value=db):
+            service.ensure_cinematic_manifest_indexes()
+
+        versions = db.collections["cinematic_manifest_versions"].indexes
+        active = db.collections["cinematic_manifest_active"].indexes
+        self.assertTrue(
+            any(options.get("unique") for _keys, options in versions)
+        )
+        self.assertTrue(any(options.get("unique") for _keys, options in active))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_phase16_lineage_cinema_compiler.py
+++ b/backend/tests/test_phase16_lineage_cinema_compiler.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import unittest
+
+from app.core.relationship_catalog import (
+    ALLOWED_RELATIONSHIP_TYPES,
+    PARENT_RELATIONSHIP_TYPES,
+    PARTNER_RELATIONSHIP_TYPES,
+    SIBLING_RELATIONSHIP_TYPES,
+)
+from app.services.lineage_cinema_compiler import (
+    LINEAGE_CINEMA_COMPILER_VERSION,
+    compile_lineage_cinema,
+)
+
+
+def _state(member_id: str, title: str, generation: int) -> dict:
+    return {
+        "id": f"member-{member_id}",
+        "member_id": member_id,
+        "title": title,
+        "node": title,
+        "generation": generation,
+    }
+
+
+def _relationship(
+    source: str,
+    target: str,
+    relationship_type: str,
+    *,
+    mode: str = "verified",
+    marker: str = "verified",
+) -> dict:
+    return {
+        "source_member_id": source,
+        "target_member_id": target,
+        "relationship_type": relationship_type,
+        "relationship_mode": mode,
+        "status_marker": marker,
+        "privacy_scope": "household_private",
+    }
+
+
+class Phase16LineageCinemaCompilerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.states = [
+            _state("malik", "Malik Moreland", 1),
+            _state("elias", "Elias Moreland", 0),
+            _state("clara", "Clara Moreland", 0),
+            _state("naomi", "Naomi Moreland", 1),
+            _state("eli", "Eli Moreland", 2),
+            _state("imani", "Imani Benton / Imani Moreland", 2),
+            _state("marcus", "Marcus Benton", 2),
+            _state("micah", "Micah Benton", 3),
+            _state("zara", "Zara Benton", 3),
+            _state("selah", "Selah Carter", 1),
+            _state("andre", "Andre Carter", 1),
+            _state("camille", "Camille Carter", 2),
+            _state("julian", "Julian Moreland", 1),
+        ]
+        self.relationships = [
+            _relationship("elias", "clara", "spouse"),
+            _relationship("elias", "malik", "biological_parent"),
+            _relationship("clara", "malik", "biological_parent"),
+            _relationship("elias", "selah", "biological_parent"),
+            _relationship("clara", "selah", "biological_parent"),
+            _relationship("elias", "julian", "biological_parent"),
+            _relationship("clara", "julian", "biological_parent"),
+            _relationship("malik", "naomi", "spouse"),
+            _relationship("malik", "eli", "biological_parent"),
+            _relationship("malik", "imani", "biological_parent"),
+            _relationship("imani", "marcus", "spouse"),
+            _relationship("imani", "micah", "biological_parent"),
+            _relationship("imani", "zara", "biological_parent"),
+            _relationship("selah", "andre", "spouse"),
+            _relationship("selah", "camille", "biological_parent"),
+        ]
+
+    def _compile(self, states=None, relationships=None):
+        return compile_lineage_cinema(
+            states=list(self.states if states is None else states),
+            relationships=list(
+                self.relationships if relationships is None else relationships
+            ),
+            anchor_state_id="member-malik",
+        )
+
+    def test_complete_moreland_style_tour_visits_every_approved_member(self):
+        compiled = self._compile()
+
+        self.assertEqual(
+            compiled["compiler_version"], LINEAGE_CINEMA_COMPILER_VERSION
+        )
+        self.assertEqual(
+            compiled["auto_advance_state_ids"][0], "member-malik"
+        )
+        self.assertEqual(
+            set(compiled["auto_advance_state_ids"]),
+            {state["id"] for state in self.states},
+        )
+        self.assertTrue(compiled["validation"]["complete"])
+        self.assertEqual(compiled["validation"]["missing_state_ids"], [])
+        self.assertEqual(
+            compiled["validation"]["eligible_state_count"], len(self.states)
+        )
+        self.assertLessEqual(
+            compiled["validation"]["tour_step_count"],
+            compiled["validation"]["max_tour_steps"],
+        )
+
+    def test_repeated_routing_states_use_unique_steps_and_reach_sibling_branches(self):
+        compiled = self._compile()
+        sequence = compiled["auto_advance_state_ids"]
+        step_ids = [step["step_id"] for step in compiled["tour_steps"]]
+
+        self.assertGreater(sequence.count("member-malik"), 1)
+        self.assertGreater(len(sequence), len(set(sequence)))
+        self.assertIn("member-selah", sequence)
+        self.assertIn("member-camille", sequence)
+        self.assertIn("member-julian", sequence)
+        self.assertEqual(len(step_ids), len(set(step_ids)))
+        self.assertTrue(any(item.startswith("Return to ") for item in compiled["path_items"]))
+
+    def test_branch_controls_expose_all_children_partners_and_siblings(self):
+        compiled = self._compile()
+        malik_navigation = compiled["navigation_by_state"]["member-malik"]
+
+        self.assertEqual(
+            set(malik_navigation["parents"]), {"member-elias", "member-clara"}
+        )
+        self.assertEqual(
+            set(malik_navigation["children"]), {"member-eli", "member-imani"}
+        )
+        self.assertEqual(malik_navigation["partners"], ["member-naomi"])
+        self.assertEqual(
+            set(malik_navigation["siblings"]), {"member-selah", "member-julian"}
+        )
+        option_targets = {
+            option["target_state_id"]
+            for option in compiled["branch_options_by_state"]["member-malik"]
+        }
+        self.assertTrue(
+            {
+                "member-elias",
+                "member-clara",
+                "member-naomi",
+                "member-eli",
+                "member-imani",
+                "member-selah",
+                "member-julian",
+            }.issubset(option_targets)
+        )
+
+    def test_visual_styles_preserve_verified_narrative_and_family_type_meaning(self):
+        states = [
+            _state("parent", "Parent", 0),
+            _state("child", "Child", 1),
+            _state("guardian", "Guardian", 0),
+            _state("adoptive", "Adoptive Parent", 0),
+            _state("former", "Former Partner", 0),
+        ]
+        relationships = [
+            _relationship("parent", "child", "biological_parent"),
+            _relationship(
+                "guardian",
+                "child",
+                "guardian",
+                mode="narrative",
+                marker="narrative",
+            ),
+            _relationship("adoptive", "child", "adoptive_parent"),
+            _relationship(
+                "parent",
+                "former",
+                "former_spouse",
+                mode="narrative",
+                marker="narrative",
+            ),
+        ]
+        compiled = compile_lineage_cinema(
+            states=states,
+            relationships=relationships,
+            anchor_state_id="member-child",
+        )
+        styles = {
+            edge["relationship_type"]: edge["visual_style"]
+            for edge in compiled["relationship_edges"]
+        }
+
+        self.assertEqual(styles["biological_parent"], "solid")
+        self.assertEqual(styles["guardian"], "dashed")
+        self.assertEqual(styles["adoptive_parent"], "double")
+        self.assertEqual(styles["former_spouse"], "historical")
+
+    def test_pending_and_disputed_relationships_do_not_enter_published_tour(self):
+        states = [_state("a", "A", 0), _state("b", "B", 1)]
+        relationships = [
+            _relationship(
+                "a", "b", "biological_parent", mode="narrative", marker="pending"
+            )
+        ]
+        compiled = compile_lineage_cinema(
+            states=states,
+            relationships=relationships,
+            anchor_state_id="member-a",
+        )
+
+        self.assertEqual(compiled["relationship_edges"], [])
+        self.assertIn("member-b", compiled["validation"]["disconnected_state_ids"])
+        self.assertEqual(
+            set(compiled["auto_advance_state_ids"]), {"member-a", "member-b"}
+        )
+
+    def test_hidden_parent_still_derives_visible_sibling_navigation(self):
+        states = [_state("child-a", "Child A", 1), _state("child-b", "Child B", 1)]
+        relationships = [
+            _relationship("hidden-parent", "child-a", "biological_parent"),
+            _relationship("hidden-parent", "child-b", "biological_parent"),
+        ]
+        compiled = compile_lineage_cinema(
+            states=states,
+            relationships=relationships,
+            anchor_state_id="member-child-a",
+        )
+
+        self.assertEqual(
+            compiled["navigation_by_state"]["member-child-a"]["siblings"],
+            ["member-child-b"],
+        )
+        self.assertEqual(compiled["validation"]["disconnected_state_ids"], [])
+
+    def test_output_is_deterministic_when_database_order_changes(self):
+        forward = self._compile()
+        reversed_input = self._compile(
+            states=reversed(self.states),
+            relationships=reversed(self.relationships),
+        )
+
+        self.assertEqual(
+            forward["auto_advance_state_ids"],
+            reversed_input["auto_advance_state_ids"],
+        )
+        self.assertEqual(
+            forward["branch_options_by_state"],
+            reversed_input["branch_options_by_state"],
+        )
+        self.assertEqual(
+            forward["relationship_edges"],
+            reversed_input["relationship_edges"],
+        )
+
+    def test_every_supported_family_type_compiles_into_the_correct_navigation_group(self):
+        for relationship_type in ALLOWED_RELATIONSHIP_TYPES:
+            with self.subTest(relationship_type=relationship_type):
+                compiled = compile_lineage_cinema(
+                    states=[
+                        _state("source", "Source", 0),
+                        _state("target", "Target", 1),
+                    ],
+                    relationships=[
+                        _relationship("source", "target", relationship_type)
+                    ],
+                    anchor_state_id="member-target",
+                )
+                self.assertEqual(
+                    compiled["relationship_edges"][0]["relationship_type"],
+                    relationship_type,
+                )
+                source_navigation = compiled["navigation_by_state"]["member-source"]
+                target_navigation = compiled["navigation_by_state"]["member-target"]
+                if relationship_type in PARENT_RELATIONSHIP_TYPES or relationship_type == "grandparent":
+                    self.assertIn("member-target", source_navigation["children"])
+                    self.assertIn("member-source", target_navigation["parents"])
+                elif relationship_type in PARTNER_RELATIONSHIP_TYPES:
+                    self.assertIn("member-target", source_navigation["partners"])
+                    self.assertIn("member-source", target_navigation["partners"])
+                elif relationship_type in SIBLING_RELATIONSHIP_TYPES:
+                    self.assertIn("member-target", source_navigation["siblings"])
+                    self.assertIn("member-source", target_navigation["siblings"])
+                else:
+                    self.assertIn("member-target", source_navigation["branches"])
+                    self.assertIn("member-source", target_navigation["branches"])
+
+    def test_large_family_tour_is_complete_and_bounded(self):
+        states = [_state(f"m{index}", f"Member {index:03d}", index) for index in range(250)]
+        relationships = [
+            _relationship(f"m{index}", f"m{index + 1}", "biological_parent")
+            for index in range(249)
+        ]
+        compiled = compile_lineage_cinema(
+            states=states,
+            relationships=relationships,
+            anchor_state_id="member-m0",
+        )
+
+        self.assertTrue(compiled["validation"]["complete"])
+        self.assertTrue(compiled["validation"]["tour_bounded"])
+        self.assertEqual(
+            compiled["validation"]["unique_state_count_in_tour"], 250
+        )
+
+    def test_maximum_package_depth_does_not_depend_on_python_recursion(self):
+        states = [
+            _state(f"m{index}", f"Member {index:03d}", index)
+            for index in range(999)
+        ]
+        relationships = [
+            _relationship(f"m{index}", f"m{index + 1}", "biological_parent")
+            for index in range(998)
+        ]
+        compiled = compile_lineage_cinema(
+            states=states,
+            relationships=relationships,
+            anchor_state_id="member-m998",
+        )
+
+        self.assertTrue(compiled["validation"]["complete"])
+        self.assertTrue(compiled["validation"]["tour_bounded"])
+        self.assertEqual(
+            compiled["validation"]["unique_state_count_in_tour"], 999
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_phase16_linked_portrait_delivery.py
+++ b/backend/tests/test_phase16_linked_portrait_delivery.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from app.routes import uploads
+from app.services import linked_network_service
+
+
+class _Collection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    def find_one(self, query):
+        return next(
+            (
+                document
+                for document in self.documents
+                if all(document.get(key) == value for key, value in query.items())
+            ),
+            None,
+        )
+
+
+class _Database:
+    def __init__(self, upload):
+        self.uploads = _Collection([upload])
+
+    def __getitem__(self, name):
+        if name == "uploaded_files":
+            return self.uploads
+        return _Collection()
+
+
+class Phase16LinkedPortraitDeliveryTests(unittest.TestCase):
+    def setUp(self):
+        self.upload_id = str(ObjectId())
+        self.member_id = str(ObjectId())
+        self.upload = {
+            "_id": ObjectId(self.upload_id),
+            "category": "member_photo",
+            "member_id": self.member_id,
+            "project_id": "linked-project",
+        }
+        self.context = {
+            "project": {"_id": "root-project"},
+            "resolved_entitlements": {"can_link_households": True},
+        }
+        self.network = {
+            "nodes": [
+                {
+                    "id": self.member_id,
+                    "source_project_id": "linked-project",
+                    "approved_photo_upload_id": self.upload_id,
+                }
+            ]
+        }
+
+    def test_explicitly_shared_linked_portrait_is_deliverable_from_root_viewer(self):
+        with (
+            patch.object(
+                uploads,
+                "require_workspace_capability",
+                return_value=self.context,
+            ),
+            patch.object(uploads, "build_linked_network", return_value=self.network),
+        ):
+            upload, context = uploads._require_linked_cinematic_upload_access(
+                self.upload_id,
+                "root-project",
+                _Database(self.upload),
+                {"id": "root-user"},
+            )
+
+        self.assertEqual(str(upload["_id"]), self.upload_id)
+        self.assertIs(context, self.context)
+
+    def test_unshared_portrait_cannot_be_unlocked_with_a_guessed_project_query(self):
+        with (
+            patch.object(
+                uploads,
+                "require_workspace_capability",
+                return_value=self.context,
+            ),
+            patch.object(uploads, "build_linked_network", return_value={"nodes": []}),
+            self.assertRaises(HTTPException) as raised,
+        ):
+            uploads._require_linked_cinematic_upload_access(
+                self.upload_id,
+                "root-project",
+                _Database(self.upload),
+                {"id": "root-user"},
+            )
+
+        self.assertEqual(raised.exception.status_code, 403)
+
+    def test_cross_household_portrait_requires_customer_visibility_and_explicit_share(self):
+        upload = {
+            **self.upload,
+            "family_id": "linked-family",
+            "scan_status": "clean",
+            "quarantined": False,
+            "approved_for_cinematic": True,
+            "verification_status": "approved",
+            "consent_status": "approved",
+            "consent_attested": True,
+            "authority_attested": True,
+            "customer_visible": True,
+            "internal_only": False,
+            "share_with_linked_families": True,
+            "privacy_scope": "linked_family_shared",
+        }
+        member = {
+            "_id": ObjectId(self.member_id),
+            "approved_photo_upload_id": self.upload_id,
+        }
+        collection = _Collection([upload])
+
+        with patch.object(
+            linked_network_service,
+            "_col",
+            return_value=collection,
+        ):
+            approved = linked_network_service._approved_portrait_for_network(
+                member,
+                family_id="linked-family",
+                is_own_household=False,
+            )
+            upload["internal_only"] = True
+            blocked = linked_network_service._approved_portrait_for_network(
+                member,
+                family_id="linked-family",
+                is_own_household=False,
+            )
+
+        self.assertIsNotNone(approved)
+        self.assertIsNone(blocked)
+
+    def test_provenance_mismatch_fails_closed(self):
+        network = {
+            "nodes": [
+                {
+                    "id": self.member_id,
+                    "source_project_id": "different-linked-project",
+                    "approved_photo_upload_id": self.upload_id,
+                }
+            ]
+        }
+        with (
+            patch.object(
+                uploads,
+                "require_workspace_capability",
+                return_value=self.context,
+            ),
+            patch.object(uploads, "build_linked_network", return_value=network),
+            self.assertRaises(HTTPException) as raised,
+        ):
+            uploads._require_linked_cinematic_upload_access(
+                self.upload_id,
+                "root-project",
+                _Database(self.upload),
+                {"id": "root-user"},
+            )
+
+        self.assertEqual(raised.exception.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_phase16_viewer_manifest_integration.py
+++ b/backend/tests/test_phase16_viewer_manifest_integration.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from app.services import viewer_manifest_service as service
+
+
+class _Cursor(list):
+    def sort(self, key, direction):
+        reverse = direction < 0
+        return _Cursor(
+            sorted(
+                self,
+                key=lambda document: str(document.get(key) or ""),
+                reverse=reverse,
+            )
+        )
+
+
+class _Collection:
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+
+    @staticmethod
+    def _matches(document, query):
+        for key, expected in (query or {}).items():
+            actual = document.get(key)
+            if isinstance(expected, dict) and "$in" in expected:
+                if actual not in expected["$in"]:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    def find(self, query=None):
+        return _Cursor(
+            deepcopy(document)
+            for document in self.documents
+            if self._matches(document, query or {})
+        )
+
+    def find_one(self, query, sort=None):
+        matches = list(self.find(query))
+        if sort:
+            for key, direction in reversed(sort):
+                matches.sort(
+                    key=lambda document: str(document.get(key) or ""),
+                    reverse=direction < 0,
+                )
+        return matches[0] if matches else None
+
+
+class _Database:
+    def __init__(self, collections=None):
+        self.collections = {
+            name: _Collection(documents)
+            for name, documents in (collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, _Collection())
+
+
+def _approved_upload(project_id: str, family_id: str, member_id: str) -> dict:
+    upload_id = ObjectId()
+    return {
+        "_id": upload_id,
+        "category": "member_photo",
+        "project_id": project_id,
+        "family_id": family_id,
+        "member_id": member_id,
+        "relative_path": f"private/{upload_id}.jpg",
+        "scan_status": "clean",
+        "quarantined": False,
+        "approved_for_cinematic": True,
+        "verification_status": "approved",
+        "consent_status": "approved",
+        "consent_attested": True,
+        "authority_attested": True,
+        "created_at": "2026-08-24T00:00:00+00:00",
+    }
+
+
+class Phase16ViewerManifestIntegrationTests(unittest.TestCase):
+    def test_pending_deletion_portrait_is_not_cinematic_ready(self):
+        member_id = str(ObjectId())
+        upload = _approved_upload("project-1", "family-1", member_id)
+        self.assertTrue(
+            service._upload_is_cinematic_ready(
+                upload,
+                project_id="project-1",
+                family_id="family-1",
+                member_id=member_id,
+            )
+        )
+        upload["deletion_status"] = "pending"
+        self.assertFalse(
+            service._upload_is_cinematic_ready(
+                upload,
+                project_id="project-1",
+                family_id="family-1",
+                member_id=member_id,
+            )
+        )
+
+    def test_approved_household_portraits_compile_into_complete_versioned_tour(self):
+        project_id = "project-household"
+        family_id = "family-household"
+        parent_id = str(ObjectId())
+        anchor_id = str(ObjectId())
+        child_id = str(ObjectId())
+        sibling_id = str(ObjectId())
+        member_specs = [
+            (parent_id, "Parent", 0, "placed"),
+            (anchor_id, "Anchor", 1, "placed"),
+            (sibling_id, "Sibling", 1, "placed"),
+            (child_id, "Child", 2, "placed"),
+        ]
+        uploads = [
+            _approved_upload(project_id, family_id, member_id)
+            for member_id, _name, _generation, _status in member_specs
+        ]
+        upload_by_member = {
+            upload["member_id"]: str(upload["_id"]) for upload in uploads
+        }
+        members = [
+            {
+                "_id": ObjectId(member_id),
+                "family_id": family_id,
+                "display_name": name,
+                "generation": generation,
+                "placement_status": placement_status,
+                "approved_photo_upload_id": upload_by_member[member_id],
+            }
+            for member_id, name, generation, placement_status in member_specs
+        ]
+        relationships = [
+            {
+                "family_id": family_id,
+                "source_member_id": parent_id,
+                "target_member_id": anchor_id,
+                "relationship_type": "biological_parent",
+                "relationship_mode": "verified",
+                "status_marker": "verified",
+            },
+            {
+                "family_id": family_id,
+                "source_member_id": parent_id,
+                "target_member_id": sibling_id,
+                "relationship_type": "biological_parent",
+                "relationship_mode": "verified",
+                "status_marker": "verified",
+            },
+            {
+                "family_id": family_id,
+                "source_member_id": anchor_id,
+                "target_member_id": child_id,
+                "relationship_type": "biological_parent",
+                "relationship_mode": "verified",
+                "status_marker": "verified",
+            },
+        ]
+        project = {
+            "_id": project_id,
+            "project_name": "Household",
+            "package_code": "household_foundation",
+            "package_name": "Household Foundation",
+        }
+        family = {"_id": family_id, "family_name": "Family"}
+        primary = next(member for member in members if str(member["_id"]) == anchor_id)
+        db = _Database(
+            {
+                "family_members": members,
+                "uploaded_files": uploads,
+                "relationships": relationships,
+            }
+        )
+
+        def _publish(manifest, **_kwargs):
+            published = deepcopy(manifest)
+            published["manifest_version"] = {"persisted": True}
+            return published
+
+        with (
+            patch.object(service, "get_database", return_value=db),
+            patch.object(service, "resolve_project_for_viewer", return_value=project),
+            patch.object(service, "_find_submission_for_project", return_value=None),
+            patch.object(
+                service,
+                "load_project_workspace_anchor",
+                return_value=(family, primary, project),
+            ),
+            patch.object(
+                service,
+                "_resolve_viewer_entitlements",
+                return_value={"max_zoom_layers": 2, "can_use_narration": False},
+            ),
+            patch.object(
+                service,
+                "publish_private_cinematic_manifest",
+                side_effect=_publish,
+            ) as publish_mock,
+        ):
+            manifest = service.build_viewer_manifest(
+                current_user={"id": "user-1", "email": "owner@example.com"},
+                project_id=project_id,
+            )
+
+        state_ids = {state["id"] for state in manifest["states"]}
+        self.assertEqual(len(state_ids), 4)
+        self.assertEqual(set(manifest["auto_advance_state_ids"]), state_ids)
+        self.assertTrue(manifest["cinema_compiler"]["validation"]["complete"])
+        self.assertEqual(manifest["navigation_mode"], "graph")
+        self.assertTrue(manifest["controls"]["allow_auto_advance"])
+        self.assertFalse(manifest["controls"]["allow_narration_auto_advance"])
+        self.assertIn(f"member-{sibling_id}", {
+            option["target_state_id"]
+            for option in manifest["branch_options_by_state"][f"member-{anchor_id}"]
+        })
+        self.assertTrue(manifest["manifest_version"]["persisted"])
+        publish_mock.assert_called_once()
+
+    def test_network_manifest_uses_only_privacy_filtered_linked_nodes_and_edges(self):
+        project_id = "project-network"
+        family_id = "family-root"
+        anchor_id = str(ObjectId())
+        linked_id = str(ObjectId())
+        unaligned_id = str(ObjectId())
+        anchor_upload_id = str(ObjectId())
+        linked_upload_id = str(ObjectId())
+        unaligned_upload_id = str(ObjectId())
+        project = {
+            "_id": project_id,
+            "project_name": "Estate Network",
+            "package_code": "family_estate_concierge",
+            "package_name": "Family Estate Concierge",
+        }
+        family = {"_id": family_id, "family_name": "Root Family"}
+        primary = {
+            "_id": ObjectId(anchor_id),
+            "display_name": "Root Anchor",
+            "generation": 1,
+        }
+        network = {
+            "nodes": [
+                {
+                    "id": anchor_id,
+                    "display_name": "Root Anchor",
+                    "aligned_generation": 1,
+                    "placement_status": "placed",
+                    "approved_photo_upload_id": anchor_upload_id,
+                    "source_household_id": "household-root",
+                    "source_household_name": "Root Household",
+                    "source_project_id": project_id,
+                    "visibility_scope": "household",
+                },
+                {
+                    "id": linked_id,
+                    "display_name": "Shared Relative",
+                    "aligned_generation": 2,
+                    "placement_status": "placed",
+                    "approved_photo_upload_id": linked_upload_id,
+                    "source_household_id": "household-linked",
+                    "source_household_name": "Linked Household",
+                    "source_project_id": "project-linked",
+                    "visibility_scope": "linked",
+                },
+                {
+                    "id": unaligned_id,
+                    "display_name": "Unaligned Relative",
+                    "aligned_generation": None,
+                    "local_generation": 4,
+                    "placement_status": "unplaced",
+                    "approved_photo_upload_id": unaligned_upload_id,
+                    "source_household_id": "household-unaligned",
+                    "source_household_name": "Unaligned Household",
+                    "source_project_id": "project-unaligned",
+                    "visibility_scope": "linked",
+                },
+            ],
+            "edges": [
+                {
+                    "id": "household-bridge::1",
+                    "source_member_id": anchor_id,
+                    "target_member_id": linked_id,
+                    "relationship_type": "biological_parent",
+                    "relationship_mode": "verified",
+                    "status_marker": "verified",
+                    "privacy_scope": "linked_family_shared",
+                    "is_household_bridge": True,
+                }
+            ],
+        }
+        db = _Database({"family_members": []})
+
+        with (
+            patch.object(service, "get_database", return_value=db),
+            patch.object(service, "resolve_project_for_viewer", return_value=project),
+            patch.object(service, "_find_submission_for_project", return_value=None),
+            patch.object(
+                service,
+                "load_project_workspace_anchor",
+                return_value=(family, primary, project),
+            ),
+            patch.object(
+                service,
+                "_resolve_viewer_entitlements",
+                return_value={
+                    "max_zoom_layers": 999,
+                    "can_use_narration": True,
+                    "can_link_households": True,
+                },
+            ),
+            patch.object(service, "build_linked_network", return_value=network) as network_mock,
+            patch.object(
+                service,
+                "publish_private_cinematic_manifest",
+                side_effect=lambda manifest, **_kwargs: manifest,
+            ),
+        ):
+            manifest = service.build_viewer_manifest(
+                current_user={"id": "user-1", "email": "owner@example.com"},
+                project_id=project_id,
+            )
+
+        self.assertEqual(len(manifest["states"]), 2)
+        linked_state = next(
+            state for state in manifest["states"] if state["member_id"] == linked_id
+        )
+        self.assertEqual(linked_state["source_household_name"], "Linked Household")
+        self.assertEqual(linked_state["privacy_scope"], "linked")
+        self.assertIn(
+            "viewer_project_id=project-network", linked_state["image"]
+        )
+        self.assertEqual(
+            manifest["relationship_edges"][0]["privacy_scope"],
+            "linked_family_shared",
+        )
+        self.assertEqual(
+            set(manifest["auto_advance_state_ids"]),
+            {f"member-{anchor_id}", f"member-{linked_id}"},
+        )
+        self.assertEqual(
+            manifest["network_alignment"]["status"],
+            "partial_unaligned_excluded",
+        )
+        self.assertEqual(
+            manifest["network_alignment"]["excluded_unaligned_member_count"], 1
+        )
+        network_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_phase3_organization_viewer_anchor.py
+++ b/backend/tests/test_phase3_organization_viewer_anchor.py
@@ -216,6 +216,11 @@ def test_household_manifest_keeps_family_viewer_controls():
             "load_project_workspace_anchor",
             return_value=(family, primary_member, project),
         ),
+        patch.object(
+            viewer_manifest_service,
+            "publish_private_cinematic_manifest",
+            side_effect=lambda manifest, **_kwargs: manifest,
+        ),
     ):
         manifest = viewer_manifest_service.build_viewer_manifest(
             current_user={"id": "user-1", "email": "owner@example.com"},

--- a/backend/tests/test_startup_initialization.py
+++ b/backend/tests/test_startup_initialization.py
@@ -24,6 +24,7 @@ class StartupInitializationTests(unittest.TestCase):
             patch.object(main_module, "ensure_finance_event_indexes") as finance_init_mock,
             patch.object(main_module, "ensure_continuity_runtime_indexes") as continuity_init_mock,
             patch.object(main_module, "ensure_organization_indexes") as organization_init_mock,
+            patch.object(main_module, "ensure_cinematic_manifest_indexes") as cinematic_init_mock,
             patch.object(main_module, "bootstrap_admin_access_controls") as admin_access_bootstrap_mock,
             patch.object(main_module, "close_mongo_connection") as close_mock,
         ):
@@ -41,6 +42,7 @@ class StartupInitializationTests(unittest.TestCase):
         finance_init_mock.assert_called_once()
         continuity_init_mock.assert_called_once()
         organization_init_mock.assert_called_once()
+        cinematic_init_mock.assert_called_once()
         admin_access_bootstrap_mock.assert_called_once()
         close_mock.assert_called_once()
 
@@ -62,6 +64,7 @@ class StartupInitializationTests(unittest.TestCase):
             patch.object(main_module, "ensure_finance_event_indexes") as finance_init_mock,
             patch.object(main_module, "ensure_continuity_runtime_indexes") as continuity_init_mock,
             patch.object(main_module, "ensure_organization_indexes") as organization_init_mock,
+            patch.object(main_module, "ensure_cinematic_manifest_indexes") as cinematic_init_mock,
             patch.object(main_module, "bootstrap_admin_access_controls") as admin_access_bootstrap_mock,
             patch.object(main_module, "close_mongo_connection") as close_mock,
         ):
@@ -79,6 +82,7 @@ class StartupInitializationTests(unittest.TestCase):
         finance_init_mock.assert_not_called()
         continuity_init_mock.assert_not_called()
         organization_init_mock.assert_not_called()
+        cinematic_init_mock.assert_not_called()
         admin_access_bootstrap_mock.assert_not_called()
         close_mock.assert_called_once()
 

--- a/browser-tests/moreland-viewer-flow.spec.mjs
+++ b/browser-tests/moreland-viewer-flow.spec.mjs
@@ -58,11 +58,15 @@ test("customer family manifests autoplay every approved portrait without requiri
     };
     window.__runFamilyAutoAdvance = () => {
       // app.js also owns a five-second housekeeping timer. The viewer boots
-      // after app.js, so its slideshow timer is the most recently registered
-      // five-second interval.
-      const entry = callbacks
-        .filter((candidate) => candidate.delay === 5000)
-        .at(-1);
+      // after app.js; select the callback that owns lineage progression and
+      // retain registration order only as a compatibility fallback.
+      const fiveSecondEntries = callbacks.filter(
+        (candidate) => candidate.delay === 5000,
+      );
+      const entry =
+        fiveSecondEntries.find((candidate) =>
+          String(candidate.callback).includes("getNextAutoAdvanceStateId"),
+        ) || fiveSecondEntries.at(-1);
       if (!entry) throw new Error("Customer family autoplay interval was not registered.");
       entry.callback(...entry.args);
     };
@@ -142,6 +146,9 @@ test("customer family manifests autoplay every approved portrait without requiri
     await expect(page.locator("#viewerTitle")).toHaveText(expectedTitles[index]);
     await expect(page.locator(`[data-path-index="${index}"]`)).toHaveClass(/is-current/);
     await expect(page.locator("#narrationDisplay")).toHaveCSS("opacity", "0");
+    // Real autoplay waits five seconds; leave the initial 140 ms image-state
+    // transition lock before manually invoking the captured timer.
+    await page.waitForTimeout(200);
     if (index < expectedTitles.length - 1) {
       await page.evaluate(() => window.__runFamilyAutoAdvance());
       await page.waitForTimeout(200);

--- a/browser-tests/moreland-viewer-flow.spec.mjs
+++ b/browser-tests/moreland-viewer-flow.spec.mjs
@@ -57,7 +57,12 @@ test("customer family manifests autoplay every approved portrait without requiri
       return intervalId;
     };
     window.__runFamilyAutoAdvance = () => {
-      const entry = callbacks.find((candidate) => candidate.delay === 5000);
+      // app.js also owns a five-second housekeeping timer. The viewer boots
+      // after app.js, so its slideshow timer is the most recently registered
+      // five-second interval.
+      const entry = callbacks
+        .filter((candidate) => candidate.delay === 5000)
+        .at(-1);
       if (!entry) throw new Error("Customer family autoplay interval was not registered.");
       entry.callback(...entry.args);
     };

--- a/browser-tests/moreland-viewer-flow.spec.mjs
+++ b/browser-tests/moreland-viewer-flow.spec.mjs
@@ -44,3 +44,161 @@ test("Moreland autoplay traverses the complete family tree without looping at Ma
     }
   }
 });
+
+
+test("customer family manifests autoplay every approved portrait without requiring narration", async ({ page }) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("tol_access_token", "phase16-test-token");
+    let intervalId = 0;
+    const callbacks = [];
+    window.setInterval = (callback, delay, ...args) => {
+      intervalId += 1;
+      callbacks.push({ callback, delay, args, intervalId });
+      return intervalId;
+    };
+    window.__runFamilyAutoAdvance = () => {
+      const entry = callbacks.find((candidate) => candidate.delay === 5000);
+      if (!entry) throw new Error("Customer family autoplay interval was not registered.");
+      entry.callback(...entry.args);
+    };
+  });
+
+  const pixel =
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+  await page.route("**/viewer/manifest?*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        mode: "dynamic",
+        navigation_mode: "graph",
+        hero_title: "Private Family Viewer",
+        path_items: ["Anchor", "Parent", "Return to Anchor", "Child"],
+        auto_advance_state_ids: [
+          "member-anchor",
+          "member-parent",
+          "member-anchor",
+          "member-child",
+        ],
+        initial_state_id: "member-anchor",
+        controls: {
+          allow_lineage_navigation: true,
+          allow_zoom: true,
+          allow_reset: true,
+          allow_auto_advance: true,
+          allow_narration_auto_advance: false,
+          allow_gaze_navigation: true,
+          allow_branch_navigation: true,
+          max_zoom_layers: 2,
+        },
+        branch_options_by_state: {
+          "member-anchor": [
+            {
+              label: "Child / descendant: Child",
+              target_state_id: "member-child",
+            },
+          ],
+        },
+        states: [
+          {
+            id: "member-anchor",
+            image: pixel,
+            title: "Anchor",
+            node: "Anchor",
+            description: "Anchor description",
+            narration: "Paid narration is disabled.",
+            left_state_id: "member-parent",
+            right_state_id: "member-child",
+          },
+          {
+            id: "member-parent",
+            image: pixel,
+            title: "Parent",
+            node: "Parent",
+            left_state_id: "",
+            right_state_id: "member-anchor",
+          },
+          {
+            id: "member-child",
+            image: pixel,
+            title: "Child",
+            node: "Child",
+            left_state_id: "member-anchor",
+            right_state_id: "",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/viewer/?project_id=phase16-family");
+
+  const expectedTitles = ["Anchor", "Parent", "Anchor", "Child"];
+  for (let index = 0; index < expectedTitles.length; index += 1) {
+    await expect(page.locator("#viewerTitle")).toHaveText(expectedTitles[index]);
+    await expect(page.locator(`[data-path-index="${index}"]`)).toHaveClass(/is-current/);
+    await expect(page.locator("#narrationDisplay")).toHaveCSS("opacity", "0");
+    if (index < expectedTitles.length - 1) {
+      await page.evaluate(() => window.__runFamilyAutoAdvance());
+      await page.waitForTimeout(200);
+    }
+  }
+
+  await expect(page.locator("#narrationToggleBtn")).toHaveText("Slideshow: ON");
+});
+
+
+test("dynamic graph zoom controls navigate lineage and pause customer autoplay", async ({ page }) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("tol_access_token", "phase16-test-token");
+  });
+  const pixel =
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+  await page.route("**/viewer/manifest?*", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        mode: "dynamic",
+        navigation_mode: "graph",
+        path_items: ["Anchor", "Child"],
+        auto_advance_state_ids: ["member-anchor", "member-child"],
+        initial_state_id: "member-anchor",
+        controls: {
+          allow_lineage_navigation: true,
+          allow_zoom: true,
+          allow_reset: true,
+          allow_auto_advance: true,
+          allow_narration_auto_advance: false,
+          allow_gaze_navigation: true,
+          allow_branch_navigation: true,
+          max_zoom_layers: 2,
+        },
+        states: [
+          {
+            id: "member-anchor",
+            image: pixel,
+            title: "Anchor",
+            node: "Anchor",
+            right_state_id: "member-child",
+          },
+          {
+            id: "member-child",
+            image: pixel,
+            title: "Child",
+            node: "Child",
+            left_state_id: "member-anchor",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/viewer/?project_id=phase16-graph");
+  await expect(page.locator("#viewerTitle")).toHaveText("Anchor");
+  await page.locator("#zoomInBtn").click();
+  await expect(page.locator("#viewerTitle")).toHaveText("Child");
+  await expect(page.locator("#narrationToggleBtn")).toHaveText(
+    "Resume Slideshow",
+  );
+  await page.locator("#zoomOutBtn").click();
+  await expect(page.locator("#viewerTitle")).toHaveText("Anchor");
+});

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -305,6 +305,6 @@
     <script src="../config.js?v=20260509-visualfix"></script>
     <script src="../app.js?v=20260509-visualfix"></script>
     <script src="js/genesis-prototype-manifest.js?v=20260509-visualfix"></script>
-    <script src="js/script.js?v=20260824-full-tree-flow"></script>
+    <script src="js/script.js?v=20260824-universal-lineage-cinema"></script>
   </body>
 </html>

--- a/viewer/js/script.js
+++ b/viewer/js/script.js
@@ -72,7 +72,7 @@
     path_items: ["Private project content is not loaded on public routes."],
     nav_labels: { left: "Origins", right: "Future Line" },
     initial_state_id: "unavailable",
-    controls: { allow_lineage_navigation: false, allow_zoom: false, allow_reset: true, allow_narration_auto_advance: false, allow_gaze_navigation: false, allow_branch_navigation: false },
+    controls: { allow_lineage_navigation: false, allow_zoom: false, allow_reset: true, allow_auto_advance: false, allow_narration_auto_advance: false, allow_gaze_navigation: false, allow_branch_navigation: false },
     states: [{ id: "unavailable", image: "", title: "Private viewer locked", status: "Private Viewer", node: "Private viewer", description: "This family viewer is protected. Open it from your Tomb of Light workspace after your project has been approved and provisioned.", narration: "", left_state_id: "", right_state_id: "", eye_targets: DEFAULT_DYNAMIC_EYE_TARGETS }],
   };
 
@@ -316,8 +316,33 @@
     return String(manifest?.mode || "").trim() === "secure_share";
   }
 
-  function isGraphDemoMode() {
-    return currentManifest?.mode === "demo" && currentManifest?.navigationMode === "graph";
+  function isGraphNavigationMode() {
+    return currentManifest?.navigationMode === "graph";
+  }
+
+  function isAutoAdvanceEnabled() {
+    const controls = currentManifest?.controls || {};
+    if (Object.prototype.hasOwnProperty.call(controls, "allow_auto_advance")) {
+      return Boolean(controls.allow_auto_advance);
+    }
+    return isControlEnabled("allow_narration_auto_advance", true);
+  }
+
+  function playbackControlLabel() {
+    const hasNarration = isControlEnabled(
+      "allow_narration_auto_advance",
+      true,
+    );
+    if (isPlaying) {
+      return hasNarration ? "Narration: ON" : "Slideshow: ON";
+    }
+    return hasNarration ? "Resume Narration" : "Resume Slideshow";
+  }
+
+  function syncPlaybackControlLabel() {
+    if (narrationToggleBtn) {
+      narrationToggleBtn.textContent = playbackControlLabel();
+    }
   }
 
   function getAutoAdvanceStateIds() {
@@ -427,15 +452,19 @@
     const canNarration =
       !isSecureShareMode(manifest) &&
       isControlEnabled("allow_narration_auto_advance", true);
+    const canAutoAdvance =
+      !isSecureShareMode(manifest) && isAutoAdvanceEnabled();
 
     if (navLeftBtn) navLeftBtn.style.display = canLineageNavigate ? "" : "none";
     if (navRightBtn) navRightBtn.style.display = canLineageNavigate ? "" : "none";
     if (zoomOutBtn) zoomOutBtn.style.display = canZoom ? "" : "none";
     if (zoomInBtn) zoomInBtn.style.display = canZoom ? "" : "none";
     if (resetViewerBtn) resetViewerBtn.style.display = canReset ? "" : "none";
-    if (narrationToggleBtn) narrationToggleBtn.style.display = canNarration ? "" : "none";
+    if (narrationToggleBtn) {
+      narrationToggleBtn.style.display = canAutoAdvance ? "" : "none";
+    }
     const hasVisibleControls = Boolean(
-      canLineageNavigate || canZoom || canReset || canNarration,
+      canLineageNavigate || canZoom || canReset || canAutoAdvance,
     );
     if (controlsContainer) {
       controlsContainer.classList.toggle("is-hidden", !hasVisibleControls);
@@ -443,9 +472,12 @@
     if (viewerLine) {
       viewerLine.classList.toggle("is-hidden", !hasVisibleControls);
     }
-    if (!canNarration) {
+    syncPlaybackControlLabel();
+    if (!canAutoAdvance) {
       isPlaying = false;
       stopNarrationAutoAdvance();
+    }
+    if (!canNarration) {
       showNarration("");
     }
     if (!isControlEnabled("allow_gaze_navigation", true)) {
@@ -586,7 +618,7 @@
 
   function startNarrationAutoAdvance() {
     if (EMBED_MODE) return;
-    if (!isControlEnabled("allow_narration_auto_advance", true)) return;
+    if (!isPlaying || !isAutoAdvanceEnabled()) return;
     if (narrationInterval) clearInterval(narrationInterval);
 
     narrationInterval = setInterval(function () {
@@ -613,13 +645,9 @@
 
   function toggleNarration() {
     if (EMBED_MODE) return;
-    if (!isControlEnabled("allow_narration_auto_advance", true)) return;
+    if (!isAutoAdvanceEnabled()) return;
     isPlaying = !isPlaying;
-    if (narrationToggleBtn) {
-      narrationToggleBtn.textContent = isPlaying
-        ? "Narration: ON"
-        : "Resume Narration";
-    }
+    syncPlaybackControlLabel();
     if (isPlaying) {
       showNarration(statesById[state]?.narration || "");
       startNarrationAutoAdvance();
@@ -630,11 +658,9 @@
 
   function pauseNarrationForManualControl() {
     if (EMBED_MODE || !isPlaying) return;
-    if (!isControlEnabled("allow_narration_auto_advance", true)) return;
+    if (!isAutoAdvanceEnabled()) return;
     isPlaying = false;
-    if (narrationToggleBtn) {
-      narrationToggleBtn.textContent = "Resume Narration";
-    }
+    syncPlaybackControlLabel();
     stopNarrationAutoAdvance();
   }
 
@@ -985,7 +1011,7 @@
     if (!isControlEnabled("allow_zoom", true)) return;
     markInteraction();
     pauseNarrationForManualControl();
-    if (isGraphDemoMode()) {
+    if (isGraphNavigationMode()) {
       const next = resolveRightTarget();
       if (next) {
         animatePortalTransition("right", next);
@@ -1002,7 +1028,7 @@
     if (!isControlEnabled("allow_zoom", true)) return;
     markInteraction();
     pauseNarrationForManualControl();
-    if (isGraphDemoMode()) {
+    if (isGraphNavigationMode()) {
       const next = resolveLeftTarget();
       if (next) {
         animatePortalTransition("left", next);
@@ -1014,7 +1040,7 @@
 
   function resetViewer() {
     if (EMBED_MODE) return;
-    if (!isControlEnabled("allow_zoom", true)) return;
+    if (!isControlEnabled("allow_reset", true)) return;
     setZoom(1, false);
     applyState(currentManifest?.initialStateId || stateOrder[0] || "");
     if (isPlaying) startNarrationAutoAdvance();
@@ -1029,7 +1055,7 @@
   function syncControlStates() {
     const leftTarget = resolveLeftTarget();
     const rightTarget = resolveRightTarget();
-    if (isGraphDemoMode()) {
+    if (isGraphNavigationMode()) {
       setButtonDisabled(zoomOutBtn, !leftTarget);
       setButtonDisabled(zoomInBtn, !rightTarget);
     } else {


### PR DESCRIPTION
## Phase 16 — Universal Lineage Cinema

Turns the Moreland prototype behavior into a private, data-driven family viewer for every eligible household and linked family network.

### What this delivers
- deterministically compiles every approved family portrait into a complete, bounded cinematic tour
- supports the full canonical relationship catalog: parents, children, step/adoptive/foster/guardian/chosen relationships, spouses/former partners, siblings, cousins, elders, in-laws, and linked-household bridges
- preserves generation placement and blocks conflicting linked-family alignment
- requires clean scan, consent, authority, master approval, and non-deletion status before a portrait enters the viewer
- delivers linked portraits only through the requesting user's current privacy-filtered network and exact member/project provenance
- removes the six-item preview cap and adds full path, branch choices, repeated-step-safe autoplay, and graph navigation
- separates family slideshow playback from the paid narration entitlement
- stores immutable private manifest versions before atomically activating their pointer
- keeps private family data separate from NFT/public metadata

### Verification added
- complete Moreland-style multi-branch traversal
- every canonical relationship type
- deterministic compilation and unique repeated tour steps
- hidden-parent sibling derivation
- pending/disputed exclusion
- 250-member and 999-generation stress coverage
- household/network manifest integration
- linked portrait privacy/provenance failure tests
- immutable version/pointer failure tests
- Chromium autoplay and graph-control journeys

### Final verification
- full backend regression: **1,907 passed, 2 skipped; 134 subtests passed**
- browser execution: **24 passed**
- architecture and contract guardrails: passed
- dependency security audit: **no known vulnerabilities**
- Python compilation, JavaScript syntax, diff integrity, and secret scan: passed
- all four GitHub Actions jobs: passed

Remote head `a0a1329` has the exact same Git tree as locally reviewed head `912eb1c` (`8063347c15e7d20590bb490ff5e09e93bcc6fd8d`).

No production accounts, customer records, uploads, billing data, blockchain state, or live configuration were changed.