### PR TITLE
Phase 21.1 — Mobile recovery and secure private-event access

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -9,7 +9,7 @@
       name="description"
       content="Learn about Tomb of Light’s accessibility commitment and ongoing efforts to improve website usability and inclusive access."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -231,6 +231,6 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/account-security.html
+++ b/account-security.html
@@ -9,7 +9,7 @@
       name="description"
       content="Reset or change your Tomb of Light password through the protected account security layer."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -68,10 +68,11 @@
               id="reset-request"
               data-password-reset-request-panel
             >
-              <span class="eyebrow">Reset Request</span>
+              <span class="eyebrow">Account Recovery</span>
               <p class="card-copy">
-                Enter the email attached to your Tomb of Light account. If it
-                exists, a secure password reset link will be emailed to you.
+                Enter the email attached to your Tomb of Light account. If
+                setup is unfinished, we will send a new activation link. If
+                the account is active, we will send a password-reset link.
               </p>
               <p class="card-copy" style="font-size: 0.875rem; color: var(--color-muted, #888);">
                 Passwords must be at least 12 characters and include at least
@@ -93,7 +94,7 @@
 
                 <div class="inline-actions" style="margin-top: 1rem">
                   <button class="btn btn-primary" type="submit">
-                    Request Password Reset
+                    Recover Account Access
                   </button>
                 </div>
               </form>
