### PR TITLE
Phase 21: Governed customer account self-service

### DIFF
--- a/backend/app/routes/billing.py
+++ b/backend/app/routes/billing.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from app.dependencies.auth import get_current_user
+from app.dependencies.auth import get_current_user, is_customer_account
 from app.schemas.billing import (
     BillingConfigResponse,
     BillingOverviewResponse,
@@ -27,18 +27,24 @@ from app.services.billing_service import (
 router = APIRouter(prefix="/billing", tags=["Billing"])
 
 
+def _require_customer_billing(user: dict[str, Any]) -> None:
+    if not is_customer_account(user):
+        raise HTTPException(status_code=403, detail="Billing is available only in customer accounts.")
+
+
 class BillingPortalRequest(BaseModel):
     return_url: str | None = Field(default=None, max_length=500)
 
 
 @router.get("/config", response_model=BillingConfigResponse)
 def billing_config_route(current_user: dict[str, Any] = Depends(get_current_user)):
-    del current_user
+    _require_customer_billing(current_user)
     return get_billing_config()
 
 
 @router.get("/overview", response_model=BillingOverviewResponse)
 def billing_overview_route(current_user: dict[str, Any] = Depends(get_current_user)):
+    _require_customer_billing(current_user)
     try:
         payload = get_billing_overview(current_user)
     except ValueError as exc:
@@ -72,6 +78,7 @@ def billing_overview_route(current_user: dict[str, Any] = Depends(get_current_us
 def create_setup_intent_route(
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _require_customer_billing(current_user)
     try:
         return create_setup_intent_for_user(current_user)
     except ValueError as exc:
@@ -88,6 +95,7 @@ def set_default_payment_method_route(
     payment_method_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _require_customer_billing(current_user)
     try:
         return set_default_payment_method_for_user(current_user, payment_method_id)
     except ValueError as exc:
@@ -104,6 +112,7 @@ def detach_payment_method_route(
     payment_method_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _require_customer_billing(current_user)
     try:
         return detach_payment_method_for_user(current_user, payment_method_id)
     except ValueError as exc:
@@ -117,6 +126,7 @@ def create_billing_portal_session_route(
     payload: BillingPortalRequest | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _require_customer_billing(current_user)
     try:
         return create_billing_portal_session_for_user(
             current_user,

--- a/backend/app/routes/stripe_webhooks.py
+++ b/backend/app/routes/stripe_webhooks.py
@@ -23,6 +23,7 @@ from app.services.maintenance_subscription_service import (
     sync_maintenance_invoice_event,
     sync_maintenance_subscription_event,
 )
+from app.services.billing_service import sync_billing_customer_updated_event
 from app.services.order_service import upsert_order_from_stripe_event
 
 try:
@@ -204,6 +205,7 @@ def _downstream_failures(
     event_type: str,
     order_result: dict[str, Any],
     maintenance_result: dict[str, Any],
+    billing_customer_result: dict[str, Any] | None = None,
 ) -> list[str]:
     failures: list[str] = []
     if event_type == "checkout.session.completed":
@@ -239,6 +241,10 @@ def _downstream_failures(
                 or "maintenance_event_not_persisted"
             )
         )
+    elif event_type == "customer.updated" and (
+        billing_customer_result or {}
+    ).get("error") == "billing_customer_sync_failed":
+        failures.append("billing_customer_sync_failed")
     return list(dict.fromkeys(failure for failure in failures if failure))
 
 
@@ -295,6 +301,7 @@ async def stripe_webhook(request: Request) -> Dict[str, Any]:
 
     order_result: Dict[str, Any] = {"order_id": None}
     maintenance_result: Dict[str, Any] = {"updated": False}
+    billing_customer_result: Dict[str, Any] = {"updated": False}
 
     # Order upsert currently maps Stripe Checkout sessions to orders.
     if event_type == "checkout.session.completed":
@@ -327,10 +334,22 @@ async def stripe_webhook(request: Request) -> Dict[str, Any]:
             logger.error("Stripe invoice maintenance sync failed", exc_info=True)
             maintenance_result = {"updated": False, "error": "maintenance_invoice_sync_failed", "type": event_type}
 
+    if event_type == "customer.updated":
+        try:
+            billing_customer_result = sync_billing_customer_updated_event(event)
+        except Exception:
+            logger.error("Stripe billing customer sync failed", exc_info=True)
+            billing_customer_result = {
+                "updated": False,
+                "error": "billing_customer_sync_failed",
+                "type": event_type,
+            }
+
     failures = _downstream_failures(
         event_type=event_type,
         order_result=order_result,
         maintenance_result=maintenance_result,
+        billing_customer_result=billing_customer_result,
     )
     finished_at = datetime.now(timezone.utc)
     if failures:
@@ -358,6 +377,12 @@ async def stripe_webhook(request: Request) -> Dict[str, Any]:
         now=finished_at,
     )
 
+    if event_id and event_type == "customer.updated":
+        events_col.update_one(
+            {"event_id": event_id},
+            {"$set": {"billing_customer_result": billing_customer_result}},
+        )
+
     logger.info("Stripe webhook processed")
 
     return {
@@ -365,4 +390,5 @@ async def stripe_webhook(request: Request) -> Dict[str, Any]:
         "type": event_type,
         "order": order_result,
         "maintenance": maintenance_result,
+        "billing_customer": billing_customer_result,
     }

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,15 +1,44 @@
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
-from app.dependencies.auth import get_current_user, require_capability, require_permission
-from app.schemas.experience import UserProfileResponse, UserProfileUpdate
+from app.config import settings
+from app.dependencies.auth import (
+    get_current_user,
+    is_customer_account,
+    require_capability,
+    require_permission,
+)
+from app.schemas.experience import (
+    UserEmailChangeConfirm,
+    UserEmailChangeRequest,
+    UserEmailChangeResponse,
+    UserProfileResponse,
+    UserProfileUpdate,
+)
 from app.schemas.user import UserCreate, UserResponse, build_user_response
 from app.services.auth_service import get_user_by_id
-from app.services.user_service import list_users, update_user_profile
+from app.services.user_service import (
+    confirm_email_change,
+    list_users,
+    request_email_change,
+    update_user_profile,
+)
+from app.services.rate_limit_service import enforce_rate_limit
 from app.services.workspace_access_service import build_workspace_context_snapshot
 
 router = APIRouter(prefix="/users", tags=["Users"])
+
+
+def _apply_no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+
+
+def _request_key(request: Request, principal: str) -> str:
+    client_host = str((request.client.host if request.client else "") or "").strip()
+    return f"{client_host or 'unknown'}:{principal}"
 
 
 def _current_user_id(user: dict[str, Any]) -> str:
@@ -20,6 +49,53 @@ def _current_user_id(user: dict[str, Any]) -> str:
             detail="Authenticated user id is missing.",
         )
     return str(raw_id)
+
+
+def _require_customer_self_service(user: dict[str, Any]) -> None:
+    if not is_customer_account(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Customer account self-service is not available to internal accounts.",
+        )
+
+
+def _profile_response(user: dict[str, Any], current_user: dict[str, Any]) -> dict[str, Any]:
+    user_id = (
+        _current_user_id(user)
+        if user.get("_id") or user.get("id") or user.get("user_id")
+        else _current_user_id(current_user)
+    )
+    address = user.get("mailing_address_structured")
+    if not isinstance(address, dict):
+        address = None
+    return {
+        "id": str(user.get("_id") or user.get("id") or user_id),
+        "email": str(user.get("email") or current_user.get("email") or "").strip().lower(),
+        "full_name": str(
+            user.get("full_name")
+            or current_user.get("full_name")
+            or current_user.get("name")
+            or ""
+        ).strip(),
+        "role": str(user.get("role") or current_user.get("role") or "user").strip(),
+        "status": str(user.get("status") or current_user.get("status") or "active").strip(),
+        "created_at": str(user.get("created_at") or current_user.get("created_at") or ""),
+        "last_login_at": user.get("last_login_at") or current_user.get("last_login_at"),
+        "policy_version": user.get("policy_version") or current_user.get("policy_version"),
+        "phone_number": user.get("phone_number") or None,
+        "mailing_address": address,
+        "pending_email": user.get("pending_email") or None,
+        "billing_sync_status": user.get("billing_profile_sync_status") or None,
+        "legal_acceptance": {
+            "policy_version": user.get("policy_version") or current_user.get("policy_version"),
+            "terms_accepted_at": user.get("terms_accepted_at") or current_user.get("terms_accepted_at"),
+            "privacy_accepted_at": user.get("privacy_accepted_at") or current_user.get("privacy_accepted_at"),
+            "eligibility_attested_at": (
+                user.get("eligibility_attested_at")
+                or current_user.get("eligibility_attested_at")
+            ),
+        },
+    }
 
 
 @router.get("/", response_model=list[UserResponse])
@@ -44,57 +120,87 @@ def create_user_route(
 
 
 @router.get("/me/profile", response_model=UserProfileResponse)
-def get_my_profile(current_user: dict[str, Any] = Depends(get_current_user)):
+def get_my_profile(response: Response, current_user: dict[str, Any] = Depends(get_current_user)):
+    _apply_no_store(response)
+    _require_customer_self_service(current_user)
     user_id = _current_user_id(current_user)
     user = get_user_by_id(user_id) or current_user
-    return {
-        "id": str(user.get("_id") or user.get("id") or user_id),
-        "email": str(user.get("email") or current_user.get("email") or "").strip().lower(),
-        "full_name": str(user.get("full_name") or current_user.get("full_name") or current_user.get("name") or "").strip(),
-        "role": str(user.get("role") or current_user.get("role") or "user").strip(),
-        "status": str(user.get("status") or current_user.get("status") or "active").strip(),
-        "created_at": str(user.get("created_at") or current_user.get("created_at") or ""),
-        "last_login_at": user.get("last_login_at") or current_user.get("last_login_at"),
-        "policy_version": user.get("policy_version") or current_user.get("policy_version"),
-        "legal_acceptance": {
-            "policy_version": user.get("policy_version") or current_user.get("policy_version"),
-            "terms_accepted_at": user.get("terms_accepted_at") or current_user.get("terms_accepted_at"),
-            "privacy_accepted_at": user.get("privacy_accepted_at") or current_user.get("privacy_accepted_at"),
-            "eligibility_attested_at": user.get("eligibility_attested_at") or current_user.get("eligibility_attested_at"),
-        },
-    }
+    return _profile_response(user, current_user)
 
 
 @router.patch("/me/profile", response_model=UserProfileResponse)
 def patch_my_profile(
     payload: UserProfileUpdate,
+    response: Response,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
+    _apply_no_store(response)
+    _require_customer_self_service(current_user)
     user_id = _current_user_id(current_user)
     try:
-        updated_user = update_user_profile(user_id, full_name=payload.full_name)
+        profile_updates: dict[str, Any] = {"full_name": payload.full_name}
+        if "phone_number" in payload.model_fields_set:
+            profile_updates["phone_number"] = payload.phone_number
+        if "mailing_address" in payload.model_fields_set:
+            profile_updates["mailing_address"] = (
+                payload.mailing_address.model_dump() if payload.mailing_address else None
+            )
+        updated_user = update_user_profile(user_id, **profile_updates)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     if updated_user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
 
-    return {
-        "id": str(updated_user.get("_id") or user_id),
-        "email": str(updated_user.get("email") or current_user.get("email") or "").strip().lower(),
-        "full_name": str(updated_user.get("full_name") or payload.full_name).strip(),
-        "role": str(updated_user.get("role") or current_user.get("role") or "user").strip(),
-        "status": str(updated_user.get("status") or current_user.get("status") or "active").strip(),
-        "created_at": str(updated_user.get("created_at") or current_user.get("created_at") or ""),
-        "last_login_at": updated_user.get("last_login_at") or current_user.get("last_login_at"),
-        "policy_version": updated_user.get("policy_version") or current_user.get("policy_version"),
-        "legal_acceptance": {
-            "policy_version": updated_user.get("policy_version") or current_user.get("policy_version"),
-            "terms_accepted_at": updated_user.get("terms_accepted_at") or current_user.get("terms_accepted_at"),
-            "privacy_accepted_at": updated_user.get("privacy_accepted_at") or current_user.get("privacy_accepted_at"),
-            "eligibility_attested_at": updated_user.get("eligibility_attested_at") or current_user.get("eligibility_attested_at"),
-        },
-    }
+    return _profile_response(updated_user, current_user)
+
+
+@router.post("/me/email-change/request", response_model=UserEmailChangeResponse)
+def request_my_email_change(
+    payload: UserEmailChangeRequest,
+    request: Request,
+    response: Response,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _apply_no_store(response)
+    _require_customer_self_service(current_user)
+    enforce_rate_limit(
+        scope="customer_email_change_request",
+        key=_request_key(request, _current_user_id(current_user)),
+        limit=max(1, int(settings.auth_password_reset_request_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+    )
+    try:
+        return request_email_change(
+            _current_user_id(current_user),
+            new_email=str(payload.new_email),
+            current_password=payload.current_password,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+
+@router.post("/me/email-change/confirm", response_model=UserEmailChangeResponse)
+def confirm_my_email_change(
+    payload: UserEmailChangeConfirm,
+    request: Request,
+    response: Response,
+):
+    _apply_no_store(response)
+    enforce_rate_limit(
+        scope="customer_email_change_confirm",
+        key=_request_key(request, "token"),
+        limit=max(1, int(settings.auth_password_reset_request_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+    )
+    try:
+        return confirm_email_change(payload.token)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
 
 
 @router.get("/me/workspace-context")

--- a/backend/app/schemas/experience.py
+++ b/backend/app/schemas/experience.py
@@ -2,11 +2,54 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field, model_validator
+
+
+class MailingAddress(BaseModel):
+    line1: str = Field(default="", max_length=150)
+    line2: str = Field(default="", max_length=150)
+    city: str = Field(default="", max_length=100)
+    region: str = Field(default="", max_length=100)
+    postal_code: str = Field(default="", max_length=20)
+    country: str = Field(default="US", min_length=2, max_length=2)
+
+    @model_validator(mode="after")
+    def validate_complete_address(self) -> "MailingAddress":
+        values = [
+            self.line1.strip(),
+            self.line2.strip(),
+            self.city.strip(),
+            self.region.strip(),
+            self.postal_code.strip(),
+        ]
+        if not any(values):
+            return self
+        if not all((self.line1.strip(), self.city.strip(), self.region.strip(), self.postal_code.strip())):
+            raise ValueError(
+                "Street address, city, state or region, and postal code are required."
+            )
+        return self
 
 
 class UserProfileUpdate(BaseModel):
     full_name: str = Field(..., min_length=1, max_length=150)
+    phone_number: str | None = Field(default=None, max_length=32)
+    mailing_address: MailingAddress | None = None
+
+
+class UserEmailChangeRequest(BaseModel):
+    new_email: EmailStr
+    current_password: str = Field(..., min_length=8, max_length=128)
+
+
+class UserEmailChangeConfirm(BaseModel):
+    token: str = Field(..., min_length=16, max_length=512)
+
+
+class UserEmailChangeResponse(BaseModel):
+    success: bool = True
+    message: str
+    expires_at: str | None = None
 
 
 class UserProfileResponse(BaseModel):
@@ -18,6 +61,10 @@ class UserProfileResponse(BaseModel):
     created_at: str
     last_login_at: str | None = None
     policy_version: str | None = None
+    phone_number: str | None = None
+    mailing_address: MailingAddress | None = None
+    pending_email: str | None = None
+    billing_sync_status: str | None = None
     legal_acceptance: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -236,6 +236,95 @@ def _serialize_card_created(value: Any) -> str | None:
         return _normalize_text(value) or None
 
 
+def sync_account_contact_to_stripe(
+    *,
+    customer_id: str,
+    full_name: str,
+    phone_number: str | None,
+    mailing_address: dict[str, str] | None,
+    include_phone: bool = True,
+    include_address: bool = True,
+) -> None:
+    """Mirror verified account contact fields to Stripe's billing customer."""
+    _require_stripe_secret_key()
+    normalized_customer_id = _normalize_text(customer_id)
+    if not normalized_customer_id:
+        raise ValueError("Stripe customer id is required.")
+    payload: dict[str, Any] = {"name": _normalize_text(full_name)}
+    if include_phone:
+        payload["phone"] = _normalize_text(phone_number)
+    if include_address:
+        payload["address"] = {
+            "line1": _normalize_text((mailing_address or {}).get("line1")),
+            "line2": _normalize_text((mailing_address or {}).get("line2")),
+            "city": _normalize_text((mailing_address or {}).get("city")),
+            "state": _normalize_text((mailing_address or {}).get("region")),
+            "postal_code": _normalize_text((mailing_address or {}).get("postal_code")),
+            "country": _normalize_text((mailing_address or {}).get("country")) or "US",
+        }
+    stripe.Customer.modify(normalized_customer_id, **payload)
+
+
+def sync_verified_email_to_stripe(*, customer_id: str, email: str) -> None:
+    """Push a Tomb of Light-verified login email to the billing customer."""
+    _require_stripe_secret_key()
+    normalized_customer_id = _normalize_text(customer_id)
+    normalized_email = _normalize_text(email).lower()
+    if not normalized_customer_id or not normalized_email:
+        raise ValueError("Stripe customer id and verified email are required.")
+    stripe.Customer.modify(normalized_customer_id, email=normalized_email)
+
+
+def sync_billing_customer_updated_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Store Stripe portal edits as billing-only contact data.
+
+    Stripe billing email never becomes a Tomb of Light login credential.
+    """
+    payload = cast(dict[str, Any], ((event.get("data") or {}).get("object") or {}))
+    customer_id = _normalize_text(payload.get("id"))
+    if not customer_id:
+        return {"updated": False, "error": "stripe_customer_id_missing"}
+    address = payload.get("address") or {}
+    billing_contact = {
+        "name": _normalize_text(payload.get("name")) or None,
+        "email": _normalize_text(payload.get("email")).lower() or None,
+        "phone": _normalize_text(payload.get("phone")) or None,
+        "address": {
+            "line1": _normalize_text(address.get("line1")) or None,
+            "line2": _normalize_text(address.get("line2")) or None,
+            "city": _normalize_text(address.get("city")) or None,
+            "region": _normalize_text(address.get("state")) or None,
+            "postal_code": _normalize_text(address.get("postal_code")) or None,
+            "country": _normalize_text(address.get("country")) or None,
+        },
+        "source": "stripe_customer_updated_webhook",
+        "updated_at": _now_iso(),
+    }
+    result = _users_collection().update_one(
+        {"stripe_customer_id": customer_id},
+        {
+            "$set": {
+                "billing_contact": billing_contact,
+                "billing_profile_sync_status": "synced",
+                "billing_profile_synced_at": _now_iso(),
+            }
+        },
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        return {"updated": False, "error": "stripe_customer_not_linked", "customer_id": customer_id}
+    try:
+        create_audit_log(
+            "billing_contact_updated_from_stripe",
+            None,
+            "stripe_customer",
+            customer_id,
+            {"login_email_changed": False},
+        )
+    except Exception:
+        pass
+    return {"updated": True, "customer_id": customer_id}
+
+
 def get_billing_overview(user: dict[str, Any]) -> dict[str, Any]:
     _require_stripe_secret_key()
     customer_id = _existing_customer_id_for_user(user)

--- a/backend/app/services/db_bootstrap_service.py
+++ b/backend/app/services/db_bootstrap_service.py
@@ -14,6 +14,14 @@ CORE_COLLECTIONS: dict[str, list[tuple[list[tuple[str, int]], dict]]] = {
     "users": [
         ([("email", ASCENDING)], {"unique": True, "name": "idx_users_email_unique"}),
         ([("role", ASCENDING)], {"name": "idx_users_role"}),
+        (
+            [("pending_email_change_token_hash", ASCENDING)],
+            {
+                "unique": True,
+                "sparse": True,
+                "name": "idx_users_pending_email_change_token_unique",
+            },
+        ),
     ],
     "roles": [
         (

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -439,6 +439,71 @@ def send_password_changed_email(*, to_email: str) -> None:
     )
 
 
+def send_email_change_verification_email(
+    *,
+    to_email: str,
+    verification_url: str,
+    expires_at: str,
+) -> dict[str, Any]:
+    """Verify ownership of a proposed new login email address."""
+    safe_url = escape(_normalize_text(verification_url), quote=True)
+    safe_expires_at = escape(_normalize_text(expires_at), quote=True)
+    subject = "Confirm your new Tomb of Light email"
+    text_body = (
+        "Hello,\n\n"
+        "A request was made to use this email address for a Tomb of Light account.\n\n"
+        f"Confirm the change using this secure link:\n{verification_url}\n\n"
+        f"This link expires at {expires_at}.\n\n"
+        "If you did not request this change, do not use the link and contact support.\n\n"
+        "Tomb of Light Security\n"
+    )
+    html_body = (
+        "<p>Hello,</p>"
+        "<p>A request was made to use this email address for a Tomb of Light account.</p>"
+        f'<p><a href="{safe_url}">Confirm new email address</a></p>'
+        f"<p>This link expires at {safe_expires_at}.</p>"
+        "<p>If you did not request this change, do not use the link and contact support.</p>"
+        "<p>Tomb of Light Security</p>"
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        email_type="email_change_verification",
+    )
+
+
+def send_email_changed_notice(*, to_email: str, new_email: str) -> dict[str, Any]:
+    """Notify the former login mailbox after a verified email change."""
+    changed_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    safe_new_email = escape(_normalize_email(new_email), quote=True)
+    safe_changed_at = escape(changed_at, quote=True)
+    subject = "Your Tomb of Light email was changed"
+    text_body = (
+        "Hello,\n\n"
+        f"The login email for your Tomb of Light account was changed to {new_email}.\n\n"
+        f"Security notice time: {changed_at}.\n\n"
+        "If you did not make this change, contact support immediately.\n\n"
+        "Tomb of Light Security\n"
+    )
+    html_body = (
+        "<p>Hello,</p>"
+        "<p>The login email for your Tomb of Light account was changed to "
+        f"<strong>{safe_new_email}</strong>.</p>"
+        f"<p><strong>Security notice time:</strong> {safe_changed_at}.</p>"
+        "<p>If you did not make this change, contact support immediately.</p>"
+        "<p>Tomb of Light Security</p>"
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        email_type="email_changed_notice",
+    )
+
+
 def _public_app_base_url() -> str:
     source = (
         _normalize_text(settings.password_reset_base_url_clean)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,7 +1,106 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime, timedelta
+import hashlib
+import re
+import secrets
+from typing import Any
+from urllib.parse import quote, urlsplit, urlunsplit
 
+from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
+
+from app.config import settings
 from app.database import get_database
 from app.schemas.user import UserCreate
+from app.services.audit_log_service import write_audit_log
+from app.services.email_service import (
+    send_email_change_verification_email,
+    send_email_changed_notice,
+)
+
+
+EMAIL_CHANGE_TTL_MINUTES = 30
+_UNSET = object()
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: Any) -> str:
+    return _normalize_text(value).lower()
+
+
+def _user_query(user_id: str) -> dict[str, Any]:
+    try:
+        return {"_id": ObjectId(user_id)}
+    except Exception:
+        return {"_id": user_id}
+
+
+def normalize_phone_number(value: str | None) -> str | None:
+    raw = _normalize_text(value)
+    if not raw:
+        return None
+    digits = re.sub(r"\D", "", raw)
+    if len(digits) == 10:
+        return f"+1{digits}"
+    if len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    if raw.startswith("+") and 8 <= len(digits) <= 15:
+        return f"+{digits}"
+    raise ValueError("Enter a valid phone number, including country code when outside the United States.")
+
+
+def normalize_mailing_address(value: dict[str, Any] | None) -> dict[str, str] | None:
+    if value is None:
+        return None
+    normalized = {
+        "line1": _normalize_text(value.get("line1")),
+        "line2": _normalize_text(value.get("line2")),
+        "city": _normalize_text(value.get("city")),
+        "region": _normalize_text(value.get("region")),
+        "postal_code": _normalize_text(value.get("postal_code")),
+        "country": (_normalize_text(value.get("country")) or "US").upper(),
+    }
+    if not any(normalized[key] for key in ("line1", "line2", "city", "region", "postal_code")):
+        return None
+    if not all(normalized[key] for key in ("line1", "city", "region", "postal_code")):
+        raise ValueError("Street address, city, state or region, and postal code are required.")
+    if len(normalized["country"]) != 2:
+        raise ValueError("Country must use a two-letter country code.")
+    return normalized
+
+
+def format_mailing_address(address: dict[str, str] | None) -> str | None:
+    if not address:
+        return None
+    street = ", ".join(part for part in (address.get("line1"), address.get("line2")) if part)
+    locality = ", ".join(part for part in (address.get("city"), address.get("region")) if part)
+    tail = " ".join(part for part in (locality, address.get("postal_code")) if part)
+    return ", ".join(part for part in (street, tail, address.get("country")) if part)
+
+
+def _email_change_url(token: str) -> str:
+    source = (
+        settings.password_reset_base_url_clean
+        or settings.stripe_billing_portal_return_url_clean
+        or "https://tomboflight.com"
+    )
+    parsed = urlsplit(source)
+    base_url = urlunsplit(
+        (
+            parsed.scheme or "https",
+            parsed.netloc or "tomboflight.com",
+            "/billing.html",
+            "",
+            "",
+        )
+    )
+    return f"{base_url}#mode=email-change&token={quote(token, safe='')}"
+
+
+def _email_change_token_hash(token: str) -> str:
+    return hashlib.sha256(_normalize_text(token).encode("utf-8")).hexdigest()
 
 
 def list_users() -> list[dict]:
@@ -41,7 +140,13 @@ def create_user(payload: UserCreate) -> dict:
 
 
 
-def update_user_profile(user_id: str, *, full_name: str) -> dict | None:
+def update_user_profile(
+    user_id: str,
+    *,
+    full_name: str,
+    phone_number: str | None | object = _UNSET,
+    mailing_address: dict[str, Any] | None | object = _UNSET,
+) -> dict | None:
     db = get_database()
     if db is None:
         return None
@@ -50,20 +155,241 @@ def update_user_profile(user_id: str, *, full_name: str) -> dict | None:
     if not normalized_name:
         raise ValueError('full_name is required.')
 
-    try:
-        from bson import ObjectId
-
-        object_id = ObjectId(user_id)
-    except Exception:
+    query = _user_query(user_id)
+    before = db.users.find_one(query)
+    if before is None:
         return None
 
-    db.users.update_one(
-        {'_id': object_id},
-        {
-            '$set': {
-                'full_name': normalized_name,
-                'updated_at': datetime.now(UTC).isoformat(),
-            }
-        },
+    phone_was_supplied = phone_number is not _UNSET
+    address_was_supplied = mailing_address is not _UNSET
+    normalized_phone = (
+        normalize_phone_number(phone_number if isinstance(phone_number, str) else None)
+        if phone_was_supplied
+        else before.get("phone_number")
     )
-    return db.users.find_one({'_id': object_id})
+    normalized_address = (
+        normalize_mailing_address(mailing_address if isinstance(mailing_address, dict) else None)
+        if address_was_supplied
+        else before.get("mailing_address_structured")
+    )
+    now = datetime.now(UTC).isoformat()
+    updates: dict[str, Any] = {
+        'full_name': normalized_name,
+        'phone_number': normalized_phone,
+        'mailing_address': format_mailing_address(normalized_address),
+        'mailing_address_structured': normalized_address,
+        'updated_at': now,
+        'billing_profile_sync_status': 'pending' if before.get('stripe_customer_id') else 'not_linked',
+        'billing_profile_sync_requested_at': now,
+    }
+
+    db.users.update_one(
+        query,
+        {'$set': updates},
+    )
+
+    billing_sync_status = updates['billing_profile_sync_status']
+    if before.get('stripe_customer_id'):
+        try:
+            from app.services.billing_service import sync_account_contact_to_stripe
+
+            sync_account_contact_to_stripe(
+                customer_id=_normalize_text(before.get('stripe_customer_id')),
+                full_name=normalized_name,
+                phone_number=normalized_phone,
+                mailing_address=normalized_address,
+                include_phone=phone_was_supplied,
+                include_address=address_was_supplied,
+            )
+            billing_sync_status = 'synced'
+        except Exception:
+            billing_sync_status = 'pending'
+        db.users.update_one(
+            query,
+            {'$set': {
+                'billing_profile_sync_status': billing_sync_status,
+                'billing_profile_synced_at': now if billing_sync_status == 'synced' else None,
+            }},
+        )
+
+    after = db.users.find_one(query)
+    try:
+        write_audit_log(
+            actor_user_id=user_id,
+            actor_email=_normalize_email((after or {}).get('email')) or None,
+            actor_name=normalized_name,
+            action='customer_profile_updated',
+            target_type='user',
+            target_id=user_id,
+            before={
+                'full_name': before.get('full_name'),
+                'phone_number': before.get('phone_number'),
+                'mailing_address': before.get('mailing_address_structured') or before.get('mailing_address'),
+            },
+            after={
+                'full_name': normalized_name,
+                'phone_number': normalized_phone,
+                'mailing_address': normalized_address,
+                'billing_sync_status': billing_sync_status,
+            },
+            context={'source': 'customer_self_service'},
+        )
+    except Exception:
+        pass
+    return after
+
+
+def request_email_change(user_id: str, *, new_email: str, current_password: str) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    query = _user_query(user_id)
+    user = db.users.find_one(query)
+    if user is None:
+        raise ValueError("User account not found.")
+
+    normalized_email = _normalize_email(new_email)
+    current_email = _normalize_email(user.get("email"))
+    if normalized_email == current_email:
+        raise ValueError("Enter a different email address.")
+    duplicate = db.users.find_one({"email": normalized_email}, {"_id": 1})
+    if duplicate is not None:
+        raise ValueError("That email address is already connected to an account.")
+
+    from app.services.auth_service import verify_password
+
+    if not verify_password(current_password, _normalize_text(user.get("password_hash"))):
+        raise ValueError("Current password is incorrect.")
+
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(UTC) + timedelta(minutes=EMAIL_CHANGE_TTL_MINUTES)
+    pending = {
+        "pending_email": normalized_email,
+        "pending_email_change_token_hash": _email_change_token_hash(token),
+        "pending_email_change_requested_at": datetime.now(UTC).isoformat(),
+        "pending_email_change_expires_at": expires_at.isoformat(),
+    }
+    db.users.update_one(query, {"$set": pending})
+    delivery = send_email_change_verification_email(
+        to_email=normalized_email,
+        verification_url=_email_change_url(token),
+        expires_at=expires_at.isoformat(),
+    )
+    if not bool(delivery.get("sent")):
+        db.users.update_one(
+            query,
+            {"$unset": {key: "" for key in pending}},
+        )
+        raise RuntimeError("Verification email could not be delivered. Try again later.")
+
+    try:
+        write_audit_log(
+            actor_user_id=user_id,
+            actor_email=current_email or None,
+            actor_name=_normalize_text(user.get("full_name")) or None,
+            action="customer_email_change_requested",
+            target_type="user",
+            target_id=user_id,
+            before={"email": current_email},
+            after={"pending_email": normalized_email},
+            context={"source": "customer_self_service", "delivery_sent": True},
+        )
+    except Exception:
+        pass
+    return {
+        "success": True,
+        "message": "Verification sent to the new email address.",
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+def confirm_email_change(token: str) -> dict[str, Any]:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    token_hash = _email_change_token_hash(token)
+    user = db.users.find_one({"pending_email_change_token_hash": token_hash})
+    if user is None:
+        raise ValueError("Email change link is invalid, expired, or already used.")
+    expires_raw = _normalize_text(user.get("pending_email_change_expires_at"))
+    try:
+        expires_at = datetime.fromisoformat(expires_raw.replace("Z", "+00:00"))
+    except Exception as exc:
+        raise ValueError("Email change link is invalid, expired, or already used.") from exc
+    if expires_at < datetime.now(UTC):
+        raise ValueError("Email change link is invalid, expired, or already used.")
+
+    user_id = str(user.get("_id"))
+    old_email = _normalize_email(user.get("email"))
+    new_email = _normalize_email(user.get("pending_email"))
+    if not new_email or db.users.find_one({"email": new_email, "_id": {"$ne": user.get("_id")}}, {"_id": 1}):
+        raise ValueError("That email address is already connected to an account.")
+
+    now = datetime.now(UTC).isoformat()
+    try:
+        result = db.users.update_one(
+            {
+                "_id": user.get("_id"),
+                "pending_email_change_token_hash": token_hash,
+                "pending_email": new_email,
+            },
+            {
+                "$set": {
+                    "email": new_email,
+                    "email_verified_at": now,
+                    "email_updated_at": now,
+                    "session_token_version": int(user.get("session_token_version") or 0) + 1,
+                },
+                "$addToSet": {"email_aliases": old_email},
+                "$unset": {
+                    "pending_email": "",
+                    "pending_email_change_token_hash": "",
+                    "pending_email_change_requested_at": "",
+                    "pending_email_change_expires_at": "",
+                },
+            },
+        )
+    except DuplicateKeyError as exc:
+        raise ValueError("That email address is already connected to an account.") from exc
+    if int(getattr(result, "modified_count", 0)) != 1:
+        raise ValueError("Email change link is invalid, expired, or already used.")
+
+    stripe_customer_id = _normalize_text(user.get("stripe_customer_id"))
+    if stripe_customer_id:
+        try:
+            from app.services.billing_service import sync_verified_email_to_stripe
+
+            sync_verified_email_to_stripe(customer_id=stripe_customer_id, email=new_email)
+        except Exception:
+            db.users.update_one(
+                {"_id": user.get("_id")},
+                {
+                    "$set": {
+                        "billing_profile_sync_status": "pending",
+                        "billing_profile_sync_requested_at": now,
+                    }
+                },
+            )
+
+    try:
+        write_audit_log(
+            actor_user_id=user_id,
+            actor_email=new_email,
+            actor_name=_normalize_text(user.get("full_name")) or None,
+            action="customer_email_changed",
+            target_type="user",
+            target_id=user_id,
+            before={"email": old_email},
+            after={"email": new_email, "sessions_revoked": True},
+            context={"source": "verified_customer_self_service"},
+        )
+    except Exception:
+        pass
+    try:
+        send_email_changed_notice(to_email=old_email, new_email=new_email)
+    except Exception:
+        pass
+    return {
+        "success": True,
+        "message": "Email updated. Sign in again with your new email address.",
+    }

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -16,6 +16,7 @@ PORTAL_CACHE_OVERRIDES = {
         "auth.js": "20260713-livefix3",
         "dashboard-intake.js": "20260824-phase20",
     },
+    "billing.html": {"styles.css": "20260828-phase21"},
     "link-keys.html": {"link-keys.js": "20260823-phase13-1"},
     "portrait-upload.html": {"portrait-upload.js": "20260824-phase18"},
     "tree-view.html": {"tree-view.js": "20260823-phase13-1"},

--- a/backend/tests/test_phase21_customer_account_management.py
+++ b/backend/tests/test_phase21_customer_account_management.py
@@ -1,0 +1,210 @@
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+
+from app.services import billing_service, user_service
+
+
+class _UsersCollection:
+    def __init__(self, user: dict):
+        self.user = deepcopy(user)
+
+    def find_one(self, query, projection=None):
+        del projection
+        if "stripe_customer_id" in query:
+            return (
+                deepcopy(self.user)
+                if self.user.get("stripe_customer_id") == query["stripe_customer_id"]
+                else None
+            )
+        if "pending_email_change_token_hash" in query:
+            return (
+                deepcopy(self.user)
+                if self.user.get("pending_email_change_token_hash")
+                == query["pending_email_change_token_hash"]
+                else None
+            )
+        if "email" in query:
+            expected = query["email"]
+            if isinstance(expected, str):
+                return deepcopy(self.user) if self.user.get("email") == expected else None
+            return None
+        expected_id = query.get("_id")
+        return deepcopy(self.user) if expected_id == self.user.get("_id") else None
+
+    def update_one(self, query, update, **kwargs):
+        del kwargs
+        existing = self.find_one(query)
+        if existing is None:
+            return SimpleNamespace(matched_count=0, modified_count=0)
+        for key, value in (update.get("$set") or {}).items():
+            self.user[key] = value
+        for key in (update.get("$unset") or {}):
+            self.user.pop(key, None)
+        for key, value in (update.get("$addToSet") or {}).items():
+            values = list(self.user.get(key) or [])
+            if value not in values:
+                values.append(value)
+            self.user[key] = values
+        return SimpleNamespace(matched_count=1, modified_count=1)
+
+
+class _Database:
+    def __init__(self, user: dict):
+        self.users = _UsersCollection(user)
+
+    def get_collection(self, name: str):
+        assert name == "users"
+        return self.users
+
+
+class Phase21CustomerAccountManagementTests(unittest.TestCase):
+    def setUp(self):
+        self.user_id = ObjectId()
+        self.user = {
+            "_id": self.user_id,
+            "email": "customer@example.com",
+            "full_name": "Customer Name",
+            "password_hash": "hash",
+            "session_token_version": 2,
+            "stripe_customer_id": "cus_123",
+        }
+
+    def test_profile_update_normalizes_contact_and_preserves_structured_address(self):
+        database = _Database(self.user)
+        with (
+            patch.object(user_service, "get_database", return_value=database),
+            patch.object(user_service, "write_audit_log"),
+            patch.object(billing_service, "sync_account_contact_to_stripe") as sync_stripe,
+        ):
+            updated = user_service.update_user_profile(
+                str(self.user_id),
+                full_name="Customer Updated",
+                phone_number="(912) 555-0123",
+                mailing_address={
+                    "line1": "100 Main Street",
+                    "line2": "Suite 2",
+                    "city": "Savannah",
+                    "region": "GA",
+                    "postal_code": "31401",
+                    "country": "us",
+                },
+            )
+
+        assert updated is not None
+        self.assertEqual(updated["phone_number"], "+19125550123")
+        self.assertEqual(updated["mailing_address_structured"]["country"], "US")
+        self.assertEqual(updated["billing_profile_sync_status"], "synced")
+        sync_stripe.assert_called_once()
+
+    def test_profile_update_records_pending_when_stripe_sync_fails(self):
+        database = _Database(self.user)
+        with (
+            patch.object(user_service, "get_database", return_value=database),
+            patch.object(user_service, "write_audit_log"),
+            patch.object(
+                billing_service,
+                "sync_account_contact_to_stripe",
+                side_effect=RuntimeError("stripe unavailable"),
+            ),
+        ):
+            updated = user_service.update_user_profile(
+                str(self.user_id),
+                full_name="Customer Name",
+                phone_number=None,
+                mailing_address=None,
+            )
+
+        assert updated is not None
+        self.assertEqual(updated["billing_profile_sync_status"], "pending")
+
+    def test_email_change_requires_password_and_verifies_new_mailbox(self):
+        database = _Database(self.user)
+        with (
+            patch.object(user_service, "get_database", return_value=database),
+            patch("app.services.auth_service.verify_password", return_value=True),
+            patch.object(user_service, "write_audit_log"),
+            patch.object(
+                user_service,
+                "send_email_change_verification_email",
+                return_value={"sent": True},
+            ) as send_verification,
+        ):
+            result = user_service.request_email_change(
+                str(self.user_id),
+                new_email="new@example.com",
+                current_password="CurrentPassword!123",
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(database.users.user["pending_email"], "new@example.com")
+        self.assertNotIn("token", result)
+        verification_url = send_verification.call_args.kwargs["verification_url"]
+        self.assertIn("#mode=email-change&token=", verification_url)
+
+    def test_email_confirmation_changes_login_revokes_sessions_and_preserves_alias(self):
+        token = "phase21-email-change-token"
+        self.user.update(
+            {
+                "pending_email": "new@example.com",
+                "pending_email_change_token_hash": user_service._email_change_token_hash(token),
+                "pending_email_change_expires_at": "2999-01-01T00:00:00+00:00",
+            }
+        )
+        database = _Database(self.user)
+        with (
+            patch.object(user_service, "get_database", return_value=database),
+            patch.object(user_service, "write_audit_log"),
+            patch.object(user_service, "send_email_changed_notice"),
+            patch.object(billing_service, "sync_verified_email_to_stripe"),
+        ):
+            result = user_service.confirm_email_change(token)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(database.users.user["email"], "new@example.com")
+        self.assertEqual(database.users.user["session_token_version"], 3)
+        self.assertIn("customer@example.com", database.users.user["email_aliases"])
+        self.assertNotIn("pending_email_change_token_hash", database.users.user)
+
+    def test_stripe_customer_webhook_cannot_change_login_email(self):
+        database = _Database(self.user)
+        event = {
+            "data": {
+                "object": {
+                    "id": "cus_123",
+                    "email": "billing@example.com",
+                    "name": "Billing Name",
+                    "phone": "+19125550123",
+                    "address": {"line1": "10 Billing Way", "country": "US"},
+                }
+            }
+        }
+        with (
+            patch.object(billing_service, "get_database", return_value=database),
+            patch.object(billing_service, "create_audit_log"),
+        ):
+            result = billing_service.sync_billing_customer_updated_event(event)
+
+        self.assertTrue(result["updated"])
+        self.assertEqual(database.users.user["email"], "customer@example.com")
+        self.assertEqual(database.users.user["billing_contact"]["email"], "billing@example.com")
+
+    def test_customer_ui_exposes_structured_profile_and_verified_email_controls(self):
+        root = Path(__file__).resolve().parents[2]
+        billing_html = (root / "billing.html").read_text(encoding="utf-8")
+        billing_js = (root / "billing.js").read_text(encoding="utf-8")
+        dashboard_html = (root / "dashboard.html").read_text(encoding="utf-8")
+        self.assertIn("data-account-details-form", billing_html)
+        self.assertIn('autocomplete="address-line1"', billing_html)
+        self.assertIn("data-email-change-form", billing_html)
+        self.assertIn('"/users/me/profile"', billing_js)
+        self.assertIn('"/users/me/email-change/request"', billing_js)
+        self.assertIn("billing.html#personal-details", dashboard_html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/billing.html
+++ b/billing.html
@@ -9,7 +9,7 @@
       name="description"
       content="Manage Tomb of Light billing, payment methods, maintenance subscriptions, and saved cards."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -63,6 +63,81 @@
 
         <section class="page-sections">
           <div class="container form-shell portal-account-grid">
+            <div class="form-panel portal-account-details-panel" id="personal-details">
+              <span class="eyebrow">Personal Details</span>
+              <h2>Account contact information</h2>
+              <p class="card-copy">
+                Keep your Tomb of Light contact record current. Saved details are mirrored to your connected billing profile; past orders remain unchanged.
+              </p>
+
+              <form class="form-grid two-col portal-account-details-form" data-account-details-form novalidate>
+                <label>
+                  Full Name
+                  <input type="text" name="full_name" autocomplete="name" maxlength="150" required />
+                </label>
+                <label>
+                  Phone Number
+                  <input type="tel" name="phone_number" autocomplete="tel" maxlength="32" placeholder="(555) 555-0123" />
+                </label>
+                <label class="portal-form-span-2">
+                  Street Address
+                  <input type="text" name="address_line1" autocomplete="address-line1" maxlength="150" />
+                </label>
+                <label class="portal-form-span-2">
+                  Apartment, Suite, or Unit
+                  <input type="text" name="address_line2" autocomplete="address-line2" maxlength="150" />
+                </label>
+                <label>
+                  City
+                  <input type="text" name="address_city" autocomplete="address-level2" maxlength="100" />
+                </label>
+                <label>
+                  State or Region
+                  <input type="text" name="address_region" autocomplete="address-level1" maxlength="100" />
+                </label>
+                <label>
+                  ZIP or Postal Code
+                  <input type="text" name="address_postal_code" autocomplete="postal-code" maxlength="20" />
+                </label>
+                <label>
+                  Country Code
+                  <input type="text" name="address_country" autocomplete="country" maxlength="2" pattern="[A-Za-z]{2}" value="US" aria-describedby="address-country-help" />
+                  <span class="helper" id="address-country-help">Use the two-letter code, such as US or CA.</span>
+                </label>
+                <div class="portal-form-span-2 inline-actions">
+                  <button class="btn btn-primary" type="submit" data-account-details-save>
+                    Save Personal Details
+                  </button>
+                </div>
+                <p class="status-message portal-form-span-2" data-account-details-status role="status" aria-live="polite"></p>
+              </form>
+            </div>
+
+            <div class="form-panel portal-email-control-panel">
+              <span class="eyebrow">Login Email</span>
+              <h2>Verified account email</h2>
+              <p class="card-copy">
+                Your login email is separate from any billing email entered in Stripe. A new address must be verified before it can replace your current login.
+              </p>
+              <p class="portal-identity-value" data-account-current-email>Loading…</p>
+              <form class="form-grid two-col" data-email-change-form novalidate>
+                <label>
+                  New Email Address
+                  <input type="email" name="new_email" autocomplete="email" maxlength="254" required />
+                </label>
+                <label>
+                  Current Password
+                  <input type="password" name="current_password" autocomplete="current-password" minlength="8" maxlength="128" required />
+                </label>
+                <div class="portal-form-span-2 inline-actions">
+                  <button class="btn btn-secondary" type="submit" data-email-change-submit>
+                    Send Verification Link
+                  </button>
+                </div>
+                <p class="status-message portal-form-span-2" data-email-change-status role="status" aria-live="polite"></p>
+              </form>
+            </div>
+
             <div class="form-panel">
               <span class="eyebrow">Subscription Actions</span>
               <p class="card-copy" data-billing-subscriptions-status>
@@ -160,6 +235,6 @@
     <script src="config.js?v=20260331-2"></script>
     <script src="app.js?v=20260825-phase20-1"></script>
     <script src="auth.js?v=20260509-audit"></script>
-    <script src="billing.js?v=20260331-2"></script>
+    <script src="billing.js?v=20260828-phase21"></script>
   </body>
 </html>

--- a/billing.js
+++ b/billing.js
@@ -10,6 +10,7 @@
 
   let currentUser = null;
   let currentContext = null;
+  let currentProfile = null;
   let stripeClient = null;
   let stripeCardElement = null;
 
@@ -65,6 +66,26 @@
       return "Unable to load data right now.";
     }
     return getErrorMessage(error);
+  }
+
+  function getAccountErrorMessage(error) {
+    const message = getErrorMessage(error);
+    const normalized = message.toLowerCase();
+    const safeAccountErrors = [
+      "full name is required",
+      "enter a valid phone number",
+      "street address, city, state or region, and postal code are required",
+      "country must use a two-letter country code",
+      "current password is incorrect",
+      "enter a different email address",
+      "that email address is already connected to an account",
+      "verification email could not be delivered",
+      "email change link is invalid, expired, or already used",
+    ];
+    if (safeAccountErrors.some(function (safeText) { return normalized.includes(safeText); })) {
+      return message.replace(/^\d+\s*:\s*/, "");
+    }
+    return getUserFacingErrorMessage(error);
   }
 
   function buildSubscriptionCard(item) {
@@ -146,6 +167,149 @@
     } finally {
       renderMaintenanceLinks();
     }
+  }
+
+  function setField(form, name, value) {
+    const field = form && form.elements ? form.elements.namedItem(name) : null;
+    if (field) field.value = String(value || "");
+  }
+
+  async function loadAccountProfile() {
+    const form = document.querySelector("[data-account-details-form]");
+    const emailNode = document.querySelector("[data-account-current-email]");
+    const statusNode = document.querySelector("[data-account-details-status]");
+    if (!form) return;
+    try {
+      currentProfile = await app.apiRequest("/users/me/profile", { method: "GET" });
+      const address = (currentProfile && currentProfile.mailing_address) || {};
+      setField(form, "full_name", currentProfile && currentProfile.full_name);
+      setField(form, "phone_number", currentProfile && currentProfile.phone_number);
+      setField(form, "address_line1", address.line1);
+      setField(form, "address_line2", address.line2);
+      setField(form, "address_city", address.city);
+      setField(form, "address_region", address.region);
+      setField(form, "address_postal_code", address.postal_code);
+      setField(form, "address_country", address.country || "US");
+      if (emailNode) {
+        emailNode.textContent = String((currentProfile && currentProfile.email) || "—");
+      }
+      const pendingEmail = String((currentProfile && currentProfile.pending_email) || "");
+      if (pendingEmail) {
+        app.setStatus(
+          document.querySelector("[data-email-change-status]"),
+          `Verification is pending for ${pendingEmail}.`,
+          "info",
+        );
+      }
+    } catch (error) {
+      app.setStatus(statusNode, "Personal details could not be loaded. Try again.", "error");
+    }
+  }
+
+  async function handleAccountDetailsSave(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const statusNode = document.querySelector("[data-account-details-status]");
+    const button = document.querySelector("[data-account-details-save]");
+    const formData = new FormData(form);
+    const payload = {
+      full_name: String(formData.get("full_name") || "").trim(),
+      phone_number: String(formData.get("phone_number") || "").trim() || null,
+      mailing_address: {
+        line1: String(formData.get("address_line1") || "").trim(),
+        line2: String(formData.get("address_line2") || "").trim(),
+        city: String(formData.get("address_city") || "").trim(),
+        region: String(formData.get("address_region") || "").trim(),
+        postal_code: String(formData.get("address_postal_code") || "").trim(),
+        country: String(formData.get("address_country") || "US").trim().toUpperCase(),
+      },
+    };
+    if (!payload.full_name) {
+      app.setStatus(statusNode, "Full name is required.", "error");
+      return;
+    }
+    if (button) button.disabled = true;
+    try {
+      app.setStatus(statusNode, "Saving your personal details…", "info");
+      currentProfile = await app.apiRequest("/users/me/profile", {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      });
+      const syncStatus = String((currentProfile && currentProfile.billing_sync_status) || "");
+      const message = syncStatus === "pending"
+        ? "Personal details saved. Billing synchronization is still pending."
+        : syncStatus === "synced"
+          ? "Personal details saved and your connected billing profile is current."
+          : "Personal details saved. No connected billing profile needed updating.";
+      app.setStatus(statusNode, message, "success");
+    } catch (error) {
+      app.setStatus(statusNode, getAccountErrorMessage(error), "error");
+    } finally {
+      if (button) button.disabled = false;
+    }
+  }
+
+  async function handleEmailChangeRequest(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const statusNode = document.querySelector("[data-email-change-status]");
+    const button = document.querySelector("[data-email-change-submit]");
+    const formData = new FormData(form);
+    const newEmail = String(formData.get("new_email") || "").trim().toLowerCase();
+    const currentPassword = String(formData.get("current_password") || "");
+    if (!newEmail || !currentPassword) {
+      app.setStatus(statusNode, "New email and current password are required.", "error");
+      return;
+    }
+    if (button) button.disabled = true;
+    try {
+      const result = await app.apiRequest("/users/me/email-change/request", {
+        method: "POST",
+        body: JSON.stringify({ new_email: newEmail, current_password: currentPassword }),
+      });
+      form.reset();
+      app.setStatus(
+        statusNode,
+        String((result && result.message) || "Verification sent to the new email address."),
+        "success",
+      );
+    } catch (error) {
+      app.setStatus(statusNode, getAccountErrorMessage(error), "error");
+    } finally {
+      if (button) button.disabled = false;
+    }
+  }
+
+  function emailChangeTokenFromHash() {
+    const rawHash = String(window.location.hash || "").replace(/^#/, "");
+    const params = new URLSearchParams(rawHash);
+    return params.get("mode") === "email-change" ? String(params.get("token") || "") : "";
+  }
+
+  async function handleEmailChangeConfirmation() {
+    const token = emailChangeTokenFromHash();
+    if (!token) return false;
+    window.history.replaceState({}, document.title, `${window.location.pathname}${window.location.search}`);
+    const pageStatus = document.querySelector("[data-billing-page-status]");
+    try {
+      app.setStatus(pageStatus, "Confirming your new email address…", "info");
+      const result = await app.apiRequest("/users/me/email-change/confirm", {
+        method: "POST",
+        body: JSON.stringify({ token }),
+      });
+      app.clearSession();
+      app.setStatus(
+        pageStatus,
+        String((result && result.message) || "Email updated. Sign in again."),
+        "success",
+      );
+      window.setTimeout(function () {
+        window.location.replace("signin.html");
+      }, 2200);
+    } catch (error) {
+      app.setStatus(pageStatus, getAccountErrorMessage(error), "error");
+    }
+    return true;
   }
 
   async function refreshOverview() {
@@ -398,6 +562,16 @@
   }
 
   function bindInteractions() {
+    const accountDetailsForm = document.querySelector("[data-account-details-form]");
+    if (accountDetailsForm) {
+      accountDetailsForm.addEventListener("submit", handleAccountDetailsSave);
+    }
+
+    const emailChangeForm = document.querySelector("[data-email-change-form]");
+    if (emailChangeForm) {
+      emailChangeForm.addEventListener("submit", handleEmailChangeRequest);
+    }
+
     const form = document.querySelector("[data-billing-card-form]");
     if (form) {
       form.addEventListener("submit", handleCardSave);
@@ -450,6 +624,7 @@
   }
 
   document.addEventListener("DOMContentLoaded", async function () {
+    if (await handleEmailChangeConfirmation()) return;
     currentUser = await app.requireSession("signin.html");
     if (!currentUser) return;
     if (isInternalUser(currentUser)) {
@@ -458,6 +633,11 @@
     }
 
     bindInteractions();
-    await Promise.allSettled([loadContext(), ensureStripeClient(), refreshOverview()]);
+    await Promise.allSettled([
+      loadContext(),
+      loadAccountProfile(),
+      ensureStripeClient(),
+      refreshOverview(),
+    ]);
   });
 })();

--- a/browser-tests/customer-account-phase21.spec.mjs
+++ b/browser-tests/customer-account-phase21.spec.mjs
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+
+const CUSTOMER = {
+  id: "phase21-customer",
+  _id: "phase21-customer",
+  email: "customer@example.com",
+  full_name: "Customer Example",
+  role: "user",
+  account_type: "customer",
+  status: "active",
+};
+
+async function seedCustomerSession(page) {
+  await page.addInitScript((user) => {
+    localStorage.setItem("tol_access_token", "phase21-fixture-token");
+    localStorage.setItem("tol_user", JSON.stringify(user));
+  }, CUSTOMER);
+}
+
+test.describe("Phase 21 customer account management", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("updates structured contact details and requests verified email replacement", async ({ page }) => {
+    const requests = [];
+    await seedCustomerSession(page);
+    await page.route("https://js.stripe.com/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/javascript", body: "" }),
+    );
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname.replace(/^\/api-gateway/, "");
+      const method = request.method();
+      const json = (payload, status = 200) =>
+        route.fulfill({ status, contentType: "application/json", body: JSON.stringify(payload) });
+
+      if (method === "GET" && path === "/auth/me") return json(CUSTOMER);
+      if (method === "GET" && path === "/users/me/profile") {
+        return json({
+          ...CUSTOMER,
+          created_at: "2026-08-28T00:00:00Z",
+          phone_number: "+19125550123",
+          mailing_address: {
+            line1: "100 Main Street",
+            line2: "",
+            city: "Savannah",
+            region: "GA",
+            postal_code: "31401",
+            country: "US",
+          },
+          pending_email: null,
+          billing_sync_status: "synced",
+          legal_acceptance: {},
+        });
+      }
+      if (method === "PATCH" && path === "/users/me/profile") {
+        const body = request.postDataJSON();
+        requests.push({ type: "profile", body });
+        return json({
+          ...CUSTOMER,
+          ...body,
+          created_at: "2026-08-28T00:00:00Z",
+          billing_sync_status: "synced",
+          legal_acceptance: {},
+        });
+      }
+      if (method === "POST" && path === "/users/me/email-change/request") {
+        const body = request.postDataJSON();
+        requests.push({ type: "email", body });
+        return json({ success: true, message: "Verification sent to the new email address." });
+      }
+      if (method === "GET" && path === "/billing/overview") {
+        return json({
+          customer_id: "cus_fixture",
+          max_cards: 3,
+          cards_on_file: 0,
+          can_add_card: true,
+          payment_methods: [],
+          subscriptions: [],
+        });
+      }
+      if (method === "GET" && path === "/billing/config") {
+        return json({ publishable_key: "", max_cards: 3 });
+      }
+      if (method === "GET" && path === "/orders/my-orders") return json([]);
+      if (method === "POST" && path === "/auth/logout") return json({ ok: true });
+      if (path.startsWith("/")) {
+        if (request.resourceType() === "document" || ["script", "stylesheet", "image", "font"].includes(request.resourceType())) {
+          return route.continue();
+        }
+        return json({ ok: true });
+      }
+      return route.continue();
+    });
+
+    await page.goto("/billing.html#personal-details", { waitUntil: "load" });
+    await expect(page.locator('[name="full_name"]')).toHaveValue("Customer Example");
+    await expect(page.locator('[name="address_city"]')).toHaveValue("Savannah");
+    await expect(page.locator("[data-account-current-email]")).toHaveText("customer@example.com");
+
+    await page.locator('[name="phone_number"]').fill("(912) 555-0199");
+    await page.locator('[name="address_line2"]').fill("Suite 9");
+    await page.locator("[data-account-details-save]").click();
+    await expect(page.locator("[data-account-details-status]")).toContainText(
+      "Personal details saved",
+    );
+
+    await page.locator('[name="new_email"]').fill("new@example.com");
+    await page.locator('[name="current_password"]').fill("CurrentPassword!123");
+    await page.locator("[data-email-change-submit]").click();
+    await expect(page.locator("[data-email-change-status]")).toContainText(
+      "Verification sent",
+    );
+
+    expect(requests[0].body.phone_number).toBe("(912) 555-0199");
+    expect(requests[0].body.mailing_address.line2).toBe("Suite 9");
+    expect(requests[1].body).toEqual({
+      new_email: "new@example.com",
+      current_password: "CurrentPassword!123",
+    });
+
+    const width = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+    }));
+    expect(width.document).toBeLessThanOrEqual(width.viewport + 1);
+  });
+});

--- a/dashboard.html
+++ b/dashboard.html
@@ -813,6 +813,9 @@
                 <a class="btn btn-secondary" href="account-security.html">
                   Account Security
                 </a>
+                <a class="btn btn-secondary" href="billing.html#personal-details" data-dashboard-customer-only>
+                  Personal Details
+                </a>
                 <a
                   class="btn btn-secondary"
                   href="billing.html"

--- a/styles.css
+++ b/styles.css
@@ -3482,6 +3482,41 @@ textarea {
   gap: 24px;
 }
 
+.portal-account-details-panel,
+.portal-email-control-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.portal-account-details-panel::before,
+.portal-email-control-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--gold), rgba(120, 181, 255, 0.65));
+}
+
+.portal-account-details-panel h2,
+.portal-email-control-panel h2 {
+  margin-bottom: 0.55rem;
+}
+
+.portal-form-span-2 {
+  grid-column: 1 / -1;
+}
+
+.portal-identity-value {
+  margin: 1rem 0 1.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(214, 176, 102, 0.22);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--tol-text);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
 .portal-command-center-grid {
   margin-top: 1rem;
   display: grid;


### PR DESCRIPTION
## Summary

- adds structured customer self-service for name, phone number, and mailing address
- adds a secure verified email-change workflow with password confirmation, a hashed 30-minute token, notice to the former address, and session revocation
- keeps Stripe billing email separate from login identity and reconciles billing details from authoritative `customer.updated` webhooks
- preserves historical order records and restricts billing/account self-service routes to the owning customer
- adds audit coverage and Phase 21 backend/browser regression tests

## Verification

- 1,967 backend tests passed
- 2 expected skips
- 139 subtests passed
- 36 browser tests discovered; Chromium execution is delegated to GitHub CI

No production customer data, Stripe records, blockchain records, or MongoDB records were changed.