### PR TITLE
Phase 21.2 — Mobile Admin Control Center

### DIFF
--- a/admin-control-center-mobile.css
+++ b/admin-control-center-mobile.css
@@ -1,0 +1,219 @@
+/* Phase 21.2 — mobile-first CEO Control Center navigation and workspace flow. */
+
+.admin-rail-heading-actions {
+  display: grid;
+  gap: 6px;
+  justify-items: start;
+  min-width: 0;
+}
+
+.admin-rail-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 8px 14px;
+  border: 1px solid var(--admin-border, #c7d5e3);
+  border-radius: 999px;
+  background: var(--admin-panel, #ffffff);
+  color: var(--admin-text, #132238);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 850;
+  line-height: 1.15;
+  cursor: pointer;
+}
+
+.admin-rail-toggle:hover,
+.admin-rail-toggle:focus-visible {
+  border-color: var(--admin-accent, #0a6597);
+  outline: 3px solid color-mix(in srgb, var(--admin-accent, #0a6597) 22%, transparent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 1180px) {
+  .admin-control-center-body {
+    overflow-x: hidden;
+  }
+
+  .admin-control-center-body .admin-case-console-shell {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .admin-control-center-body .admin-case-rail {
+    position: static;
+    inset: auto;
+    z-index: auto;
+    min-width: 0;
+  }
+
+  .admin-control-center-body .admin-rail-heading {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 0;
+  }
+
+  .admin-rail-heading-actions {
+    justify-items: end;
+  }
+
+  .admin-rail-toggle {
+    display: inline-flex;
+  }
+
+  .admin-control-center-body .admin-case-rail[data-mobile-nav="collapsed"] .admin-case-nav {
+    display: none;
+  }
+
+  .admin-control-center-body .admin-case-rail[data-mobile-nav="expanded"] .admin-case-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  .admin-control-center-body .admin-nav-group summary,
+  .admin-control-center-body .admin-case-nav button {
+    min-height: 44px;
+  }
+
+  .admin-control-center-body .admin-case-list,
+  .admin-control-center-body .admin-case-tab-content {
+    max-height: none;
+    min-height: 0;
+  }
+}
+
+@media (max-width: 1024px) {
+  .admin-control-center-body .admin-case-center,
+  .admin-control-center-body .admin-case-context-panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-control-center-body .admin-case-context-panel {
+    display: grid;
+    grid-column: 1;
+  }
+
+  .admin-control-center-body .admin-case-rail[data-mobile-nav="expanded"] .admin-case-nav {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-control-center-body .admin-case-list-panel,
+  .admin-control-center-body .admin-case-workspace-panel,
+  .admin-control-center-body .admin-case-context-panel {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 700px) {
+  .admin-control-center-body .site-header-inner {
+    min-height: 60px;
+  }
+
+  .admin-control-center-body .brand {
+    font-size: clamp(1.28rem, 7vw, 1.65rem);
+  }
+
+  .admin-control-center-body .menu-toggle {
+    min-height: 44px;
+    padding: 8px 14px;
+    font-size: 0.95rem;
+  }
+
+  .admin-control-center-body .admin-ops-page {
+    padding: 10px 0 28px;
+  }
+
+  .admin-control-center-body .admin-ops-shell,
+  .admin-control-center-body .site-header-inner {
+    width: min(100% - 12px, 100%);
+  }
+
+  .admin-control-center-body .admin-case-rail,
+  .admin-control-center-body .admin-case-list-panel,
+  .admin-control-center-body .admin-case-workspace-panel,
+  .admin-control-center-body .admin-case-context-panel {
+    padding: 10px;
+  }
+
+  .admin-control-center-body .admin-rail-heading h3 {
+    font-size: 1rem;
+  }
+
+  .admin-control-center-body .admin-active-queue {
+    max-width: 10rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .admin-control-center-body .admin-case-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 4px;
+    scrollbar-width: thin;
+  }
+
+  .admin-control-center-body .admin-case-tabs button {
+    flex: 0 0 auto;
+    min-height: 44px;
+  }
+
+  .admin-control-center-body .admin-case-row {
+    grid-template-columns: 22px minmax(0, 1fr);
+  }
+
+  .admin-control-center-body .admin-open-case {
+    grid-column: 2;
+    grid-row: auto;
+    width: 100%;
+    min-height: 44px;
+  }
+
+  .admin-control-center-body .admin-case-primary p,
+  .admin-control-center-body .admin-case-detail strong,
+  .admin-control-center-body .admin-case-guidance strong {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .admin-control-center-body .admin-field-grid,
+  .admin-control-center-body .admin-decision-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-control-center-body .admin-priority-repair-item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-control-center-body .admin-priority-repair-item .btn,
+  .admin-control-center-body .admin-action-group .btn,
+  .admin-control-center-body .admin-context-card .inline-actions .btn {
+    width: 100%;
+    min-height: 44px;
+    white-space: normal;
+  }
+
+  .admin-control-center-body .admin-context-card .inline-actions .admin-field {
+    width: 100%;
+    min-width: 0 !important;
+  }
+}
+
+@media (max-width: 430px) {
+  .admin-control-center-body .admin-rail-heading {
+    grid-template-columns: minmax(0, 1fr) minmax(132px, auto);
+  }
+
+  .admin-control-center-body .admin-rail-toggle {
+    width: 100%;
+    padding-inline: 10px;
+  }
+}

--- a/admin-control-center-mobile.js
+++ b/admin-control-center-mobile.js
@@ -1,0 +1,73 @@
+(function () {
+  "use strict";
+
+  const MOBILE_CONTROL_CENTER = "(max-width: 1180px)";
+
+  function setupMobileOperationsRail() {
+    const rail = document.querySelector(".admin-case-rail[data-mobile-nav]");
+    const toggle = document.querySelector("[data-admin-rail-toggle]");
+    const toggleLabel = document.querySelector("[data-admin-rail-toggle-label]");
+    const navigation = document.querySelector("#admin-operations-navigation");
+    const caseCenter = document.querySelector(".admin-case-center");
+
+    if (!rail || !toggle || !navigation) return;
+
+    const viewport = window.matchMedia(MOBILE_CONTROL_CENTER);
+
+    function setExpanded(expanded) {
+      const isMobile = viewport.matches;
+      const shouldExpand = isMobile ? Boolean(expanded) : true;
+
+      rail.dataset.mobileNav = shouldExpand ? "expanded" : "collapsed";
+      toggle.setAttribute("aria-expanded", shouldExpand ? "true" : "false");
+      navigation.setAttribute("aria-hidden", isMobile && !shouldExpand ? "true" : "false");
+      if (toggleLabel) {
+        toggleLabel.textContent = shouldExpand ? "Close operations" : "Browse operations";
+      }
+    }
+
+    function syncViewport() {
+      setExpanded(!viewport.matches);
+    }
+
+    toggle.addEventListener("click", function () {
+      const expanded = toggle.getAttribute("aria-expanded") === "true";
+      setExpanded(!expanded);
+    });
+
+    navigation.querySelectorAll("details").forEach(function (group) {
+      group.addEventListener("toggle", function () {
+        if (!viewport.matches || !group.open) return;
+        navigation.querySelectorAll("details[open]").forEach(function (openGroup) {
+          if (openGroup !== group) openGroup.open = false;
+        });
+      });
+    });
+
+    navigation.addEventListener("click", function (event) {
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest("[data-case-queue]") || !viewport.matches) {
+        return;
+      }
+
+      setExpanded(false);
+      toggle.focus({ preventScroll: true });
+      if (caseCenter) {
+        window.requestAnimationFrame(function () {
+          caseCenter.scrollIntoView({ block: "start", behavior: "auto" });
+        });
+      }
+    });
+
+    if (typeof viewport.addEventListener === "function") {
+      viewport.addEventListener("change", syncViewport);
+    } else if (typeof viewport.addListener === "function") {
+      viewport.addListener(syncViewport);
+    }
+
+    window.addEventListener("pageshow", syncViewport);
+    syncViewport();
+  }
+
+  document.addEventListener("DOMContentLoaded", setupMobileOperationsRail);
+})();

--- a/admin-control-center.html
+++ b/admin-control-center.html
@@ -10,6 +10,7 @@
       content="Internal premium operations console for Tomb of Light customer cases, repairs, entitlements, mint readiness, and audit review."
     />
     <link rel="stylesheet" href="styles.css?v=20260828-phase21-1" />
+    <link rel="stylesheet" href="admin-control-center-mobile.css?v=20260828-phase21-2" />
   </head>
   <body class="admin-control-center-body">
     <div class="page-wrap">
@@ -103,15 +104,30 @@
           </div>
 
           <div class="admin-case-console-shell">
-              <aside class="admin-case-rail" aria-label="Operations rail">
+              <aside class="admin-case-rail" aria-label="Operations rail" data-mobile-nav="collapsed">
                 <div class="admin-rail-heading">
                   <div>
                     <span class="eyebrow">Command map</span>
                     <h3>Operations Rail</h3>
                   </div>
-                  <span class="admin-active-queue" data-admin-active-queue>Overview</span>
+                  <div class="admin-rail-heading-actions">
+                    <span class="admin-active-queue" data-admin-active-queue>Overview</span>
+                    <button
+                      class="admin-rail-toggle"
+                      type="button"
+                      aria-controls="admin-operations-navigation"
+                      aria-expanded="false"
+                      data-admin-rail-toggle
+                    >
+                      <span data-admin-rail-toggle-label>Browse operations</span>
+                    </button>
+                  </div>
                 </div>
-                <nav class="admin-case-nav" aria-label="Admin operations navigation">
+                <nav
+                  class="admin-case-nav"
+                  id="admin-operations-navigation"
+                  aria-label="Admin operations navigation"
+                >
                   <details class="admin-nav-group" data-admin-nav-group="workflow" open>
                     <summary>Customer Workflow</summary>
                     <div>
@@ -559,5 +575,6 @@
     <script src="app.js?v=20260828-phase21-1"></script>
     <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="admin-control-center.js?v=20260824-phase19-1"></script>
+    <script src="admin-control-center-mobile.js?v=20260828-phase21-2"></script>
   </body>
 </html>

--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -10,6 +10,7 @@ RUNTIME_PATH = REPO_ROOT / "backend" / "app" / "services" / "continuity_runtime_
 AUTH_PATH = REPO_ROOT / "backend" / "app" / "services" / "auth_service.py"
 DEPENDENCY_PATH = REPO_ROOT / "backend" / "app" / "dependencies" / "auth.py"
 CONTROL_JS_PATH = REPO_ROOT / "admin-control-center.js"
+MOBILE_CONTROL_JS_PATH = REPO_ROOT / "admin-control-center-mobile.js"
 APP_JS_PATH = REPO_ROOT / "app.js"
 AUTH_JS_PATH = REPO_ROOT / "auth.js"
 
@@ -21,6 +22,7 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
         cls.auth = AUTH_PATH.read_text(encoding="utf-8")
         cls.dependencies = DEPENDENCY_PATH.read_text(encoding="utf-8")
         cls.control_js = CONTROL_JS_PATH.read_text(encoding="utf-8")
+        cls.mobile_control_js = MOBILE_CONTROL_JS_PATH.read_text(encoding="utf-8")
         cls.app_js = APP_JS_PATH.read_text(encoding="utf-8")
         cls.auth_js = AUTH_JS_PATH.read_text(encoding="utf-8")
 
@@ -85,7 +87,15 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
 
     def test_06_every_control_center_button_is_referenced_by_a_loaded_script(self) -> None:
         html = (REPO_ROOT / "admin-control-center.html").read_text(encoding="utf-8")
-        combined_scripts = self.control_js + "\n" + self.app_js + "\n" + self.auth_js
+        combined_scripts = (
+            self.control_js
+            + "\n"
+            + self.mobile_control_js
+            + "\n"
+            + self.app_js
+            + "\n"
+            + self.auth_js
+        )
         button_sources = html + "\n" + self.control_js
         buttons = re.findall(r"<button\b[^>]*>", button_sources, flags=re.IGNORECASE | re.DOTALL)
         self.assertGreaterEqual(len(buttons), 30)

--- a/backend/tests/test_phase21_2_mobile_admin_control_center.py
+++ b/backend/tests/test_phase21_2_mobile_admin_control_center.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from unittest import TestCase
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+REVISION = "20260828-phase21-2"
+
+
+class Phase212MobileAdminControlCenterContractTests(TestCase):
+    def test_control_center_loads_scoped_mobile_assets_and_disclosure(self):
+        html = (REPOSITORY_ROOT / "admin-control-center.html").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            f"admin-control-center-mobile.css?v={REVISION}",
+            html,
+        )
+        self.assertIn(
+            f"admin-control-center-mobile.js?v={REVISION}",
+            html,
+        )
+        self.assertIn('data-mobile-nav="collapsed"', html)
+        self.assertIn("data-admin-rail-toggle", html)
+        self.assertIn('aria-controls="admin-operations-navigation"', html)
+        self.assertIn('id="admin-operations-navigation"', html)
+
+    def test_mobile_layout_removes_sticky_rail_and_desktop_columns(self):
+        styles = (
+            REPOSITORY_ROOT / "admin-control-center-mobile.css"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("@media (max-width: 1180px)", styles)
+        self.assertIn("position: static", styles)
+        self.assertIn('[data-mobile-nav="collapsed"] .admin-case-nav', styles)
+        self.assertIn("display: none", styles)
+        self.assertIn("@media (max-width: 1024px)", styles)
+        self.assertIn("grid-template-columns: minmax(0, 1fr)", styles)
+        self.assertIn("min-height: 44px", styles)
+        self.assertIn("flex-direction: column", styles)
+
+    def test_mobile_navigation_collapses_after_queue_selection(self):
+        script = (
+            REPOSITORY_ROOT / "admin-control-center-mobile.js"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('MOBILE_CONTROL_CENTER = "(max-width: 1180px)"', script)
+        self.assertIn('target.closest("[data-case-queue]")', script)
+        self.assertIn('navigation.querySelectorAll("details[open]")', script)
+        self.assertIn("setExpanded(false)", script)
+        self.assertIn('navigation.setAttribute("aria-hidden"', script)
+        self.assertIn("caseCenter.scrollIntoView", script)

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -155,6 +155,8 @@ test("[asset-versioning] dashboard and control center include current cache-bust
     nodes.map((node) => node.getAttribute("href") || ""),
   );
   expect(controlCenterStyles.some((href) => href.includes("styles.css?v=20260828-phase21-1"))).toBeTruthy();
+  expect(controlCenterStyles.some((href) => href.includes("admin-control-center-mobile.css?v=20260828-phase21-2"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
   expect(controlCenterScripts.some((src) => src.includes("admin-control-center.js?v=20260824-phase19-1"))).toBeTruthy();
+  expect(controlCenterScripts.some((src) => src.includes("admin-control-center-mobile.js?v=20260828-phase21-2"))).toBeTruthy();
 });

--- a/browser-tests/master-admin.spec.mjs
+++ b/browser-tests/master-admin.spec.mjs
@@ -879,9 +879,21 @@ test("[responsive] keeps the CEO command center compact and readable at 960px", 
   await expect(page.locator("[data-admin-control-title]")).toContainText("CEO Master Administrator");
   await expect(page.locator("[data-super-admin-create-account]")).toBeVisible();
   await expect(page.locator("[data-super-admin-manage-team-access]")).toBeVisible();
+  await expect(page.locator("[data-admin-rail-toggle]")).toBeVisible();
+  await expect(page.locator("[data-admin-rail-toggle]")).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("#admin-operations-navigation")).not.toBeVisible();
   await expect(page.locator("[data-admin-nav-group]")).toHaveCount(4);
   await expect(page.locator('[data-admin-nav-group="workflow"]')).toHaveAttribute("open", "");
   await expect(page.locator('[data-admin-nav-group="finance"]')).not.toHaveAttribute("open", "");
+  const compactLayout = await page.evaluate(() => ({
+    railPosition: window.getComputedStyle(document.querySelector(".admin-case-rail")).position,
+    caseColumns: window.getComputedStyle(document.querySelector(".admin-case-center")).gridTemplateColumns,
+    railBottom: document.querySelector(".admin-case-rail").getBoundingClientRect().bottom,
+    caseTop: document.querySelector(".admin-case-center").getBoundingClientRect().top,
+  }));
+  expect(compactLayout.railPosition).toBe("static");
+  expect(compactLayout.caseColumns.trim().split(/\s+/)).toHaveLength(1);
+  expect(compactLayout.railBottom).toBeLessThanOrEqual(compactLayout.caseTop + 1);
   const overflow = await page.evaluate(() => ({
     viewport: document.documentElement.clientWidth,
     content: document.documentElement.scrollWidth,
@@ -889,6 +901,47 @@ test("[responsive] keeps the CEO command center compact and readable at 960px", 
   expect(overflow.content).toBeLessThanOrEqual(overflow.viewport + 1);
   await expect(page.locator("[data-open-case]").first()).toBeVisible();
   await expect(page.locator("[data-admin-case-workspace]")).toContainText("Identity");
+});
+
+test("[responsive] keeps portrait and landscape admin actions reachable", async ({ page }) => {
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 844, height: 390 },
+  ]) {
+    await page.setViewportSize(viewport);
+    const railToggle = page.locator("[data-admin-rail-toggle]");
+    await expect(railToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("#admin-operations-navigation")).not.toBeVisible();
+
+    await railToggle.click();
+    await expect(railToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#admin-operations-navigation")).toBeVisible();
+    await page.locator('[data-admin-nav-group="finance"] summary').click();
+    await expect(page.locator('[data-admin-nav-group="workflow"]')).not.toHaveAttribute("open", "");
+    await expect(page.locator('[data-admin-nav-group="finance"]')).toHaveAttribute("open", "");
+    await page.locator('[data-admin-nav-group="workflow"] summary').click();
+
+    await page.locator('[data-case-queue="manual_fulfillment"]').click();
+    await expect(railToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("#admin-operations-navigation")).not.toBeVisible();
+    await expect(page.locator("[data-admin-active-queue]")).toContainText("Paid");
+
+    const layout = await page.evaluate(() => ({
+      viewportWidth: document.documentElement.clientWidth,
+      contentWidth: document.documentElement.scrollWidth,
+      railPosition: window.getComputedStyle(document.querySelector(".admin-case-rail")).position,
+      caseColumns: window.getComputedStyle(document.querySelector(".admin-case-center")).gridTemplateColumns,
+      pageScrollHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight,
+    }));
+    expect(layout.contentWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
+    expect(layout.railPosition).toBe("static");
+    expect(layout.caseColumns.trim().split(/\s+/)).toHaveLength(1);
+    expect(layout.pageScrollHeight).toBeGreaterThan(layout.viewportHeight);
+
+    await page.evaluate(() => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "instant" }));
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  }
 });
 
 test("[contrast] validates WCAG AA contrast thresholds for key selectors", async ({ page }) => {


### PR DESCRIPTION
## Summary

- collapse the Operations Rail by default on mobile and tablet widths
- remove sticky/overlay behavior from the mobile rail
- use a single-column case workspace in iPhone portrait and landscape layouts
- keep only one operation group open at a time
- close navigation and return focus to the case workspace after queue selection
- make case, audit, and governed-operation controls touch-sized and prevent clipped content

## Safety boundaries

- no authentication, authorization, customer-data, Stripe, MongoDB, or Continuity Kernel behavior changed
- route-scoped CSS and JavaScript keep the correction isolated to the Admin Control Center
- remote Git tree `620735353ab76f26eef5b2c4c50135555d393477` exactly matches verified local commit `df586da`

## Verification

- 9 architecture tests passed
- 1,312 contract tests passed, 11 skipped
- 22 focused Phase 21.2, link-integrity, and control-surface tests passed
- JavaScript syntax and Git diff checks passed
- 41 browser tests discovered
- portrait (390×844), landscape (844×390), and 960px responsive assertions are included for CI Chromium execution