@@ -396,9 +397,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
-    <script src="account-security.js?v=20260823-phase12"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
+    <script src="account-security.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/account-security.js
+++ b/account-security.js
@@ -446,20 +446,20 @@
       }
 
       try {
-        const payload = await app.apiRequest("/auth/password-reset/request", {
+        const payload = await app.apiRequest("/auth/account-recovery/request", {
           method: "POST",
           body: JSON.stringify({ email }),
         });
         const message = String(
           (payload && payload.message) ||
-            "Password reset request created successfully.",
+            "If this email is connected to an account, the appropriate secure access link has been sent.",
         );
         app.setStatus(statusNode, message, "success");
         form.reset();
       } catch (error) {
         app.setStatus(
           statusNode,
-          getErrorMessage(error) || "Unable to request password reset.",
+          getErrorMessage(error) || "Unable to request account recovery.",
           "error",
         );
       }

--- a/add-member.html
+++ b/add-member.html
@@ -9,7 +9,7 @@
     name="description"
     content="Add a family member to your Tomb of Light lineage structure."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <div class="page-wrap">
@@ -277,7 +277,7 @@
   </div>
 
   <script src="config.js"></script>
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
   <script src="auth.js"></script>
   <script src="member.js?v=20260823-phase13-1"></script>
 </body>

--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -9,7 +9,7 @@
       name="description"
       content="Internal premium operations console for Tomb of Light customer cases, repairs, entitlements, mint readiness, and audit review."
     />
-    <link rel="stylesheet" href="styles.css?v=20260821-phase10-1" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="admin-control-center-body">
     <div class="page-wrap">
@@ -32,6 +32,7 @@
           <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
             <a href="dashboard.html">Dashboard</a>
             <a href="admin-control-center.html" aria-current="page">Control Center</a>
+            <a href="admin-event-access.html">Event Access</a>
             <a href="admin-intake-queue.html">Admin Intake Queue</a>
             <a href="admin-family-manager.html">Family Manager</a>
             <a href="admin-portrait-review.html">Portrait Review</a>
@@ -554,9 +555,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260727-masterops1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-control-center.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/admin-event-access.css
+++ b/admin-event-access.css
@@ -1,0 +1,47 @@
+.admin-event-confirmation > span {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 0.75rem;
+  line-height: 1.55;
+}
+
+.admin-event-confirmation input[type="checkbox"] {
+  width: 20px;
+  min-width: 20px;
+  max-width: 20px;
+  height: 20px;
+  min-height: 20px;
+  margin: 0.1rem 0 0;
+  padding: 0;
+  accent-color: var(--gold);
+}
+
+[data-admin-event-invitation-list] > .card {
+  min-width: 0;
+}
+
+[data-admin-event-invitation-list] h3,
+[data-admin-event-invitation-list] .card-copy {
+  overflow-wrap: anywhere;
+}
+
+[data-admin-event-invitation-list] .form-grid:empty {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  [data-admin-event-access-page] .page-hero {
+    padding-top: 28px;
+  }
+
+  [data-admin-event-access-page] .page-hero-panel,
+  [data-admin-event-access-page] .form-panel {
+    padding: 22px;
+  }
+
+  [data-admin-event-access-page] .inline-actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/admin-event-access.html
+++ b/admin-event-access.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
+    <title>Private Event Access | Tomb of Light</title>
+    <meta
+      name="description"
+      content="CEO-only private event invitation and delivery controls for Tomb of Light."
+    />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
+    <link rel="stylesheet" href="admin-event-access.css?v=20260828-secure-event-access" />
+  </head>
+  <body class="admin-control-center-body">
+    <div class="page-wrap">
+      <header class="site-header">
+        <div class="container site-header-inner">
+          <a class="brand" href="index.html" aria-label="Tomb of Light home">
+            <span>Tomb of Light<span class="brand-symbol">™</span></span>
+          </a>
+
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-label="Toggle navigation menu"
+            aria-expanded="false"
+            aria-controls="site-nav"
+          >
+            Menu
+          </button>
+
+          <nav class="site-nav" id="site-nav" aria-label="Primary navigation">
+            <a href="dashboard.html">Dashboard</a>
+            <a href="admin-control-center.html">Control Center</a>
+            <a href="admin-event-access.html" aria-current="page">Event Access</a>
+            <a href="admin-portrait-review.html">Portrait Review</a>
+            <a href="admin-verification-review.html">Evidence Review</a>
+            <a href="faq.html">FAQ</a>
+          </nav>
+
+          <div class="header-actions">
+            <a class="btn btn-secondary" href="admin-control-center.html">Back to Control Center</a>
+            <button class="btn btn-secondary" type="button" data-logout-btn>Log Out</button>
+          </div>
+        </div>
+      </header>
+
+      <main data-admin-event-access-page>
+        <section class="page-hero">
+          <div class="container">
+            <div class="page-hero-panel">
+              <span class="eyebrow">CEO-Only Secure Delivery</span>
+              <h1>Private Event Access</h1>
+              <p data-admin-event-page-status>
+                Confirming authorization and protected event configuration…
+              </p>
+              <div class="hero-meta" aria-label="Private access safeguards">
+                <span class="meta-pill">No codes in source</span>
+                <span class="meta-pill">One invited mailbox</span>
+                <span class="meta-pill">One selected package</span>
+                <span class="meta-pill">Audited delivery</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="page-sections">
+          <div class="container form-shell">
+            <div class="form-panel">
+              <span class="eyebrow">Deployment Readiness</span>
+              <h2>Protected configuration</h2>
+              <p class="card-copy">
+                Promotion values live only in the backend runtime. This page receives package names and readiness
+                state, never the values themselves.
+              </p>
+              <div class="notice" data-admin-event-configuration role="status" aria-live="polite">
+                Checking protected configuration…
+              </div>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Issue One Invitation</span>
+              <h2>Recipient-bound event access</h2>
+              <p class="card-copy">
+                The recipient receives a one-time link. After the invited email is verified, the package-specific
+                offer is delivered to that same mailbox.
+              </p>
+
+              <form class="form-grid" data-admin-event-invitation-form novalidate>
+                <div class="form-grid two-col">
+                  <label>
+                    Invited Email Address
+                    <input
+                      type="email"
+                      name="email"
+                      autocomplete="off"
+                      maxlength="254"
+                      required
+                    />
+                  </label>
+
+                  <label>
+                    Selected Package
+                    <select name="package_code" required>
+                      <option value="">Select one package</option>
+                      <option value="legacy_snapshot">Legacy Snapshot</option>
+                      <option value="legacy_portrait_intro">Legacy Portrait Intro</option>
+                      <option value="digital_legacy_portrait">Digital Legacy Portrait</option>
+                      <option value="household_foundation">Household Foundation</option>
+                      <option value="heirloom_legacy_tree">Heirloom Legacy Tree</option>
+                      <option value="legacy_plus">Legacy Plus</option>
+                      <option value="family_estate_concierge">Family Estate Concierge</option>
+                      <option value="command_structure_network">Command Structure Network</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label>
+                  Internal Reason
+                  <textarea
+                    name="reason"
+                    rows="3"
+                    maxlength="500"
+                    placeholder="Example: Verified Event 2 guest registration"
+                    required
+                  ></textarea>
+                </label>
+
+                <label class="notice admin-event-confirmation">
+                  <span>
+                    <input type="checkbox" name="confirmed" required />
+                    I verified the recipient email and selected package. Send one audited invitation.
+                  </span>
+                </label>
+
+                <div class="inline-actions">
+                  <button class="btn btn-primary" type="submit" data-admin-event-send disabled>
+                    Send Secure Invitation
+                  </button>
+                  <button class="btn btn-secondary" type="button" data-admin-event-refresh>
+                    Refresh Delivery History
+                  </button>
+                </div>
+
+                <p
+                  class="status-message"
+                  data-admin-event-action-status
+                  role="status"
+                  aria-live="polite"
+                ></p>
+              </form>
+            </div>
+
+            <div class="form-panel">
+              <span class="eyebrow">Audited Delivery History</span>
+              <h2>Event invitations</h2>
+              <p class="card-copy">
+                Revocation disables an unused invitation immediately. Fulfilled, expired, and already revoked
+                records remain visible as evidence.
+              </p>
+              <div class="grid-3" data-admin-event-invitation-list></div>
+              <p class="helper" data-admin-event-empty hidden>No invitations have been issued.</p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container">
+          <div class="footer-card">
+            <div class="footer-bottom">
+              <span>© 2026 Tomb of Light LLC. All rights reserved.</span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
+    <script src="admin-event-access.js?v=20260828-secure-event-access"></script>
+  </body>
+</html>

--- a/admin-event-access.js
+++ b/admin-event-access.js
@@ -1,0 +1,228 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") return;
+
+  const packageNames = {
+    legacy_snapshot: "Legacy Snapshot",
+    legacy_portrait_intro: "Legacy Portrait Intro",
+    digital_legacy_portrait: "Digital Legacy Portrait",
+    household_foundation: "Household Foundation",
+    heirloom_legacy_tree: "Heirloom Legacy Tree",
+    legacy_plus: "Legacy Plus",
+    family_estate_concierge: "Family Estate Concierge",
+    command_structure_network: "Command Structure Network",
+  };
+
+  let configurationReady = false;
+
+  function escapeHtml(value) {
+    return String(value == null ? "" : value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function formatDate(value) {
+    if (!value) return "—";
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? "—" : parsed.toLocaleString();
+  }
+
+  function setStatus(node, message, state) {
+    if (!node) return;
+    app.setStatus(node, message, state || "info");
+  }
+
+  function userFacingError(error, fallback) {
+    const message = String((error && error.message) || "").trim();
+    if (message && message.length <= 240) return message;
+    return fallback;
+  }
+
+  function renderConfiguration(configuration) {
+    const node = document.querySelector("[data-admin-event-configuration]");
+    const sendButton = document.querySelector("[data-admin-event-send]");
+    const required = Array.isArray(configuration && configuration.required_packages)
+      ? configuration.required_packages
+      : Object.keys(packageNames);
+    const configured = new Set(
+      Array.isArray(configuration && configuration.configured_packages)
+        ? configuration.configured_packages
+        : [],
+    );
+    configurationReady = Boolean(configuration && configuration.configured);
+
+    const labels = required.map(function (code) {
+      const label = packageNames[code] || code;
+      return `${label}: ${configured.has(code) ? "ready" : "not configured"}`;
+    });
+    const error = String((configuration && configuration.configuration_error) || "").trim();
+    const expiration = formatDate(configuration && configuration.expires_at);
+    const summary = configurationReady
+      ? `Ready. All ${required.length} package values are protected in the backend. Offer expiration: ${expiration}.`
+      : `Sending is blocked until protected deployment configuration is complete. ${error || labels.join(" · ")}`;
+
+    setStatus(node, summary, configurationReady ? "success" : "error");
+    if (sendButton) sendButton.disabled = !configurationReady;
+  }
+
+  function renderInvitations(items) {
+    const list = document.querySelector("[data-admin-event-invitation-list]");
+    const empty = document.querySelector("[data-admin-event-empty]");
+    if (!list || !empty) return;
+    const records = Array.isArray(items) ? items : [];
+    empty.hidden = records.length > 0;
+    list.innerHTML = records
+      .map(function (item) {
+        const status = String(item.status || "unknown");
+        const revocable = [
+          "pending",
+          "delivered",
+          "delivery_failed",
+          "fulfillment_in_progress",
+        ].includes(status);
+        const revokeControls = revocable
+          ? `<label>
+              Revocation reason
+              <input type="text" maxlength="500" data-admin-event-revoke-reason="${escapeHtml(item.id)}" />
+            </label>
+            <button class="btn btn-secondary" type="button" data-admin-event-revoke="${escapeHtml(item.id)}">
+              Revoke Invitation
+            </button>`
+          : "";
+        return `<article class="card">
+          <span class="eyebrow">${escapeHtml(status.replaceAll("_", " "))}</span>
+          <h3>${escapeHtml(item.email)}</h3>
+          <p class="card-copy"><strong>Package:</strong> ${escapeHtml(item.package_name || packageNames[item.package_code] || item.package_code)}</p>
+          <p class="card-copy"><strong>Invitation email:</strong> ${escapeHtml(item.invitation_delivery_status || "—")}</p>
+          <p class="card-copy"><strong>Offer email:</strong> ${escapeHtml(item.promotion_delivery_status || "—")}</p>
+          <p class="card-copy"><strong>Created:</strong> ${escapeHtml(formatDate(item.created_at))}</p>
+          <p class="card-copy"><strong>Expires:</strong> ${escapeHtml(formatDate(item.expires_at))}</p>
+          <div class="form-grid">${revokeControls}</div>
+        </article>`;
+      })
+      .join("");
+  }
+
+  async function loadInvitations() {
+    const statusNode = document.querySelector("[data-admin-event-page-status]");
+    const payload = await app.apiRequest("/bridge-events/paint/invitations", {
+      method: "GET",
+    });
+    renderConfiguration(payload && payload.configuration);
+    renderInvitations(payload && payload.items);
+    if (statusNode) {
+      statusNode.textContent = configurationReady
+        ? "Protected invitation delivery is operational."
+        : "Protected invitation delivery is blocked pending deployment configuration.";
+    }
+  }
+
+  async function handleSend(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const statusNode = document.querySelector("[data-admin-event-action-status]");
+    const submitButton = document.querySelector("[data-admin-event-send]");
+    const data = new FormData(form);
+    const payload = {
+      email: String(data.get("email") || "").trim().toLowerCase(),
+      package_code: String(data.get("package_code") || "").trim(),
+      reason: String(data.get("reason") || "").trim(),
+      confirmed: data.get("confirmed") === "on",
+    };
+
+    if (!configurationReady) {
+      setStatus(statusNode, "Protected deployment configuration is incomplete. Sending remains blocked.", "error");
+      return;
+    }
+    if (!form.reportValidity() || !payload.confirmed) return;
+
+    submitButton.disabled = true;
+    try {
+      setStatus(statusNode, "Sending one protected invitation…", "info");
+      const result = await app.apiRequest("/bridge-events/paint/invitations", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      form.reset();
+      setStatus(
+        statusNode,
+        result && result.invitation_created === false
+          ? "An active invitation already exists. It was reused and no duplicate email was sent."
+          : "Secure invitation sent and audit evidence recorded.",
+        "success",
+      );
+      await loadInvitations();
+    } catch (error) {
+      setStatus(statusNode, userFacingError(error, "The invitation could not be sent."), "error");
+    } finally {
+      submitButton.disabled = !configurationReady;
+    }
+  }
+
+  async function handleRevoke(button) {
+    const invitationId = String(button.getAttribute("data-admin-event-revoke") || "");
+    const reasonNode = document.querySelector(
+      `[data-admin-event-revoke-reason="${CSS.escape(invitationId)}"]`,
+    );
+    const reason = String((reasonNode && reasonNode.value) || "").trim();
+    const statusNode = document.querySelector("[data-admin-event-action-status]");
+    if (reason.length < 3) {
+      setStatus(statusNode, "Enter a revocation reason of at least 3 characters.", "error");
+      if (reasonNode) reasonNode.focus();
+      return;
+    }
+    if (!window.confirm("Revoke this unused private-event invitation? This cannot be undone.")) return;
+
+    button.disabled = true;
+    try {
+      await app.apiRequest(
+        `/bridge-events/paint/invitations/${encodeURIComponent(invitationId)}/revoke`,
+        {
+          method: "POST",
+          body: JSON.stringify({ reason, confirmed: true }),
+        },
+      );
+      setStatus(statusNode, "Invitation revoked and audit evidence recorded.", "success");
+      await loadInvitations();
+    } catch (error) {
+      button.disabled = false;
+      setStatus(statusNode, userFacingError(error, "The invitation could not be revoked."), "error");
+    }
+  }
+
+  async function setupPage() {
+    const page = document.querySelector("[data-admin-event-access-page]");
+    if (!page) return;
+    const token = app.getToken ? app.getToken() : null;
+    if (!token) {
+      window.location.replace("signin.html");
+      return;
+    }
+
+    const form = document.querySelector("[data-admin-event-invitation-form]");
+    const refresh = document.querySelector("[data-admin-event-refresh]");
+    if (form) form.addEventListener("submit", handleSend);
+    if (refresh) refresh.addEventListener("click", loadInvitations);
+    document.addEventListener("click", function (event) {
+      const button = event.target.closest("[data-admin-event-revoke]");
+      if (button) handleRevoke(button);
+    });
+
+    try {
+      await app.apiRequest("/auth/me", { method: "GET" });
+      await loadInvitations();
+    } catch (error) {
+      const pageStatus = document.querySelector("[data-admin-event-page-status]");
+      const configNode = document.querySelector("[data-admin-event-configuration]");
+      if (pageStatus) pageStatus.textContent = "CEO authorization could not be confirmed.";
+      setStatus(configNode, "This surface requires canonical CEO authorization.", "error");
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", setupPage);
+})();

--- a/admin-family-manager.html
+++ b/admin-family-manager.html
@@ -9,7 +9,7 @@
       name="description"
       content="Admin family build manager for Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -494,9 +494,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260325-5"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-family-manager.js?v=20260824-phase18"></script>
   </body>
 </html>

--- a/admin-intake-queue.html
+++ b/admin-intake-queue.html
@@ -9,7 +9,7 @@
       name="description"
       content="Admin review queue for Tomb of Light intake submissions."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -142,9 +142,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260325-4"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-intake.js?v=20260410-1"></script>
   </body>
 </html>

--- a/admin-intake-review.html
+++ b/admin-intake-review.html
@@ -9,7 +9,7 @@
       name="description"
       content="Admin review detail page for Tomb of Light intake submissions."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -251,9 +251,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260325-5"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-intake.js?v=20260410-1"></script>
   </body>
 </html>

--- a/admin-portrait-review.html
+++ b/admin-portrait-review.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
     <title>Master Portrait Review | Tomb of Light</title>
-    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="page-wrap">
@@ -44,9 +44,9 @@
         </div></section>
       </main>
     </div>
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-portrait-review.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/admin-verification-review.html
+++ b/admin-verification-review.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
     <title>Master Verification Review | Tomb of Light</title>
-    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="page-wrap">
@@ -42,9 +42,9 @@
         </div></section>
       </main>
     </div>
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-verification-review.js?v=20260824-phase19-1"></script>
   </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@
   const FOUNDER_MAINTENANCE_PENDING_KEY = "tol_founder_maintenance_pending";
   const LIGHT_NEVER_DIES_CAMPAIGN = "LIGHT_NEVER_DIES";
   const API_BASE_URL_STORAGE_KEY = "tol_api_base_url";
+  const API_DISCOVERY_TIMEOUT_MS = 15000;
   const API_REQUEST_TIMEOUT_MS = 30000;
   const API_REQUEST_RETRY_ATTEMPTS = 1;
 
@@ -575,12 +576,21 @@
     const urls = uniqueNonEmptyValues(candidates);
     const failures = [];
     for (const apiBaseUrl of urls) {
+      let timeoutId = null;
       try {
-        const response = await fetch(`${apiBaseUrl}/health`, {
+        const requestOptions = {
           method: "GET",
           headers: { Accept: "application/json" },
           credentials: "include",
-        });
+        };
+        if (typeof AbortController === "function") {
+          const controller = new AbortController();
+          requestOptions.signal = controller.signal;
+          timeoutId = window.setTimeout(function () {
+            controller.abort();
+          }, API_DISCOVERY_TIMEOUT_MS);
+        }
+        const response = await fetch(`${apiBaseUrl}/health`, requestOptions);
         if (response && response.ok && isJsonApiResponse(response)) {
           saveApiBaseUrl(apiBaseUrl);
           return apiBaseUrl;
@@ -592,6 +602,10 @@
         );
       } catch (_error) {
         failures.push(`${apiBaseUrl} could not be reached`);
+      } finally {
+        if (timeoutId) {
+          window.clearTimeout(timeoutId);
+        }
       }
     }
 
@@ -605,7 +619,7 @@
   function buildNetworkErrorMessage(apiBaseUrls) {
     const candidates = uniqueNonEmptyValues(apiBaseUrls);
     if (!isLocalApp()) {
-      return `Service temporarily unavailable (NET-API-UNREACHABLE). Unable to reach ${candidates[0] || "the API host"}. Use Retry.`;
+      return "Service temporarily unavailable (NET-API-UNREACHABLE). Tomb of Light could not reach its secure account service. No account change was completed. Use Retry.";
     }
 
     const details = [
@@ -1442,10 +1456,15 @@
     });
 
     window.addEventListener("resize", function () {
-      if (window.innerWidth > 860) {
+      if (window.innerWidth > 1180) {
         closeMenu();
       }
     });
+
+    // Back-forward cache restores can preserve a stale body scroll lock even
+    // though the expanded menu is no longer visible. Always restore the closed
+    // state when the document becomes active again.
+    window.addEventListener("pageshow", closeMenu);
   }
 
   function setupHeaderScrollState() {

--- a/auth.js
+++ b/auth.js
@@ -2032,6 +2032,24 @@
     return "";
   }
 
+  function isExistingAccountError(error) {
+    const statusCode = Number(error?.status || 0);
+    const message = getErrorMessage(error).toLowerCase();
+    return (
+      statusCode === 400 &&
+      (message.includes("email already registered") ||
+        message.includes("email address is already connected to an account"))
+    );
+  }
+
+  async function requestExistingAccountRecovery(email) {
+    await app.apiRequest("/auth/account-recovery/request", {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    });
+    return "An account is already connected to this email. If it is eligible for recovery, the appropriate secure link was sent: activation if setup is unfinished, or password reset if the account is active. Check the inbox and spam folder.";
+  }
+
   function setupSignupForm() {
     const form = document.querySelector("[data-signup-form]");
     if (!form) return;
@@ -2194,6 +2212,25 @@
         }
         redirectAfterLogin();
       } catch (error) {
+        if (isExistingAccountError(error)) {
+          try {
+            app.setStatus(
+              statusNode,
+              "This email is already connected to an account. Sending the appropriate secure recovery link…",
+              "info",
+            );
+            const recoveryMessage = await requestExistingAccountRecovery(email);
+            app.setStatus(statusNode, recoveryMessage, "success");
+          } catch (recoveryError) {
+            app.setStatus(
+              statusNode,
+              getUnavailableAccountSetupMessage(recoveryError) ||
+                "This email is already connected to an account, but the secure recovery email could not be requested. Use Account Security or contact support@tomboflight.com.",
+              "error",
+            );
+          }
+          return;
+        }
         app.setStatus(
           statusNode,
           getUnavailableAccountSetupMessage(error) ||

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -84,3 +84,10 @@ POSTMARK_SERVER_TOKEN_FILE=""
 POSTMARK_FROM_EMAIL="admin@tomboflight.com"
 POSTMARK_FROM_NAME="Tomb of Light Security"
 POSTMARK_MESSAGE_STREAM="outbound"
+
+# Private Bridge Event access. Create new replacement promotion codes in
+# Stripe, revoke every value previously published in static source, and place
+# only the replacement mapping in the protected production environment.
+BRIDGE_PAINT_PROMOTION_CODES_JSON="{}"
+BRIDGE_PAINT_EVENT_EXPIRES_AT="2026-08-30T03:59:00+00:00"
+BRIDGE_PAINT_ACCESS_RATE_LIMIT="5"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -408,6 +408,23 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("POSTMARK_MESSAGE_STREAM"),
     )
 
+    # Private Bridge Event access. Promotion codes are runtime secrets and
+    # must never be committed to the repository or returned by an API.
+    bridge_paint_promotion_codes_json: str = Field(
+        default="",
+        validation_alias=AliasChoices("BRIDGE_PAINT_PROMOTION_CODES_JSON"),
+    )
+    bridge_paint_event_expires_at: str = Field(
+        default="2026-08-30T03:59:00+00:00",
+        validation_alias=AliasChoices("BRIDGE_PAINT_EVENT_EXPIRES_AT"),
+    )
+    bridge_paint_access_rate_limit: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        validation_alias=AliasChoices("BRIDGE_PAINT_ACCESS_RATE_LIMIT"),
+    )
+
     allowed_origins: str = Field(
         default=("https://tomboflight.com," "https://www.tomboflight.com"),
         validation_alias=AliasChoices("ALLOWED_ORIGINS"),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from app.routes.admin_maintenance import router as admin_maintenance_router
 from app.routes.audit_logs import router as audit_logs_router
 from app.routes.auth import router as auth_router
 from app.routes.billing import router as billing_router
+from app.routes.bridge_event_access import router as bridge_event_access_router
 from app.routes.canonical_persons import router as canonical_persons_router
 from app.routes.certificate_versions import router as certificate_versions_router
 from app.routes.consistency import router as consistency_router
@@ -81,6 +82,7 @@ from app.routes.organizations import router as organizations_router
 from app.services.project_entitlement_service import ensure_project_entitlement_indexes
 from app.services.admin_access_bootstrap_service import bootstrap_admin_access_controls
 from app.services.admin_control_service import ensure_finance_event_indexes
+from app.services.bridge_event_access_service import ensure_bridge_event_invite_indexes
 from app.services.continuity_runtime_service import ensure_continuity_runtime_indexes
 from app.services.organization_service import ensure_organization_indexes
 from app.routes.package_catalog import router as package_catalog_router
@@ -178,6 +180,7 @@ async def lifespan(app: FastAPI):
         initialize_mint_job_indexes()
         ensure_stripe_event_indexes()
         ensure_finance_event_indexes()
+        ensure_bridge_event_invite_indexes()
         ensure_continuity_runtime_indexes()
         ensure_organization_indexes()
         ensure_cinematic_manifest_indexes()
@@ -278,6 +281,7 @@ async def handle_database_unavailable(_: Request, exc: DatabaseUnavailableError)
 app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(billing_router)
+app.include_router(bridge_event_access_router)
 app.include_router(intake_router)
 app.include_router(intake_options_router)
 app.include_router(intake_submissions_router)
@@ -396,6 +400,8 @@ def root():
             "/auth/login",
             "/auth/logout",
             "/auth/me",
+            "/auth/account-activation/request",
+            "/auth/account-recovery/request",
             "/auth/password-reset/request",
             "/auth/password-reset/confirm",
             "/auth/password-change",

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -40,6 +40,7 @@ from app.services.auth_service import (
     get_user_by_email,
     register_user,
     request_account_activation,
+    request_account_recovery,
     revoke_user_sessions,
     request_password_reset,
     reset_password_with_token,
@@ -517,6 +518,24 @@ def password_reset_request_route(payload: PasswordResetRequest, response: Respon
         audit_action="password_reset_request_throttled",
     )
     result = request_password_reset(payload.email)
+    _apply_no_store(response)
+    return result
+
+
+@router.post("/account-recovery/request", response_model=PasswordResetResponse)
+def account_recovery_request_route(
+    payload: PasswordResetRequest,
+    request: Request,
+    response: Response,
+):
+    _enforce_rate_limit_with_audit(
+        scope="auth_account_recovery_request",
+        key=_rate_key_from_request(request, principal=payload.email),
+        limit=max(1, int(settings.auth_password_reset_request_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+        audit_action="account_recovery_request_throttled",
+    )
+    result = request_account_recovery(payload.email)
     _apply_no_store(response)
     return result
 

--- a/backend/app/routes/bridge_event_access.py
+++ b/backend/app/routes/bridge_event_access.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import BaseModel, EmailStr, Field
+
+from app.config import settings
+from app.dependencies.auth import require_super_admin
+from app.services.bridge_event_access_service import (
+    create_bridge_paint_invitation,
+    list_bridge_paint_invitations,
+    request_bridge_paint_access,
+    revoke_bridge_paint_invitation,
+)
+from app.services.rate_limit_service import enforce_rate_limit
+
+
+router = APIRouter(prefix="/bridge-events/paint", tags=["Private Bridge Event"])
+
+
+class BridgePaintAccessRequest(BaseModel):
+    email: EmailStr
+    access_token: str = Field(min_length=24, max_length=256)
+
+
+class BridgePaintInvitationCreate(BaseModel):
+    email: EmailStr
+    package_code: str = Field(min_length=1, max_length=80)
+    reason: str = Field(min_length=3, max_length=500)
+    confirmed: bool = False
+
+
+class BridgePaintInvitationRevoke(BaseModel):
+    reason: str = Field(min_length=3, max_length=500)
+    confirmed: bool = False
+
+
+def _no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+
+
+def _client_host(request: Request) -> str:
+    client_host = str((request.client.host if request.client else "") or "").strip()
+    return client_host or "unknown"
+
+
+def _request_key(request: Request, principal: str) -> str:
+    return f"{_client_host(request)}:{str(principal or '').strip().lower()}"
+
+
+@router.post("/access/request")
+def bridge_paint_access_request_route(
+    payload: BridgePaintAccessRequest,
+    request: Request,
+    response: Response,
+):
+    _no_store(response)
+    enforce_rate_limit(
+        scope="bridge_paint_access_request",
+        key=_request_key(request, str(payload.email)),
+        limit=max(1, int(settings.bridge_paint_access_rate_limit or 5)),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+    )
+    enforce_rate_limit(
+        scope="bridge_paint_access_request_ip",
+        key=_client_host(request),
+        limit=max(10, int(settings.bridge_paint_access_rate_limit or 5) * 4),
+        window_seconds=max(1, int(settings.auth_rate_limit_window_seconds or 60)),
+    )
+    try:
+        return request_bridge_paint_access(
+            email=str(payload.email),
+            access_token=payload.access_token,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Secure event access is temporarily unavailable.",
+        ) from exc
+
+
+@router.get("/invitations")
+def list_bridge_paint_invitations_route(
+    response: Response,
+    limit: int = Query(default=100, ge=1, le=500),
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    del current_user
+    _no_store(response)
+    try:
+        return list_bridge_paint_invitations(limit=limit)
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/invitations", status_code=status.HTTP_201_CREATED)
+def create_bridge_paint_invitation_route(
+    payload: BridgePaintInvitationCreate,
+    response: Response,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    _no_store(response)
+    if not payload.confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Confirm the invited recipient and selected package before sending.",
+        )
+    try:
+        result = create_bridge_paint_invitation(
+            current_user=current_user,
+            email=str(payload.email),
+            package_code=payload.package_code,
+            reason=payload.reason,
+        )
+        if not bool(result.get("invitation_created", True)):
+            response.status_code = status.HTTP_200_OK
+        return result
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/invitations/{invitation_id}/revoke")
+def revoke_bridge_paint_invitation_route(
+    invitation_id: str,
+    payload: BridgePaintInvitationRevoke,
+    response: Response,
+    current_user: dict[str, Any] = Depends(require_super_admin),
+):
+    _no_store(response)
+    if not payload.confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Confirm revocation before continuing.",
+        )
+    try:
+        return revoke_bridge_paint_invitation(
+            invitation_id=invitation_id,
+            current_user=current_user,
+            reason=payload.reason,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc

--- a/backend/app/services/admin_control_service.py
+++ b/backend/app/services/admin_control_service.py
@@ -654,7 +654,7 @@ def admin_control_bulk_action_allowed(
 # Bumped alongside the static frontend cache-busting query string
 # (see admin-control-center.html / dashboard.html `?v=` suffix) whenever a
 # hotfix ships to the admin control center or dashboard assets.
-FRONTEND_ASSET_REVISION = "20260824-phase19-1"
+FRONTEND_ASSET_REVISION = "20260828-phase21-1"
 
 
 def _backend_release_identifier() -> str:

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1128,6 +1128,90 @@ def request_password_reset(
     return generic_response
 
 
+def request_account_recovery(
+    email: str,
+    *,
+    include_delivery_status: bool = False,
+) -> dict[str, object]:
+    """Send the recovery email appropriate for the account's current state.
+
+    Public callers always receive the same response. Internally, an unfinished
+    account receives a fresh activation link and an active account receives a
+    password-reset link. Suspended, archived, deleted, and unknown identities
+    receive no credential path and remain indistinguishable to the caller.
+    """
+
+    normalized_email = _normalize_text(email).lower()
+    generic_response: dict[str, object] = {
+        "success": True,
+        "message": (
+            "If this email is connected to an account, the appropriate secure "
+            "access link has been sent."
+        ),
+        "delivery_mode": "email",
+    }
+
+    db = _get_database_or_none()
+    if db is None:
+        if include_delivery_status:
+            generic_response.update(
+                {
+                    "success": False,
+                    "delivery_sent": False,
+                    "delivery_error": "identity_store_unavailable",
+                    "recovery_mode": "none",
+                }
+            )
+        return generic_response
+
+    user = db.users.find_one({"email": normalized_email})
+    if user is None or _normalize_text(user.get("account_type")).lower() == "deleted_tombstone":
+        if include_delivery_status:
+            generic_response.update(
+                {
+                    "success": False,
+                    "delivery_sent": False,
+                    "delivery_error": "account_not_found",
+                    "recovery_mode": "none",
+                }
+            )
+        return generic_response
+
+    account_status = _normalize_text(user.get("status")).lower()
+    delivery: dict[str, object]
+    recovery_mode = "none"
+    if account_status in {"pending_activation", "checkout_pending_activation"}:
+        recovery_mode = "activation"
+        delivery = request_account_activation(
+            normalized_email,
+            include_delivery_status=include_delivery_status,
+        )
+    elif account_status in {"", "active"}:
+        recovery_mode = "password_reset"
+        delivery = request_password_reset(
+            normalized_email,
+            include_delivery_status=include_delivery_status,
+        )
+    else:
+        delivery = {
+            "success": False,
+            "delivery_sent": False,
+            "delivery_error": "account_not_active",
+        }
+
+    if include_delivery_status:
+        generic_response.update(
+            {
+                "success": bool(delivery.get("success")),
+                "delivery_sent": bool(delivery.get("delivery_sent")),
+                "delivery_provider": delivery.get("delivery_provider"),
+                "delivery_error": delivery.get("delivery_error"),
+                "recovery_mode": recovery_mode,
+            }
+        )
+    return generic_response
+
+
 def reset_password_with_token(token: str, new_password: str) -> dict[str, object]:
     normalized_token = _normalize_text(token)
     if not normalized_token:

--- a/backend/app/services/bridge_event_access_service.py
+++ b/backend/app/services/bridge_event_access_service.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+import hmac
+import json
+import secrets
+from typing import Any
+
+from bson import ObjectId
+from pymongo import ASCENDING, DESCENDING, ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from app.config import settings
+from app.database import get_database
+from app.services.audit_log_service import write_audit_log
+from app.services.email_service import (
+    send_bridge_paint_invitation_email,
+    send_bridge_paint_promotion_email,
+)
+
+
+COLLECTION = "bridge_event_invitations"
+EVENT_CODE = "bridge_paint_2026"
+LEGACY_EXPOSED_CODE_PREFIX = "BRIDGE-PAINT-"
+PACKAGE_NAMES: dict[str, str] = {
+    "legacy_snapshot": "Legacy Snapshot",
+    "legacy_portrait_intro": "Legacy Portrait Intro",
+    "digital_legacy_portrait": "Digital Legacy Portrait",
+    "household_foundation": "Household Foundation",
+    "heirloom_legacy_tree": "Heirloom Legacy Tree",
+    "legacy_plus": "Legacy Plus",
+    "family_estate_concierge": "Family Estate Concierge",
+    "command_structure_network": "Command Structure Network",
+}
+PUBLIC_ACCESS_RESPONSE: dict[str, Any] = {
+    "success": True,
+    "message": (
+        "If this invitation is valid and matches the invited email address, "
+        "the private event offer will be sent to that mailbox."
+    ),
+}
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: Any) -> str:
+    return _normalize(value).lower()
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _collection():
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+    return db[COLLECTION]
+
+
+def ensure_bridge_event_invite_indexes() -> None:
+    collection = _collection()
+    collection.create_index(
+        [("token_hash", ASCENDING)],
+        name="bridge_event_invite_token_hash_unique",
+        unique=True,
+        partialFilterExpression={"token_hash": {"$type": "string"}},
+    )
+    collection.create_index(
+        [("active_key", ASCENDING)],
+        name="bridge_event_invite_active_key_unique",
+        unique=True,
+        partialFilterExpression={"active_key": {"$type": "string"}},
+    )
+    collection.create_index(
+        [("event_code", ASCENDING), ("email", ASCENDING), ("status", ASCENDING)],
+        name="bridge_event_invite_recipient_status",
+    )
+    collection.create_index(
+        [("event_code", ASCENDING), ("created_at", DESCENDING)],
+        name="bridge_event_invite_created_desc",
+    )
+
+
+def _event_expiration() -> datetime:
+    raw = _normalize(settings.bridge_paint_event_expires_at)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except Exception as exc:
+        raise RuntimeError("Private Bridge Event expiration is not configured correctly.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _promotion_codes() -> dict[str, str]:
+    raw = _normalize(settings.bridge_paint_promotion_codes_json)
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except Exception as exc:
+        raise RuntimeError("Private Bridge Event promotion configuration is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Private Bridge Event promotion configuration is invalid.")
+
+    codes: dict[str, str] = {}
+    for package_code in PACKAGE_NAMES:
+        value = _normalize(payload.get(package_code))
+        if not value:
+            continue
+        if value.upper().startswith(LEGACY_EXPOSED_CODE_PREFIX):
+            raise RuntimeError(
+                "Previously published Bridge Event promotion codes must be revoked and replaced."
+            )
+        codes[package_code] = value
+    return codes
+
+
+def bridge_paint_configuration_status() -> dict[str, Any]:
+    try:
+        configured_packages = sorted(_promotion_codes())
+        expiration = _event_expiration()
+        error = None
+    except RuntimeError as exc:
+        configured_packages = []
+        expiration = None
+        error = str(exc)
+    return {
+        "event_code": EVENT_CODE,
+        "configured": len(configured_packages) == len(PACKAGE_NAMES) and error is None,
+        "configured_packages": configured_packages,
+        "required_packages": sorted(PACKAGE_NAMES),
+        "expires_at": expiration.isoformat() if expiration else None,
+        "configuration_error": error,
+    }
+
+
+def _token_hash(token: str) -> str:
+    normalized = _normalize(token)
+    key = _normalize(settings.secret_key).encode("utf-8")
+    if not normalized or not key:
+        return ""
+    return hmac.new(key, normalized.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _active_key(email: str, package_code: str) -> str:
+    payload = f"{EVENT_CODE}:{_normalize_email(email)}:{_normalize(package_code).lower()}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _actor(current_user: dict[str, Any]) -> dict[str, str | None]:
+    return {
+        "user_id": _normalize(
+            current_user.get("_id")
+            or current_user.get("id")
+            or current_user.get("user_id")
+        )
+        or None,
+        "email": _normalize_email(current_user.get("email")) or None,
+        "name": _normalize(current_user.get("full_name") or current_user.get("name"))
+        or None,
+    }
+
+
+def _safe_audit(
+    *,
+    current_user: dict[str, Any] | None,
+    action: str,
+    target_id: str,
+    email: str,
+    package_code: str,
+    result: str = "success",
+) -> None:
+    actor = _actor(current_user or {})
+    try:
+        write_audit_log(
+            actor_user_id=actor["user_id"],
+            actor_email=actor["email"],
+            actor_name=actor["name"],
+            action=action,
+            target_type="bridge_event_invitation",
+            target_id=target_id,
+            after={
+                "event_code": EVENT_CODE,
+                "recipient_email": email,
+                "package_code": package_code,
+            },
+            context={"surface": "secure_bridge_event_access"},
+            result=result,
+        )
+    except Exception:
+        # The invitation record retains audit_status=pending for operational
+        # reconciliation if the shared audit collection is temporarily down.
+        try:
+            _collection().update_one(
+                {"_id": ObjectId(target_id)},
+                {"$set": {"audit_status": "pending", "updated_at": _now()}},
+            )
+        except Exception:
+            pass
+
+
+def _serialize_invitation(document: dict[str, Any]) -> dict[str, Any]:
+    expires_at = document.get("expires_at")
+    status = _normalize(document.get("status")) or "unknown"
+    if isinstance(expires_at, datetime) and expires_at <= _now() and status == "delivered":
+        status = "expired"
+    return {
+        "id": _normalize(document.get("_id")),
+        "event_code": EVENT_CODE,
+        "email": _normalize_email(document.get("email")),
+        "package_code": _normalize(document.get("package_code")),
+        "package_name": PACKAGE_NAMES.get(
+            _normalize(document.get("package_code")),
+            _normalize(document.get("package_code")),
+        ),
+        "status": status,
+        "expires_at": expires_at.isoformat() if isinstance(expires_at, datetime) else _normalize(expires_at),
+        "invitation_delivery_status": _normalize(
+            document.get("invitation_delivery_status")
+        )
+        or None,
+        "promotion_delivery_status": _normalize(
+            document.get("promotion_delivery_status")
+        )
+        or None,
+        "created_at": (
+            document.get("created_at").isoformat()
+            if isinstance(document.get("created_at"), datetime)
+            else _normalize(document.get("created_at"))
+        ),
+        "fulfilled_at": (
+            document.get("fulfilled_at").isoformat()
+            if isinstance(document.get("fulfilled_at"), datetime)
+            else _normalize(document.get("fulfilled_at")) or None
+        ),
+    }
+
+
+def create_bridge_paint_invitation(
+    *,
+    current_user: dict[str, Any],
+    email: str,
+    package_code: str,
+    reason: str,
+) -> dict[str, Any]:
+    normalized_email = _normalize_email(email)
+    normalized_package = _normalize(package_code).lower()
+    normalized_reason = _normalize(reason)
+    if "@" not in normalized_email:
+        raise ValueError("A valid invited email address is required.")
+    if normalized_package not in PACKAGE_NAMES:
+        raise ValueError("Select an eligible Tomb of Light package.")
+    if len(normalized_reason) < 3:
+        raise ValueError("An operational reason of at least 3 characters is required.")
+
+    codes = _promotion_codes()
+    if normalized_package not in codes:
+        raise RuntimeError(
+            "A rotated promotion code is not configured for the selected package."
+        )
+    expires_at = _event_expiration()
+    if expires_at <= _now():
+        raise RuntimeError("The private Bridge Event offer has expired.")
+
+    collection = _collection()
+    now = _now()
+    active_key = _active_key(normalized_email, normalized_package)
+    existing = collection.find_one({"active_key": active_key})
+    if existing:
+        existing_expiration = existing.get("expires_at")
+        if isinstance(existing_expiration, datetime) and existing_expiration > now:
+            result = _serialize_invitation(existing)
+            result["invitation_created"] = False
+            return result
+        collection.update_one(
+            {"_id": existing.get("_id"), "active_key": active_key},
+            {
+                "$set": {"status": "expired", "updated_at": now},
+                "$unset": {"token_hash": "", "active_key": ""},
+            },
+        )
+    collection.update_many(
+        {
+            "event_code": EVENT_CODE,
+            "email": normalized_email,
+            "package_code": normalized_package,
+            "status": {"$in": ["pending", "delivered", "delivery_failed"]},
+        },
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_reason": "superseded_by_new_invitation",
+                "revoked_at": now,
+                "updated_at": now,
+            },
+            "$unset": {"token_hash": "", "active_key": ""},
+        },
+    )
+
+    access_token = "tolbe_" + secrets.token_urlsafe(32)
+    document = {
+        "event_code": EVENT_CODE,
+        "email": normalized_email,
+        "package_code": normalized_package,
+        "active_key": active_key,
+        "token_hash": _token_hash(access_token),
+        "status": "pending",
+        "reason": normalized_reason,
+        "expires_at": expires_at,
+        "created_at": now,
+        "updated_at": now,
+        "created_by_user_id": _actor(current_user)["user_id"],
+        "created_by_email": _actor(current_user)["email"],
+        "invitation_delivery_status": "pending",
+        "promotion_delivery_status": "not_requested",
+        "audit_status": "recorded",
+    }
+    try:
+        inserted = collection.insert_one(document)
+    except DuplicateKeyError:
+        raced = collection.find_one({"active_key": active_key})
+        if raced:
+            result = _serialize_invitation(raced)
+            result["invitation_created"] = False
+            return result
+        raise RuntimeError("The secure invitation could not be created safely.")
+    invitation_id = str(inserted.inserted_id)
+    delivery = send_bridge_paint_invitation_email(
+        to_email=normalized_email,
+        access_token=access_token,
+        package_name=PACKAGE_NAMES[normalized_package],
+        expires_at=expires_at.isoformat(),
+    )
+    if not bool(delivery.get("sent")):
+        collection.update_one(
+            {"_id": inserted.inserted_id},
+            {
+                "$set": {
+                    "status": "delivery_failed",
+                    "invitation_delivery_status": "failed",
+                    "invitation_delivery_error": _normalize(delivery.get("error"))[:200],
+                    "updated_at": _now(),
+                },
+                "$unset": {"token_hash": "", "active_key": ""},
+            },
+        )
+        _safe_audit(
+            current_user=current_user,
+            action="bridge_event.invitation_delivery_failed",
+            target_id=invitation_id,
+            email=normalized_email,
+            package_code=normalized_package,
+            result="failed",
+        )
+        raise RuntimeError("The secure invitation email could not be delivered.")
+
+    collection.update_one(
+        {"_id": inserted.inserted_id},
+        {
+            "$set": {
+                "status": "delivered",
+                "invitation_delivery_status": "sent",
+                "invitation_sent_at": _now(),
+                "updated_at": _now(),
+            }
+        },
+    )
+    _safe_audit(
+        current_user=current_user,
+        action="bridge_event.invitation_sent",
+        target_id=invitation_id,
+        email=normalized_email,
+        package_code=normalized_package,
+    )
+    refreshed = collection.find_one({"_id": inserted.inserted_id}) or {
+        **document,
+        "_id": inserted.inserted_id,
+        "status": "delivered",
+        "invitation_delivery_status": "sent",
+    }
+    result = _serialize_invitation(refreshed)
+    result["invitation_created"] = True
+    return result
+
+
+def request_bridge_paint_access(*, email: str, access_token: str) -> dict[str, Any]:
+    normalized_email = _normalize_email(email)
+    token_hash = _token_hash(access_token)
+    if "@" not in normalized_email or not token_hash:
+        return dict(PUBLIC_ACCESS_RESPONSE)
+
+    collection = _collection()
+    invitation = collection.find_one(
+        {
+            "event_code": EVENT_CODE,
+            "email": normalized_email,
+            "token_hash": token_hash,
+            "status": "delivered",
+        }
+    )
+    if not invitation:
+        return dict(PUBLIC_ACCESS_RESPONSE)
+    expires_at = invitation.get("expires_at")
+    if not isinstance(expires_at, datetime) or expires_at <= _now():
+        collection.update_one(
+            {"_id": invitation.get("_id"), "status": "delivered"},
+            {
+                "$set": {"status": "expired", "updated_at": _now()},
+                "$unset": {"token_hash": "", "active_key": ""},
+            },
+        )
+        return dict(PUBLIC_ACCESS_RESPONSE)
+
+    locked = collection.find_one_and_update(
+        {
+            "_id": invitation.get("_id"),
+            "token_hash": token_hash,
+            "status": "delivered",
+        },
+        {
+            "$set": {
+                "status": "fulfillment_in_progress",
+                "fulfillment_started_at": _now(),
+                "updated_at": _now(),
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not locked:
+        return dict(PUBLIC_ACCESS_RESPONSE)
+
+    package_code = _normalize(locked.get("package_code"))
+    try:
+        promotion_code = _promotion_codes().get(package_code, "")
+    except RuntimeError:
+        promotion_code = ""
+    if not promotion_code:
+        collection.update_one(
+            {"_id": locked.get("_id"), "status": "fulfillment_in_progress"},
+            {
+                "$set": {
+                    "status": "delivered",
+                    "promotion_delivery_status": "configuration_blocked",
+                    "updated_at": _now(),
+                }
+            },
+        )
+        return dict(PUBLIC_ACCESS_RESPONSE)
+
+    delivery = send_bridge_paint_promotion_email(
+        to_email=normalized_email,
+        promotion_code=promotion_code,
+        package_name=PACKAGE_NAMES.get(package_code, package_code),
+        expires_at=expires_at.isoformat(),
+    )
+    invitation_id = _normalize(locked.get("_id"))
+    if not bool(delivery.get("sent")):
+        collection.update_one(
+            {"_id": locked.get("_id"), "status": "fulfillment_in_progress"},
+            {
+                "$set": {
+                    "status": "delivered",
+                    "promotion_delivery_status": "failed",
+                    "promotion_delivery_error": _normalize(delivery.get("error"))[:200],
+                    "updated_at": _now(),
+                }
+            },
+        )
+        _safe_audit(
+            current_user=None,
+            action="bridge_event.promotion_delivery_failed",
+            target_id=invitation_id,
+            email=normalized_email,
+            package_code=package_code,
+            result="failed",
+        )
+        return dict(PUBLIC_ACCESS_RESPONSE)
+
+    collection.update_one(
+        {"_id": locked.get("_id"), "status": "fulfillment_in_progress"},
+        {
+            "$set": {
+                "status": "fulfilled",
+                "promotion_delivery_status": "sent",
+                "fulfilled_at": _now(),
+                "updated_at": _now(),
+            },
+            "$unset": {
+                "token_hash": "",
+                "active_key": "",
+                "promotion_delivery_error": "",
+            },
+        },
+    )
+    _safe_audit(
+        current_user=None,
+        action="bridge_event.promotion_delivered",
+        target_id=invitation_id,
+        email=normalized_email,
+        package_code=package_code,
+    )
+    return dict(PUBLIC_ACCESS_RESPONSE)
+
+
+def list_bridge_paint_invitations(*, limit: int = 100) -> dict[str, Any]:
+    collection = _collection()
+    records = list(
+        collection.find({"event_code": EVENT_CODE})
+        .sort("created_at", DESCENDING)
+        .limit(max(1, min(int(limit), 500)))
+    )
+    return {
+        "configuration": bridge_paint_configuration_status(),
+        "count": len(records),
+        "items": [_serialize_invitation(record) for record in records],
+    }
+
+
+def revoke_bridge_paint_invitation(
+    *,
+    invitation_id: str,
+    current_user: dict[str, Any],
+    reason: str,
+) -> dict[str, Any]:
+    normalized_reason = _normalize(reason)
+    if len(normalized_reason) < 3:
+        raise ValueError("A revocation reason of at least 3 characters is required.")
+    if not ObjectId.is_valid(invitation_id):
+        raise ValueError("Invitation id is invalid.")
+    collection = _collection()
+    invitation = collection.find_one({"_id": ObjectId(invitation_id), "event_code": EVENT_CODE})
+    if not invitation:
+        raise ValueError("Invitation was not found.")
+    if _normalize(invitation.get("status")) in {"fulfilled", "revoked", "expired"}:
+        raise ValueError("This invitation can no longer be revoked.")
+
+    collection.update_one(
+        {"_id": invitation.get("_id")},
+        {
+            "$set": {
+                "status": "revoked",
+                "revoked_reason": normalized_reason,
+                "revoked_at": _now(),
+                "updated_at": _now(),
+            },
+            "$unset": {"token_hash": "", "active_key": ""},
+        },
+    )
+    _safe_audit(
+        current_user=current_user,
+        action="bridge_event.invitation_revoked",
+        target_id=invitation_id,
+        email=_normalize_email(invitation.get("email")),
+        package_code=_normalize(invitation.get("package_code")),
+    )
+    refreshed = collection.find_one({"_id": invitation.get("_id")}) or {
+        **invitation,
+        "status": "revoked",
+    }
+    return _serialize_invitation(refreshed)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -582,3 +582,90 @@ def send_household_invite_email(
         html_body=html_body,
         email_type="household_invite",
     )
+
+
+def send_bridge_paint_invitation_email(
+    *,
+    to_email: str,
+    access_token: str,
+    package_name: str,
+    expires_at: str,
+) -> dict[str, Any]:
+    """Send a one-time event-access link without exposing it in server logs."""
+
+    token = quote_plus(_normalize_text(access_token))
+    access_url = f"{_public_app_base_url()}/bridge-paint.html#invite={token}"
+    safe_access_url = escape(access_url, quote=True)
+    safe_package_name = escape(_normalize_text(package_name), quote=True)
+    safe_expires_at = escape(_normalize_text(expires_at), quote=True)
+    subject = "Your private Tomb of Light Sip & Paint invitation"
+    text_body = (
+        "Hello,\n\n"
+        "You have been invited to the private Tomb of Light Sip & Paint offer.\n\n"
+        f"Selected package: {package_name}\n"
+        f"Secure access link: {access_url}\n"
+        f"This invitation expires at {expires_at}.\n\n"
+        "The link is tied to this email address and may be used once to request "
+        "the private offer code. Do not forward it.\n\n"
+        "If you did not expect this invitation, ignore this message.\n"
+    )
+    html_body = (
+        "<p>Hello,</p>"
+        "<p>You have been invited to the private Tomb of Light Sip &amp; Paint offer.</p>"
+        f"<p><strong>Selected package:</strong> {safe_package_name}</p>"
+        f'<p><a href="{safe_access_url}">Open secure event access</a></p>'
+        f"<p>This invitation expires at {safe_expires_at}.</p>"
+        "<p>The link is tied to this email address and may be used once to request "
+        "the private offer code. Do not forward it.</p>"
+        "<p>If you did not expect this invitation, ignore this message.</p>"
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        email_type="bridge_paint_invitation",
+    )
+
+
+def send_bridge_paint_promotion_email(
+    *,
+    to_email: str,
+    promotion_code: str,
+    package_name: str,
+    expires_at: str,
+) -> dict[str, Any]:
+    """Deliver one server-held promotion code to its invited recipient."""
+
+    normalized_code = _normalize_text(promotion_code)
+    safe_code = escape(normalized_code, quote=True)
+    safe_package_name = escape(_normalize_text(package_name), quote=True)
+    safe_expires_at = escape(_normalize_text(expires_at), quote=True)
+    subject = "Your private Tomb of Light event offer"
+    text_body = (
+        "Hello,\n\n"
+        "Your private Sip & Paint event access was verified.\n\n"
+        f"Selected package: {package_name}\n"
+        f"Private offer code: {normalized_code}\n"
+        f"Offer expiration: {expires_at}\n\n"
+        "Enter this code during the standard Stripe checkout for the selected "
+        "package. It does not apply to maintenance, subscriptions, add-ons, "
+        "services, taxes, or future balances. Do not share this code.\n"
+    )
+    html_body = (
+        "<p>Hello,</p>"
+        "<p>Your private Sip &amp; Paint event access was verified.</p>"
+        f"<p><strong>Selected package:</strong> {safe_package_name}</p>"
+        f"<p><strong>Private offer code:</strong> <code>{safe_code}</code></p>"
+        f"<p><strong>Offer expiration:</strong> {safe_expires_at}</p>"
+        "<p>Enter this code during the standard Stripe checkout for the selected "
+        "package. It does not apply to maintenance, subscriptions, add-ons, "
+        "services, taxes, or future balances. Do not share this code.</p>"
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=subject,
+        text_body=text_body,
+        html_body=html_body,
+        email_type="bridge_paint_promotion",
+    )

--- a/backend/docs/governance/bridge_event_secure_access_runbook.md
+++ b/backend/docs/governance/bridge_event_secure_access_runbook.md
@@ -1,0 +1,68 @@
+# Private Bridge Event Secure Access Runbook
+
+Date: 2026-08-28
+
+Owner: canonical CEO / Super Admin
+
+## Security boundary
+
+Private Event 2 promotion values are backend runtime secrets. They must not be placed in HTML, JavaScript, MongoDB invitation records, API responses, audit payloads, tickets, screenshots, chat, or Git history.
+
+The customer flow is:
+
+1. The CEO selects one invited email address and one eligible package in `admin-event-access.html`.
+2. The backend stores only an HMAC hash of a high-entropy, one-time access token.
+3. Postmark sends the token as a URL fragment so it is not included in normal HTTP request or referrer logs.
+4. The guest enters the exact invited email address.
+5. The backend atomically consumes the token and sends only that package's private promotion value to the invited mailbox.
+6. The promotion value is never returned to the browser or stored in the invitation record.
+
+The public claim endpoint is recipient- and IP-rate-limited, returns the same generic response for valid and invalid claims, and sends `Cache-Control: no-store`.
+
+## Required rotation before deployment
+
+Values previously committed to public source must be treated as compromised even after removal. Do not reuse or rename them.
+
+1. In Stripe, deactivate every previously published Event 2 promotion code.
+2. Confirm each retired value can no longer be applied at checkout.
+3. Create one new promotion code for each canonical package. Each Stripe promotion must:
+   - apply only to its intended one-time package product;
+   - provide the approved 50% Event 2 discount;
+   - exclude maintenance, subscriptions, add-ons, services, taxes, and future balances;
+   - expire at the approved Event 2 deadline;
+   - use the approved redemption limit.
+4. Place the new mapping only in Render's protected environment variable `BRIDGE_PAINT_PROMOTION_CODES_JSON` using these keys:
+
+```json
+{
+  "legacy_snapshot": "<new Stripe value>",
+  "legacy_portrait_intro": "<new Stripe value>",
+  "digital_legacy_portrait": "<new Stripe value>",
+  "household_foundation": "<new Stripe value>",
+  "heirloom_legacy_tree": "<new Stripe value>",
+  "legacy_plus": "<new Stripe value>",
+  "family_estate_concierge": "<new Stripe value>",
+  "command_structure_network": "<new Stripe value>"
+}
+```
+
+5. Set `BRIDGE_PAINT_EVENT_EXPIRES_AT` to the approved UTC deadline and keep `BRIDGE_PAINT_ACCESS_RATE_LIMIT` at or below the reviewed value.
+6. Redeploy the backend. Do not place real values in `.env.example` or any local file that can be committed.
+
+## Verification gate
+
+Before issuing an invitation:
+
+1. Sign in as the canonical CEO.
+2. Open `admin-event-access.html`.
+3. Confirm **Protected configuration** reports all eight packages ready and shows the correct expiration.
+4. Issue a test invitation to a controlled mailbox and select one package.
+5. Confirm the invitation link contains the token after `#invite=` and that the browser removes it from the address bar after loading.
+6. Confirm the public page never displays or returns a promotion value.
+7. Confirm the private offer email reaches only the invited mailbox.
+8. Confirm the invitation history changes to `fulfilled` and the same link cannot deliver again.
+9. Confirm audit evidence exists for invitation delivery and promotion delivery.
+
+## Incident response
+
+If a replacement value is exposed, deactivate it in Stripe first. Then remove it from the protected environment, create a new value, update Render, redeploy, revoke affected pending invitations, and issue new invitations. Source removal alone is not remediation because public history and caches may retain the former value.

--- a/backend/docs/governance/continuity_kernel_phase9_control_surface_security.md
+++ b/backend/docs/governance/continuity_kernel_phase9_control_surface_security.md
@@ -46,7 +46,7 @@ The pre-existing Phase 8 action registry continues to cover case mutations, safe
 - Overview payloads are reduced server-side to finance, operations, or marketing domains for restricted officer roles.
 - Administrator-assisted password reset never exposes the reset token. The verified account email receives the link, and an unconfirmed email delivery is recorded as a partial failure rather than success.
 - Upload scanning defaults to fail closed. Infected files, scanner errors, and unavailable scanning enter quarantine.
-- Customer, administrative, and general public application pages include a restrictive Content Security Policy; inline scripts are authorized by exact hashes. Three separately managed commercial pages (`pricing.html` and two invite-event pages) are excluded because their legacy discount/redemption payload requires a dedicated sanitized migration.
+- Customer, administrative, and general public application pages include a restrictive Content Security Policy; inline scripts are authorized by exact hashes. The private Sip & Paint page has completed its sanitized migration: promotion values are no longer present in public source, recipient access uses a one-time server-verified link, and the protected runtime delivers an eligible package value only to the invited mailbox. `pricing.html` and the remaining legacy invite page continue as separately managed commercial surfaces pending their own migration.
 - Pinned dependencies were upgraded and the legacy JWT dependency was removed. `pip-audit` reports no known vulnerabilities for `backend/requirements.txt` at this revision.
 - Pull requests now run the dependency audit plus Phase 9 runtime and security suites.
 

--- a/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase10_command_center.py
@@ -22,10 +22,10 @@ class TestContinuityKernelPhase10CommandCenter(unittest.TestCase):
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     def test_01_control_center_assets_preserve_phase10_base_and_current_control_revision(self) -> None:
-        self.assertIn("styles.css?v=20260821-phase10-1", self.html)
-        self.assertIn("app.js?v=20260825-phase20-1", self.html)
+        self.assertIn("styles.css?v=20260828-phase21-1", self.html)
+        self.assertIn("app.js?v=20260828-phase21-1", self.html)
         self.assertIn("admin-control-center.js?v=20260824-phase19-1", self.html)
-        self.assertIn('FRONTEND_ASSET_REVISION = "20260824-phase19-1"', self.service)
+        self.assertIn('FRONTEND_ASSET_REVISION = "20260828-phase21-1"', self.service)
 
     def test_02_account_creation_and_closure_are_visible_previewed_workflows(self) -> None:
         for marker in (

--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -103,7 +103,6 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
     def test_07_app_pages_have_csp_valid_inline_hashes_and_current_cache_revision(self) -> None:
         app_pages = []
         separately_managed_commercial_pages = {
-            "bridge-paint.html",
             "bridge-taste.html",
             "pricing.html",
         }
@@ -114,7 +113,7 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
             if path.name in separately_managed_commercial_pages:
                 continue
             app_pages.append(path.name)
-            expected_revision = "20260825-phase20-1"
+            expected_revision = "20260828-phase21-1"
             self.assertIn(f"app.js?v={expected_revision}", source, path.name)
             csp_match = re.search(
                 r'http-equiv="Content-Security-Policy"\s+content="([^"]+)"',

--- a/backend/tests/contracts/test_phase13_family_operating_machine.py
+++ b/backend/tests/contracts/test_phase13_family_operating_machine.py
@@ -81,7 +81,7 @@ class TestPhase13FamilyOperatingMachine(unittest.TestCase):
             with self.subTest(html_path=html_path, asset=asset):
                 self.assertIn(f'{asset}?v={asset_revision}', _read(html_path))
         self.assertIn(
-            'FRONTEND_ASSET_REVISION = "20260824-phase19-1"',
+            'FRONTEND_ASSET_REVISION = "20260828-phase21-1"',
             _read("backend/app/services/admin_control_service.py"),
         )
 

--- a/backend/tests/contracts/test_phase19_1_production_truth_corrections.py
+++ b/backend/tests/contracts/test_phase19_1_production_truth_corrections.py
@@ -46,7 +46,7 @@ class TestPhase191ProductionTruthCorrections(unittest.TestCase):
         html = _read("admin-control-center.html")
         portrait_html = _read("admin-portrait-review.html")
         evidence_html = _read("admin-verification-review.html")
-        self.assertIn('FRONTEND_ASSET_REVISION = "20260824-phase19-1"', service)
+        self.assertIn('FRONTEND_ASSET_REVISION = "20260828-phase21-1"', service)
         self.assertIn("admin-control-center.js?v=20260824-phase19-1", html)
         self.assertIn("admin-portrait-review.js?v=20260824-phase19-1", portrait_html)
         self.assertIn("admin-verification-review.js?v=20260824-phase19-1", evidence_html)

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -10,13 +10,11 @@ from app.services import household_access_service
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AUDIT_CACHE_VERSION = "20260509-audit"
+SHARED_ASSET_CACHE_VERSION = "20260828-phase21-1"
 PORTAL_CACHE_OVERRIDES = {
     "dashboard.html": {
-        "styles.css": "20260824-phase20",
-        "auth.js": "20260713-livefix3",
         "dashboard-intake.js": "20260824-phase20",
     },
-    "billing.html": {"styles.css": "20260828-phase21"},
     "link-keys.html": {"link-keys.js": "20260823-phase13-1"},
     "portrait-upload.html": {"portrait-upload.js": "20260824-phase18"},
     "tree-view.html": {"tree-view.js": "20260823-phase13-1"},
@@ -131,11 +129,11 @@ class CustomerDashboardIntegrityTests(unittest.TestCase):
                 source = (REPO_ROOT / page).read_text(encoding="utf-8")
                 overrides = PORTAL_CACHE_OVERRIDES.get(page, {})
                 self.assertIn(
-                    f"styles.css?v={overrides.get('styles.css', AUDIT_CACHE_VERSION)}",
+                    f"styles.css?v={SHARED_ASSET_CACHE_VERSION}",
                     source,
                 )
                 self.assertIn(
-                    f"auth.js?v={overrides.get('auth.js', AUDIT_CACHE_VERSION)}",
+                    f"auth.js?v={SHARED_ASSET_CACHE_VERSION}",
                     source,
                 )
 

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -244,7 +244,7 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
             bridge_page,
         )
         self.assertIn("data-bridge-paint-access-form", bridge_page)
-        self.assertIn("bridge-paint.js?v=20260828-secure-event-access", bridge_page)
+        self.assertIn("bridge-paint.js?v=20260828-secure-event-access-1", bridge_page)
         self.assertIn("Previously published event codes are retired", bridge_page)
         self.assertNotIn("Important: do not modify Stripe URLs", bridge_page)
         self.assertNotIn("Private Bridge Event Access", homepage)

--- a/backend/tests/test_frontend_link_integrity.py
+++ b/backend/tests/test_frontend_link_integrity.py
@@ -219,20 +219,10 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
 
         bridge_page_text = html.unescape(bridge_page)
         pricing_page_text = html.unescape(pricing_page)
-        bridge_paint_codes = [
-            "BRIDGE-PAINT-SNAPSHOT",
-            "BRIDGE-PAINT-PORTRAIT",
-            "BRIDGE-PAINT-DIGITAL",
-            "BRIDGE-PAINT-HOUSEHOLD",
-            "BRIDGE-PAINT-HEIRLOOM",
-            "BRIDGE-PAINT-PLUS",
-            "BRIDGE-PAINT-ESTATE",
-            "BRIDGE-PAINT-COMMAND",
-        ]
-
-        for package_code in bridge_paint_codes:
-            self.assertIn(package_code, bridge_page)
-            self.assertNotIn(package_code, homepage)
+        self.assertNotRegex(
+            bridge_page,
+            r"BRIDGE-PAINT-[A-Z0-9][A-Z0-9-]{3,}",
+        )
 
         for expected_content in [
             "Sip & Paint",
@@ -243,38 +233,36 @@ class FrontendLinkIntegrityTests(unittest.TestCase):
             "Norfolk, VA",
             "Private Event",
             "Invite Only",
-            "BRIDGE-PAINT",
+            "Open your secure invitation",
+            "One-time secure link",
         ]:
             self.assertIn(expected_content, bridge_page_text)
 
-        self.assertIn("Private Bridge Event Access", bridge_page)
+        self.assertIn("VERIFIED INVITED-GUEST ACCESS", bridge_page)
         self.assertIn(
-            "Use the standard Tomb of Light package checkout and enter your private Bridge Event code directly at",
+            "The offer is never displayed",
             bridge_page,
         )
+        self.assertIn("data-bridge-paint-access-form", bridge_page)
+        self.assertIn("bridge-paint.js?v=20260828-secure-event-access", bridge_page)
+        self.assertIn("Previously published event codes are retired", bridge_page)
         self.assertNotIn("Important: do not modify Stripe URLs", bridge_page)
         self.assertNotIn("Private Bridge Event Access", homepage)
         self.assertNotIn("BRIDGE-TASTE", homepage)
         self.assertNotIn("BRIDGE-PAINT", homepage)
         self.assertNotRegex(homepage, r"BRIDGE-(?:TASTE|PAINT)-")
         self.assertIn("bridge-paint.html", pricing_page)
-        self.assertIn("BRIDGE-PAINT", pricing_page)
+        self.assertNotIn("BRIDGE-PAINT", pricing_page)
+        self.assertIn("one-time access link", pricing_page)
         self.assertIn("Sip & Paint — Event 2 of 4", pricing_page_text)
         self.assertNotIn("BRIDGE-TASTE", pricing_page)
 
         self.assertIn("Bridge Event 1 Has Concluded", archived_bridge_page)
         self.assertIn('href="bridge-paint.html"', archived_bridge_page)
-        for package_code in [
-            "BRIDGE-TASTE-SNAPSHOT",
-            "BRIDGE-TASTE-PORTRAIT",
-            "BRIDGE-TASTE-DIGITAL",
-            "BRIDGE-TASTE-HOUSEHOLD",
-            "BRIDGE-TASTE-HEIRLOOM",
-            "BRIDGE-TASTE-PLUS",
-            "BRIDGE-TASTE-ESTATE",
-            "BRIDGE-TASTE-COMMAND",
-        ]:
-            self.assertNotIn(package_code, archived_bridge_page)
+        self.assertNotRegex(
+            archived_bridge_page,
+            r"BRIDGE-TASTE-[A-Z0-9][A-Z0-9-]{3,}",
+        )
 
         for inactive_campaign in ["BRIDGE-LINEAGE", "GRANDOPENING"]:
             self.assertNotIn(inactive_campaign, homepage)

--- a/backend/tests/test_phase21_1_mobile_account_recovery.py
+++ b/backend/tests/test_phase21_1_mobile_account_recovery.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.services import auth_service
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+REVISION = "20260828-phase21-1"
+
+
+class _Users:
+    def __init__(self, user):
+        self.user = user
+
+    def find_one(self, query):
+        del query
+        return self.user
+
+
+class Phase211AccountRecoveryTests(TestCase):
+    def _database(self, user):
+        return SimpleNamespace(users=_Users(user))
+
+    def test_pending_identity_receives_activation_without_public_state_disclosure(self):
+        activation_delivery = {
+            "success": True,
+            "delivery_sent": True,
+            "delivery_provider": "postmark",
+        }
+        with (
+            patch.object(
+                auth_service,
+                "_get_database_or_none",
+                return_value=self._database(
+                    {
+                        "email": "pending@example.test",
+                        "status": "pending_activation",
+                        "account_type": "customer",
+                    }
+                ),
+            ),
+            patch.object(
+                auth_service,
+                "request_account_activation",
+                return_value=activation_delivery,
+            ) as activation,
+            patch.object(auth_service, "request_password_reset") as password_reset,
+        ):
+            public_result = auth_service.request_account_recovery(
+                "Pending@Example.Test"
+            )
+
+        activation.assert_called_once_with(
+            "pending@example.test",
+            include_delivery_status=False,
+        )
+        password_reset.assert_not_called()
+        self.assertEqual(
+            public_result,
+            {
+                "success": True,
+                "message": (
+                    "If this email is connected to an account, the appropriate "
+                    "secure access link has been sent."
+                ),
+                "delivery_mode": "email",
+            },
+        )
+
+    def test_active_identity_receives_password_reset(self):
+        reset_delivery = {
+            "success": True,
+            "delivery_sent": True,
+            "delivery_provider": "postmark",
+        }
+        with (
+            patch.object(
+                auth_service,
+                "_get_database_or_none",
+                return_value=self._database(
+                    {
+                        "email": "active@example.test",
+                        "status": "active",
+                        "account_type": "customer",
+                    }
+                ),
+            ),
+            patch.object(auth_service, "request_account_activation") as activation,
+            patch.object(
+                auth_service,
+                "request_password_reset",
+                return_value=reset_delivery,
+            ) as password_reset,
+        ):
+            result = auth_service.request_account_recovery(
+                "active@example.test",
+                include_delivery_status=True,
+            )
+
+        activation.assert_not_called()
+        password_reset.assert_called_once_with(
+            "active@example.test",
+            include_delivery_status=True,
+        )
+        self.assertEqual(result["recovery_mode"], "password_reset")
+        self.assertTrue(result["delivery_sent"])
+
+    def test_unknown_suspended_and_deleted_identities_do_not_receive_credentials(self):
+        identities = [
+            None,
+            {
+                "email": "suspended@example.test",
+                "status": "disabled",
+                "account_type": "customer",
+            },
+            {
+                "email": "deleted@example.test",
+                "status": "permanently_deleted",
+                "account_type": "deleted_tombstone",
+            },
+        ]
+        public_messages = []
+        for identity in identities:
+            with (
+                self.subTest(identity=identity),
+                patch.object(
+                    auth_service,
+                    "_get_database_or_none",
+                    return_value=self._database(identity),
+                ),
+                patch.object(auth_service, "request_account_activation") as activation,
+                patch.object(auth_service, "request_password_reset") as password_reset,
+            ):
+                result = auth_service.request_account_recovery(
+                    "private@example.test"
+                )
+                activation.assert_not_called()
+                password_reset.assert_not_called()
+                public_messages.append(result)
+
+        self.assertEqual(public_messages[0], public_messages[1])
+        self.assertEqual(public_messages[1], public_messages[2])
+
+
+class Phase211FrontendContractTests(TestCase):
+    def test_customer_recovery_and_mobile_unlock_are_wired(self):
+        auth_js = (REPOSITORY_ROOT / "auth.js").read_text(encoding="utf-8")
+        security_js = (REPOSITORY_ROOT / "account-security.js").read_text(
+            encoding="utf-8"
+        )
+        app_js = (REPOSITORY_ROOT / "app.js").read_text(encoding="utf-8")
+        styles = (REPOSITORY_ROOT / "styles.css").read_text(encoding="utf-8")
+
+        self.assertIn('"/auth/account-recovery/request"', auth_js)
+        self.assertIn('"/auth/account-recovery/request"', security_js)
+        self.assertIn('window.addEventListener("pageshow", closeMenu)', app_js)
+        self.assertIn("if (window.innerWidth > 1180)", app_js)
+        self.assertIn("API_DISCOVERY_TIMEOUT_MS = 15000", app_js)
+        self.assertIn("No account change was completed", app_js)
+        self.assertIn("body.menu-open .site-header", styles)
+        self.assertIn("overflow-y: auto", styles)
+
+    def test_every_shared_asset_reference_uses_the_phase21_1_revision(self):
+        html_files = list(REPOSITORY_ROOT.glob("*.html"))
+        html_files.extend((REPOSITORY_ROOT / "reviews").glob("*.html"))
+        html_files.extend((REPOSITORY_ROOT / "viewer").glob("*.html"))
+
+        stale = []
+        for path in html_files:
+            source = path.read_text(encoding="utf-8")
+            for asset in ("styles.css", "config.js", "app.js", "auth.js"):
+                marker = f"{asset}?v="
+                if marker in source and f"{marker}{REVISION}" not in source:
+                    stale.append(f"{path.relative_to(REPOSITORY_ROOT)}:{asset}")
+
+        self.assertEqual(stale, [])

--- a/backend/tests/test_secure_bridge_event_access.py
+++ b/backend/tests/test_secure_bridge_event_access.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
+import re
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from bson import ObjectId
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from app.dependencies.auth import require_super_admin
+from app.routes import bridge_event_access as route_module
+from app.services import bridge_event_access_service as service
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class FakeCursor(list):
+    def sort(self, field_name, direction):
+        return FakeCursor(
+            sorted(
+                self,
+                key=lambda item: item.get(field_name) or datetime.min.replace(tzinfo=UTC),
+                reverse=direction < 0,
+            )
+        )
+
+    def limit(self, value):
+        return FakeCursor(self[:value])
+
+
+class FakeCollection:
+    def __init__(self, documents=None):
+        self.documents = [deepcopy(item) for item in (documents or [])]
+        self.indexes = []
+
+    @staticmethod
+    def _matches(document, query):
+        for key, expected in (query or {}).items():
+            actual = document.get(key)
+            if isinstance(expected, dict) and "$in" in expected:
+                if actual not in expected["$in"]:
+                    return False
+            elif actual != expected:
+                return False
+        return True
+
+    @staticmethod
+    def _apply(document, update):
+        for key, value in (update.get("$set") or {}).items():
+            document[key] = value
+        for key in (update.get("$unset") or {}):
+            document.pop(key, None)
+
+    def create_index(self, *keys, **kwargs):
+        self.indexes.append((keys, kwargs))
+        return kwargs.get("name")
+
+    def find_one(self, query):
+        return next(
+            (document for document in self.documents if self._matches(document, query)),
+            None,
+        )
+
+    def find(self, query):
+        return FakeCursor(
+            [document for document in self.documents if self._matches(document, query)]
+        )
+
+    def insert_one(self, payload):
+        active_key = payload.get("active_key")
+        if active_key and any(item.get("active_key") == active_key for item in self.documents):
+            raise DuplicateKeyError("duplicate active invitation")
+        stored = deepcopy(payload)
+        stored.setdefault("_id", ObjectId())
+        self.documents.append(stored)
+        return SimpleNamespace(inserted_id=stored["_id"])
+
+    def update_one(self, query, update):
+        document = self.find_one(query)
+        if not document:
+            return SimpleNamespace(matched_count=0, modified_count=0)
+        self._apply(document, update)
+        return SimpleNamespace(matched_count=1, modified_count=1)
+
+    def update_many(self, query, update):
+        modified = 0
+        for document in self.documents:
+            if self._matches(document, query):
+                self._apply(document, update)
+                modified += 1
+        return SimpleNamespace(modified_count=modified)
+
+    def find_one_and_update(self, query, update, return_document=None):
+        document = self.find_one(query)
+        if not document:
+            return None
+        before = deepcopy(document)
+        self._apply(document, update)
+        return document if return_document == ReturnDocument.AFTER else before
+
+
+def _future_expiration():
+    return datetime.now(UTC) + timedelta(days=1)
+
+
+def _configured_values():
+    return {
+        package_code: f"rotated-fixture-{index:02d}"
+        for index, package_code in enumerate(service.PACKAGE_NAMES, start=1)
+    }
+
+
+class TestSecureBridgeEventAccess(unittest.TestCase):
+    def test_public_assets_do_not_contain_redeemable_event_values(self):
+        paint_html = (REPO_ROOT / "bridge-paint.html").read_text(encoding="utf-8")
+        pricing_html = (REPO_ROOT / "pricing.html").read_text(encoding="utf-8")
+        paint_js = (REPO_ROOT / "bridge-paint.js").read_text(encoding="utf-8")
+        combined = "\n".join((paint_html, pricing_html, paint_js))
+
+        self.assertIsNone(re.search(r"BRIDGE-PAINT-[A-Z0-9][A-Z0-9-]{3,}", combined))
+        self.assertNotIn('class="offer-code"', combined)
+        self.assertNotIn("data-copy-offer", combined)
+        self.assertIn("data-bridge-paint-access-form", paint_html)
+        self.assertIn('http-equiv="Content-Security-Policy"', paint_html)
+        self.assertIn("sessionStorage", paint_js)
+        self.assertIn("history.replaceState", paint_js)
+
+    def test_deployment_example_contains_no_promotion_value(self):
+        source = (REPO_ROOT / "backend" / ".env.example").read_text(encoding="utf-8")
+        self.assertIn('BRIDGE_PAINT_PROMOTION_CODES_JSON="{}"', source)
+        for value in _configured_values().values():
+            self.assertNotIn(value, source)
+
+    def test_retired_campaign_prefix_is_rejected_by_runtime_configuration(self):
+        payload = {
+            "legacy_snapshot": f"{service.LEGACY_EXPOSED_CODE_PREFIX}RETIRED-FIXTURE"
+        }
+        with patch.object(
+            service.settings,
+            "bridge_paint_promotion_codes_json",
+            json.dumps(payload),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "revoked and replaced"):
+                service._promotion_codes()
+
+    def test_configuration_status_exposes_names_but_never_values(self):
+        values = _configured_values()
+        with (
+            patch.object(
+                service.settings,
+                "bridge_paint_promotion_codes_json",
+                json.dumps(values),
+            ),
+            patch.object(
+                service.settings,
+                "bridge_paint_event_expires_at",
+                _future_expiration().isoformat(),
+            ),
+        ):
+            status = service.bridge_paint_configuration_status()
+
+        self.assertTrue(status["configured"])
+        self.assertEqual(set(status["configured_packages"]), set(service.PACKAGE_NAMES))
+        serialized = json.dumps(status)
+        for value in values.values():
+            self.assertNotIn(value, serialized)
+
+    def test_invitation_stores_only_hash_and_deduplicates_active_delivery(self):
+        collection = FakeCollection()
+        deliveries = []
+
+        def capture_delivery(**kwargs):
+            deliveries.append(kwargs)
+            return {"sent": True}
+
+        with (
+            patch.object(service.settings, "secret_key", "s" * 64),
+            patch.object(service, "_collection", return_value=collection),
+            patch.object(service, "_promotion_codes", return_value=_configured_values()),
+            patch.object(service, "_event_expiration", side_effect=_future_expiration),
+            patch.object(
+                service,
+                "send_bridge_paint_invitation_email",
+                side_effect=capture_delivery,
+            ),
+            patch.object(service, "_safe_audit"),
+        ):
+            first = service.create_bridge_paint_invitation(
+                current_user={"_id": "ceo-1", "email": "ceo@example.test"},
+                email="Invitee@Example.test",
+                package_code="legacy_snapshot",
+                reason="Verified private event guest",
+            )
+            second = service.create_bridge_paint_invitation(
+                current_user={"_id": "ceo-1", "email": "ceo@example.test"},
+                email="invitee@example.test",
+                package_code="legacy_snapshot",
+                reason="Retry after uncertain browser response",
+            )
+
+        self.assertEqual(len(deliveries), 1)
+        token = deliveries[0]["access_token"]
+        self.assertTrue(token.startswith("tolbe_"))
+        stored = collection.documents[0]
+        self.assertNotEqual(stored["token_hash"], token)
+        self.assertNotIn("access_token", stored)
+        self.assertNotIn("promotion_code", stored)
+        self.assertEqual(first["id"], second["id"])
+        self.assertTrue(first["invitation_created"])
+        self.assertFalse(second["invitation_created"])
+        self.assertNotIn(token, json.dumps(first))
+
+    def test_one_time_claim_delivers_server_value_without_returning_it(self):
+        token = "tolbe_fixture_token_with_enough_entropy_123456"
+        secret_value = "rotated-server-only-fixture"
+        with patch.object(service.settings, "secret_key", "s" * 64):
+            token_hash = service._token_hash(token)
+        invitation_id = ObjectId()
+        collection = FakeCollection(
+            [
+                {
+                    "_id": invitation_id,
+                    "event_code": service.EVENT_CODE,
+                    "email": "invitee@example.test",
+                    "package_code": "legacy_snapshot",
+                    "status": "delivered",
+                    "expires_at": _future_expiration(),
+                    "token_hash": token_hash,
+                    "active_key": "active-fixture",
+                }
+            ]
+        )
+
+        with (
+            patch.object(service.settings, "secret_key", "s" * 64),
+            patch.object(service, "_collection", return_value=collection),
+            patch.object(
+                service,
+                "_promotion_codes",
+                return_value={"legacy_snapshot": secret_value},
+            ),
+            patch.object(
+                service,
+                "send_bridge_paint_promotion_email",
+                return_value={"sent": True},
+            ) as send_email,
+            patch.object(service, "_safe_audit"),
+        ):
+            first = service.request_bridge_paint_access(
+                email="invitee@example.test",
+                access_token=token,
+            )
+            second = service.request_bridge_paint_access(
+                email="invitee@example.test",
+                access_token=token,
+            )
+
+        self.assertEqual(first, service.PUBLIC_ACCESS_RESPONSE)
+        self.assertEqual(second, service.PUBLIC_ACCESS_RESPONSE)
+        self.assertNotIn(secret_value, json.dumps(first))
+        self.assertEqual(send_email.call_count, 1)
+        self.assertEqual(send_email.call_args.kwargs["promotion_code"], secret_value)
+        stored = collection.documents[0]
+        self.assertEqual(stored["status"], "fulfilled")
+        self.assertNotIn("token_hash", stored)
+        self.assertNotIn("active_key", stored)
+
+    def test_public_route_is_generic_no_store_and_dual_rate_limited(self):
+        app = FastAPI()
+        app.include_router(route_module.router)
+        client = TestClient(app)
+        with (
+            patch.object(
+                route_module,
+                "request_bridge_paint_access",
+                return_value=dict(service.PUBLIC_ACCESS_RESPONSE),
+            ),
+            patch.object(route_module, "enforce_rate_limit") as rate_limit,
+        ):
+            response = client.post(
+                "/bridge-events/paint/access/request",
+                json={
+                    "email": "invitee@example.com",
+                    "access_token": "tolbe_fixture_token_with_enough_entropy_123456",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), service.PUBLIC_ACCESS_RESPONSE)
+        self.assertEqual(rate_limit.call_count, 2)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertEqual(response.headers["pragma"], "no-cache")
+
+    def test_every_admin_invitation_route_requires_super_admin(self):
+        protected = {
+            "/bridge-events/paint/invitations",
+            "/bridge-events/paint/invitations/{invitation_id}/revoke",
+        }
+        routes = {
+            route.path: route
+            for route in route_module.router.routes
+            if route.path in protected
+        }
+        self.assertEqual(set(routes), protected)
+        for route in routes.values():
+            dependencies = {dependency.call for dependency in route.dependant.dependencies}
+            self.assertIn(require_super_admin, dependencies)
+
+    def test_duplicate_admin_request_returns_ok_instead_of_false_created_status(self):
+        app = FastAPI()
+        app.include_router(route_module.router)
+        app.dependency_overrides[require_super_admin] = lambda: {
+            "_id": "ceo-fixture",
+            "email": "ceo@example.com",
+        }
+        client = TestClient(app)
+        with patch.object(
+            route_module,
+            "create_bridge_paint_invitation",
+            return_value={
+                "id": "invitation-fixture",
+                "status": "delivered",
+                "invitation_created": False,
+            },
+        ) as create:
+            response = client.post(
+                "/bridge-events/paint/invitations",
+                json={
+                    "email": "invitee@example.com",
+                    "package_code": "legacy_snapshot",
+                    "reason": "Retry after uncertain response",
+                    "confirmed": True,
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["invitation_created"])
+        self.assertEqual(create.call_count, 1)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_secure_bridge_event_access.py
+++ b/backend/tests/test_secure_bridge_event_access.py
@@ -133,6 +133,7 @@ class TestSecureBridgeEventAccess(unittest.TestCase):
         self.assertIn('http-equiv="Content-Security-Policy"', paint_html)
         self.assertIn("sessionStorage", paint_js)
         self.assertIn("history.replaceState", paint_js)
+        self.assertIn('window.addEventListener("hashchange"', paint_js)
 
     def test_deployment_example_contains_no_promotion_value(self):
         source = (REPO_ROOT / "backend" / ".env.example").read_text(encoding="utf-8")

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -520,7 +520,7 @@ class AccountActivationSecurityTests(unittest.TestCase):
         self.assertIn("activation_token", auth_source)
         self.assertIn("window.history.replaceState", auth_source)
         self.assertNotIn("Email verified. Enter your account details", auth_source)
-        self.assertIn("auth.js?v=20260822-phase11", signup_source)
+        self.assertIn("auth.js?v=20260828-phase21-1", signup_source)
 
 
 class ContinuityLegacyRouteGuardTests(unittest.TestCase):
@@ -800,4 +800,3 @@ class RootDisclosureTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/backend/tests/test_startup_initialization.py
+++ b/backend/tests/test_startup_initialization.py
@@ -22,6 +22,7 @@ class StartupInitializationTests(unittest.TestCase):
             patch.object(main_module, "initialize_mint_job_indexes") as mint_job_init_mock,
             patch.object(main_module, "ensure_stripe_event_indexes") as stripe_init_mock,
             patch.object(main_module, "ensure_finance_event_indexes") as finance_init_mock,
+            patch.object(main_module, "ensure_bridge_event_invite_indexes") as bridge_event_init_mock,
             patch.object(main_module, "ensure_continuity_runtime_indexes") as continuity_init_mock,
             patch.object(main_module, "ensure_organization_indexes") as organization_init_mock,
             patch.object(main_module, "ensure_cinematic_manifest_indexes") as cinematic_init_mock,
@@ -40,6 +41,7 @@ class StartupInitializationTests(unittest.TestCase):
         mint_job_init_mock.assert_called_once()
         stripe_init_mock.assert_called_once()
         finance_init_mock.assert_called_once()
+        bridge_event_init_mock.assert_called_once()
         continuity_init_mock.assert_called_once()
         organization_init_mock.assert_called_once()
         cinematic_init_mock.assert_called_once()
@@ -62,6 +64,7 @@ class StartupInitializationTests(unittest.TestCase):
             patch.object(main_module, "initialize_mint_job_indexes") as mint_job_init_mock,
             patch.object(main_module, "ensure_stripe_event_indexes") as stripe_init_mock,
             patch.object(main_module, "ensure_finance_event_indexes") as finance_init_mock,
+            patch.object(main_module, "ensure_bridge_event_invite_indexes") as bridge_event_init_mock,
             patch.object(main_module, "ensure_continuity_runtime_indexes") as continuity_init_mock,
             patch.object(main_module, "ensure_organization_indexes") as organization_init_mock,
             patch.object(main_module, "ensure_cinematic_manifest_indexes") as cinematic_init_mock,
@@ -80,6 +83,7 @@ class StartupInitializationTests(unittest.TestCase):
         mint_job_init_mock.assert_not_called()
         stripe_init_mock.assert_not_called()
         finance_init_mock.assert_not_called()
+        bridge_event_init_mock.assert_not_called()
         continuity_init_mock.assert_not_called()
         organization_init_mock.assert_not_called()
         cinematic_init_mock.assert_not_called()

--- a/billing.html
+++ b/billing.html
@@ -9,7 +9,7 @@
       name="description"
       content="Manage Tomb of Light billing, payment methods, maintenance subscriptions, and saved cards."
     />
-    <link rel="stylesheet" href="styles.css?v=20260828-phase21" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -232,9 +232,9 @@
     </div>
 
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="billing.js?v=20260828-phase21"></script>
   </body>
 </html>

--- a/bridge-paint.html
+++ b/bridge-paint.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
     <title>Tomb of Light | Sip &amp; Paint — Private Bridge Event</title>
     <meta
       name="description"
@@ -27,7 +29,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=20260508-1" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
     <link rel="manifest" href="site.webmanifest?v=20260508-1" />
-    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="homepage-body pricing-page-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -85,61 +87,57 @@
         <section class="section section-tight" aria-labelledby="bridge-access-title">
           <div class="container">
             <div class="section-head section-head-wide">
-              <span class="eyebrow">PRIVATE BRIDGE EVENT ACCESS</span>
-              <h2 id="bridge-access-title">Private Bridge Event Access</h2>
+              <span class="eyebrow">VERIFIED INVITED-GUEST ACCESS</span>
+              <h2 id="bridge-access-title">Open your secure invitation</h2>
               <p class="section-lead">
-                Invited Sip &amp; Paint guests may use their private BRIDGE-PAINT code for 50% off an eligible Tomb of
-                Light package purchase.
+                Private event offers are now issued through one-time links tied
+                to the invited guest's email address and selected package.
               </p>
             </div>
 
             <article class="cta-panel cta-panel-premium offer-panel offer-panel-private">
-              <div class="hero-meta" aria-label="Bridge offer details">
-                <span class="meta-pill">BRIDGE-PAINT</span>
+              <div class="hero-meta" aria-label="Private offer safeguards">
+                <span class="meta-pill">One invited mailbox</span>
+                <span class="meta-pill">One selected package</span>
+                <span class="meta-pill">One-time secure link</span>
                 <span class="meta-pill">50% off eligible package purchases</span>
                 <span class="meta-pill">Expires August 29, 2026 at 11:59 PM</span>
-                <span class="meta-pill">Limited to 25 redemptions per package code</span>
               </div>
-              <div class="offer-code-list bridge-access-grid">
-                <div class="offer-code-item">
-                  <strong>Legacy Snapshot</strong>
-                  <code class="offer-code">BRIDGE-PAINT-SNAPSHOT</code>
+
+              <form class="form-grid" data-bridge-paint-access-form novalidate>
+                <label>
+                  Invited Email Address
+                  <input
+                    type="email"
+                    name="email"
+                    autocomplete="email"
+                    maxlength="254"
+                    required
+                  />
+                </label>
+                <div class="inline-actions">
+                  <button class="btn btn-primary" type="submit" data-bridge-paint-access-submit>
+                    Request My Private Offer
+                  </button>
                 </div>
-                <div class="offer-code-item">
-                  <strong>Legacy Portrait Intro</strong>
-                  <code class="offer-code">BRIDGE-PAINT-PORTRAIT</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Digital Legacy Portrait</strong>
-                  <code class="offer-code">BRIDGE-PAINT-DIGITAL</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Household Foundation</strong>
-                  <code class="offer-code">BRIDGE-PAINT-HOUSEHOLD</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Heirloom Legacy Tree</strong>
-                  <code class="offer-code">BRIDGE-PAINT-HEIRLOOM</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Legacy Plus</strong>
-                  <code class="offer-code">BRIDGE-PAINT-PLUS</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Family Estate Concierge</strong>
-                  <code class="offer-code">BRIDGE-PAINT-ESTATE</code>
-                </div>
-                <div class="offer-code-item">
-                  <strong>Command Structure Network</strong>
-                  <code class="offer-code">BRIDGE-PAINT-COMMAND</code>
-                </div>
-              </div>
+                <p
+                  class="status-message"
+                  data-bridge-paint-access-status
+                  role="status"
+                  aria-live="polite"
+                >
+                  Open the one-time link from your invitation email to continue.
+                </p>
+              </form>
+
               <p class="section-note">
-                Use the standard Tomb of Light package checkout and enter your private Bridge Event code directly at
-                Stripe checkout when prompted.
+                After verification, the private offer is delivered only to the
+                mailbox named on the invitation. The offer is never displayed
+                publicly or returned by this page.
               </p>
               <p class="section-note">
-                Bridge Event codes apply to eligible package purchases only. They do not apply to maintenance,
+                Previously published event codes are retired. Private offers
+                apply to eligible package purchases only and do not apply to maintenance,
                 subscriptions, add-ons, services, rush delivery, NFT services, white-glove support, taxes, or future
                 balances.
               </p>
@@ -184,7 +182,8 @@
         </div>
       </footer>
     </div>
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="bridge-paint.js?v=20260828-secure-event-access"></script>
   </body>
 </html>

--- a/bridge-paint.html
+++ b/bridge-paint.html
@@ -184,6 +184,6 @@
     </div>
     <script src="config.js?v=20260828-phase21-1"></script>
     <script src="app.js?v=20260828-phase21-1"></script>
-    <script src="bridge-paint.js?v=20260828-secure-event-access"></script>
+    <script src="bridge-paint.js?v=20260828-secure-event-access-1"></script>
   </body>
 </html>

--- a/bridge-paint.js
+++ b/bridge-paint.js
@@ -52,10 +52,24 @@
     const submitButton = document.querySelector("[data-bridge-paint-access-submit]");
     if (!form || !statusNode || !submitButton) return;
 
-    const hashToken = tokenFromHash();
-    if (hashToken) saveInviteToken(hashToken);
-    removeTokenFromAddressBar();
-    let accessToken = hashToken || storedInviteToken();
+    let accessToken = storedInviteToken();
+
+    function acceptTokenFromAddressBar() {
+      const hashToken = tokenFromHash();
+      if (!hashToken) return false;
+      saveInviteToken(hashToken);
+      removeTokenFromAddressBar();
+      accessToken = hashToken;
+      submitButton.disabled = false;
+      app.setStatus(
+        statusNode,
+        "Secure invitation detected. Enter the exact email address that received it.",
+        "success",
+      );
+      return true;
+    }
+
+    const acceptedAddressBarToken = acceptTokenFromAddressBar();
 
     if (!accessToken) {
       submitButton.disabled = true;
@@ -64,13 +78,18 @@
         "Open the one-time link from your invitation email. Contact the event organizer if you need a new invitation.",
         "info",
       );
-    } else {
+    } else if (!acceptedAddressBarToken) {
       app.setStatus(
         statusNode,
         "Secure invitation detected. Enter the exact email address that received it.",
         "success",
       );
     }
+
+    // A mail client or in-app browser can reuse an already-open event page and
+    // append the one-time fragment without reloading the document. Capture and
+    // remove that fragment immediately, just as we do during a fresh page load.
+    window.addEventListener("hashchange", acceptTokenFromAddressBar);
 
     form.addEventListener("submit", async function (event) {
       event.preventDefault();

--- a/bridge-paint.js
+++ b/bridge-paint.js
@@ -1,0 +1,118 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  if (!app || typeof app.apiRequest !== "function") return;
+
+  const INVITE_TOKEN_KEY = "tol_bridge_paint_invite_token";
+
+  function tokenFromHash() {
+    const rawHash = String(window.location.hash || "").replace(/^#/, "");
+    if (!rawHash) return "";
+    const params = new URLSearchParams(rawHash);
+    return String(params.get("invite") || "").trim();
+  }
+
+  function saveInviteToken(token) {
+    try {
+      if (token) window.sessionStorage.setItem(INVITE_TOKEN_KEY, token);
+    } catch (_error) {
+      // The in-memory value still supports this page session.
+    }
+  }
+
+  function storedInviteToken() {
+    try {
+      return String(window.sessionStorage.getItem(INVITE_TOKEN_KEY) || "").trim();
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function clearInviteToken() {
+    try {
+      window.sessionStorage.removeItem(INVITE_TOKEN_KEY);
+    } catch (_error) {
+      // Nothing else is required when browser storage is unavailable.
+    }
+  }
+
+  function removeTokenFromAddressBar() {
+    if (!window.location.hash) return;
+    window.history.replaceState(
+      {},
+      document.title,
+      `${window.location.pathname}${window.location.search}`,
+    );
+  }
+
+  function setupSecureEventAccess() {
+    const form = document.querySelector("[data-bridge-paint-access-form]");
+    const statusNode = document.querySelector("[data-bridge-paint-access-status]");
+    const submitButton = document.querySelector("[data-bridge-paint-access-submit]");
+    if (!form || !statusNode || !submitButton) return;
+
+    const hashToken = tokenFromHash();
+    if (hashToken) saveInviteToken(hashToken);
+    removeTokenFromAddressBar();
+    let accessToken = hashToken || storedInviteToken();
+
+    if (!accessToken) {
+      submitButton.disabled = true;
+      app.setStatus(
+        statusNode,
+        "Open the one-time link from your invitation email. Contact the event organizer if you need a new invitation.",
+        "info",
+      );
+    } else {
+      app.setStatus(
+        statusNode,
+        "Secure invitation detected. Enter the exact email address that received it.",
+        "success",
+      );
+    }
+
+    form.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const email = String(formData.get("email") || "").trim().toLowerCase();
+      if (!email || !accessToken) {
+        app.setStatus(
+          statusNode,
+          "A valid invitation link and invited email address are required.",
+          "error",
+        );
+        return;
+      }
+
+      submitButton.disabled = true;
+      try {
+        app.setStatus(statusNode, "Verifying private event access…", "info");
+        const payload = await app.apiRequest("/bridge-events/paint/access/request", {
+          method: "POST",
+          body: JSON.stringify({ email, access_token: accessToken }),
+        });
+        clearInviteToken();
+        accessToken = "";
+        form.reset();
+        app.setStatus(
+          statusNode,
+          String(
+            (payload && payload.message) ||
+              "If the invitation is valid, the private offer will be sent to the invited mailbox.",
+          ),
+          "success",
+        );
+      } catch (_error) {
+        submitButton.disabled = false;
+        app.setStatus(
+          statusNode,
+          "Secure event access is temporarily unavailable. No invitation was consumed. Try again.",
+          "error",
+        );
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", setupSecureEventAccess);
+})();

--- a/bridge-taste.html
+++ b/bridge-taste.html
@@ -27,7 +27,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=20260508-1" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
     <link rel="manifest" href="site.webmanifest?v=20260508-1" />
-    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="homepage-body pricing-page-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -114,7 +114,7 @@
         </div>
       </footer>
     </div>
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/browser-tests/customer-recovery-mobile-phase21-1.spec.mjs
+++ b/browser-tests/customer-recovery-mobile-phase21-1.spec.mjs
@@ -22,8 +22,13 @@ test.describe("Phase 21.1 mobile recovery", () => {
     expect(state.headerPosition).toBe("relative");
     expect(state.scrollHeight).toBeGreaterThan(state.viewportHeight);
 
-    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
-    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+    await page.evaluate(() =>
+      window.scrollTo({
+        top: document.documentElement.scrollHeight,
+        behavior: "instant",
+      }),
+    );
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   });
 
   test("account recovery chooses one secure endpoint without exposing state", async ({ page }) => {

--- a/browser-tests/customer-recovery-mobile-phase21-1.spec.mjs
+++ b/browser-tests/customer-recovery-mobile-phase21-1.spec.mjs
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Phase 21.1 mobile recovery", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("mobile navigation remains vertically scrollable", async ({ page }) => {
+    await page.goto("/signup.html", { waitUntil: "load" });
+    await page.getByRole("button", { name: "Toggle navigation menu" }).click();
+
+    const state = await page.evaluate(() => ({
+      bodyOverflowY: window.getComputedStyle(document.body).overflowY,
+      headerPosition: window.getComputedStyle(
+        document.querySelector(".site-header"),
+      ).position,
+      menuOpen: document.body.classList.contains("menu-open"),
+      scrollHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight,
+    }));
+
+    expect(state.menuOpen).toBe(true);
+    expect(state.bodyOverflowY).not.toBe("hidden");
+    expect(state.headerPosition).toBe("relative");
+    expect(state.scrollHeight).toBeGreaterThan(state.viewportHeight);
+
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  });
+
+  test("account recovery chooses one secure endpoint without exposing state", async ({ page }) => {
+    let recoveryRequests = 0;
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.pathname === "/health") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "ok" }),
+        });
+      }
+      if (request.method() === "GET" && url.pathname === "/auth/me") {
+        return route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "No active session." }),
+        });
+      }
+      if (
+        request.method() === "POST" &&
+        url.pathname.endsWith("/auth/account-recovery/request")
+      ) {
+        recoveryRequests += 1;
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message:
+              "If this email is connected to an account, the appropriate secure access link has been sent.",
+          }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.goto("/account-security.html#reset-request", { waitUntil: "load" });
+    await page.getByLabel("Email Address").fill("fixture@example.test");
+    await page.getByRole("button", { name: "Recover Account Access" }).click();
+
+    await expect(page.locator("[data-password-reset-request-status]")).toContainText(
+      "appropriate secure access link",
+    );
+    expect(recoveryRequests).toBe(1);
+  });
+});

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -143,7 +143,7 @@ test("[asset-versioning] dashboard and control center include current cache-bust
     nodes.map((node) => node.getAttribute("href") || ""),
   );
   expect(dashboardStyles.some((href) => href.includes("styles.css?v=20260824-phase20"))).toBeTruthy();
-  expect(dashboardScripts.some((src) => src.includes("app.js?v=20260825-phase20-1"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-intake.js?v=20260824-phase20"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-admin.js?v=20260713-livefix3"))).toBeTruthy();
 
@@ -155,6 +155,6 @@ test("[asset-versioning] dashboard and control center include current cache-bust
     nodes.map((node) => node.getAttribute("href") || ""),
   );
   expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260821-phase10"))).toBeTruthy();
-  expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260825-phase20-1"))).toBeTruthy();
+  expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260824-phase19-1"))).toBeTruthy();
 });

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -142,7 +142,7 @@ test("[asset-versioning] dashboard and control center include current cache-bust
   const dashboardStyles = await page.locator("link[rel='stylesheet']").evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute("href") || ""),
   );
-  expect(dashboardStyles.some((href) => href.includes("styles.css?v=20260824-phase20"))).toBeTruthy();
+  expect(dashboardStyles.some((href) => href.includes("styles.css?v=20260828-phase21-1"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-intake.js?v=20260824-phase20"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-admin.js?v=20260713-livefix3"))).toBeTruthy();
@@ -154,7 +154,7 @@ test("[asset-versioning] dashboard and control center include current cache-bust
   const controlCenterStyles = await page.locator("link[rel='stylesheet']").evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute("href") || ""),
   );
-  expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260821-phase10"))).toBeTruthy();
+  expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260828-phase21-1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260824-phase19-1"))).toBeTruthy();
 });

--- a/browser-tests/secure-bridge-event-access.spec.mjs
+++ b/browser-tests/secure-bridge-event-access.spec.mjs
@@ -117,7 +117,7 @@ test.describe("secure private event access", () => {
     );
     await expect(page.locator("[data-admin-event-send]")).toBeEnabled();
     await page.getByLabel("Invited Email Address").fill("invitee@example.test");
-    await page.getByLabel("Selected Package", { exact: true }).selectOption("legacy_snapshot");
+    await page.locator('select[name="package_code"]').selectOption("legacy_snapshot");
     await page.getByLabel("Internal Reason").fill("Verified Event 2 guest registration");
     await page.getByRole("checkbox").check();
     await page.getByRole("button", { name: "Send Secure Invitation" }).click();

--- a/browser-tests/secure-bridge-event-access.spec.mjs
+++ b/browser-tests/secure-bridge-event-access.spec.mjs
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+const PACKAGES = [
+  "legacy_snapshot",
+  "legacy_portrait_intro",
+  "digital_legacy_portrait",
+  "household_foundation",
+  "heirloom_legacy_tree",
+  "legacy_plus",
+  "family_estate_concierge",
+  "command_structure_network",
+];
+
+function json(route, payload, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  });
+}
+
+test.describe("secure private event access", () => {
+  test("public page requires a one-time fragment and never renders an offer value", async ({ page }) => {
+    let submitted = null;
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+      const path = new URL(request.url()).pathname.replace(/^\/api-gateway/, "");
+      if (request.method() === "GET" && path === "/health") {
+        return json(route, { status: "ok" });
+      }
+      if (request.method() === "POST" && path === "/bridge-events/paint/access/request") {
+        submitted = request.postDataJSON();
+        return json(route, {
+          success: true,
+          message:
+            "If this invitation is valid and matches the invited email address, the private event offer will be sent to that mailbox.",
+        });
+      }
+      return route.continue();
+    });
+
+    await page.goto("/bridge-paint.html", { waitUntil: "load" });
+    await expect(page.locator("[data-bridge-paint-access-submit]")).toBeDisabled();
+    await expect(page.locator("body")).not.toContainText(/BRIDGE-PAINT-[A-Z0-9]/);
+
+    const token = "tolbe_browser_fixture_with_enough_entropy_123456";
+    await page.goto(`/bridge-paint.html#invite=${token}`, { waitUntil: "load" });
+    await expect(page).not.toHaveURL(/#invite=/);
+    await page.getByLabel("Invited Email Address").fill("invitee@example.test");
+    await page.getByRole("button", { name: "Request My Private Offer" }).click();
+
+    await expect(page.locator("[data-bridge-paint-access-status]")).toContainText(
+      "private event offer will be sent",
+    );
+    expect(submitted).toEqual({ email: "invitee@example.test", access_token: token });
+    expect(
+      await page.evaluate(() => sessionStorage.getItem("tol_bridge_paint_invite_token")),
+    ).toBeNull();
+  });
+
+  test("CEO console receives readiness and delivery state but no protected value", async ({ page }) => {
+    const admin = {
+      id: "ceo-fixture",
+      _id: "ceo-fixture",
+      email: "ceo@example.test",
+      role_codes: ["ceo_master_admin"],
+    };
+    const records = [];
+    let createRequest = null;
+    await page.addInitScript((user) => {
+      localStorage.setItem("tol_access_token", "secure-event-admin-fixture");
+      localStorage.setItem("tol_user", JSON.stringify(user));
+    }, admin);
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+      const path = new URL(request.url()).pathname.replace(/^\/api-gateway/, "");
+      if (request.method() === "GET" && path === "/health") {
+        return json(route, { status: "ok" });
+      }
+      if (request.method() === "GET" && path === "/auth/me") {
+        return json(route, admin);
+      }
+      if (request.method() === "GET" && path === "/bridge-events/paint/invitations") {
+        return json(route, {
+          configuration: {
+            configured: true,
+            configured_packages: PACKAGES,
+            required_packages: PACKAGES,
+            expires_at: "2026-08-30T03:59:00Z",
+            configuration_error: null,
+          },
+          count: records.length,
+          items: records,
+        });
+      }
+      if (request.method() === "POST" && path === "/bridge-events/paint/invitations") {
+        createRequest = request.postDataJSON();
+        records.unshift({
+          id: "invitation-fixture",
+          email: createRequest.email,
+          package_code: createRequest.package_code,
+          package_name: "Legacy Snapshot",
+          status: "delivered",
+          invitation_delivery_status: "sent",
+          promotion_delivery_status: "not_requested",
+          created_at: "2026-08-28T12:00:00Z",
+          expires_at: "2026-08-30T03:59:00Z",
+        });
+        return json(route, records[0], 201);
+      }
+      return route.continue();
+    });
+
+    await page.goto("/admin-event-access.html", { waitUntil: "load" });
+    await expect(page.locator("[data-admin-event-configuration]")).toContainText(
+      "All 8 package values are protected",
+    );
+    await expect(page.locator("[data-admin-event-send]")).toBeEnabled();
+    await page.getByLabel("Invited Email Address").fill("invitee@example.test");
+    await page.getByLabel("Selected Package").selectOption("legacy_snapshot");
+    await page.getByLabel("Internal Reason").fill("Verified Event 2 guest registration");
+    await page.getByRole("checkbox").check();
+    await page.getByRole("button", { name: "Send Secure Invitation" }).click();
+
+    await expect(page.locator("[data-admin-event-action-status]")).toContainText(
+      "Secure invitation sent",
+    );
+    expect(createRequest).toEqual({
+      email: "invitee@example.test",
+      package_code: "legacy_snapshot",
+      reason: "Verified Event 2 guest registration",
+      confirmed: true,
+    });
+    expect(JSON.stringify(createRequest)).not.toContain("promotion_code");
+    expect(JSON.stringify(createRequest)).not.toContain("access_token");
+  });
+});

