### PR TITLE
Block unsafe intake approval and provisioning

### DIFF
--- a/backend/app/services/intake_pipeline_service.py
+++ b/backend/app/services/intake_pipeline_service.py
@@ -10,6 +10,7 @@ from app.core.package_type_catalog import normalize_package_type
 from app.core.state_catalog import normalize_visibility_state
 from app.database import get_database
 from app.dependencies.auth import transition_project
+from app.services.intake_submission_service import assert_approval_requirements
 from app.services.viewer_manifest_service import ensure_project_workspace_anchor
 
 
@@ -137,6 +138,10 @@ def provision_build_from_submission(
     }
     if status not in allowed_statuses:
         raise ValueError("Submission must be approved before provisioning a build.")
+
+    # Defense in depth: do not trust a historical/legacy approved status if the
+    # record itself no longer satisfies the immutable consent and authority gate.
+    assert_approval_requirements(submission)
 
     existing_family_root_id = str(submission.get("family_root_id") or "").strip()
     existing_household_id = str(submission.get("household_id") or "").strip()

--- a/backend/app/services/intake_submission_service.py
+++ b/backend/app/services/intake_submission_service.py
@@ -20,6 +20,7 @@ PIPELINE_STATUSES = {
 }
 LOCKED_STATUSES = {"submitted", "in_review", "approved"} | PIPELINE_STATUSES
 REVIEWABLE_STATUSES = {"submitted", "in_review", "approved", "rejected"} | PIPELINE_STATUSES
+APPROVAL_GATED_STATUSES = {"approved"} | PIPELINE_STATUSES
 
 ALLOWED_VISIBILITY_PREFERENCES = {"private", "family", "public"}
 ALLOWED_PRIMARY_ASSET_TYPES = {"", "photos", "videos", "documents", "mixed"}
@@ -68,6 +69,44 @@ def _clean_section(section: Any) -> dict[str, Any]:
         else:
             cleaned[key] = value
     return cleaned
+
+
+def get_approval_requirement_errors(submission: dict[str, Any]) -> list[str]:
+    """Return fail-closed approval blockers for an intake submission.
+
+    Submission creation validates the same confirmations, but legacy, migrated,
+    manually-edited, or otherwise inconsistent records can predate or bypass that
+    creation path. Approval and downstream production therefore re-check these
+    immutable safety requirements at the point where status would become trusted.
+    """
+
+    uploads = _clean_section(submission.get("uploads"))
+    consent = _clean_section(submission.get("consent"))
+    review = _clean_section(submission.get("review"))
+
+    errors: list[str] = []
+    if not bool(uploads.get("uploads_rights_confirmed")):
+        errors.append("Upload rights confirmation is required.")
+    if not bool(uploads.get("uploads_minimization_confirmed")):
+        errors.append("Upload minimization confirmation is required.")
+    if not bool(consent.get("consent_process")):
+        errors.append("Consent to process is required.")
+    if not bool(consent.get("consent_store")):
+        errors.append("Consent to store is required.")
+    if not bool(consent.get("consent_authority")):
+        errors.append("Authority confirmation is required.")
+    if not bool(consent.get("consent_review_disclaimer")):
+        errors.append("Review disclaimer acknowledgment is required.")
+    if not bool(review.get("confirm_accuracy")):
+        errors.append("Intake accuracy confirmation is required.")
+
+    return errors
+
+
+def assert_approval_requirements(submission: dict[str, Any]) -> None:
+    errors = get_approval_requirement_errors(submission)
+    if errors:
+        raise ValueError("Intake approval blocked: " + " ".join(errors))
 
 
 def _validate_payload(payload: dict[str, Any]) -> None:
