### PR TITLE
Phase 19.1 — Production truth and review safety corrections

### DIFF
--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -557,6 +557,6 @@
     <script src="config.js?v=20260329-1"></script>
     <script src="app.js?v=20260821-phase10-1"></script>
     <script src="auth.js?v=20260727-masterops1"></script>
-    <script src="admin-control-center.js?v=20260824-phase19"></script>
+    <script src="admin-control-center.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/admin-control-center.js
+++ b/admin-control-center.js
@@ -1930,20 +1930,24 @@
     if (backendTab === "orders_billing") {
       const primaryOrder = tabData && tabData.primary_order ? tabData.primary_order : {};
       const related = Array.isArray(tabData && tabData.related_orders) ? tabData.related_orders : [];
+      const paymentRequired = tabData.payment_required !== false;
       node.innerHTML = `
         ${warningMarkup}
         <article class="admin-dossier-card admin-dossier-card--wide">
-          <div class="admin-card-header"><span class="admin-card-badge">O</span><h3 class="admin-card-title">Primary Order</h3></div>
+          <div class="admin-card-header"><span class="admin-card-badge">O</span><h3 class="admin-card-title">${paymentRequired ? "Primary Order" : "Package Acquisition"}</h3></div>
           ${renderFieldGrid([
             { label: "Package", value: tabData.package_name || primaryOrder.package_name },
             { label: "Package Code", value: tabData.package_code || primaryOrder.package_code, mono: true },
             { label: "Lane", value: tabData.lane || primaryOrder.lane, chip: true },
-            { label: "Order Status", value: tabData.order_status || primaryOrder.status, chip: true },
-            { label: "Paid", value: tabData.paid, chip: true },
-            { label: "Stripe Session", value: tabData.stripe_session_id || primaryOrder.stripe_session_id, mono: true },
-            { label: "Payment Link", value: tabData.payment_link_id || primaryOrder.payment_link_id, mono: true },
+            { label: "Acquisition Source", value: tabData.acquisition_source, chip: true },
+            { label: "Payment Required", value: paymentRequired, chip: true },
+            { label: "Acquisition Satisfied", value: tabData.acquisition_satisfied, chip: true },
+            { label: "Order Status", value: paymentRequired ? (tabData.order_status || primaryOrder.status) : "not_applicable", chip: true },
+            { label: "Paid", value: paymentRequired ? tabData.paid : "not_applicable", chip: true },
+            { label: "Stripe Session", value: paymentRequired ? (tabData.stripe_session_id || primaryOrder.stripe_session_id) : "not_applicable", mono: true },
+            { label: "Payment Link", value: paymentRequired ? (tabData.payment_link_id || primaryOrder.payment_link_id) : "not_applicable", mono: true },
             { label: "Project Link", value: tabData.project_link_status, chip: true },
-            { label: "Subscription", value: tabData.subscription || primaryOrder.subscription_id, mono: true },
+            { label: "Subscription", value: paymentRequired ? (tabData.subscription || primaryOrder.subscription_id) : "not_applicable", mono: true },
             { label: "Maintenance", value: tabData.maintenance_state, chip: true },
             { label: "Next Charge", value: formatDate(tabData.next_charge_date) },
           ])}
@@ -2161,6 +2165,8 @@
             { label: "Package Code", value: tabData.package_code, mono: true },
             { label: "Lane", value: tabData.project_lane || tabData.lane, chip: true },
             { label: "Normalization", value: tabData.package_normalization_status, chip: true },
+            { label: "Acquisition Source", value: tabData.acquisition_source || "paid_order", chip: true },
+            { label: "Payment Required", value: tabData.payment_required !== false, chip: true },
             { label: "Source", value: tabData.source || "—" },
             { label: "Raw Value", value: tabData.raw_value || "—" },
           ])}

--- a/admin-portrait-review.html
+++ b/admin-portrait-review.html
@@ -47,6 +47,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260821-phase9"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="admin-portrait-review.js?v=20260824-phase18"></script>
+    <script src="admin-portrait-review.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/admin-portrait-review.js
+++ b/admin-portrait-review.js
@@ -18,10 +18,10 @@
   }
 
   const BLOCKER_LABELS = {
-    security_scan_not_clean: "security scan has not returned clean",
+    security_scan_not_clean: "Run the security scan and obtain a clean verdict before previewing this file.",
     customer_consent_attestation_missing: "customer consent attestation is missing",
     upload_authority_attestation_missing: "upload-authority attestation is missing",
-    durable_private_storage_missing: "durable private storage is incomplete",
+    durable_private_storage_missing: "Private storage migration must complete before preview.",
     orphaned_project_reference: "the project record was removed and must be reconciled",
     orphaned_family_reference: "the family record was removed and must be reconciled",
     orphaned_member_reference: "the family-member record was removed and must be reconciled",
@@ -124,6 +124,14 @@
         !item.quarantined &&
         item.durable_private_storage
       );
+      const previewBlockers = Array.isArray(item.preview_blockers)
+        ? item.preview_blockers
+        : approvalBlockers(item).filter(function (code) {
+            return ["security_scan_not_clean", "durable_private_storage_missing"].includes(code);
+          });
+      const previewAvailable = item.preview_available === true || (
+        item.preview_available == null && previewBlockers.length === 0
+      );
       const customerRecoveryUrl = item.family_id
         ? `portrait-upload.html?family_id=${encodeURIComponent(item.family_id)}`
         : "portrait-upload.html";
@@ -146,9 +154,19 @@
               ? `<div class="notice" data-review-blockers><strong>Approval blocked:</strong> ${escapeHtml(blockerText(blockers))}.</div>`
               : '<div class="notice"><strong>Ready:</strong> clean scan and required attestations are recorded.</div>'
           }
+          ${
+            item.possible_duplicate
+              ? `<div class="notice"><strong>Possible duplicate:</strong> ${escapeHtml(item.possible_duplicate_count)} distinct upload records share the same customer, file, and review identity. Review each record before reconciliation.</div>`
+              : ""
+          }
+          ${
+            previewAvailable
+              ? ""
+              : `<div class="notice" data-preview-blockers><strong>Preview blocked:</strong> ${escapeHtml(item.preview_blocker_message || blockerText(previewBlockers))}</div>`
+          }
           <div data-review-preview style="margin: 0.75rem 0"></div>
           <div class="inline-actions">
-            <button class="btn btn-secondary" type="button" data-preview-id="${escapeHtml(item.id)}">Preview</button>
+            <button class="btn btn-secondary" type="button" data-preview-id="${escapeHtml(item.id)}" ${previewAvailable ? "" : "disabled"}>${previewAvailable ? "Preview" : "Preview Blocked"}</button>
             ${
               scanReady || orphaned
                 ? ""

--- a/admin-verification-review.html
+++ b/admin-verification-review.html
@@ -45,6 +45,6 @@
     <script src="config.js?v=20260328-7"></script>
     <script src="app.js?v=20260821-phase9"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="admin-verification-review.js?v=20260824-phase18"></script>
+    <script src="admin-verification-review.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/admin-verification-review.js
+++ b/admin-verification-review.js
@@ -17,6 +17,18 @@
     if (node) node.textContent = message;
   }
 
+  const PREVIEW_BLOCKER_LABELS = {
+    security_scan_not_clean: "Run the security scan and obtain a clean verdict before previewing this file.",
+    durable_private_storage_missing: "Private storage migration must complete before preview.",
+  };
+
+  function previewBlockerText(item, blockers) {
+    if (item.preview_blocker_message) return item.preview_blocker_message;
+    return blockers.map(function (code) {
+      return PREVIEW_BLOCKER_LABELS[code] || String(code).replaceAll("_", " ");
+    }).join(" ");
+  }
+
   function reviewIdempotencyKey(action, uploadId) {
     const suffix = window.crypto && typeof window.crypto.randomUUID === "function"
       ? window.crypto.randomUUID()
@@ -88,6 +100,17 @@
         item.durable_private_storage
       );
       const approvalReady = canApprove(item);
+      const previewBlockers = Array.isArray(item.preview_blockers)
+        ? item.preview_blockers
+        : [
+            ...(String(item.scan_status || "").toLowerCase() === "clean" && !item.quarantined
+              ? []
+              : ["security_scan_not_clean"]),
+            ...(item.durable_private_storage ? [] : ["durable_private_storage_missing"]),
+          ];
+      const previewAvailable = item.preview_available === true || (
+        item.preview_available == null && previewBlockers.length === 0
+      );
       return `
         <article class="family-record-card" data-evidence-card="${escapeHtml(item.id)}">
           <span class="eyebrow">${escapeHtml(item.scan_status || "pending scan")}</span>
@@ -106,8 +129,18 @@
               ? '<div class="notice"><strong>Ready:</strong> clean scan and durable private storage are required for approval.</div>'
               : `<div class="notice" data-evidence-blockers><strong>Approval blocked:</strong> ${escapeHtml(orphaned ? "orphaned project or family reference requires reconciliation" : (!item.durable_private_storage ? "durable private storage is incomplete" : "security scan has not returned clean"))}.</div>`
           }
