### PR TITLE
Phase 17 — Fail-Closed NFT Signer Ownership Preflight

### DIFF
--- a/backend/app/services/blockchain_mint_service.py
+++ b/backend/app/services/blockchain_mint_service.py
@@ -12,6 +12,10 @@ TRANSFER_EVENT_SIGNATURE = (
 )
 EVM_WALLET_PATTERN = re.compile(r"^0x[a-fA-F0-9]{40}$")
 HEX_PRIVATE_KEY_PATTERN = re.compile(r"^(0x)?[a-fA-F0-9]{64}$")
+SUPPORTED_NFT_CHAIN_IDS = {
+    "base-mainnet": 8453,
+    "base-sepolia": 84532,
+}
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +73,25 @@ def _web3_client() -> Any:
     if not client.is_connected():
         raise RuntimeError("Unable to connect to the configured NFT RPC endpoint.")
     return client
+
+
+def _expected_chain_id() -> int:
+    configured_chain = _normalize(settings.nft_chain).lower()
+    expected_chain_id = SUPPORTED_NFT_CHAIN_IDS.get(configured_chain)
+    if expected_chain_id is None:
+        supported = ", ".join(sorted(SUPPORTED_NFT_CHAIN_IDS))
+        raise RuntimeError(
+            f"NFT_CHAIN '{configured_chain or 'missing'}' is unsupported. "
+            f"Supported values: {supported}."
+        )
+    return expected_chain_id
+
+
+def _connected_chain_id(client: Any) -> int:
+    try:
+        return int(client.eth.chain_id)
+    except Exception as exc:
+        raise RuntimeError("Unable to resolve the configured NFT RPC chain ID.") from exc
 
 
 def _contract_abi() -> list[dict[str, Any]]:
@@ -239,14 +262,65 @@ def _contract_owner(contract: Any) -> str | None:
         raise RuntimeError("Unable to resolve the NFT contract owner.") from exc
 
 
-def _assert_contract_owner(contract: Any, signer_address: str) -> None:
+def _assert_contract_owner(contract: Any, signer_address: str) -> str:
     owner_address = _contract_owner(contract)
     if owner_address is None:
-        return
+        raise RuntimeError(
+            "NFT contract does not expose owner(); signer ownership cannot be verified."
+        )
     if owner_address.lower() != signer_address.lower():
         raise RuntimeError(
             "Configured NFT minter wallet is not the owner of the NFT contract."
         )
+    return owner_address
+
+
+def validate_mint_signer_contract_owner() -> dict[str, Any]:
+    """Verify the configured signer against the live contract without signing.
+
+    This startup preflight performs read-only RPC calls only. It never builds,
+    signs, stores, or broadcasts a transaction.
+    """
+
+    _require_mint_runtime()
+    client = _web3_client()
+    expected_chain_id = _expected_chain_id()
+    connected_chain_id = _connected_chain_id(client)
+    if connected_chain_id != expected_chain_id:
+        raise RuntimeError(
+            "Configured NFT RPC is connected to the wrong chain: "
+            f"expected {expected_chain_id}, received {connected_chain_id}."
+        )
+
+    contract_address = _checksum_address(
+        settings.nft_contract_address,
+        field_name="NFT contract address",
+    )
+    contract = client.eth.contract(
+        address=contract_address,
+        abi=_contract_abi(),
+    )
+    signer = _account()
+    owner_address = _assert_contract_owner(contract, signer.address)
+
+    result = {
+        "chain": _normalize(settings.nft_chain).lower(),
+        "chain_id": connected_chain_id,
+        "contract_address": contract_address,
+        "contract_owner": owner_address,
+        "signer_address": signer.address,
+        "verified": True,
+    }
+    logger.info(
+        "NFT mint signer ownership preflight passed: "
+        "signer=%s owner=%s contract=%s chain_id=%s",
+        signer.address,
+        owner_address,
+        contract_address,
+        connected_chain_id,
+        extra=result,
+    )
+    return result
 
 
 def _gas_fields(client: Any) -> dict[str, int]:

--- a/backend/app/services/nft_runtime_validation_service.py
+++ b/backend/app/services/nft_runtime_validation_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from app.config import settings
+from app.services.blockchain_mint_service import validate_mint_signer_contract_owner
 from app.services.r2_storage_service import r2_is_configured
 
 EVM_WALLET_PATTERN = re.compile(r"^0x[a-fA-F0-9]{40}$")