--- a/browser-tests/secure-bridge-event-access.spec.mjs
+++ b/browser-tests/secure-bridge-event-access.spec.mjs
@@ -117,7 +117,7 @@ test.describe("secure private event access", () => {
     );
     await expect(page.locator("[data-admin-event-send]")).toBeEnabled();
     await page.getByLabel("Invited Email Address").fill("invitee@example.test");
-    await page.getByLabel("Selected Package").selectOption("legacy_snapshot");
+    await page.getByLabel("Selected Package", { exact: true }).selectOption("legacy_snapshot");
     await page.getByLabel("Internal Reason").fill("Verified Event 2 guest registration");
     await page.getByRole("checkbox").check();
     await page.getByRole("button", { name: "Send Secure Invitation" }).click();

--- a/compliance.html
+++ b/compliance.html
@@ -21,7 +21,7 @@
   <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
   <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
 
@@ -348,6 +348,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/cookie-policy.html
+++ b/cookie-policy.html
@@ -9,7 +9,7 @@
     name="description"
     content="Read the Tomb of Light Cookie Policy and learn how the website may use essential and optional cookie-based technologies."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -214,6 +214,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/create-family.html
+++ b/create-family.html
@@ -9,7 +9,7 @@
       name="description"
       content="Create your first Tomb of Light family record."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -152,9 +152,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-4"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="family.js?v=20260322-4"></script>
   </body>
 </html>

--- a/create-relationship.html
+++ b/create-relationship.html
@@ -9,7 +9,7 @@
     name="description"
     content="Create a relationship between family members in Tomb of Light."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <div class="page-wrap">
@@ -249,7 +249,7 @@
   </div>
 
   <script src="config.js"></script>
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
   <script src="auth.js"></script>
   <script src="relationship.js?v=20260823-phase13-1"></script>
 </body>

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,7 +9,7 @@
       name="description"
       content="Your private Tomb of Light customer or internal operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260824-phase20" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -857,9 +857,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260329-1"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260713-livefix3"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="dashboard-intake.js?v=20260824-phase20"></script>
     <script src="dashboard-admin.js?v=20260713-livefix3"></script>
   </body>

--- a/data-request.html
+++ b/data-request.html
@@ -9,7 +9,7 @@
       name="description"
       content="Submit a privacy or data-related request to Tomb of Light, including access, correction, deletion, or related inquiries."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -315,7 +315,7 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
     <script>
       (function () {
         "use strict";

--- a/digital-collectible.html
+++ b/digital-collectible.html
@@ -10,7 +10,7 @@
       content="Your Tomb of Light NFT-authenticated digital collectible delivery page. Access and download your delivered digital asset files."
     />
     <link rel="canonical" href="https://tomboflight.com/digital-collectible.html" />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -324,8 +324,8 @@
       </main>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="digital-collectible.js?v=20260414-2"></script>
   </body>
 </html>

--- a/family-graph.html
+++ b/family-graph.html
@@ -9,7 +9,7 @@
     name="description"
     content="View a Tomb of Light family graph with members, relationships, and lineage summary."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <div class="page-wrap">
@@ -103,7 +103,7 @@
   </div>
 
   <script src="config.js"></script>
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
   <script src="auth.js"></script>
   <script src="family-graph.js"></script>
 </body>

--- a/family-reunion.html
+++ b/family-reunion.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; form-action 'self'; upgrade-insecure-requests" />
     <title>Family Reunion Readiness | Tomb of Light</title>
     <meta name="description" content="See which linked family members are ready without exposing private family files." />
-    <link rel="stylesheet" href="styles.css?v=20260823-phase13" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -64,9 +64,9 @@
         </div></div></div>
       </footer>
     </div>
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="family-reunion.js?v=20260823-phase13"></script>
   </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -21,7 +21,7 @@
   <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
   <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
 
@@ -543,6 +543,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/household-access.html
+++ b/household-access.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://tomboflight-api.onrender.com https://*.onrender.com http://127.0.0.1:* http://localhost:*; media-src 'self' blob: https:; worker-src 'self' blob:; form-action 'self' https://buy.stripe.com; upgrade-insecure-requests" />
     <title>Members &amp; Access | Tomb of Light</title>
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-household-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -167,9 +167,9 @@
         </section>
       </main>
     </div>
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="household-access.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -21,7 +21,7 @@
     <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
     <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -421,7 +421,7 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260327-4"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="homepage-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -593,7 +593,7 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260509-visualfix"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/intake-consent.html
+++ b/intake-consent.html
@@ -9,7 +9,7 @@
       name="description"
       content="Consent and privacy preferences for Tomb of Light onboarding."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -306,9 +306,9 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260326-3"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260326-3"></script>
   </body>
 </html>

--- a/intake-family-map.html
+++ b/intake-family-map.html
@@ -9,7 +9,7 @@
       name="description"
       content="Outline your household family structure for Tomb of Light onboarding."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -227,9 +227,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-10"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260322-10"></script>
   </body>
 </html>

--- a/intake-household.html
+++ b/intake-household.html
@@ -9,7 +9,7 @@
       name="description"
       content="Set up your Tomb of Light household information."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -225,9 +225,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-10"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260322-10"></script>
   </body>
 </html>

--- a/intake-review.html
+++ b/intake-review.html
@@ -9,7 +9,7 @@
       name="description"
       content="Review your Tomb of Light intake details before submission."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -257,9 +257,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-10"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260508-451"></script>
   </body>
 </html>

--- a/intake-uploads.html
+++ b/intake-uploads.html
@@ -9,7 +9,7 @@
       name="description"
       content="Upload planning and asset scope for Tomb of Light onboarding. This step plans what you will upload — it does not upload files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-intake-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -323,9 +323,9 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260326-3"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260508-451"></script>
   </body>
 </html>

--- a/intake-welcome.html
+++ b/intake-welcome.html
@@ -9,7 +9,7 @@
       name="description"
       content="Welcome to Tomb of Light intake. Begin your family legacy onboarding."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -159,9 +159,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-10"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260410-2"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="intake.js?v=20260322-10"></script>
   </body>
 </html>

--- a/lineage-certificate.html
+++ b/lineage-certificate.html
@@ -9,7 +9,7 @@
       name="description"
       content="Generate and view executive lineage certificates for Tomb of Light family records."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-certificate-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -130,9 +130,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260322-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="lineage-certificate.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/lineage-intelligence.html
+++ b/lineage-intelligence.html
@@ -10,7 +10,7 @@
 <meta name="description"
 content="Lineage intelligence dashboard for analyzing family structure, generations, and relationship networks inside Tomb of Light."/>
 
-<link rel="stylesheet" href="styles.css?v=20260507-434">
+<link rel="stylesheet" href="styles.css?v=20260828-phase21-1">
 </head>
 
 <body>
@@ -133,7 +133,7 @@ Select a family to generate lineage intelligence.
 </div>
 
 <script src="config.js"></script>
-<script src="app.js?v=20260825-phase20-1"></script>
+<script src="app.js?v=20260828-phase21-1"></script>
 <script src="auth.js"></script>
 <script src="lineage-intelligence.js"></script>
 

--- a/link-keys.html
+++ b/link-keys.html
@@ -9,7 +9,7 @@
       name="description"
       content="Generate, share, approve, and manage Tomb of Light link keys for eligible portrait, household, and network workspaces."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-link-keys-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -313,9 +313,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="link-keys.js?v=20260823-phase13-1"></script>
   </body>
 </html>

--- a/platform.html
+++ b/platform.html
@@ -21,7 +21,7 @@
     <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
     <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -488,7 +488,7 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260327-4"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/portal-help.html
+++ b/portal-help.html
@@ -9,7 +9,7 @@
       name="description"
       content="Private support guidance for package questions, secure workspace help, maintenance decisions, and Tomb of Light checkout support."
     />
-    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="homepage-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -122,7 +122,7 @@
         </div>
       </footer>
     </div>
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/portal-review.html
+++ b/portal-review.html
@@ -9,7 +9,7 @@
       name="description"
       content="Review your Tomb of Light production and submit your approval or revision request."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -227,9 +227,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260326-3"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script>
     (function () {
       "use strict";

--- a/portal-upgrade.html
+++ b/portal-upgrade.html
@@ -9,7 +9,7 @@
       name="description"
       content="Private upgrade route for authenticated Tomb of Light customer portal users."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body">
     <div class="site-watermark" aria-hidden="true"></div>
@@ -44,9 +44,9 @@
         </section>
       </main>
     </div>
-    <script src="config.js?v=20260331-2"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script>
       document.addEventListener("DOMContentLoaded", async function () {
         const params = new URLSearchParams(window.location.search);

--- a/portrait-upload.html
+++ b/portrait-upload.html
@@ -9,7 +9,7 @@
       name="description"
       content="Upload portrait images for your Tomb of Light portrait workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-portrait-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -366,9 +366,9 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="portrait-upload.js?v=20260824-phase18"></script>
   </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -31,7 +31,7 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png?v=20260508-1" />
     <link rel="manifest" href="site.webmanifest?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260518-founder-polish" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="homepage-body pricing-page-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -711,22 +711,22 @@
                 <span class="eyebrow">Private Bridge Event Access</span>
                 <h3>Sip &amp; Paint — Event 2 of 4</h3>
                 <p class="section-lead">
-                  BRIDGE-PAINT remains invite-only and separate from the main catalog. Invited Sip &amp; Paint guests
-                  may review their private event access and enter their BRIDGE-PAINT code during standard Stripe
-                  checkout.
+                  Sip &amp; Paint access remains invite-only and separate from the main catalog. Invited guests receive
+                  a one-time access link at their verified email address, followed by the private offer for their
+                  selected package.
                 </p>
                 <div class="hero-meta" aria-label="Bridge offer details">
-                  <span class="meta-pill">BRIDGE-PAINT</span>
+                  <span class="meta-pill">Verified invited guests only</span>
                   <span class="meta-pill">50% off eligible package purchases</span>
                   <span class="meta-pill">Expires August 29, 2026 at 11:59 PM</span>
-                  <span class="meta-pill">Limited to 25 redemptions per package code</span>
+                  <span class="meta-pill">Package-specific private access</span>
                 </div>
                 <div class="pricing-actions pricing-actions-inline">
                   <a class="btn btn-primary" href="bridge-paint.html">View Private Sip &amp; Paint Access</a>
                   <a class="btn btn-secondary" href="portal-help.html">Need help choosing?</a>
                 </div>
                 <p class="section-note">
-                  Bridge Event codes apply to package purchases only. They do not apply to maintenance,
+                  Private event offers apply to package purchases only. They do not apply to maintenance,
                   subscriptions, add-ons, services, rush delivery, NFT services, white-glove support, taxes, or
                   future balances.
                 </p>
@@ -809,7 +809,7 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260509-visualfix"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/privacy-choices.html
+++ b/privacy-choices.html
@@ -9,7 +9,7 @@
     name="description"
     content="Manage privacy-related website choices for Tomb of Light, including optional analytics preferences stored on your device."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -171,6 +171,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/privacy-state-notices.html
+++ b/privacy-state-notices.html
@@ -9,7 +9,7 @@
       name="description"
       content="Review Tomb of Light state privacy notices and additional rights information for users in certain U.S. states."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -343,6 +343,6 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -21,7 +21,7 @@
     <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
     <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -669,6 +669,6 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/refunds-delivery.html
+++ b/refunds-delivery.html
@@ -21,7 +21,7 @@
   <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
   <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -229,6 +229,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/reviews/index.html
+++ b/reviews/index.html
@@ -85,7 +85,7 @@
       }
     </script>
 
-    <link rel="stylesheet" href="../styles.css?v=20260509-1" />
+    <link rel="stylesheet" href="../styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -326,7 +326,7 @@
       </div>
     </div>
 
-    <script src="../config.js?v=20260331-1"></script>
-    <script src="../app.js?v=20260410-1"></script>
+    <script src="../config.js?v=20260828-phase21-1"></script>
+    <script src="../app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/roadmap.html
+++ b/roadmap.html
@@ -9,7 +9,7 @@
     name="description"
     content="Review the Tomb of Light platform roadmap, from foundational web infrastructure to immersive family lineage experiences."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -171,6 +171,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/security.html
+++ b/security.html
@@ -21,7 +21,7 @@
     <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
     <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -417,6 +417,6 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -9,7 +9,7 @@
       name="description"
       content="Enter your private Tomb of Light customer or operations workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-visualfix" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-login-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -440,8 +440,8 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260509-visualfix"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-visualfix"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -9,7 +9,7 @@
       name="description"
       content="Create your private Tomb of Light account and open the protected workspace for your legacy build."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-visualfix" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -128,6 +128,12 @@
                   Creating an account opens your private Tomb of Light portal.
                   Guided intake, uploads, and lineage tools unlock according to
                   the package you purchase.
+                </div>
+
+                <div class="helper">
+                  Already started an account? Use
+                  <a href="account-security.html#reset-request">Account Recovery</a>
+                  to receive the correct secure activation or password-reset link.
                 </div>
 
                 <div style="display: grid; gap: 0.85rem; margin-top: 0.85rem">
@@ -320,8 +326,8 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260509-visualfix"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260822-phase11"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -270,6 +270,15 @@ a {
 }
 
 @media (max-width: 1180px) {
+  body.menu-open {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  body.menu-open .site-header {
+    position: relative;
+  }
+
   .site-header-inner {
     flex-wrap: wrap;
   }

--- a/team.html
+++ b/team.html
@@ -9,7 +9,7 @@
     name="description"
     content="Meet the leadership behind Tomb of Light and the mission to preserve family history through secure digital infrastructure."
   />
-  <link rel="stylesheet" href="styles.css?v=20260507-434" />
+  <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -135,6 +135,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260825-phase20-1"></script>
+  <script src="app.js?v=20260828-phase21-1"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -21,7 +21,7 @@
     <meta property="og:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
     <meta name="twitter:image" content="https://tomboflight.com/logo.png?v=20260508-1" />
 
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -599,6 +599,6 @@
       </div>
     </div>
 
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -9,7 +9,7 @@
       name="description"
       content="Your Tomb of Light payment was successful. Review your next steps and continue into your workspace."
     />
-    <link rel="stylesheet" href="styles.css?v=20260507-434" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body>
     <div class="page-wrap">
@@ -119,8 +119,8 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260331-1"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
     <script src="thank-you.js?v=20260331-1"></script>
   </body>
 </html>

--- a/tree-view.html
+++ b/tree-view.html
@@ -9,7 +9,7 @@
       name="description"
       content="Visual family tree renderer for Tomb of Light lineage data."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
     <style>
       .tree-shell {
         overflow: visible;
@@ -560,9 +560,9 @@
       </footer>
     </div>
 
-    <script src="config.js?v=20260415-1"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="tree-view.js?v=20260823-phase13-1"></script>
   </body>
 </html>

--- a/upload-hub.html
+++ b/upload-hub.html
@@ -9,7 +9,7 @@
       name="description"
       content="The Tomb of Light Upload Hub. Choose where to upload portraits, verification documents, or private vault files."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-upload-hub-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -358,8 +358,8 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260326-3"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
   </body>
 </html>

--- a/vault-upload.html
+++ b/vault-upload.html
@@ -9,7 +9,7 @@
       name="description"
       content="Upload private vault files — voice messages, video messages, and protected legacy media — to your Tomb of Light vault."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-vault-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -392,9 +392,9 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260326-3"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="vault-upload.js?v=20260509-audit"></script>
   </body>
 </html>

--- a/verification-upload.html
+++ b/verification-upload.html
@@ -9,7 +9,7 @@
       name="description"
       content="Upload verification records and supporting family documents to Tomb of Light."
     />
-    <link rel="stylesheet" href="styles.css?v=20260509-audit" />
+    <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
   </head>
   <body class="portal-dashboard-body portal-verification-body">
     <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -418,9 +418,9 @@
       </div>
     </div>
 
-    <script src="config.js?v=20260328-7"></script>
-    <script src="app.js?v=20260825-phase20-1"></script>
-    <script src="auth.js?v=20260509-audit"></script>
+    <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="app.js?v=20260828-phase21-1"></script>
+    <script src="auth.js?v=20260828-phase21-1"></script>
 
     <script>
       document.addEventListener("DOMContentLoaded", async function () {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -302,8 +302,8 @@
       </main>
     </div>
 
-    <script src="../config.js?v=20260509-visualfix"></script>
-    <script src="../app.js?v=20260509-visualfix"></script>
+    <script src="../config.js?v=20260828-phase21-1"></script>
+    <script src="../app.js?v=20260828-phase21-1"></script>
     <script src="js/genesis-prototype-manifest.js?v=20260509-visualfix"></script>
     <script src="js/script.js?v=20260824-universal-lineage-cinema"></script>
   </body>


### PR DESCRIPTION
## Outcome

Restores mobile scrolling and unified account recovery, then removes the Event 2 promotion values from current public source and replaces them with an audited, CEO-issued invitation flow.

## Customer and mobile recovery

- Keeps mobile navigation and long account pages vertically scrollable.
- Routes existing-account registration conflicts into one non-enumerating recovery request.
- Recovers activation or password access without exposing account state.
- Updates shared cache revisions so deployed browsers receive the repair.

## Secure private-event access

- Removes retired Event 2 values from current HTML, tests, and documentation.
- Adds a canonical-CEO-only invitation console with package readiness, delivery history, and revocation.
- Uses a high-entropy one-time URL-fragment token and stores only its HMAC hash.
- Keeps replacement promotion values in protected backend runtime configuration only.
- Delivers the selected package offer only to the invited mailbox.
- Returns generic public responses with no-store headers, recipient/IP throttling, atomic consumption, and duplicate-send protection.
- Adds an operational rotation and incident-response runbook.

## Verification

- 1,981 backend tests passed
- 2 intentional skips
- 142 subtests passed
- 40 Playwright tests discovered, including two secure-event scenarios
- Local Chromium was unavailable; GitHub CI is the required browser-execution gate
- Remote final tree SHA matches the locally verified tree exactly

## Required deployment gate

Before deployment, deactivate all previously published Event 2 promotion values in Stripe, confirm they cannot be redeemed, create replacements with the approved product/discount/expiration restrictions, and set the protected Render variables documented in the runbook. No live Stripe, MongoDB, customer, or email mutation was performed during implementation.