@@ -361,6 +400,9 @@ def update_status(
     status_normalized = str(new_status).strip().lower()
     if status_normalized not in REVIEWABLE_STATUSES:
         raise ValueError("Invalid intake submission status.")
+
+    if status_normalized in APPROVAL_GATED_STATUSES:
+        assert_approval_requirements(existing)
 
     now = _now()
 

--- a/backend/tests/test_intake_approval_safety_p0.py
+++ b/backend/tests/test_intake_approval_safety_p0.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from bson import ObjectId
+
+from app.services import intake_pipeline_service as pipeline_service
+from app.services import intake_submission_service as submission_service
+
+
+def _safe_submission(*, status: str = "submitted") -> dict:
+    return {
+        "_id": ObjectId(),
+        "user_id": ObjectId(),
+        "email": "intake.safety@example.test",
+        "package_slug": "legacy_plus",
+        "package_name": "Legacy Plus",
+        "status": status,
+        "review_locked": True,
+        "household": {
+            "household_name": "Safety Family",
+            "primary_contact_name": "Safety Customer",
+            "primary_contact_email": "intake.safety@example.test",
+        },
+        "family_map": {"family_branch_name": "Safety Family"},
+        "uploads": {
+            "primary_asset_type": "mixed",
+            "uploads_rights_confirmed": True,
+            "uploads_minimization_confirmed": True,
+        },
+        "consent": {
+            "consent_process": True,
+            "consent_store": True,
+            "consent_authority": True,
+            "consent_review_disclaimer": True,
+            "visibility_preference": "private",
+        },
+        "review": {"confirm_accuracy": True},
+    }
+
+
+class FakeCollection:
+    def __init__(self, document: dict | None = None):
+        self.document = deepcopy(document) if document is not None else None
+        self.update_calls: list[tuple[dict, dict]] = []
+        self.insert_calls: list[dict] = []
+
+    def find_one(self, query: dict, *args, **kwargs):
+        if self.document is None:
+            return None
+        requested_id = query.get("_id")
+        if requested_id is not None and requested_id != self.document.get("_id"):
+            return None
+        return deepcopy(self.document)
+
+    def update_one(self, query: dict, update: dict):
+        self.update_calls.append((deepcopy(query), deepcopy(update)))
+        if self.document is not None:
+            for key, value in update.get("$set", {}).items():
+                self.document[key] = value
+            for key in update.get("$unset", {}):
+                self.document.pop(key, None)
+        return object()
+
+    def insert_one(self, payload: dict):
+        self.insert_calls.append(deepcopy(payload))
+        result = type("InsertResult", (), {})()
+        result.inserted_id = ObjectId()
+        return result
+
+
+class FakeDatabase:
+    def __init__(self, intake_document: dict):
+        self.collections = {
+            "intake_submissions": FakeCollection(intake_document),
+            "families": FakeCollection(),
+            "households": FakeCollection(),
+            "projects": FakeCollection(),
+            "family_members": FakeCollection(),
+        }
+
+    def __getitem__(self, name: str):
+        return self.collections.setdefault(name, FakeCollection())
+
+
+def test_approval_requirements_identify_every_required_confirmation():
+    submission = _safe_submission()
+    submission["uploads"]["uploads_rights_confirmed"] = False
+    submission["uploads"]["uploads_minimization_confirmed"] = False
+    submission["consent"]["consent_process"] = False
+    submission["consent"]["consent_store"] = False
+    submission["consent"]["consent_authority"] = False
+    submission["consent"]["consent_review_disclaimer"] = False
+    submission["review"]["confirm_accuracy"] = False
+
+    errors = submission_service.get_approval_requirement_errors(submission)
+
+    assert errors == [
+        "Upload rights confirmation is required.",
+        "Upload minimization confirmation is required.",
+        "Consent to process is required.",
+        "Consent to store is required.",
+        "Authority confirmation is required.",
+        "Review disclaimer acknowledgment is required.",
+        "Intake accuracy confirmation is required.",
+    ]
+
+
+def test_admin_approval_fails_closed_when_required_attestation_is_false(monkeypatch):
+    submission = _safe_submission()
+    submission["uploads"]["uploads_rights_confirmed"] = False
+    submission["consent"]["consent_authority"] = False
+    collection = FakeCollection(submission)
+    monkeypatch.setattr(submission_service, "_collection", lambda: collection)
+
+    with pytest.raises(ValueError) as exc_info:
+        submission_service.update_status(
+            submission_id=str(submission["_id"]),
+            new_status="approved",
+            reviewed_by="ceo@example.test",
+        )
+
+    message = str(exc_info.value)
+    assert message.startswith("Intake approval blocked:")
+    assert "Upload rights confirmation is required." in message
+    assert "Authority confirmation is required." in message
+    assert collection.update_calls == []
+
+
+def test_incomplete_intake_can_enter_review_without_becoming_approved(monkeypatch):
+    submission = _safe_submission()
+    submission["consent"]["consent_review_disclaimer"] = False
+    collection = FakeCollection(submission)
+    monkeypatch.setattr(submission_service, "_collection", lambda: collection)
+
+    updated = submission_service.update_status(
+        submission_id=str(submission["_id"]),
+        new_status="in_review",
+        reviewed_by="reviewer@example.test",
+    )
+
+    assert updated["status"] == "in_review"
+    assert len(collection.update_calls) == 1
+
+
+def test_complete_intake_can_be_approved(monkeypatch):
+    submission = _safe_submission()
+    collection = FakeCollection(submission)
+    monkeypatch.setattr(submission_service, "_collection", lambda: collection)
+
+    updated = submission_service.update_status(
+        submission_id=str(submission["_id"]),
+        new_status="approved",
+        reviewed_by="ceo@example.test",
+        approval_notes="Verified complete.",
+    )
+
+    assert updated["status"] == "approved"
+    assert updated["review_locked"] is True
+    assert len(collection.update_calls) == 1
+
+
+def test_previously_approved_unsafe_record_cannot_be_provisioned(monkeypatch):
+    submission = _safe_submission(status="approved")
+    submission["uploads"]["uploads_minimization_confirmed"] = False
+    fake_db = FakeDatabase(submission)
+    monkeypatch.setattr(pipeline_service, "get_database", lambda: fake_db)
+
+    with pytest.raises(ValueError) as exc_info:
+        pipeline_service.provision_build_from_submission(
+            submission_id=str(submission["_id"]),
+            provisioned_by="ceo@example.test",
+            provisioned_by_user_id=str(ObjectId()),
+        )
+
+    assert "Intake approval blocked:" in str(exc_info.value)
+    assert "Upload minimization confirmation is required." in str(exc_info.value)
+    assert fake_db["families"].insert_calls == []
+    assert fake_db["households"].insert_calls == []
+    assert fake_db["projects"].insert_calls == []

--- a/backend/tests/test_phase3_organization_viewer_anchor.py
+++ b/backend/tests/test_phase3_organization_viewer_anchor.py
@@ -98,8 +98,18 @@ def test_command_structure_network_provisioning_does_not_create_family_or_member
                             "project_scope": "Command graph setup",
                         },
                         "family_map": {},