+          ${
+            item.possible_duplicate
+              ? `<div class="notice"><strong>Possible duplicate:</strong> ${escapeHtml(item.possible_duplicate_count)} distinct upload records share the same customer, file, and review identity. Review each record before reconciliation.</div>`
+              : ""
+          }
+          ${
+            previewAvailable
+              ? ""
+              : `<div class="notice" data-evidence-preview-blockers><strong>Preview blocked:</strong> ${escapeHtml(previewBlockerText(item, previewBlockers))}</div>`
+          }
           <div class="inline-actions">
-            <button class="btn btn-secondary" type="button" data-evidence-preview="${escapeHtml(item.id)}">Open Secure Preview</button>
+            <button class="btn btn-secondary" type="button" data-evidence-preview="${escapeHtml(item.id)}" ${previewAvailable ? "" : "disabled"}>${previewAvailable ? "Open Secure Preview" : "Preview Blocked"}</button>
             ${
               securityReady || orphaned
                 ? ""

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -619,6 +619,12 @@ def _serialize_admin_upload_review(
     if member_id:
         member = _find_reference_record(db, "family_members", member_id)
 
+    preview_blockers = _admin_preview_blockers(record)
+    preview_messages = {
+        "security_scan_not_clean": "Run the security scan and obtain a clean verdict before previewing this file.",
+        "durable_private_storage_missing": "Private storage migration must complete before preview.",
+    }
+
     return {
         **serialized,
         "project_id": project_id or None,
@@ -632,6 +638,15 @@ def _serialize_admin_upload_review(
         "orphaned_family_reference": bool(family_id and family is None),
         "orphaned_member_reference": bool(member_id and member is None),
         "durable_private_storage": _upload_has_durable_private_storage(record),
+        "preview_available": not preview_blockers,
+        "preview_blockers": preview_blockers,
+        "preview_blocker_message": " ".join(
+            preview_messages[code]
+            for code in preview_blockers
+            if code in preview_messages
+        ) or None,
+        "possible_duplicate": int(record.get("_possible_duplicate_count") or 0) > 1,
+        "possible_duplicate_count": int(record.get("_possible_duplicate_count") or 0),
         "master_review_notes": _normalize_value(
             record.get("master_review_notes")
         ),
@@ -659,6 +674,36 @@ def _admin_review_record_identity(record: dict[str, Any]) -> str:
     return f"{category}:record:{record_id}"
 
 
+def _admin_review_semantic_identity(record: dict[str, Any]) -> str:
+    """Group duplicate-looking records without suppressing distinct uploads."""
+
+    filename = _normalize_value(record.get("original_filename")).lower()
+    if not filename:
+        return ""
+    scope = _normalize_value(
+        record.get("member_id")
+        or record.get("family_id")
+        or record.get("project_id")
+        or record.get("uploaded_by_user_id")
+        or record.get("uploaded_by")
+    ).lower()
+    if not scope:
+        return ""
+    return ":".join(
+        [
+            _normalize_value(record.get("category")).lower() or "upload",
+            scope,
+            _normalize_value(
+                record.get("verification_type") or record.get("evidence_kind")
+            ).lower(),
+            filename,
+            _normalize_value(
+                record.get("file_size") or record.get("size_bytes") or record.get("size")
+            ),
+        ]
+    )
+
+
 def _deduplicate_admin_review_records(
     records: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], int]:
@@ -670,6 +715,14 @@ def _deduplicate_admin_review_records(
             continue
         seen.add(identity)
         deduplicated.append(record)
+    semantic_counts: dict[str, int] = {}
+    for record in deduplicated:
+        semantic_identity = _admin_review_semantic_identity(record)
+        if semantic_identity:
+            semantic_counts[semantic_identity] = semantic_counts.get(semantic_identity, 0) + 1
+    for record in deduplicated:
+        semantic_identity = _admin_review_semantic_identity(record)
+        record["_possible_duplicate_count"] = semantic_counts.get(semantic_identity, 0)
     return deduplicated, len(records) - len(deduplicated)
 
 
@@ -1004,14 +1057,11 @@ def _scan_and_quarantine_upload(*, db: Any, upload_record: dict[str, Any]) -> di
 def _upload_scan_blocks_download(upload_record: dict[str, Any]) -> bool:
     scan_status = _normalize_value(upload_record.get("scan_status")).lower()
     deletion_status = _normalize_value(upload_record.get("deletion_status")).lower()
-    return deletion_status in {"pending", "failed"} or bool(
-        upload_record.get("quarantined")
-    ) or scan_status in {
-        "infected",
-        "error",
-        "skipped",
-        "pending",
-    }
+    return (
+        deletion_status in {"pending", "failed"}
+        or bool(upload_record.get("quarantined"))
+        or scan_status != "clean"
+    )
 
 
 def _upload_has_durable_private_storage(upload_record: dict[str, Any]) -> bool:
@@ -1021,6 +1071,15 @@ def _upload_has_durable_private_storage(upload_record: dict[str, Any]) -> bool:
         _normalize_value(upload_record.get("storage_provider")).lower() == "r2"
         and _normalize_value(upload_record.get("storage_key"))
     )
+
+
+def _admin_preview_blockers(upload_record: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if _upload_scan_blocks_download(upload_record):
+        blockers.append("security_scan_not_clean")
+    if not _upload_has_durable_private_storage(upload_record):
+        blockers.append("durable_private_storage_missing")
+    return blockers
 
 
 def _upload_read_limit(upload_record: dict[str, Any]) -> int:

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Callable
 
 from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
 
 from app.config import settings
 from app.core.admin_permission_registry import (
@@ -653,7 +654,7 @@ def admin_control_bulk_action_allowed(
 # Bumped alongside the static frontend cache-busting query string
 # (see admin-control-center.html / dashboard.html `?v=` suffix) whenever a
 # hotfix ships to the admin control center or dashboard assets.
-FRONTEND_ASSET_REVISION = "20260823-phase13-1"
+FRONTEND_ASSET_REVISION = "20260824-phase19-1"
 
 
 def _backend_release_identifier() -> str:
@@ -1406,6 +1407,34 @@ def _project_lane_value(project: dict[str, Any]) -> str:
     return ""
 
 
+def _project_payment_required(project: dict[str, Any] | None) -> bool:
+    """Return False only when the project explicitly records a non-payment grant.
+
+    Legacy projects predate the field, so an absent or unrecognized value stays
+    fail-closed on the paid-order path. This prevents a missing flag from being
+    interpreted as CEO authorization to bypass Stripe-backed package truth.
+    """
+
+    if not isinstance(project, dict):
+        return True
+    value = project.get("payment_required")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = _normalize(value).lower()
+    if normalized in {"false", "no", "0"}:
+        return False
+    return True
+
+
+def _project_acquisition_source(project: dict[str, Any] | None) -> str:
+    if _project_payment_required(project):
+        return "paid_order"
+    source = _normalize((project or {}).get("package_assignment_source")).lower()
+    return source or "governed_non_payment_grant"
+
+
 def _package_fields_from_context(
     project: dict[str, Any],
     order: dict[str, Any] | None,
@@ -1494,6 +1523,8 @@ def _package_fields_from_context(
         "raw_value": (chosen.get("raw_values") or [None])[0],
         "normalization_status": normalization_status,
         "is_known": bool(chosen.get("is_known")),
+        "payment_required": _project_payment_required(project),
+        "acquisition_source": _project_acquisition_source(project),
         "warnings": list(dict.fromkeys(warnings)),
         "sources": sources,
     }
@@ -1557,6 +1588,8 @@ def _serialize_project(project: dict[str, Any]) -> dict[str, Any]:
         "status": _normalize(project.get("status")) or None,
         "phase": _normalize(project.get("phase")) or None,
         "source": _normalize(project.get("source") or project.get("provisioning_source")) or None,
+        "package_assignment_source": _normalize(project.get("package_assignment_source")) or None,
+        "payment_required": _project_payment_required(project),
         "intake_status": _normalize(project.get("intake_status") or project.get("intake_readiness")) or None,
         "family_id": _normalize(project.get("family_id")) or None,
         "household_id": _normalize(project.get("household_id")) or None,
@@ -2671,9 +2704,17 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
     order_ref = order or {}
     order_package_code = normalize_package_code(_normalize(order_ref.get("package_code") or order_ref.get("package_slug")))
     entitlement_package_code = normalize_package_code(_normalize((entitlement or {}).get("package_code")))
-    package_synced = bool(project_package_code and order_package_code and project_package_code == order_package_code == package_fields["package_code"])
+    payment_required = _project_payment_required(project)
+    canonical_package_code = _normalize(package_fields.get("package_code"))
+    package_synced = bool(
+        project_package_code
+        and canonical_package_code
+        and project_package_code == canonical_package_code
+        and (not payment_required or order_package_code == canonical_package_code)
+        and (not order or order_package_code == canonical_package_code)
+    )
     if entitlement:
-        package_synced = package_synced and entitlement_package_code == package_fields["package_code"]
+        package_synced = package_synced and entitlement_package_code == canonical_package_code
 
     lane_value = _normalize(project.get("project_lane")).lower()
     entitlement_lane = _normalize((entitlement or {}).get("package_lane")).lower()
@@ -2681,6 +2722,12 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
 
     linked_project_id = _normalize_object_id((order or {}).get("project_id"))
     order_linked = bool(order and linked_project_id and linked_project_id == _normalize_object_id(project_id_str))
+    acquisition_satisfied = bool(
+        (order_linked and _is_paid_package_order(order))
+        if payment_required
+        else True
+    )
+    acquisition_source = _project_acquisition_source(project)
     entitlement_exists = entitlement is not None
 
     upload_count = count_workspace_uploads(project_id=project_id_str)
@@ -2706,7 +2753,7 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
         and phase_ready
         and package_synced
         and lane_assigned
-        and order_linked
+        and acquisition_satisfied
         and entitlement_exists
     )
     mint_eligible = bool(mint_eligibility.get("eligible") and mint_review_ready and uploads_present)
@@ -2720,7 +2767,7 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
         blocking_reasons.append("package_not_synced")
     if not mint_already_completed and not lane_assigned:
         blocking_reasons.append("lane_not_assigned")
-    if not mint_already_completed and not order_linked:
+    if not mint_already_completed and not acquisition_satisfied:
         blocking_reasons.append("order_not_linked")
     if not mint_already_completed and not entitlement_exists:
         blocking_reasons.append("missing_entitlement")
@@ -2745,6 +2792,9 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
         "package_synced": package_synced,
         "lane_assigned": lane_assigned,
         "order_linked": order_linked,
+        "payment_required": payment_required,
+        "acquisition_source": acquisition_source,
+        "acquisition_satisfied": acquisition_satisfied,
         "entitlement_exists": entitlement_exists,
         "uploads_present": uploads_present,
         "build_ready": status_ready,
@@ -2757,6 +2807,9 @@ def run_readiness_check(*, project_id: str, order_id: str = "") -> dict[str, Any
             "package_synced": "yes" if package_synced else "no",
             "lane_assigned": "yes" if lane_assigned else "no",
             "order_linked": "yes" if order_linked else "no",
+            "payment_required": "yes" if payment_required else "no",
+            "acquisition_source": acquisition_source,
+            "acquisition_satisfied": "yes" if acquisition_satisfied else "no",
             "entitlement_exists": "yes" if entitlement_exists else "no",
             "mint_eligible": "yes" if mint_eligible else "no",
             "canonical_mint_status": canonical_mint.get("current_status") or "none",
@@ -2955,6 +3008,11 @@ def project_workspace_snapshot(
         "package_synced": bool(filtered_readiness.get("package_synced")),
         "lane_assigned": bool(filtered_readiness.get("lane_assigned")),
         "order_linked": bool(filtered_readiness.get("order_linked")),
+        "payment_required": bool(filtered_readiness.get("payment_required", True)),
+        "acquisition_source": _normalize(filtered_readiness.get("acquisition_source")) or "paid_order",
+        "acquisition_satisfied": bool(
+            filtered_readiness.get("acquisition_satisfied", filtered_readiness.get("order_linked"))
+        ),
         "entitlement_exists": bool(filtered_readiness.get("entitlement_exists")),
         "summary": _normalize(filtered_readiness.get("summary")) or "Finance scope snapshot",
     }
@@ -3562,7 +3620,11 @@ def admin_console_overview(*, limit: int = 20) -> dict[str, Any]:
                 executive_escalations += 1
         if readiness.get("mint_review_ready"):
             mint_ready_count += 1
-        if not readiness.get("package_synced") or not readiness.get("lane_assigned") or not readiness.get("order_linked") or not readiness.get("entitlement_exists"):
+        acquisition_satisfied = readiness.get(
+            "acquisition_satisfied",
+            readiness.get("order_linked"),
+        )
+        if not readiness.get("package_synced") or not readiness.get("lane_assigned") or not acquisition_satisfied or not readiness.get("entitlement_exists"):
             mismatches.append(
                 {
                     "project_id": project_id,
@@ -4368,7 +4430,11 @@ def _case_alerts(
         alerts.append("mint_blocked")
 
     maintenance_status = _normalize((entitlement or {}).get("maintenance_status")).lower()
-    if entitlement and maintenance_status in {"", "not_started"}:
+    if (
+        entitlement
+        and _project_payment_required(project)
+        and maintenance_status in {"", "not_started"}
+    ):
         alerts.append("maintenance_not_started")
 
     if duplicate_identity:
@@ -5394,7 +5460,15 @@ def super_admin_apply_user_state_action(
 
 
 def super_admin_preview_customer_create(*, payload: dict[str, Any]) -> dict[str, Any]:
-    email = _validate_super_admin_email(_normalize(payload.get("email")), user_id="")
+    requested_email = _normalize_email(payload.get("email"))
+    if requested_email and "@" in requested_email:
+        existing_user = _db()["users"].find_one({"email": requested_email}, {"_id": 1})
+        if existing_user is not None:
+            raise ValueError(
+                "A customer account already exists for this email. Open the existing "
+                "customer case and use Provision First Customer Project + Package."
+            )
+    email = _validate_super_admin_email(requested_email, user_id="")
     full_name = _normalize(payload.get("full_name"))
     if not full_name:
         raise ValueError("full_name is required.")
@@ -5473,7 +5547,13 @@ def super_admin_create_customer(
         "source": "ceo_master_admin",
     }
     db = _db()
-    db["users"].insert_one(document)
+    try:
+        db["users"].insert_one(document)
+    except DuplicateKeyError as exc:
+        raise ValueError(
+            "A customer account already exists for this email. Open the existing "
+            "customer case and use Provision First Customer Project + Package."
+        ) from exc
     user_id = str(document["_id"])
 
     project_id: str | None = None
@@ -8846,6 +8926,9 @@ def _build_user_workspace_payload(user: dict[str, Any]) -> dict[str, Any]:
                 "warnings": [],
                 "package_normalization_status": "not_applicable",
                 "package_normalized": True,
+                "payment_required": bool(primary_project.get("payment_required", True)),
+                "acquisition_source": primary_project.get("package_assignment_source")
+                or ("paid_order" if primary_order else "unassigned"),
             },
             "orders_billing": {
                 "package_slug": package_code,
@@ -8854,8 +8937,26 @@ def _build_user_workspace_payload(user: dict[str, Any]) -> dict[str, Any]:
                 "lane": package_lane,
                 "order_status": primary_order.get("status"),
                 "paid": bool(primary_order and primary_order.get("status") in PAID_ORDER_STATUSES),
-                "project_link_status": "linked" if primary_order.get("project_id") else "not_linked",
-                "maintenance_state": primary_entitlement.get("maintenance_status"),
+                "payment_required": bool(primary_project.get("payment_required", True)),
+                "acquisition_source": primary_project.get("package_assignment_source")
+                or ("paid_order" if primary_order else "unassigned"),
+                "acquisition_satisfied": bool(primary_order)
+                if bool(primary_project.get("payment_required", True))
+                else True,
+                "project_link_status": (
+                    "linked"
+                    if primary_order.get("project_id")
+                    else "not_required_non_payment_grant"
+                    if primary_project and not bool(primary_project.get("payment_required", True))
+                    else "not_linked"
+                ),
+                "maintenance_state": (
+                    "not_applicable_to_non_payment_grant"
+                    if primary_project
+                    and not bool(primary_project.get("payment_required", True))
+                    and _normalize(primary_entitlement.get("maintenance_status")).lower() in {"", "not_started"}
+                    else primary_entitlement.get("maintenance_status")
+                ),
                 "primary_order": primary_order,
                 "related_orders": related_orders,
             },
@@ -9259,6 +9360,8 @@ def _build_case_workspace_payload(
                 "maintenance_defaults": control_profile.get("maintenance_default"),
                 "package_normalization_status": package_fields.get("normalization_status"),
                 "package_normalized": package_fields.get("normalization_status") != "unknown",
+                "payment_required": readiness.get("payment_required", True),
+                "acquisition_source": readiness.get("acquisition_source") or "paid_order",
                 "source": package_fields.get("source"),
                 "raw_value": package_fields.get("raw_value"),
                 "sources": package_fields.get("sources") or {},
@@ -9271,11 +9374,28 @@ def _build_case_workspace_payload(
                 "warnings": package_fields.get("warnings") or [],
                 "order_status": (order_snapshot or {}).get("status"),
                 "paid": bool(order and _is_paid_package_order(order)),
+                "payment_required": readiness.get("payment_required", True),
+                "acquisition_source": readiness.get("acquisition_source") or "paid_order",
+                "acquisition_satisfied": readiness.get(
+                    "acquisition_satisfied",
+                    readiness.get("order_linked"),
+                ),
                 "stripe_session_id": (order_snapshot or {}).get("stripe_session_id"),
                 "payment_link_id": (order_snapshot or {}).get("payment_link_id"),
-                "project_link_status": "linked" if (order_snapshot or {}).get("project_id") else "not_linked",
+                "project_link_status": (
+                    "linked"
+                    if (order_snapshot or {}).get("project_id")
+                    else "not_required_non_payment_grant"
+                    if not readiness.get("payment_required", True)
+                    else "not_linked"
+                ),
                 "subscription": (order_snapshot or {}).get("subscription_id"),
-                "maintenance_state": (entitlement or {}).get("maintenance_status"),
+                "maintenance_state": (
+                    "not_applicable_to_non_payment_grant"
+                    if not readiness.get("payment_required", True)
+                    and _normalize((entitlement or {}).get("maintenance_status")).lower() in {"", "not_started"}
+                    else (entitlement or {}).get("maintenance_status")
+                ),
                 "next_charge_date": (order_snapshot or {}).get("next_charge_date")
                 or _serialize_datetime((entitlement or {}).get("maintenance_renews_at")),
                 "primary_order": order_snapshot,
@@ -9375,6 +9495,11 @@ def _filter_workspace_for_access(workspace: dict[str, Any], current_user: dict[s
         "package_synced": bool(readiness.get("package_synced")),
         "lane_assigned": bool(readiness.get("lane_assigned")),
         "order_linked": bool(readiness.get("order_linked")),
+        "payment_required": bool(readiness.get("payment_required", True)),
+        "acquisition_source": _normalize(readiness.get("acquisition_source")) or "paid_order",
+        "acquisition_satisfied": bool(
+            readiness.get("acquisition_satisfied", readiness.get("order_linked"))
+        ),
         "entitlement_exists": bool(readiness.get("entitlement_exists")),
         "summary": _normalize(readiness.get("summary")) or "Finance scope snapshot",
     }

--- a/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
@@ -24,8 +24,8 @@ class TestContinuityKernelPhase10CommandCenter(unittest.TestCase):
     def test_01_control_center_assets_preserve_phase10_base_and_current_control_revision(self) -> None:
         self.assertIn("styles.css?v=20260821-phase10-1", self.html)
         self.assertIn("app.js?v=20260821-phase10-1", self.html)
-        self.assertIn("admin-control-center.js?v=20260824-phase19", self.html)
-        self.assertIn('FRONTEND_ASSET_REVISION = "20260823-phase13-1"', self.service)
+        self.assertIn("admin-control-center.js?v=20260824-phase19-1", self.html)
+        self.assertIn('FRONTEND_ASSET_REVISION = "20260824-phase19-1"', self.service)
 
     def test_02_account_creation_and_closure_are_visible_previewed_workflows(self) -> None:
         for marker in (

--- a/backend/tests/contracts/test_phase13_family_operating_machine.py
+++ b/backend/tests/contracts/test_phase13_family_operating_machine.py
@@ -76,12 +76,12 @@ class TestPhase13FamilyOperatingMachine(unittest.TestCase):
                 self.assertIn(f'{asset}?v={revision}', _read(html_path))
         for html_path, asset, asset_revision in (
             ("portrait-upload.html", "portrait-upload.js", "20260824-phase18"),
-            ("admin-control-center.html", "admin-control-center.js", "20260824-phase19"),
+            ("admin-control-center.html", "admin-control-center.js", "20260824-phase19-1"),
         ):
             with self.subTest(html_path=html_path, asset=asset):
                 self.assertIn(f'{asset}?v={asset_revision}', _read(html_path))
         self.assertIn(
-            f'FRONTEND_ASSET_REVISION = "{revision}"',
+            'FRONTEND_ASSET_REVISION = "20260824-phase19-1"',
             _read("backend/app/services/admin_control_service.py"),
         )
 

--- a/backend/tests/contracts/test_phase18_ceo_fulfillment_review_control.py
+++ b/backend/tests/contracts/test_phase18_ceo_fulfillment_review_control.py
@@ -70,7 +70,15 @@ class TestPhase18CeoFulfillmentReviewControl(unittest.TestCase):
         }
         for html_path, asset in expected.items():
             with self.subTest(html_path=html_path):
-                expected_version = "20260824-phase19" if asset == "admin-control-center.js" else "20260824-phase18"
+                expected_version = (
+                    "20260824-phase19-1"
+                    if asset in {
+                        "admin-control-center.js",
+                        "admin-portrait-review.js",
+                        "admin-verification-review.js",
+                    }
+                    else "20260824-phase18"
+                )
                 self.assertIn(f'{asset}?v={expected_version}', _read(html_path))
 
 

--- a/backend/tests/contracts/test_phase19_1_production_truth_corrections.py
+++ b/backend/tests/contracts/test_phase19_1_production_truth_corrections.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+class TestPhase191ProductionTruthCorrections(unittest.TestCase):
+    def test_non_payment_grants_are_distinct_from_stripe_backed_sales(self):
+        service = _read("backend/app/services/admin_control_service.py")
+        self.assertIn("def _project_payment_required", service)
+        self.assertIn('"acquisition_satisfied": acquisition_satisfied', service)
+        self.assertIn('if not mint_already_completed and not acquisition_satisfied:', service)
+        self.assertIn("and _project_payment_required(project)", service)
+        self.assertIn("Legacy projects predate the field", service)
+
+    def test_existing_customer_email_is_routed_to_existing_account_provisioning(self):
+        service = _read("backend/app/services/admin_control_service.py")
+        self.assertIn("A customer account already exists for this email", service)
+        self.assertIn("Provision First Customer Project + Package", service)
+        self.assertIn("except DuplicateKeyError as exc", service)
+
+    def test_review_previews_explain_fail_closed_blockers(self):
+        routes = _read("backend/app/routes/uploads.py")
+        portrait = _read("admin-portrait-review.js")
+        evidence = _read("admin-verification-review.js")
+        self.assertIn('"preview_available": not preview_blockers', routes)
+        self.assertIn('or scan_status != "clean"', routes)
+        self.assertIn("Preview Blocked", portrait)
+        self.assertIn("Preview Blocked", evidence)
+        self.assertIn("Private storage migration must complete before preview", portrait)
+        self.assertIn("Private storage migration must complete before preview", evidence)
+
+    def test_duplicate_candidates_are_visible_without_collapsing_distinct_records(self):
+        routes = _read("backend/app/routes/uploads.py")
+        self.assertIn("def _admin_review_semantic_identity", routes)
+        self.assertIn('"possible_duplicate_count"', routes)
+        self.assertIn("without suppressing distinct uploads", routes)
+
+    def test_control_center_release_identity_matches_cache_busted_asset(self):
+        service = _read("backend/app/services/admin_control_service.py")
+        html = _read("admin-control-center.html")
+        portrait_html = _read("admin-portrait-review.html")
+        evidence_html = _read("admin-verification-review.html")
+        self.assertIn('FRONTEND_ASSET_REVISION = "20260824-phase19-1"', service)
+        self.assertIn("admin-control-center.js?v=20260824-phase19-1", html)
+        self.assertIn("admin-portrait-review.js?v=20260824-phase19-1", portrait_html)
+        self.assertIn("admin-verification-review.js?v=20260824-phase19-1", evidence_html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/contracts/test_phase19_ceo_finance_completion.py
+++ b/backend/tests/contracts/test_phase19_ceo_finance_completion.py
@@ -65,7 +65,7 @@ class TestPhase19CeoFinanceCompletion(unittest.TestCase):
 
     def test_phase19_control_center_asset_is_cache_busted(self):
         html = _read("admin-control-center.html")
-        self.assertIn("admin-control-center.js?v=20260824-phase19", html)
+        self.assertIn("admin-control-center.js?v=20260824-phase19-1", html)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_admin_console.py
+++ b/backend/tests/test_admin_console.py
@@ -1031,6 +1031,130 @@ class AdminUserQueueTests(unittest.TestCase):
 
 
 class SuperAdminControlsTests(unittest.TestCase):
+    def test_non_payment_grant_readiness_uses_entitlement_truth_without_fabricating_an_order(self):
+        project_id = ObjectId()
+        project = {
+            "_id": project_id,
+            "owner_email": "grant.customer@example.com",
+            "package_code": "digital_legacy_portrait",
+            "project_lane": "portrait",
+            "status": "intake_pending",
+            "phase": "intake_pending",
+            "package_assignment_source": "complimentary_package",
+            "payment_required": False,
+        }
+        entitlement = {
+            "project_id": project_id,
+            "package_code": "digital_legacy_portrait",
+            "package_lane": "portrait",
+            "maintenance_status": "not_started",
+        }
+        db = FakeDatabase({"projects": [project], "orders": []})
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=entitlement),
+            patch.object(admin_control_service, "count_workspace_uploads", return_value=0),
+            patch.object(
+                admin_control_service,
+                "describe_project_mint_eligibility",
+                return_value={"eligible": False, "reasons": [], "nft_addon": {}},
+            ),
+            patch.object(
+                admin_control_service,
+                "resolve_canonical_mint_status",
+                return_value={"is_minted": False, "current_status": "none"},
+            ),
+        ):
+            readiness = admin_control_service.run_readiness_check(
+                project_id=str(project_id)
+            )
+
+        self.assertTrue(readiness["package_synced"])
+        self.assertFalse(readiness["order_linked"])
+        self.assertFalse(readiness["payment_required"])
+        self.assertTrue(readiness["acquisition_satisfied"])
+        self.assertEqual(readiness["acquisition_source"], "complimentary_package")
+        self.assertNotIn("order_not_linked", readiness["blocking_reasons"])
+        self.assertNotIn("package_not_synced", readiness["blocking_reasons"])
+
+        alerts = admin_control_service._case_alerts(
+            project=project,
+            order=None,
+            entitlement=entitlement,
+            readiness=readiness,
+            upload_count=0,
+            duplicate_identity=False,
+        )
+        self.assertNotIn("paid_order_not_linked", alerts)
+        self.assertNotIn("maintenance_not_started", alerts)
+
+    def test_legacy_or_paid_project_still_fails_closed_without_a_paid_order(self):
+        project_id = ObjectId()
+        project = {
+            "_id": project_id,
+            "package_code": "digital_legacy_portrait",
+            "project_lane": "portrait",
+            "status": "intake_pending",
+            "phase": "intake_pending",
+        }
+        entitlement = {
+            "project_id": project_id,
+            "package_code": "digital_legacy_portrait",
+            "package_lane": "portrait",
+        }
+        db = FakeDatabase({"projects": [project], "orders": []})
+        with (
+            patch.object(admin_control_service, "get_database", return_value=db),
+            patch.object(admin_control_service, "get_project_entitlement", return_value=entitlement),
+            patch.object(admin_control_service, "count_workspace_uploads", return_value=0),
+            patch.object(
+                admin_control_service,
+                "describe_project_mint_eligibility",
+                return_value={"eligible": False, "reasons": [], "nft_addon": {}},
+            ),
+            patch.object(
+                admin_control_service,
+                "resolve_canonical_mint_status",
+                return_value={"is_minted": False, "current_status": "none"},
+            ),
+        ):
+            readiness = admin_control_service.run_readiness_check(
+                project_id=str(project_id)
+            )
+
+        self.assertTrue(readiness["payment_required"])
+        self.assertFalse(readiness["acquisition_satisfied"])
+        self.assertFalse(readiness["package_synced"])
+        self.assertIn("order_not_linked", readiness["blocking_reasons"])
+
+    def test_new_customer_preview_routes_existing_email_to_existing_customer_provisioning(self):
+        user_id = ObjectId()
+        db = FakeDatabase(
+            {
+                "users": [
+                    {
+                        "_id": user_id,
+                        "email": "existing.customer@example.com",
+                        "role": "user",
+                    }
+                ]
+            }
+        )
+        with patch.object(admin_control_service, "get_database", return_value=db):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Provision First Customer Project \\+ Package",
+            ):
+                admin_control_service.super_admin_preview_customer_create(
+                    payload={
+                        "email": "Existing.Customer@example.com",
+                        "full_name": "Existing Customer",
+                        "package_code": "digital_legacy_portrait",
+                    }
+                )
+
+        self.assertEqual(len(db["users"].documents), 1)
+
     def test_existing_customer_without_project_can_receive_ceo_granted_first_package(self):
         user_id = ObjectId()
         db = FakeDatabase(

--- a/backend/tests/test_private_upload_r2_storage.py
+++ b/backend/tests/test_private_upload_r2_storage.py
@@ -368,6 +368,62 @@ class PrivateUploadAccessTests(unittest.TestCase):
         self.assertIs(records[0], first)
         self.assertIs(records[1], separate)
 
+    def test_distinct_duplicate_looking_uploads_remain_visible_and_are_flagged(self):
+        first = self._record()
+        first.update(
+            {
+                "member_id": "member-1",
+                "original_filename": "government-id.pdf",
+                "file_size": 12345,
+            }
+        )
+        second_id = ObjectId()
+        second = {
+            **first,
+            "_id": second_id,
+            "id": str(second_id),
+            "storage_key": f"private-uploads/v1/evidence/{second_id}/government-id",
+        }
+
+        records, suppressed = upload_routes._deduplicate_admin_review_records(
+            [first, second]
+        )
+
+        self.assertEqual(len(records), 2)
+        self.assertEqual(suppressed, 0)
+        self.assertEqual(first["_possible_duplicate_count"], 2)
+        self.assertEqual(second["_possible_duplicate_count"], 2)
+
+    def test_admin_review_serialization_explains_preview_blockers_before_open(self):
+        record = self._record()
+        record.update(
+            {
+                "scan_status": "pending",
+                "storage_provider": "local_disk",
+                "storage_key": "",
+            }
+        )
+        db = FakeDatabase(
+            {"projects": [], "families": [], "family_members": []}
+        )
+
+        with patch.object(upload_routes.settings, "environment", "production"):
+            serialized = upload_routes._serialize_admin_upload_review(
+                record,
+                db=db,
+            )
+
+        self.assertFalse(serialized["preview_available"])
+        self.assertEqual(
+            serialized["preview_blockers"],
+            ["security_scan_not_clean", "durable_private_storage_missing"],
+        )
+        self.assertIn("clean verdict", serialized["preview_blocker_message"])
+        self.assertIn("Private storage migration", serialized["preview_blocker_message"])
+
+    def test_unknown_scan_state_fails_closed_for_admin_preview(self):
+        self.assertTrue(upload_routes._upload_scan_blocks_download({}))
+
     def test_admin_rescan_recovers_pending_private_r2_upload(self):
         record = self._record()
         record.update(

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -155,5 +155,5 @@ test("[asset-versioning] dashboard and control center include current cache-bust
   );
   expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260821-phase10"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260821-phase10"))).toBeTruthy();
-  expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260824-phase19"))).toBeTruthy();
+  expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260824-phase19-1"))).toBeTruthy();
 });

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -32,11 +32,12 @@ function makeCase(seed) {
 
 function workspacePayload(seed) {
   const now = new Date().toISOString();
+  const isNonPaymentGrant = seed.case_id === "case-internal-validation";
   return {
     case_id: seed.case_id,
-    project: { id: seed.project_id, project_id: seed.project_id, name: seed.project, status: seed.status },
-    package: { package_code: seed.package_code, package_name: seed.package_name, package_lane: seed.lane },
-    readiness: { mint_review_ready: false, mint_eligible: false, blocking_reasons: ["upload_review_pending"] },
+    project: { id: seed.project_id, project_id: seed.project_id, name: seed.project, status: seed.status, payment_required: !isNonPaymentGrant, package_assignment_source: isNonPaymentGrant ? "internal_validation_account" : null },
+    package: { package_code: seed.package_code, package_name: seed.package_name, package_lane: seed.lane, payment_required: !isNonPaymentGrant, acquisition_source: isNonPaymentGrant ? "internal_validation_account" : "paid_order" },
+    readiness: { mint_review_ready: false, mint_eligible: false, payment_required: !isNonPaymentGrant, acquisition_source: isNonPaymentGrant ? "internal_validation_account" : "paid_order", acquisition_satisfied: true, order_linked: !isNonPaymentGrant, blocking_reasons: ["upload_review_pending"] },
     alerts: seed.alerts || [],
     tabs: {
       overview: { customer_type: seed.role, workflow_state: seed.status, warnings: [] },
@@ -56,7 +57,7 @@ function workspacePayload(seed) {
         status: seed.status,
         admin_user_relationship: seed.role,
       },
-      package_lane: { package_name: seed.package_name, package_code: seed.package_code, project_lane: seed.lane, package_normalization_status: "normalized", source: "fixture", raw_value: seed.package_code },
+      package_lane: { package_name: seed.package_name, package_code: seed.package_code, project_lane: seed.lane, package_normalization_status: "normalized", payment_required: !isNonPaymentGrant, acquisition_source: isNonPaymentGrant ? "internal_validation_account" : "paid_order", source: "fixture", raw_value: seed.package_code },
       project: {
         project_name: seed.project,
         project_id: seed.project_id,
@@ -67,7 +68,9 @@ function workspacePayload(seed) {
       },
       uploads_verification: { uploaded_files: 2, review_status: "pending", verification_readiness: "waiting_for_uploads", file_categories: ["verification"], items: [{ id: "upload-1", filename: "lineage.pdf", category: "verification", status: "pending", created_at: now }] },
       entitlements: { maintenance_status: "active", access_scope: "standard", private_vault_contents: "hidden" },
-      orders_billing: { order_status: "paid", package_name: seed.package_name, package_code: seed.package_code, lane: seed.lane, paid: true, stripe_session_id: "cs_test_fixture_only", payment_link_id: "plink_fixture", project_link_status: "linked", maintenance_state: "active", next_charge_date: now, primary_order: { id: seed.order_id, status: "paid", package_name: seed.package_name }, related_orders: [] },
+      orders_billing: isNonPaymentGrant
+        ? { order_status: null, package_name: seed.package_name, package_code: seed.package_code, lane: seed.lane, paid: false, payment_required: false, acquisition_source: "internal_validation_account", acquisition_satisfied: true, stripe_session_id: null, payment_link_id: null, project_link_status: "not_required_non_payment_grant", maintenance_state: "not_applicable_to_non_payment_grant", next_charge_date: null, primary_order: null, related_orders: [] }
+        : { order_status: "paid", package_name: seed.package_name, package_code: seed.package_code, lane: seed.lane, paid: true, payment_required: true, acquisition_source: "paid_order", acquisition_satisfied: true, stripe_session_id: "cs_test_fixture_only", payment_link_id: "plink_fixture", project_link_status: "linked", maintenance_state: "active", next_charge_date: now, primary_order: { id: seed.order_id, status: "paid", package_name: seed.package_name }, related_orders: [] },
       mint_readiness: { current_state: "blocked", eligibility: "blocked", approvals: { mint_review_ready: false }, queue_status: "pending", blocking_reasons: ["upload_review_pending"], guidance: [{ severity: "warning", title: "Uploads pending", next_action: "Review uploads" }] },
       audit_timeline: [{ action: "workspace_opened", target_type: "project", target_id: seed.project_id, actor_email: OFFICER_A.email, result: "success", timestamp: now }],
     },
@@ -987,6 +990,22 @@ test("[account360] validates all tabs + loading/empty/denied/error states and se
   await expect(page.locator("body")).not.toContainText("token=");
   await expect(page.locator("body")).not.toContainText("password_hash");
   await expect(page.locator("body")).not.toContainText("password=");
+});
+
+test("[phase19.1 acquisition] renders governed grants without unpaid-order or maintenance claims", async ({ page }) => {
+  const search = page.getByPlaceholder("Name, email, birthday, package, project, family, last4, order, session, wallet, token, certificate");
+  await search.fill("internal validation account");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("[data-admin-case-list]")).toContainText("Internal Validation Account");
+  await page.locator("[data-open-case]").click();
+  await page.getByRole("tab", { name: "Billing" }).click();
+
+  const workspace = page.locator("[data-admin-case-workspace]");
+  await expect(workspace).toContainText("Package Acquisition");
+  await expect(workspace).toContainText("internal_validation_account");
+  await expect(workspace).toContainText("not_required_non_payment_grant");
+  await expect(workspace).toContainText("not_applicable_to_non_payment_grant");
+  await expect(workspace).not.toContainText("Paid order is not linked");
 });
 
 test("[errors] backend case-search failures include actionable code + retry guidance", async ({ page }) => {

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -997,14 +997,14 @@ test("[phase19.1 acquisition] renders governed grants without unpaid-order or ma
   await search.fill("internal validation account");
   await page.keyboard.press("Enter");
   await expect(page.locator("[data-admin-case-list]")).toContainText("Internal Validation Account");
-  await page.locator("[data-open-case]").click();
+  await page.locator('[data-open-case="case-internal-validation"]').click();
   await page.getByRole("tab", { name: "Billing" }).click();
 
   const workspace = page.locator("[data-admin-case-workspace]");
   await expect(workspace).toContainText("Package Acquisition");
-  await expect(workspace).toContainText("internal_validation_account");
-  await expect(workspace).toContainText("not_required_non_payment_grant");
-  await expect(workspace).toContainText("not_applicable_to_non_payment_grant");
+  await expect(workspace).toContainText("Internal Validation Account");
+  await expect(workspace).toContainText("Not Required Non Payment Grant");
+  await expect(workspace).toContainText("Not Applicable To Non Payment Grant");
   await expect(workspace).not.toContainText("Paid order is not linked");
 });
 

--- a/browser-tests/phase19-1-review-safety.spec.mjs
+++ b/browser-tests/phase19-1-review-safety.spec.mjs
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+
+const BLOCKED_REVIEW_ITEM = {
+  id: "upload-phase19-1-blocked",
+  member_name: "Review Safety Fixture",
+  family_name: "Fixture Family",
+  original_filename: "legacy-record.pdf",
+  verification_type: "government_id",
+  scan_status: "pending",
+  quarantined: false,
+  durable_private_storage: false,
+  preview_available: false,
+  preview_blockers: [
+    "security_scan_not_clean",
+    "durable_private_storage_missing",
+  ],
+  preview_blocker_message:
+    "Run the security scan and obtain a clean verdict before previewing this file. Private storage migration must complete before preview.",
+  possible_duplicate: true,
+  possible_duplicate_count: 2,
+  consent_attested: false,
+  authority_attested: false,
+  orphaned_project_reference: false,
+  orphaned_family_reference: false,
+  orphaned_member_reference: false,
+};
+
+
+test("[phase19.1 review safety] blocks unsafe portrait and evidence previews with exact remediation", async ({ page }) => {
+  let previewRequests = 0;
+  await page.addInitScript(() => {
+    localStorage.setItem("tol_access_token", "phase19-1-review-fixture");
+    localStorage.setItem("tol_api_base_url", window.location.origin);
+  });
+  await page.route("**/*", async (route) => {
+    const requestUrl = new URL(route.request().url());
+    if (requestUrl.pathname === "/auth/me") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "ceo-fixture",
+          email: "ceo.fixture@tomboflight.test",
+          role: "ceo_master_admin",
+        }),
+      });
+    }
+    if (requestUrl.pathname === "/uploads/admin/review") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          count: 1,
+          raw_count: 1,
+          duplicates_suppressed: 0,
+          items: [BLOCKED_REVIEW_ITEM],
+        }),
+      });
+    }
+    if (/\/uploads\/[^/]+\/admin-preview$/.test(requestUrl.pathname)) {
+      previewRequests += 1;
+      return route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Preview must remain blocked." }),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto("/admin-portrait-review.html");
+  const portraitPreview = page.getByRole("button", { name: "Preview Blocked" });
+  await expect(portraitPreview).toBeDisabled();
+  await expect(page.locator("[data-preview-blockers]")).toContainText(
+    "Private storage migration must complete before preview",
+  );
+  await expect(page.locator("[data-review-list]")).toContainText(
+    "2 distinct upload records",
+  );
+
+  await page.goto("/admin-verification-review.html");
+  const evidencePreview = page.getByRole("button", { name: "Preview Blocked" });
+  await expect(evidencePreview).toBeDisabled();
+  await expect(page.locator("[data-evidence-preview-blockers]")).toContainText(
+    "clean verdict",
+  );
+  await expect(page.locator("[data-verification-review-list]")).toContainText(
+    "2 distinct upload records",
+  );
+  expect(previewRequests).toBe(0);
+});


### PR DESCRIPTION
## Summary

- distinguish governed non-payment package grants from Stripe-backed package sales without fabricating orders
- keep legacy and paid projects fail-closed when authoritative paid-order linkage is absent
- route duplicate customer emails to the existing-customer package-provisioning workflow
- suppress false paid-order and maintenance warnings for explicitly governed grants
- expose exact fail-closed preview blockers before portrait or verification files are opened
- flag duplicate-looking uploads without deleting or silently collapsing distinct records
- align Control Center and review-page release/cache identifiers with Phase 19.1

## Safety boundaries

- no production data mutation
- no Stripe transaction fabrication or paid add-on bypass
- customer impersonation remains read-only
- distinct upload records remain preserved for audit and reconciliation

## Verification

- full backend: **1,960 passed, 2 skipped, 139 subtests passed**
- focused admin/upload/contracts: **126 passed, 19 subtests passed**
- release and Phase 19.1 contracts: **31 passed, 11 subtests passed**
- Python compilation, JavaScript syntax, and diff checks passed
- all **30 Playwright tests** are discovered, including new acquisition-truth and review-preview safety coverage
- local Playwright execution could not launch because the runner lacks a Chromium binary; GitHub CI is the required browser gate
