### PR TITLE
Fix production billing gateway origin failover

### DIFF
--- a/billing-api-origin.js
+++ b/billing-api-origin.js
@@ -1,0 +1,31 @@
+(function () {
+  "use strict";
+
+  const config = window.TOL_CONFIG || (window.TOL_CONFIG = {});
+  const hostname = String(window.location && window.location.hostname || "")
+    .trim()
+    .toLowerCase();
+  const isProductionHost =
+    hostname === "tomboflight.com" || hostname === "www.tomboflight.com";
+
+  if (!isProductionHost) {
+    return;
+  }
+
+  const gatewayBase = `${window.location.origin}/api-gateway`;
+  const directBackendBase = "https://tomboflight-api.onrender.com";
+
+  config.API_BASE_URL = gatewayBase;
+  config.API_BASE_URLS = [gatewayBase, directBackendBase];
+
+  try {
+    const saved = String(
+      window.sessionStorage.getItem("tol_api_base_url") || "",
+    ).trim().replace(/\/+$/, "");
+    if (saved && saved.includes("/api-gateway") && saved !== gatewayBase) {
+      window.sessionStorage.removeItem("tol_api_base_url");
+    }
+  } catch (_error) {
+    // Storage is an optimization only. Routing must continue without it.
+  }
+})();

--- a/billing.html
+++ b/billing.html
@@ -236,6 +236,7 @@
 
     <script src="https://js.stripe.com/v3/"></script>
     <script src="config.js?v=20260828-phase21-1"></script>
+    <script src="billing-api-origin.js?v=20260906-billing-p0"></script>
     <script src="app.js?v=20260828-phase21-1"></script>
     <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="billing.js?v=20260828-phase21"></script>

--- a/browser-tests/billing-origin-gateway-p0.spec.mjs
+++ b/browser-tests/billing-origin-gateway-p0.spec.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import vm from "node:vm";
+import { expect, test } from "@playwright/test";
+
+const source = fs.readFileSync(new URL("../billing-api-origin.js", import.meta.url), "utf8");
+
+function runBootstrap(origin, savedBase = "") {
+  const storage = new Map();
+  if (savedBase) storage.set("tol_api_base_url", savedBase);
+  const url = new URL(origin);
+  const window = {
+    location: {
+      origin: url.origin,
+      hostname: url.hostname,
+    },
+    TOL_CONFIG: {
+      API_BASE_URL: "https://tomboflight.com/api-gateway",
+      API_BASE_URLS: [
+        "https://tomboflight.com/api-gateway",
+        "https://tomboflight-api.onrender.com",
+      ],
+    },
+    sessionStorage: {
+      getItem(key) {
+        return storage.get(key) || null;
+      },
+      removeItem(key) {
+        storage.delete(key);
+      },
+    },
+  };
+  vm.runInNewContext(source, { window });
+  return { config: window.TOL_CONFIG, storage };
+}
+
+test("[billing-p0] www production billing binds gateway to the active origin", () => {
+  const result = runBootstrap(
+    "https://www.tomboflight.com/billing.html",
+    "https://tomboflight.com/api-gateway",
+  );
+
+  expect(result.config.API_BASE_URL).toBe("https://www.tomboflight.com/api-gateway");
+  expect(result.config.API_BASE_URLS).toEqual([
+    "https://www.tomboflight.com/api-gateway",
+    "https://tomboflight-api.onrender.com",
+  ]);
+  expect(result.storage.has("tol_api_base_url")).toBe(false);
+});
+
+test("[billing-p0] apex production billing preserves apex same-origin gateway", () => {
+  const result = runBootstrap("https://tomboflight.com/billing.html");
+
+  expect(result.config.API_BASE_URL).toBe("https://tomboflight.com/api-gateway");
+  expect(result.config.API_BASE_URLS).toEqual([
+    "https://tomboflight.com/api-gateway",
+    "https://tomboflight-api.onrender.com",
+  ]);
+});
+
+test("[billing-p0] local development routing is not overridden", () => {
+  const result = runBootstrap("http://127.0.0.1:5500/billing.html");
+
+  expect(result.config.API_BASE_URL).toBe("https://tomboflight.com/api-gateway");
+});


### PR DESCRIPTION
## Summary
- bind the Billing page API gateway to the active production origin (`tomboflight.com` or `www.tomboflight.com`)
- clear a stale saved `/api-gateway` base when it points at the other production hostname
- preserve direct Render as the fallback backend
- leave local development routing unchanged
- add focused regression coverage for apex, `www`, and local behavior

## Root cause
The shared production config hardcodes `https://tomboflight.com/api-gateway`, while `app.js` only classifies an HTML 404/405 gateway failure as recoverable when that gateway is same-origin with the current page. A customer on `https://www.tomboflight.com` can therefore receive an HTML/static-origin 404 without entering the intended gateway failover path.

## Scope
This PR intentionally limits the correction to Billing P0 while the rest of Tomb of Light is being verified system-by-system. It does not change Stripe records, MongoDB records, customer data, Continuity Kernel state, Vault data, or blockchain state.

## Required verification
- focused new browser regression tests
- existing API gateway recovery tests
- existing customer account/billing browser test
- normal CI guardrails
- after merge/deploy: authenticated live Billing read verification on the production customer account before Billing is marked LIVE PASS