@@ -143,3 +144,4 @@ def validate_nft_runtime_configuration_on_startup() -> None:
     _validate_private_key()
     _validate_contract_abi()
     _validate_r2_configuration()
+    validate_mint_signer_contract_owner()

--- a/backend/tests/test_nft_signer_owner_preflight.py
+++ b/backend/tests/test_nft_signer_owner_preflight.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.services import blockchain_mint_service, nft_runtime_validation_service
+
+
+CONTRACT_ADDRESS = "0x39967cEb7580aB9110b349Ca3a7fe0179b950Ba5"
+OWNER_ADDRESS = "0x8d378Fd7f03fF30787827E2bB0C9486776531db9"
+OTHER_ADDRESS = "0x65ec400000000000000000000000000000049204"
+
+
+class _OwnerCall:
+    def __init__(self, owner_address: str):
+        self.owner_address = owner_address
+
+    def __call__(self):
+        return self
+
+    def call(self):
+        return self.owner_address
+
+
+class _Contract:
+    def __init__(self, owner_address: str | None):
+        self.functions = SimpleNamespace()
+        if owner_address is not None:
+            self.functions.owner = _OwnerCall(owner_address)
+
+
+class _ForbiddenSigningAccount:
+    def sign_transaction(self, *_args, **_kwargs):
+        raise AssertionError("startup preflight must never sign a transaction")
+
+
+class _Eth:
+    def __init__(self, *, chain_id: int, owner_address: str | None):
+        self.chain_id = chain_id
+        self.account = _ForbiddenSigningAccount()
+        self._owner_address = owner_address
+        self.contract_calls: list[dict] = []
+
+    def contract(self, **kwargs):
+        self.contract_calls.append(kwargs)
+        return _Contract(self._owner_address)
+
+    def send_raw_transaction(self, *_args, **_kwargs):
+        raise AssertionError("startup preflight must never broadcast a transaction")
+
+
+class _Client:
+    def __init__(self, *, chain_id: int = 8453, owner_address: str | None = OWNER_ADDRESS):
+        self.eth = _Eth(chain_id=chain_id, owner_address=owner_address)
+
+
+class NftSignerOwnerPreflightTests(unittest.TestCase):
+    def _runtime_settings(self):
+        return patch.multiple(
+            blockchain_mint_service.settings,
+            nft_mint_enabled=True,
+            nft_chain="base-mainnet",
+            nft_rpc_url="https://mainnet.base.org",
+            nft_contract_address=CONTRACT_ADDRESS,
+            nft_contract_abi_json='[{"type":"function","name":"owner"}]',
+            nft_minter_private_key="1" * 64,
+        )
+
+    def _preflight_patches(self, client: _Client, *, signer_address: str = OWNER_ADDRESS):
+        return (
+            patch.object(blockchain_mint_service, "_web3_client", return_value=client),
+            patch.object(
+                blockchain_mint_service,
+                "_checksum_address",
+                side_effect=lambda address, **_kwargs: address,
+            ),
+            patch.object(
+                blockchain_mint_service,
+                "_account",
+                return_value=SimpleNamespace(address=signer_address),
+            ),
+        )
+
+    def test_matching_signer_and_owner_pass_without_signing_or_broadcasting(self):
+        client = _Client()
+        web3_patch, checksum_patch, account_patch = self._preflight_patches(client)
+        with self._runtime_settings(), web3_patch, checksum_patch, account_patch:
+            result = blockchain_mint_service.validate_mint_signer_contract_owner()
+
+        self.assertTrue(result["verified"])
+        self.assertEqual(result["chain_id"], 8453)
+        self.assertEqual(result["signer_address"], OWNER_ADDRESS)
+        self.assertEqual(result["contract_owner"], OWNER_ADDRESS)
+        self.assertEqual(len(client.eth.contract_calls), 1)
+
+    def test_mismatched_signer_fails_closed_before_any_transaction_action(self):
+        client = _Client()
+        web3_patch, checksum_patch, account_patch = self._preflight_patches(
+            client,
+            signer_address=OTHER_ADDRESS,
+        )
+        with self._runtime_settings(), web3_patch, checksum_patch, account_patch:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "not the owner of the NFT contract",
+            ):
+                blockchain_mint_service.validate_mint_signer_contract_owner()
+
+    def test_wrong_rpc_chain_fails_closed_before_contract_access(self):
+        client = _Client(chain_id=1)
+        web3_patch, checksum_patch, account_patch = self._preflight_patches(client)
+        with self._runtime_settings(), web3_patch, checksum_patch, account_patch:
+            with self.assertRaisesRegex(RuntimeError, "wrong chain"):
+                blockchain_mint_service.validate_mint_signer_contract_owner()
+
+        self.assertEqual(client.eth.contract_calls, [])
+
+    def test_contract_without_owner_function_fails_closed(self):
+        client = _Client(owner_address=None)
+        web3_patch, checksum_patch, account_patch = self._preflight_patches(client)
+        with self._runtime_settings(), web3_patch, checksum_patch, account_patch:
+            with self.assertRaisesRegex(RuntimeError, "does not expose owner"):
+                blockchain_mint_service.validate_mint_signer_contract_owner()
+
+    def test_unavailable_rpc_fails_closed(self):
+        with (
+            self._runtime_settings(),
+            patch.object(
+                blockchain_mint_service,
+                "_web3_client",
+                side_effect=RuntimeError("Unable to connect to the configured NFT RPC endpoint."),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Unable to connect"):
+                blockchain_mint_service.validate_mint_signer_contract_owner()
+
+    def test_startup_validation_invokes_live_owner_preflight(self):
+        with (
+            patch.multiple(
+                nft_runtime_validation_service.settings,
+                nft_mint_enabled=True,
+                nft_mint_worker_enabled=True,
+                nft_auto_mint_on_review_enabled=False,
+                nft_chain="base-mainnet",
+                nft_rpc_url="https://mainnet.base.org",
+                nft_contract_address=CONTRACT_ADDRESS,
+                nft_contract_abi_json='[{"type":"function","name":"owner"}]',
+                nft_minter_private_key="1" * 64,
+                hash_salt="2" * 64,
+                metadata_base_url="https://metadata.tomboflight.com/v1",
+                poster_base_url="https://posters.tomboflight.com/v1",
+                public_token_external_base_url="https://tomboflight.com/public",
+            ),
+            patch.object(nft_runtime_validation_service, "_validate_http_url"),
+            patch.object(nft_runtime_validation_service, "_validate_contract_address"),
+            patch.object(nft_runtime_validation_service, "_validate_private_key"),
+            patch.object(nft_runtime_validation_service, "_validate_contract_abi"),
+            patch.object(nft_runtime_validation_service, "_validate_r2_configuration"),
+            patch.object(
+                nft_runtime_validation_service,
+                "validate_mint_signer_contract_owner",
+                return_value={"verified": True},
+            ) as preflight,
+        ):
+            nft_runtime_validation_service.validate_nft_runtime_configuration_on_startup()
+
+        preflight.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 17 closes the NFT runtime readiness gap by requiring a live, read-only signer ownership preflight during application startup.

- Derives the public signer address from `NFT_MINTER_PRIVATE_KEY`.
- Confirms the configured RPC chain matches `NFT_CHAIN` (Base Mainnet `8453` or Base Sepolia `84532`).
- Loads the configured NFT contract and requires a callable `owner()`.
- Compares the derived signer address with the live contract owner.
- Fails application startup on RPC failure, wrong chain, missing `owner()`, or signer-owner mismatch.
- Makes the existing mint-time ownership check fail closed when ownership cannot be verified.
- Logs only public verification evidence: signer, owner, contract, and chain ID. The private key is never logged.

## Transaction safety

The startup preflight performs read-only RPC calls only. It never builds, signs, stores, or broadcasts a transaction. New tests make signing or broadcasting an immediate failure.

No NFT was minted and no production customer data was changed.

## Verification

- `1,913 passed, 2 skipped; 134 subtests passed`
- Six targeted signer-owner preflight tests passed.
- Python compilation passed.
- Git diff validation passed.
- A live read-only Base Mainnet mismatch exercise correctly rejected a non-owner signer before any transaction action.

## Deployment acceptance

After merge and redeploy, Render must log the successful signer ownership preflight and must refuse startup unless the configured signer is the owner of contract `0x39967cEb7580aB9110b349Ca3a7fe0179b950Ba5` on Base Mainnet.