-                        "consent": {},
-                        "review": {},
+                        "uploads": {
+                            "uploads_rights_confirmed": True,
+                            "uploads_minimization_confirmed": True,
+                        },
+                        "consent": {
+                            "consent_process": True,
+                            "consent_store": True,
+                            "consent_authority": True,
+                            "consent_review_disclaimer": True,
+                            "visibility_preference": "private",
+                        },
+                        "review": {"confirm_accuracy": True},
                         "created_at": now,
                         "updated_at": now,
                     }


### PR DESCRIPTION
## Summary
- fail closed when an intake is moved to `approved` or any downstream production status unless all required rights, minimization, consent, authority, review-disclaimer, and accuracy confirmations are true
- preserve `in_review` so incomplete/legacy records can be corrected rather than dead-ending the case
- revalidate the same immutable approval requirements before provisioning a production build, so a historical or manually-corrupted `approved` record cannot create a workspace
- add focused regression coverage for unsafe approval, safe review, safe approval, and unsafe provisioning

## Root cause
Submission creation already validates the required confirmations, but `update_status()` trusted the stored record when an administrator later set `approved`. Older, migrated, or manually-edited records could therefore hold `status=approved` while required attestations were false. The provisioning service trusted that status as well.

## Safety boundary
No production intake record, customer data, MongoDB record, Stripe record, Vault item, blockchain state, or Continuity Kernel operation is changed by this PR. It changes server-side policy and tests only.

## Required verification
- focused `backend/tests/test_intake_approval_safety_p0.py`
- existing intake/admin intake tests
- normal CI guardrails/full backend regression
- after merge/deploy: verify the known contradictory intake can no longer proceed to approval/provisioning until its attestations are corrected