### PR TITLE
Make Vault production-ready across billing and downloads

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1352,6 +1352,10 @@
       hasPackageAccess: Boolean(isActive && packageCode),
       hasPaidPackage: Boolean(isActive && packageCode),
       workspaceContextSnapshot: snapshot,
+      maintenance:
+        snapshot.maintenance && typeof snapshot.maintenance === "object"
+          ? snapshot.maintenance
+          : {},
       blockingReason: normalizeValue(snapshot.blocking_reason) || null,
     };
   }
@@ -1792,6 +1796,7 @@
       currentWorkspace,
       hasPackageAccess,
       hasPaidPackage: hasPackageAccess,
+      maintenance: {},
     };
   }
 

--- a/backend/app/routes/legacy_messages.py
+++ b/backend/app/routes/legacy_messages.py
@@ -19,6 +19,7 @@ from app.services.legacy_message_service import (
 )
 from app.services.workspace_access_service import (
     require_workspace_capability,
+    require_workspace_maintenance_write_access,
     require_workspace_member_role,
 )
 
@@ -106,6 +107,11 @@ def _resolve_legacy_message_context(
             else "Your workspace role cannot access legacy messages."
         ),
     )
+    if write:
+        require_workspace_maintenance_write_access(
+            context,
+            feature_name="Future-message Vault",
+        )
     authorized_project_id = _normalize((context.get("project") or {}).get("_id"))
     if not authorized_project_id or authorized_project_id != _normalize(project_id):
         raise HTTPException(

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Literal, Optional
+from urllib.parse import quote
 
 from bson import ObjectId
 from fastapi import (
@@ -23,7 +24,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from fastapi.responses import FileResponse, RedirectResponse, Response
+from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel, Field
 
 from app.config import settings
@@ -44,7 +45,6 @@ from app.services.upload_service import (
 from app.services.r2_storage_service import (
     delete_private_object,
     download_private_bytes,
-    generate_private_download_url,
     private_storage_is_configured,
     upload_private_file,
 )
@@ -62,6 +62,7 @@ from app.services.linked_network_service import build_linked_network
 from app.services.workspace_access_service import (
     family_is_visible_to_user,
     require_workspace_capability,
+    require_workspace_maintenance_write_access,
     require_workspace_member_role,
     resolve_workspace_context,
 )
@@ -1350,6 +1351,17 @@ def _public_upload_record(
             )
             and can_manage
         )
+        if (
+            _normalize_value(record.get("category")).lower() == "private_media"
+            and not bool(
+                (context.get("maintenance_access") or {}).get(
+                    "write_allowed",
+                    True,
+                )
+            )
+        ):
+            can_manage = False
+            can_create_next_version = False
     download_ready = bool(
         can_access
         and not _upload_scan_blocks_download(record)
@@ -1908,6 +1920,22 @@ def _upload_read_limit(upload_record: dict[str, Any]) -> int:
     if category == "member_photo":
         return int(PHOTO_MAX_BYTES)
     return int(EVIDENCE_MAX_BYTES)
+
+
+def _private_content_disposition(filename: Any, *, disposition: str) -> str:
+    safe_name = Path(_normalize_value(filename) or "vault-file").name
+    safe_name = "".join(
+        character
+        for character in safe_name
+        if character.isprintable() and character not in {"/", "\\", '"'}
+    ).strip() or "vault-file"
+    ascii_fallback = safe_name.encode("ascii", "ignore").decode("ascii").strip()
+    ascii_fallback = re.sub(r"[^A-Za-z0-9._ -]", "_", ascii_fallback) or "vault-file"
+    encoded_name = quote(safe_name, safe="")
+    return (
+        f'{disposition}; filename="{ascii_fallback}"; '
+        f"filename*=UTF-8''{encoded_name}"
+    )
 
 
 def _actor_audit_identity(current_user: dict[str, Any]) -> dict[str, str | None]:
@@ -3551,7 +3579,6 @@ async def upload_member_photo(
         allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
         detail="Your role is read-only for uploads.",
     )
-
     db = get_database()
     if db is None:
         raise HTTPException(status_code=500, detail="Database is not connected.")
@@ -3853,6 +3880,7 @@ async def upload_private_media(
         allowed_roles=("billing_owner", "co_owner", "family_manager", "contributor"),
         detail="Your role is read-only for uploads.",
     )
+    require_workspace_maintenance_write_access(context, feature_name="Vault")
 
     db = get_database()
     if db is None:
@@ -4446,6 +4474,8 @@ async def replace_upload(
         action="replace",
     )
     category = _normalize_value(prior_upload.get("category")).lower()
+    if category == "private_media":
+        require_workspace_maintenance_write_access(context, feature_name="Vault")
     capabilities = _upload_category_capabilities(prior_upload)
     if not capabilities or not _context_has_any_capability(context, capabilities):
         raise HTTPException(
@@ -4710,6 +4740,8 @@ def update_upload_privacy(
         else current_scope
     )
     category = _normalize_value(upload_record.get("category")).lower()
+    if category == "private_media":
+        require_workspace_maintenance_write_access(context, feature_name="Vault")
     if category == "verification_evidence":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -5314,7 +5346,10 @@ def preview_upload_for_admin_review(
                 detail="Private object storage is unavailable for this review file.",
             ) from exc
         response = Response(content=body, media_type=content_type)
-        response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+        response.headers["Content-Disposition"] = _private_content_disposition(
+            filename,
+            disposition="inline",
+        )
     else:
         relative_path = _normalize_value(upload_record.get("relative_path"))
         absolute_path = _absolute_upload_path(relative_path)
@@ -5402,7 +5437,10 @@ def preview_upload(
                 detail="Private object storage is unavailable for this upload.",
             ) from exc
         response: Response = Response(content=body, media_type=content_type)
-        response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+        response.headers["Content-Disposition"] = _private_content_disposition(
+            filename,
+            disposition="inline",
+        )
     else:
         relative_path = _normalize_value(upload_record.get("relative_path"))
         if not relative_path:
@@ -5498,18 +5536,27 @@ def download_upload(
                 detail="Private object storage key is missing for this upload.",
             )
         try:
-            signed_url = generate_private_download_url(
+            body = download_private_bytes(
                 key=storage_key,
-                expires_seconds=120,
+                max_bytes=_upload_read_limit(upload_record),
             )
-        except Exception:
-            signed_url = None
-        if not signed_url:
+        except Exception as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Private object storage is unavailable for this upload.",
-            )
-        response = RedirectResponse(url=signed_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+            ) from exc
+        content_type = (
+            _normalize_value(upload_record.get("content_type"))
+            or "application/octet-stream"
+        )
+        filename = Path(
+            _normalize_value(upload_record.get("original_filename")) or "vault-file"
+        ).name.replace('"', "")
+        response = Response(content=body, media_type=content_type)
+        response.headers["Content-Disposition"] = _private_content_disposition(
+            filename,
+            disposition="attachment",
+        )
         response.headers["Cache-Control"] = "no-store"
         response.headers["Pragma"] = "no-cache"
         response.headers["Expires"] = "0"
@@ -5616,6 +5663,12 @@ def delete_upload(
             "tombstone_id": _deletion_tombstone_id(upload_id),
             "idempotency_replayed": True,
         }
+
+    if (
+        _normalize_value(upload_record.get("category")).lower() == "private_media"
+        and not same_retry_requester
+    ):
+        require_workspace_maintenance_write_access(context, feature_name="Vault")
 
     tombstone_id = _create_upload_deletion_tombstone(
         db=db,

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -38,6 +38,7 @@ from app.services.vault_service import (
 )
 from app.services.workspace_access_service import (
     require_workspace_capability,
+    require_workspace_maintenance_write_access,
     require_workspace_member_role,
 )
 
@@ -126,7 +127,13 @@ def _resolve_vault_context(
     )
 
 
-def _require_vault_role(context: dict[str, Any], *, write: bool = False, sensitive: bool = False) -> None:
+def _require_vault_role(
+    context: dict[str, Any],
+    *,
+    write: bool = False,
+    sensitive: bool = False,
+    mutation: bool = False,
+) -> None:
     # Item-level owner/grant checks in vault_service are authoritative for
     # existing items. Broad workspace admission here lets editor/steward/
     # executor grants work even when the base workspace role is read-only.
@@ -141,6 +148,8 @@ def _require_vault_role(context: dict[str, Any], *, write: bool = False, sensiti
             else "Your role cannot access vault items."
         )
     require_workspace_member_role(context, allowed_roles=allowed_roles, detail=detail)
+    if write or mutation:
+        require_workspace_maintenance_write_access(context, feature_name="Vault")
 
 
 def _require_additional_capability(
@@ -326,7 +335,7 @@ def update_vault_item_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     authorized_project_id = _normalize((context.get("project") or {}).get("_id"))
     if "vault_scope" in payload.model_fields_set and payload.vault_scope:
         _resolve_vault_context(
@@ -370,7 +379,7 @@ def delete_vault_item_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     authorized_project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         delete_vault_item(item_id, user_id, authorized_project_id=authorized_project_id)
@@ -450,7 +459,7 @@ def create_vault_access_grant_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     authorized_project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         return create_vault_access_grant(
@@ -507,7 +516,7 @@ def update_vault_access_grant_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         return update_vault_access_grant(
@@ -536,7 +545,7 @@ def revoke_vault_access_grant_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         return revoke_vault_access_grant(
@@ -564,7 +573,7 @@ def delete_vault_access_grant_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         delete_vault_access_grant(
@@ -602,7 +611,7 @@ def create_vault_release_rule_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     authorized_project_id = _normalize((context.get("project") or {}).get("_id"))
     _require_release_entitlements(
         current_user,
@@ -664,7 +673,7 @@ def update_vault_release_rule_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     rule = _find_vault_release_rule_by_id(rule_id)
     if not rule or _normalize(rule.get("vault_item_id")) != item_id:
@@ -704,7 +713,7 @@ def revoke_vault_release_rule_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         return revoke_vault_release_rule(
@@ -732,7 +741,7 @@ def delete_vault_release_rule_route(
         project_id=_normalize(doc.get("project_id")),
         vault_scope=_normalize(doc.get("vault_scope")),
     )
-    _require_vault_role(context, sensitive=True)
+    _require_vault_role(context, sensitive=True, mutation=True)
     project_id = _normalize((context.get("project") or {}).get("_id"))
     try:
         delete_vault_release_rule(

--- a/backend/app/services/project_entitlement_service.py
+++ b/backend/app/services/project_entitlement_service.py
@@ -20,6 +20,9 @@ from app.services.entitlement_service import (
 
 MAINTENANCE_START_DELAY_DAYS = 30
 MAINTENANCE_MONTHLY_PERIOD_DAYS = 30
+MAINTENANCE_LAPSED_STATUSES = frozenset(
+    {"canceled", "cancelled", "churned", "overdue", "past_due", "refunded", "unpaid"}
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -71,6 +74,7 @@ def _serialize(document: dict[str, Any] | None) -> dict[str, Any] | None:
         "maintenance_renews_at": document.get("maintenance_renews_at"),
         "maintenance_current_period_start": document.get("maintenance_current_period_start"),
         "maintenance_current_period_end": document.get("maintenance_current_period_end"),
+        "maintenance_lapsed_at": document.get("maintenance_lapsed_at"),
         "maintenance_stripe_subscription_id": document.get("maintenance_stripe_subscription_id"),
         "maintenance_stripe_customer_id": document.get("maintenance_stripe_customer_id"),
         "maintenance_stripe_status": document.get("maintenance_stripe_status"),
@@ -217,9 +221,12 @@ def upsert_project_entitlement(
     }
 
     if existing:
+        update_operation: dict[str, Any] = {"$set": document}
+        if maintenance_status not in MAINTENANCE_LAPSED_STATUSES:
+            update_operation["$unset"] = {"maintenance_lapsed_at": ""}
         collection.update_one(
             {"_id": existing["_id"]},
-            {"$set": document},
+            update_operation,
         )
     else:
         document["created_at"] = now
@@ -359,11 +366,19 @@ def update_project_entitlement_maintenance(
     if not existing:
         return None
 
-    updates: dict[str, Any] = {"updated_at": _utcnow()}
+    now = _utcnow()
+    updates: dict[str, Any] = {"updated_at": now}
+    unset_fields: dict[str, str] = {}
     if maintenance_plan is not None:
         updates["maintenance_plan"] = maintenance_plan
     if maintenance_status is not None:
         updates["maintenance_status"] = maintenance_status
+        normalized_maintenance_status = str(maintenance_status or "").strip().lower()
+        if normalized_maintenance_status in MAINTENANCE_LAPSED_STATUSES:
+            if not existing.get("maintenance_lapsed_at"):
+                updates["maintenance_lapsed_at"] = now
+        else:
+            unset_fields["maintenance_lapsed_at"] = ""
     if maintenance_scheduled_start_at is not None:
         updates["maintenance_scheduled_start_at"] = maintenance_scheduled_start_at
     if maintenance_started_at is not None:
@@ -383,7 +398,9 @@ def update_project_entitlement_maintenance(
 
     update_operation: dict[str, Any] = {"$set": updates}
     if clear_maintenance_started_at:
-        update_operation["$unset"] = {"maintenance_started_at": ""}
+        unset_fields["maintenance_started_at"] = ""
+    if unset_fields:
+        update_operation["$unset"] = unset_fields
     collection.update_one({"_id": existing["_id"]}, update_operation)
     saved = cast(
         dict[str, Any] | None,

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any, Iterable
 
 from bson import ObjectId
@@ -23,6 +24,18 @@ PAID_PACKAGE_STATUSES = {
     "completed",
     "succeeded",
 }
+MAINTENANCE_WRITE_GRACE_DAYS = 30
+MAINTENANCE_LAPSED_STATUSES = frozenset(
+    {
+        "canceled",
+        "cancelled",
+        "churned",
+        "overdue",
+        "past_due",
+        "refunded",
+        "unpaid",
+    }
+)
 WORKSPACE_PIPELINE_READY_STATUSES = {
     "approved",
     "build_ready",
@@ -53,6 +66,103 @@ def _normalize_value(value: Any) -> str:
 
 def _normalize_email(value: Any) -> str:
     return _normalize_value(value).lower()
+
+
+def _coerce_utc_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    normalized = _normalize_value(value)
+    if not normalized:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def resolve_maintenance_access_state(
+    entitlement: dict[str, Any] | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Resolve maintenance access while preserving customer reads.
+
+    A past-due or cancelled workspace receives a 30-day write grace period.
+    After the grace window, Vault mutations are blocked while preview and
+    download access remain available.
+    """
+
+    document = entitlement or {}
+    maintenance_status = _normalize_value(document.get("maintenance_status")).lower()
+    state: dict[str, Any] = {
+        "status": maintenance_status or "not_started",
+        "grace_days": MAINTENANCE_WRITE_GRACE_DAYS,
+        "lapsed_at": None,
+        "grace_ends_at": None,
+        "in_grace": False,
+        "read_only": False,
+        "write_allowed": True,
+    }
+    if maintenance_status not in MAINTENANCE_LAPSED_STATUSES:
+        return state
+
+    lapsed_at = (
+        _coerce_utc_datetime(document.get("maintenance_lapsed_at"))
+        or _coerce_utc_datetime(document.get("maintenance_current_period_end"))
+        or _coerce_utc_datetime(document.get("updated_at"))
+        or _coerce_utc_datetime(document.get("purchased_at"))
+    )
+    if lapsed_at is None:
+        # A lapsed row without a trustworthy timestamp cannot safely receive
+        # an unbounded grace period. Preserve reads and fail closed for writes.
+        state["read_only"] = True
+        state["write_allowed"] = False
+        return state
+
+    current_time = now or datetime.now(UTC)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=UTC)
+    else:
+        current_time = current_time.astimezone(UTC)
+    grace_ends_at = lapsed_at + timedelta(days=MAINTENANCE_WRITE_GRACE_DAYS)
+    in_grace = current_time <= grace_ends_at
+    state.update(
+        {
+            "lapsed_at": lapsed_at.isoformat(),
+            "grace_ends_at": grace_ends_at.isoformat(),
+            "in_grace": in_grace,
+            "read_only": not in_grace,
+            "write_allowed": in_grace,
+        }
+    )
+    return state
+
+
+def require_workspace_maintenance_write_access(
+    context: dict[str, Any],
+    *,
+    feature_name: str = "Vault",
+) -> dict[str, Any]:
+    if context.get("is_admin"):
+        return context
+    maintenance = context.get("maintenance_access") or resolve_maintenance_access_state(
+        context.get("entitlement")
+    )
+    if bool(maintenance.get("write_allowed", True)):
+        return context
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail=(
+            f"{feature_name} is read-only because required maintenance has been "
+            "past due or canceled for more than 30 days. Existing files remain "
+            "available to view and download; update billing to resume changes."
+        ),
+    )
 
 
 def _current_user_id(user: dict[str, Any]) -> str:
@@ -963,6 +1073,7 @@ def resolve_workspace_context(
     membership = (access_snapshot or {}).get("membership") or {}
 
     entitlement_map = _resolve_project_entitlement_map(project, current_user=current_user)
+    maintenance_access = resolve_maintenance_access_state(entitlement_map.get("entitlement"))
     return {
         "project": project,
         "family": family,
@@ -972,6 +1083,7 @@ def resolve_workspace_context(
         "resolved_entitlements": entitlement_map.get("resolved_entitlements") or {},
         "entitlement": entitlement_map.get("entitlement"),
         "paid_order": entitlement_map.get("paid_order"),
+        "maintenance_access": maintenance_access,
         "access_snapshot": access_snapshot,
         "member_role": _normalize_value(access_snapshot.get("member_role") or "viewer") or "viewer",
         "relationship_scope": _normalize_value(membership.get("relationship_scope") or "household_member")
@@ -1162,6 +1274,9 @@ def build_workspace_context_snapshot(
             key
             for key, enabled in resolved_entitlements.items()
             if str(key).startswith("can_") and bool(enabled)
+        ),
+        "maintenance": resolve_maintenance_access_state(
+            entitlement_state.get("entitlement")
         ),
     }
     if not response["entitlements"]:

--- a/backend/tests/test_upload_hub_integrity.py
+++ b/backend/tests/test_upload_hub_integrity.py
@@ -190,6 +190,7 @@ class UploadHubIntegrityTests(unittest.TestCase):
             ),
         )
         self.assertIn("VAULT_CAPABILITIES", upload_source)
+        self.assertIn("require_workspace_maintenance_write_access", upload_source)
         self.assertIn('category="private_media"', vault_list_source)
         self.assertNotIn("premium_archive_structure", upload_source)
         self.assertNotIn("premium_archive_structure", vault_list_source)
@@ -202,6 +203,10 @@ class UploadHubIntegrityTests(unittest.TestCase):
         self.assertEqual(vault_routes.HOUSEHOLD_VAULT_CAPABILITIES, ("can_use_household_vault",))
         self.assertIn("HOUSEHOLD_VAULT_CAPABILITIES", vault_source)
         self.assertNotIn("premium_archive_structure", vault_source)
+        self.assertIn(
+            "require_workspace_maintenance_write_access",
+            inspect.getsource(vault_routes._require_vault_role),
+        )
 
     def test_vault_upload_uses_correct_asset_types(self):
         """vault-upload.js must only submit the two backend-allowed asset types."""
@@ -216,6 +221,24 @@ class UploadHubIntegrityTests(unittest.TestCase):
             contents,
             "vault-upload.js must use the 'private_video_message' asset type",
         )
+
+    def test_dashboard_recognizes_every_vault_scope(self):
+        contents = self._read("dashboard-intake.js")
+        self.assertIn("function canUseVaultAccess", contents)
+        for capability in (
+            "can_use_personal_vault",
+            "can_use_household_vault",
+            "can_use_linked_household_vault",
+            "can_use_organization_records_vault",
+        ):
+            self.assertIn(capability, contents)
+        self.assertNotIn("Boolean(resolved.premium_archive_structure)", contents)
+
+    def test_vault_ui_preserves_reads_when_maintenance_is_read_only(self):
+        contents = self._read("vault-upload.js")
+        self.assertIn("maintenance.read_only", contents)
+        self.assertIn("Existing files remain available to view and download", contents)
+        self.assertIn('document.querySelector("[data-vault-upload-form]")', contents)
 
     def test_portrait_upload_js_shows_customer_status(self):
         """portrait-upload.js must display a customer-facing upload status label."""

--- a/backend/tests/test_upload_lifecycle_security.py
+++ b/backend/tests/test_upload_lifecycle_security.py
@@ -516,9 +516,8 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                     patch.object(upload_routes, "create_audit_log"),
                     patch.object(
                         upload_routes,
-                        "generate_private_download_url",
-                        return_value="https://private.example/relative-must-not-receive",
-                    ) as relative_signed_url,
+                        "download_private_bytes",
+                    ) as relative_object_read,
                 ):
                     with self.assertRaises(HTTPException) as denied:
                         upload_routes.download_upload(
@@ -528,7 +527,7 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                             current_user=relative,
                         )
                 self.assertEqual(denied.exception.status_code, 403)
-                relative_signed_url.assert_not_called()
+                relative_object_read.assert_not_called()
 
                 with (
                     patch.object(vault_service, "get_database", return_value=db),
@@ -540,9 +539,9 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                     ),
                     patch.object(
                         upload_routes,
-                        "generate_private_download_url",
-                        return_value="https://private.example/owner-download",
-                    ) as owner_signed_url,
+                        "download_private_bytes",
+                        return_value=b"owner-download",
+                    ) as owner_object_read,
                 ):
                     response = upload_routes.download_upload(
                         str(upload["_id"]),
@@ -550,9 +549,11 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                         viewer_project_id="",
                         current_user=owner,
                     )
-                self.assertEqual(response.status_code, 307)
-                self.assertEqual(response.headers["location"], "https://private.example/owner-download")
-                owner_signed_url.assert_called_once()
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.body, b"owner-download")
+                self.assertIn("attachment", response.headers["content-disposition"])
+                self.assertNotIn("location", response.headers)
+                owner_object_read.assert_called_once()
 
     def test_failed_modern_vault_link_cannot_bypass_draft_or_scheduled_release(self):
         relative = {"id": "relative-1", "email": "relative@example.com"}
@@ -633,9 +634,8 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                         patch.object(upload_routes, "create_audit_log"),
                         patch.object(
                             upload_routes,
-                            "generate_private_download_url",
-                            return_value="https://private.example/must-not-leak",
-                        ) as relative_signed_url,
+                            "download_private_bytes",
+                        ) as relative_object_read,
                     ):
                         with self.assertRaises(HTTPException) as denied:
                             upload_routes.download_upload(
@@ -644,7 +644,7 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                                 viewer_project_id="",
                                 current_user=relative,
                             )
-                    relative_signed_url.assert_not_called()
+                    relative_object_read.assert_not_called()
 
                     with (
                         patch.object(
@@ -654,9 +654,9 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                         ),
                         patch.object(
                             upload_routes,
-                            "generate_private_download_url",
-                            return_value="https://private.example/owner-recovery",
-                        ) as owner_signed_url,
+                            "download_private_bytes",
+                            return_value=b"owner-recovery",
+                        ) as owner_object_read,
                     ):
                         owner_response = upload_routes.download_upload(
                             str(record["_id"]),
@@ -668,8 +668,9 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 self.assertEqual(relative_list["count"], 0)
                 self.assertEqual(owner_list["count"], 1)
                 self.assertEqual(denied.exception.status_code, 403)
-                self.assertEqual(owner_response.status_code, 307)
-                owner_signed_url.assert_called_once()
+                self.assertEqual(owner_response.status_code, 200)
+                self.assertEqual(owner_response.body, b"owner-recovery")
+                owner_object_read.assert_called_once()
 
     def test_approved_link_status_allows_released_linked_relative(self):
         relative = {"id": "relative-1", "email": "relative@example.com"}
@@ -695,9 +696,9 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 ),
                 patch.object(
                     upload_routes,
-                    "generate_private_download_url",
-                    return_value="https://private.example/approved-relative",
-                ) as signed_url,
+                    "download_private_bytes",
+                    return_value=b"approved-relative",
+                ) as object_read,
             ):
                 response = upload_routes.download_upload(
                     str(upload["_id"]),
@@ -707,8 +708,9 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 )
 
         self.assertEqual(item["id"], str(_item["_id"]))
-        self.assertEqual(response.status_code, 307)
-        signed_url.assert_called_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b"approved-relative")
+        object_read.assert_called_once()
 
     def test_linked_viewer_preview_proxies_authorized_r2_bytes_inline(self):
         upload, _prior, _item, db = linked_viewer_fixture()
@@ -733,7 +735,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 "download_private_bytes",
                 return_value=body,
             ) as object_read,
-            patch.object(upload_routes, "generate_private_download_url") as signed_url,
         ):
             response = upload_routes.preview_upload(
                 str(upload["_id"]),
@@ -757,11 +758,11 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
             key=upload["storage_key"],
             max_bytes=upload_routes.EVIDENCE_MAX_BYTES,
         )
-        signed_url.assert_not_called()
 
-    def test_linked_viewer_download_returns_short_lived_r2_redirect(self):
+    def test_linked_viewer_download_streams_authorized_r2_bytes(self):
         upload, _prior, _item, db = linked_viewer_fixture()
         viewer = {"id": "viewer-user", "email": "viewer@example.com"}
+        body = b"linked-viewer-download"
 
         with (
             patch.object(upload_routes, "get_database", return_value=db),
@@ -776,12 +777,11 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 "list_linked_family_ids",
                 return_value=["viewer-family", "source-family"],
             ),
-            patch.object(upload_routes, "download_private_bytes") as object_read,
             patch.object(
                 upload_routes,
-                "generate_private_download_url",
-                return_value="https://private.example/linked-viewer-download",
-            ) as signed_url,
+                "download_private_bytes",
+                return_value=body,
+            ) as object_read,
         ):
             response = upload_routes.download_upload(
                 str(upload["_id"]),
@@ -790,17 +790,15 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 current_user=viewer,
             )
 
-        self.assertEqual(response.status_code, 307)
-        self.assertEqual(
-            response.headers["location"],
-            "https://private.example/linked-viewer-download",
-        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, body)
         self.assertEqual(response.headers["cache-control"], "no-store")
-        signed_url.assert_called_once_with(
+        self.assertIn("attachment", response.headers["content-disposition"])
+        self.assertNotIn("location", response.headers)
+        object_read.assert_called_once_with(
             key=upload["storage_key"],
-            expires_seconds=120,
+            max_bytes=upload_routes.EVIDENCE_MAX_BYTES,
         )
-        object_read.assert_not_called()
 
     def test_linked_viewer_versions_returns_only_current_with_read_only_permissions(self):
         current, prior, _item, db = linked_viewer_fixture(with_prior=True)
@@ -821,7 +819,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
             ),
             patch.object(upload_routes, "create_audit_log"),
             patch.object(upload_routes, "download_private_bytes") as object_read,
-            patch.object(upload_routes, "generate_private_download_url") as signed_url,
         ):
             payload = upload_routes.list_upload_versions(
                 str(current["_id"]),
@@ -846,7 +843,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
             },
         )
         object_read.assert_not_called()
-        signed_url.assert_not_called()
 
     def test_linked_viewer_unreleased_or_unshared_upload_never_reaches_storage(self):
         viewer = {"id": "viewer-user", "email": "viewer@example.com"}
@@ -877,10 +873,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                     ),
                     patch.object(upload_routes, "create_audit_log"),
                     patch.object(upload_routes, "download_private_bytes") as object_read,
-                    patch.object(
-                        upload_routes,
-                        "generate_private_download_url",
-                    ) as signed_url,
                 ):
                     with self.assertRaises(HTTPException) as preview_denied:
                         upload_routes.preview_upload(
@@ -899,7 +891,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 self.assertEqual(preview_denied.exception.status_code, 403)
                 self.assertEqual(download_denied.exception.status_code, 403)
                 object_read.assert_not_called()
-                signed_url.assert_not_called()
 
     def test_scheduled_upload_with_nonexistent_vault_item_denies_nonowner_before_storage(self):
         missing_item_id = ObjectId()
@@ -938,10 +929,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 ),
                 patch.object(upload_routes, "create_audit_log"),
                 patch.object(upload_routes, "download_private_bytes") as object_read,
-                patch.object(
-                    upload_routes,
-                    "generate_private_download_url",
-                ) as signed_url,
             ):
                 with self.assertRaises(HTTPException) as denied:
                     upload_routes.download_upload(
@@ -953,7 +940,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
 
         self.assertEqual(denied.exception.status_code, 403)
         object_read.assert_not_called()
-        signed_url.assert_not_called()
 
     def test_missing_or_pending_membership_link_denies_linked_relative(self):
         relative = {"id": "relative-1", "email": "relative@example.com"}
@@ -1018,7 +1004,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 "download_private_bytes",
                 return_value=body,
             ) as object_read,
-            patch.object(upload_routes, "generate_private_download_url") as signed_url,
         ):
             response = upload_routes.preview_upload(
                 str(record["_id"]),
@@ -1032,7 +1017,17 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
         self.assertEqual(response.headers["x-content-type-options"], "nosniff")
         self.assertIn("inline", response.headers["content-disposition"])
         object_read.assert_called_once()
-        signed_url.assert_not_called()
+
+    def test_private_content_disposition_supports_unicode_without_header_injection(self):
+        header = upload_routes._private_content_disposition(
+            'family\r\nrecord-Élodie.pdf',
+            disposition="attachment",
+        )
+
+        self.assertTrue(header.startswith("attachment;"))
+        self.assertNotIn("\r", header)
+        self.assertNotIn("\n", header)
+        self.assertIn("filename*=UTF-8''", header)
 
     def test_customer_preview_denial_happens_before_private_object_read(self):
         record = private_upload_record()
@@ -1047,7 +1042,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
                 side_effect=HTTPException(status_code=403, detail="denied"),
             ),
             patch.object(upload_routes, "download_private_bytes") as object_read,
-            patch.object(upload_routes, "generate_private_download_url") as signed_url,
         ):
             with self.assertRaises(HTTPException) as denied:
                 upload_routes.preview_upload(
@@ -1057,7 +1051,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
 
         self.assertEqual(denied.exception.status_code, 403)
         object_read.assert_not_called()
-        signed_url.assert_not_called()
 
     def test_internal_admin_cannot_use_generic_customer_preview_for_owner_private_file(self):
         record = private_upload_record(uploaded_by_user_id="customer-owner")
@@ -1074,7 +1067,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
             ),
             patch.object(upload_routes, "create_audit_log"),
             patch.object(upload_routes, "download_private_bytes") as object_read,
-            patch.object(upload_routes, "generate_private_download_url") as signed_url,
         ):
             with self.assertRaises(HTTPException) as denied:
                 upload_routes.preview_upload(
@@ -1084,7 +1076,6 @@ class UploadLifecycleSecurityTests(unittest.TestCase):
 
         self.assertEqual(denied.exception.status_code, 403)
         object_read.assert_not_called()
-        signed_url.assert_not_called()
 
     def test_admin_preview_restricts_categories_and_requires_audit_before_read(self):
         admin = {"id": "admin-1", "email": "admin@example.com", "role": "admin"}

--- a/backend/tests/test_vault_maintenance_policy.py
+++ b/backend/tests/test_vault_maintenance_policy.py
@@ -1,0 +1,186 @@
+import unittest
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from app.routes import uploads as upload_routes
+from app.routes import vault as vault_routes
+from app.services import project_entitlement_service
+from app.services.workspace_access_service import (
+    require_workspace_maintenance_write_access,
+    resolve_maintenance_access_state,
+)
+
+
+class VaultMaintenancePolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 8, 29, 12, 0, tzinfo=UTC)
+
+    def test_active_maintenance_allows_vault_writes(self):
+        state = resolve_maintenance_access_state(
+            {"maintenance_status": "active"},
+            now=self.now,
+        )
+
+        self.assertTrue(state["write_allowed"])
+        self.assertFalse(state["read_only"])
+
+    def test_lapsed_maintenance_has_thirty_day_write_grace(self):
+        state = resolve_maintenance_access_state(
+            {
+                "maintenance_status": "past_due",
+                "maintenance_lapsed_at": self.now - timedelta(days=20),
+            },
+            now=self.now,
+        )
+
+        self.assertTrue(state["write_allowed"])
+        self.assertTrue(state["in_grace"])
+        self.assertFalse(state["read_only"])
+
+    def test_lapsed_maintenance_becomes_read_only_after_grace(self):
+        state = resolve_maintenance_access_state(
+            {
+                "maintenance_status": "canceled",
+                "maintenance_lapsed_at": self.now - timedelta(days=31),
+            },
+            now=self.now,
+        )
+
+        self.assertFalse(state["write_allowed"])
+        self.assertFalse(state["in_grace"])
+        self.assertTrue(state["read_only"])
+
+    def test_lapsed_maintenance_without_timestamp_fails_closed_for_writes(self):
+        state = resolve_maintenance_access_state(
+            {"maintenance_status": "past_due"},
+            now=self.now,
+        )
+
+        self.assertFalse(state["write_allowed"])
+        self.assertTrue(state["read_only"])
+
+    def test_read_only_policy_returns_payment_required_for_mutations(self):
+        context = {
+            "maintenance_access": {"write_allowed": False},
+            "is_admin": False,
+        }
+
+        with self.assertRaises(HTTPException) as denied:
+            require_workspace_maintenance_write_access(context, feature_name="Vault")
+
+        self.assertEqual(denied.exception.status_code, 402)
+        self.assertIn("read-only", str(denied.exception.detail))
+        self.assertIn("view and download", str(denied.exception.detail))
+
+    def test_internal_admin_bypasses_maintenance_write_gate(self):
+        context = {
+            "maintenance_access": {"write_allowed": False},
+            "is_admin": True,
+        }
+
+        self.assertIs(
+            require_workspace_maintenance_write_access(context),
+            context,
+        )
+
+    def test_vault_role_check_applies_maintenance_only_to_mutations(self):
+        context = {
+            "member_role": "billing_owner",
+            "maintenance_access": {"write_allowed": False},
+            "is_admin": False,
+        }
+
+        vault_routes._require_vault_role(context)
+        with self.assertRaises(HTTPException) as denied:
+            vault_routes._require_vault_role(context, sensitive=True, mutation=True)
+
+        self.assertEqual(denied.exception.status_code, 402)
+
+    def test_private_vault_permissions_keep_reads_and_hide_mutations(self):
+        record = {
+            "_id": "upload-1",
+            "category": "private_media",
+            "content_type": "application/pdf",
+            "original_filename": "record.pdf",
+            "storage_provider": "r2",
+            "storage_key": "private/record.pdf",
+            "scan_status": "clean",
+            "is_current_version": True,
+        }
+        context = {
+            "maintenance_access": {"write_allowed": False},
+            "is_admin": False,
+        }
+
+        with (
+            patch.object(upload_routes, "_can_access_upload_record", return_value=True),
+            patch.object(upload_routes, "_can_manage_upload_record", return_value=True),
+            patch.object(upload_routes, "_context_has_any_capability", return_value=True),
+            patch.object(upload_routes, "_can_change_linked_vault_privacy", return_value=True),
+            patch.object(upload_routes, "_upload_scan_blocks_download", return_value=False),
+            patch.object(upload_routes, "_upload_has_durable_private_storage", return_value=True),
+        ):
+            payload = upload_routes._public_upload_record(
+                record,
+                context=context,
+                current_user={"id": "owner-1"},
+            )
+
+        self.assertTrue(payload["permissions"]["can_preview"])
+        self.assertTrue(payload["permissions"]["can_download"])
+        self.assertFalse(payload["permissions"]["can_replace"])
+        self.assertFalse(payload["permissions"]["can_delete"])
+        self.assertFalse(payload["permissions"]["can_change_privacy"])
+
+    def test_first_lapsed_maintenance_update_records_lapse_time(self):
+        collection = MagicMock()
+        existing = {
+            "_id": "entitlement-1",
+            "project_id": "project-1",
+            "package_code": "legacy_plus",
+            "maintenance_status": "active",
+        }
+        collection.find_one.side_effect = [existing, existing]
+
+        with patch.object(
+            project_entitlement_service,
+            "_collection",
+            return_value=collection,
+        ):
+            project_entitlement_service.update_project_entitlement_maintenance(
+                project_id="project-1",
+                maintenance_status="past_due",
+            )
+
+        update = collection.update_one.call_args.args[1]
+        self.assertIn("maintenance_lapsed_at", update["$set"])
+
+    def test_recovered_maintenance_clears_lapse_time(self):
+        collection = MagicMock()
+        existing = {
+            "_id": "entitlement-1",
+            "project_id": "project-1",
+            "package_code": "legacy_plus",
+            "maintenance_status": "past_due",
+            "maintenance_lapsed_at": self.now - timedelta(days=5),
+        }
+        collection.find_one.side_effect = [existing, existing]
+
+        with patch.object(
+            project_entitlement_service,
+            "_collection",
+            return_value=collection,
+        ):
+            project_entitlement_service.update_project_entitlement_maintenance(
+                project_id="project-1",
+                maintenance_status="active",
+            )
+
+        update = collection.update_one.call_args.args[1]
+        self.assertEqual(update["$unset"]["maintenance_lapsed_at"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/billing.html
+++ b/billing.html
@@ -140,6 +140,9 @@
 
             <div class="form-panel">
               <span class="eyebrow">Subscription Actions</span>
+              <p class="card-copy">
+                Past-due or canceled maintenance receives a 30-day grace period. After the grace period, your Vault remains available for permitted viewing and downloads but becomes read-only until maintenance billing is restored.
+              </p>
               <p class="card-copy" data-billing-subscriptions-status>
                 Loading subscriptions...
               </p>

--- a/dashboard-intake.js
+++ b/dashboard-intake.js
@@ -528,7 +528,7 @@
     );
     text(
       document.querySelector("[data-health-vault]"),
-      Boolean(resolved.premium_archive_structure) ? "Available" : "Not included",
+      canUseVaultAccess(resolved) ? "Available" : "Not included",
     );
     text(document.querySelector("[data-health-privacy]"), "Private by default");
   }
@@ -578,8 +578,15 @@
     }
     if (tool === "vault") {
       return accessStateFromFlag(
-        Boolean(resolved.premium_archive_structure),
-        hasResolvedFlag(resolved, "premium_archive_structure"),
+        canUseVaultAccess(resolved),
+        [
+          "can_use_personal_vault",
+          "can_use_household_vault",
+          "can_use_linked_household_vault",
+          "can_use_organization_records_vault",
+        ].some(function (key) {
+          return hasResolvedFlag(resolved, key);
+        }),
       );
     }
     if (tool === "tree") {
@@ -693,6 +700,15 @@
     return Boolean(resolved?.can_use_link_keys || resolved?.can_manage_link_keys);
   }
 
+  function canUseVaultAccess(resolved) {
+    return Boolean(
+      resolved?.can_use_personal_vault ||
+        resolved?.can_use_household_vault ||
+        resolved?.can_use_linked_household_vault ||
+        resolved?.can_use_organization_records_vault,
+    );
+  }
+
   function canUseHouseholdAccess(resolved) {
     return Boolean(
       resolved?.can_build_household ||
@@ -710,7 +726,7 @@
     );
     setUnlockState(
       "[data-unlock-vault]",
-      Boolean(resolved.premium_archive_structure),
+      canUseVaultAccess(resolved),
     );
     setUnlockState(
       "[data-unlock-intake]",

--- a/pricing.html
+++ b/pricing.html
@@ -578,6 +578,9 @@
                 <p class="section-lead pricing-accordion-copy">
                   Every Tomb of Light package requires a Legacy Care &amp; Maintenance plan beginning 30 days after purchase. Maintenance keeps hosting, account access, vault availability, security upkeep, preservation support, updates, and record continuity active.
                 </p>
+                <p class="section-lead pricing-accordion-copy">
+                  If required maintenance becomes past due or is canceled, Vault changes remain available during a 30-day grace period. After that grace period, the Vault becomes read-only: existing permitted files can still be viewed and downloaded, while uploads, replacements, privacy changes, and deletion remain paused until billing is restored.
+                </p>
                 <div class="maintenance-grid">
                   <article class="policy-card maintenance-card">
                     <h3>Legacy Snapshot</h3>

--- a/refunds-delivery.html
+++ b/refunds-delivery.html
@@ -138,6 +138,7 @@
               <ul class="section-list">
                 <li>Maintenance is separate from a new build or package upgrade.</li>
                 <li>Maintenance supports access continuity, storage continuity, retrieval support, and package-compatible platform updates.</li>
+                <li>Past-due or canceled maintenance receives a 30-day grace period. Afterward, existing permitted Vault files remain viewable and downloadable, but Vault changes are paused until billing is restored.</li>
                 <li>Maintenance does not include new genealogy research, new branch creation outside purchased scope, major redesigns, or unpurchased add-ons.</li>
               </ul>
             </article>

--- a/terms.html
+++ b/terms.html
@@ -356,16 +356,20 @@
                   >10. Maintenance, Subscription, and Renewal Services</span
                 >
                 <h2>
-                  Certain services may later include renewal, maintenance,
-                  hosting, storage, or continuity-related billing.
+                  Packages include required maintenance, hosting, storage, and
+                  continuity-related billing terms.
                 </h2>
                 <p class="card-copy">
-                  If Tomb of Light offers maintenance subscriptions, continuity
-                  services, renewal services, or recurring billing features,
-                  additional disclosures may apply regarding billing terms,
-                  renewal timing, cancellation methods, and what the maintenance
-                  service covers. Those additional disclosures will govern the
-                  applicable service together with these Terms.
+                  Required Legacy Care &amp; Maintenance begins 30 days after the
+                  package purchase according to the selected monthly or annual
+                  plan. If maintenance becomes past due or is canceled, Vault
+                  changes remain available during a 30-day grace period. After
+                  that period, the Vault becomes read-only: existing permitted
+                  files remain available to view and download, while uploads,
+                  replacements, privacy changes, and deletion are paused until
+                  maintenance billing is restored. Package limits, security
+                  controls, lawful access restrictions, and deletion obligations
+                  continue to apply during read-only access.
                 </p>
               </article>
 

--- a/vault-upload.js
+++ b/vault-upload.js
@@ -38,6 +38,7 @@
   let currentVaultScope = "household";
   let availableVaultScopes = [];
   let currentContext = null;
+  let maintenanceReadOnly = false;
   let currentGraph = { members: [] };
   let families = [];
   let pendingVaultUploadIdempotencyKey = "";
@@ -80,6 +81,38 @@
     if (!node) return;
     node.style.display = "none";
     node.textContent = "";
+  }
+
+  function applyMaintenanceAccess(context) {
+    const maintenance =
+      context?.maintenance || context?.workspaceContextSnapshot?.maintenance || {};
+    maintenanceReadOnly = maintenance.read_only === true;
+    const form = document.querySelector("[data-vault-upload-form]");
+    if (form) {
+      form
+        .querySelectorAll("input, select, button[type=submit]")
+        .forEach(function (control) {
+          control.disabled = maintenanceReadOnly;
+        });
+    }
+
+    const pageStatus = document.querySelector("[data-vault-page-status]");
+    if (maintenanceReadOnly && pageStatus) {
+      setStatus(
+        pageStatus,
+        "Your Vault is read-only because required maintenance has been past due or canceled for more than 30 days. Existing files remain available to view and download; update billing to resume changes.",
+        "warning",
+      );
+    } else if (maintenance.in_grace && pageStatus) {
+      const graceEnds = maintenance.grace_ends_at
+        ? formatDate(maintenance.grace_ends_at)
+        : "the end of your grace period";
+      setStatus(
+        pageStatus,
+        `Maintenance grace period active until ${graceEnds}. Vault changes remain available during this period.`,
+        "warning",
+      );
+    }
   }
 
   function syncReleaseTimingFields() {
@@ -442,6 +475,7 @@
         scopeSelect.value = currentVaultScope;
       }
       await configureVaultScope(currentVaultScope);
+      applyMaintenanceAccess(context);
     } catch (error) {
       if (pageStatus) {
         setStatus(
@@ -1118,6 +1152,7 @@
     if (scopeSelect) {
       scopeSelect.addEventListener("change", async function () {
         await configureVaultScope(String(scopeSelect.value || ""));
+        applyMaintenanceAccess(currentContext);
         renderUploads([]);
       });
     }
@@ -1277,7 +1312,9 @@
           await loadUploads();
         } catch (error) {
           const msg = error.message || "Upload failed. Please try again.";
-          if (isEntitlementError(msg)) {
+          if (msg.toLowerCase().includes("read-only") || msg.toLowerCase().includes("maintenance")) {
+            setStatus(uploadStatus, msg, "error");
+          } else if (isEntitlementError(msg)) {
             setStatus(
               uploadStatus,
               "Your active package does not allow vault file uploads. Contact support or upgrade your package.",


### PR DESCRIPTION
## Summary
- recognize every supported Vault entitlement scope in the dashboard
- add a 30-day maintenance grace period followed by read-only Vault access
- preserve preview/download while blocking uploads, replacements, privacy changes, and deletion after grace
- stream authenticated private downloads through the API with safe download headers
- align customer-facing maintenance language and Vault UI state

## Verification
- backend: 1,889 passed, 2 skipped, 139 subtests passed
- focused Vault suite: 90 passed, 18 subtests passed
- Python compileall passed
- JavaScript syntax checks passed
- Ruff high-signal checks passed
- pip dependency check passed
- Playwright discovered all 22 browser tests, including the Vault lifecycle test