### PR TITLE
Step 5 customer account completeness: account summary and safe security activity

### DIFF
--- a/account-security.html
+++ b/account-security.html
@@ -63,6 +63,67 @@
 
         <section class="page-sections">
           <div class="container form-shell portal-account-grid">
+            <div class="form-panel" data-customer-account-summary>
+              <span class="eyebrow">Account Overview</span>
+              <h2>Your account and workspace</h2>
+              <p class="card-copy" data-customer-account-summary-status>
+                Sign in to load your current account and workspace details.
+              </p>
+
+              <div class="grid-3" style="margin-top: 1rem">
+                <div>
+                  <span class="eyebrow">Account Status</span>
+                  <p class="portal-identity-value" data-summary-account-status>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Verified Login Email</span>
+                  <p class="portal-identity-value" data-summary-email>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Current Package</span>
+                  <p class="portal-identity-value" data-summary-package>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Active Project</span>
+                  <p class="portal-identity-value" data-summary-project>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Family / Household</span>
+                  <p class="portal-identity-value" data-summary-family>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Workspace Role</span>
+                  <p class="portal-identity-value" data-summary-member-role>Not available</p>
+                </div>
+                <div>
+                  <span class="eyebrow">Billing Profile Sync</span>
+                  <p class="portal-identity-value" data-summary-billing-sync>Not available</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-panel" data-security-activity-panel>
+              <span class="eyebrow">Recent Security Activity</span>
+              <h2>Account security history</h2>
+              <p class="card-copy" data-security-activity-status>
+                Sign in to view recent security activity for your account.
+              </p>
+              <div class="form-grid" data-security-activity-list style="margin-top: 1rem"></div>
+
+              <div class="notice" style="margin-top: 1.25rem">
+                Account or deletion requests begin a reviewed request process. Submitting a request does not immediately erase your account or protected records.
+              </div>
+              <div class="inline-actions" style="margin-top: 1rem">
+                <a
+                  class="btn btn-secondary"
+                  href="data-request.html"
+                  data-account-data-requests-link
+                >
+                  Account &amp; Data Requests
+                </a>
+              </div>
+            </div>
+
             <div
               class="form-panel"
               id="reset-request"
@@ -401,5 +462,6 @@
     <script src="app.js?v=20260828-phase21-1"></script>
     <script src="auth.js?v=20260828-phase21-1"></script>
     <script src="account-security.js?v=20260828-phase21-1"></script>
+    <script src="customer-account-step5.js?v=20260906-step5"></script>
   </body>
 </html>

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -3,6 +3,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.config import settings
+from app.database import get_database
 from app.dependencies.auth import (
     get_current_user,
     is_customer_account,
@@ -28,6 +29,23 @@ from app.services.rate_limit_service import enforce_rate_limit
 from app.services.workspace_access_service import build_workspace_context_snapshot
 
 router = APIRouter(prefix="/users", tags=["Users"])
+
+SECURITY_ACTIVITY_LABELS: dict[str, str] = {
+    "account_activation_requested": "Account activation requested",
+    "customer_profile_updated": "Personal details updated",
+    "customer_email_change_requested": "Email change requested",
+    "customer_email_changed": "Login email changed",
+    "password_reset_requested": "Password reset requested",
+    "password_reset_completed": "Password reset completed",
+    "password_changed": "Password changed",
+    "mfa_enrollment_verified": "Authenticator MFA enabled",
+    "mfa_disabled": "Authenticator MFA disabled",
+    "mfa_login_challenge_failed": "MFA verification failed",
+    "mfa_login_challenge_succeeded": "MFA verification succeeded",
+    "session_revoked": "Session signed out or revoked",
+    "admin_security_reset": "Account security reset",
+}
+SECURITY_ACTIVITY_LIMIT = 20
 
 
 def _apply_no_store(response: Response) -> None:
@@ -98,6 +116,51 @@ def _profile_response(user: dict[str, Any], current_user: dict[str, Any]) -> dic
     }
 
 
+def _security_activity_result(value: Any) -> str:
+    normalized = str(value or "success").strip().lower()
+    if normalized in {"success", "succeeded", "complete", "completed", "ok"}:
+        return "success"
+    if normalized in {"failure", "failed", "error", "denied", "blocked"}:
+        return "failed"
+    return "recorded"
+
+
+def _list_customer_security_activity(user_id: str) -> list[dict[str, str]]:
+    db = get_database()
+    if db is None:
+        raise RuntimeError("Database is not connected.")
+
+    query = {
+        "action": {"$in": sorted(SECURITY_ACTIVITY_LABELS)},
+        "$or": [
+            {"target_type": "user", "target_id": user_id},
+            {"actor_user_id": user_id},
+        ],
+    }
+    cursor = (
+        db["audit_logs"]
+        .find(query)
+        .sort("timestamp", -1)
+        .limit(SECURITY_ACTIVITY_LIMIT)
+    )
+
+    items: list[dict[str, str]] = []
+    for row in cursor:
+        action = str(row.get("action") or "").strip().lower()
+        label = SECURITY_ACTIVITY_LABELS.get(action)
+        if not label:
+            continue
+        items.append(
+            {
+                "action": action,
+                "label": label,
+                "result": _security_activity_result(row.get("result")),
+                "timestamp": str(row.get("timestamp") or "").strip(),
+            }
+        )
+    return items
+
+
 @router.get("/", response_model=list[UserResponse])
 def get_users(current_user: dict[str, Any] = Depends(require_permission("admin.users.read"))):
     users = list_users()
@@ -153,6 +216,23 @@ def patch_my_profile(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
 
     return _profile_response(updated_user, current_user)
+
+
+@router.get("/me/security-activity")
+def get_my_security_activity(
+    response: Response,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    _apply_no_store(response)
+    _require_customer_self_service(current_user)
+    try:
+        items = _list_customer_security_activity(_current_user_id(current_user))
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Security activity is temporarily unavailable.",
+        ) from exc
+    return {"items": items, "count": len(items)}
 
 
 @router.post("/me/email-change/request", response_model=UserEmailChangeResponse)

--- a/backend/tests/test_step5_customer_account_completeness.py
+++ b/backend/tests/test_step5_customer_account_completeness.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.responses import Response
+
+from app.routes import users as users_routes
+
+
+class _Cursor(list):
+    def sort(self, key, direction):
+        reverse = int(direction) < 0
+        return _Cursor(sorted(self, key=lambda row: str(row.get(key) or ""), reverse=reverse))
+
+    def limit(self, amount):
+        return _Cursor(self[: int(amount)])
+
+
+class _AuditCollection:
+    def __init__(self, rows):
+        self.rows = [dict(row) for row in rows]
+        self.last_query = None
+
+    @staticmethod
+    def _matches(row, query):
+        action_filter = query.get("action") or {}
+        if "$in" in action_filter and row.get("action") not in action_filter["$in"]:
+            return False
+
+        alternatives = query.get("$or") or []
+        if alternatives:
+            matched = False
+            for alternative in alternatives:
+                if all(row.get(key) == value for key, value in alternative.items()):
+                    matched = True
+                    break
+            if not matched:
+                return False
+        return True
+
+    def find(self, query):
+        self.last_query = query
+        return _Cursor([row for row in self.rows if self._matches(row, query)])
+
+
+class _Database(dict):
+    def __init__(self, rows):
+        super().__init__({"audit_logs": _AuditCollection(rows)})
+
+
+def test_customer_security_activity_is_user_scoped_allowlisted_and_redacted():
+    rows = [
+        {
+            "action": "customer_profile_updated",
+            "actor_user_id": "user-1",
+            "target_type": "user",
+            "target_id": "user-1",
+            "result": "success",
+            "timestamp": "2026-09-07T01:00:00+00:00",
+            "before": {"email": "old@example.com"},
+            "after": {"email": "new@example.com"},
+            "details": {"token": "must-not-leak"},
+            "context": {"ip": "203.0.113.10"},
+            "actor_email": "customer@example.com",
+        },
+        {
+            "action": "password_reset_completed",
+            "actor_user_id": "user-2",
+            "target_type": "user",
+            "target_id": "user-2",
+            "result": "success",
+            "timestamp": "2026-09-07T00:59:00+00:00",
+        },
+        {
+            "action": "vault_item_created",
+            "actor_user_id": "user-1",
+            "target_type": "vault_item",
+            "target_id": "vault-1",
+            "result": "success",
+            "timestamp": "2026-09-07T00:58:00+00:00",
+        },
+    ]
+    database = _Database(rows)
+    response = Response()
+
+    with (
+        patch.object(users_routes, "get_database", return_value=database),
+        patch.object(users_routes, "is_customer_account", return_value=True),
+    ):
+        result = users_routes.get_my_security_activity(
+            response=response,
+            current_user={"id": "user-1", "email": "customer@example.com", "role": "user"},
+        )
+
+    assert result["count"] == 1
+    assert result["items"] == [
+        {
+            "action": "customer_profile_updated",
+            "label": "Personal details updated",
+            "result": "success",
+            "timestamp": "2026-09-07T01:00:00+00:00",
+        }
+    ]
+    assert set(result["items"][0]) == {"action", "label", "result", "timestamp"}
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_customer_security_activity_empty_state_is_clean():
+    response = Response()
+    with (
+        patch.object(users_routes, "get_database", return_value=_Database([])),
+        patch.object(users_routes, "is_customer_account", return_value=True),
+    ):
+        result = users_routes.get_my_security_activity(
+            response=response,
+            current_user={"id": "user-empty", "email": "empty@example.com", "role": "user"},
+        )
+
+    assert result == {"items": [], "count": 0}
+
+
+def test_internal_identity_cannot_use_customer_security_activity_endpoint():
+    with patch.object(users_routes, "is_customer_account", return_value=False):
+        with pytest.raises(HTTPException) as exc_info:
+            users_routes.get_my_security_activity(
+                response=Response(),
+                current_user={"id": "admin-1", "email": "admin@example.com", "role": "super_admin"},
+            )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_step5_frontend_uses_authoritative_account_endpoints_and_safe_request_path():
+    root = Path(__file__).resolve().parents[2]
+    script = (root / "customer-account-step5.js").read_text(encoding="utf-8")
+    html = (root / "account-security.html").read_text(encoding="utf-8")
+
+    assert '"/users/me/profile"' in script
+    assert '"/users/me/workspace-context"' in script
+    assert '"/users/me/security-activity"' in script
+    assert "PACKAGE_PROFILES" not in script
+    assert "data-customer-account-summary" in html
+    assert "data-security-activity-panel" in html
+    assert 'href="data-request.html"' in html
+    assert "data-account-data-requests-link" in html
+
+
+def test_security_activity_result_normalization_does_not_echo_arbitrary_backend_text():
+    assert users_routes._security_activity_result("success") == "success"
+    assert users_routes._security_activity_result("denied") == "failed"
+    assert users_routes._security_activity_result("internal-detail-that-should-not-leak") == "recorded"

--- a/browser-tests/customer-account-step5.spec.mjs
+++ b/browser-tests/customer-account-step5.spec.mjs
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+
+const CUSTOMER = {
+  id: "step5-customer",
+  _id: "step5-customer",
+  email: "customer@example.com",
+  full_name: "Customer Example",
+  role: "user",
+  account_type: "customer",
+  status: "active",
+  mfa_enabled: false,
+};
+
+async function seedSession(page) {
+  await page.addInitScript((user) => {
+    const currentPage = window.location.pathname.split("/").pop() || "";
+    if (currentPage !== "account-security.html") return;
+    localStorage.setItem("tol_access_token", "step5-fixture-token");
+    localStorage.setItem("tol_user", JSON.stringify(user));
+  }, CUSTOMER);
+}
+
+async function routeAccountApis(page, { activityItems = null } = {}) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const resourceType = request.resourceType();
+    if (["document", "script", "stylesheet", "image", "font"].includes(resourceType)) {
+      return route.continue();
+    }
+
+    const url = new URL(request.url());
+    const path = url.pathname
+      .replace(/^\/api-gateway/, "")
+      .replace(/^\/direct-api/, "");
+    const method = request.method();
+    const json = (payload, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(payload) });
+
+    if (method === "GET" && path === "/health") return json({ status: "ok" });
+    if (method === "GET" && path === "/auth/me") return json(CUSTOMER);
+    if (method === "GET" && path === "/users/me/profile") {
+      return json({
+        ...CUSTOMER,
+        created_at: "2026-08-28T00:00:00Z",
+        billing_sync_status: "synced",
+        legal_acceptance: {},
+      });
+    }
+    if (method === "GET" && path === "/users/me/workspace-context") {
+      return json({
+        status: "active",
+        workspace: {
+          project_id: "project-1",
+          project_name: "Robinson Family Legacy Production Build",
+          family_id: "family-1",
+          family_name: "Robinson Family Legacy",
+        },
+        package: {
+          code: "legacy_plus",
+          display_name: "Legacy Plus",
+        },
+        membership: {
+          member_role: "billing_owner",
+        },
+      });
+    }
+    if (method === "GET" && path === "/users/me/security-activity") {
+      return json({
+        items:
+          activityItems === null
+            ? [
+                {
+                  action: "password_reset_completed",
+                  label: "Password reset completed",
+                  result: "success",
+                  timestamp: "2026-09-07T01:00:00Z",
+                },
+                {
+                  action: "mfa_enrollment_verified",
+                  label: "Authenticator MFA enabled",
+                  result: "success",
+                  timestamp: "2026-09-06T23:00:00Z",
+                },
+              ]
+            : activityItems,
+      });
+    }
+    if (method === "POST" && path === "/auth/logout") return json({ success: true });
+    return json({});
+  });
+}
+
+test.describe("Step 5 customer account completeness", () => {
+  test("renders authoritative account/workspace summary and safe security activity", async ({ page }) => {
+    await seedSession(page);
+    await routeAccountApis(page);
+
+    await page.goto("/account-security.html", { waitUntil: "load" });
+
+    await expect(page.locator("[data-summary-account-status]")).toHaveText("Active");
+    await expect(page.locator("[data-summary-email]")).toHaveText("customer@example.com");
+    await expect(page.locator("[data-summary-package]")).toHaveText("Legacy Plus");
+    await expect(page.locator("[data-summary-project]")).toHaveText(
+      "Robinson Family Legacy Production Build",
+    );
+    await expect(page.locator("[data-summary-family]")).toHaveText("Robinson Family Legacy");
+    await expect(page.locator("[data-summary-member-role]")).toHaveText("Billing Owner");
+    await expect(page.locator("[data-summary-billing-sync]")).toHaveText("Synced");
+
+    const activity = page.locator("[data-security-activity-list]");
+    await expect(activity).toContainText("Password reset completed");
+    await expect(activity).toContainText("Authenticator MFA enabled");
+    await expect(activity).not.toContainText("token");
+    await expect(activity).not.toContainText("203.0.113");
+
+    const requestLink = page.locator("[data-account-data-requests-link]");
+    await expect(requestLink).toHaveAttribute("href", "data-request.html");
+    await expect(page.locator("[data-security-activity-panel]")).toContainText(
+      "does not immediately erase your account",
+    );
+  });
+
+  test("renders a clean empty security-activity state", async ({ page }) => {
+    await seedSession(page);
+    await routeAccountApis(page, { activityItems: [] });
+
+    await page.goto("/account-security.html", { waitUntil: "load" });
+
+    await expect(page.locator("[data-security-activity-status]")).toHaveText(
+      "No recent security activity is available for this account.",
+    );
+    await expect(page.locator("[data-security-activity-list]")).toBeEmpty();
+  });
+});

--- a/customer-account-step5.js
+++ b/customer-account-step5.js
@@ -1,0 +1,200 @@
+(function () {
+  "use strict";
+
+  const app = window.TOLApp || window.TOLAuth;
+  const summaryPanel = document.querySelector("[data-customer-account-summary]");
+  const activityPanel = document.querySelector("[data-security-activity-panel]");
+
+  if (!app || (!summaryPanel && !activityPanel)) return;
+
+  const ROLE_LABELS = {
+    billing_owner: "Billing Owner",
+    co_owner: "Co-Owner",
+    family_manager: "Family Manager",
+    contributor: "Contributor",
+    viewer: "Viewer",
+    minor_viewer: "Minor Viewer",
+    linked_relative: "Linked Relative",
+    legacy_executor: "Legacy Executor",
+  };
+
+  function text(value) {
+    return String(value || "").trim();
+  }
+
+  function firstText() {
+    for (let index = 0; index < arguments.length; index += 1) {
+      const value = text(arguments[index]);
+      if (value) return value;
+    }
+    return "";
+  }
+
+  function setText(selector, value, fallback) {
+    const node = document.querySelector(selector);
+    if (!node) return;
+    node.textContent = text(value) || fallback || "Not available";
+  }
+
+  function friendlyStatus(value) {
+    const normalized = text(value).toLowerCase();
+    if (!normalized) return "Not available";
+    return normalized
+      .replaceAll("_", " ")
+      .replace(/\b\w/g, function (character) {
+        return character.toUpperCase();
+      });
+  }
+
+  function friendlyRole(value) {
+    const normalized = text(value).toLowerCase();
+    return ROLE_LABELS[normalized] || friendlyStatus(normalized);
+  }
+
+  function renderSummary(profile, snapshot) {
+    const workspace = snapshot && typeof snapshot.workspace === "object" ? snapshot.workspace : {};
+    const packageInfo = snapshot && typeof snapshot.package === "object" ? snapshot.package : {};
+    const entitlements = snapshot && typeof snapshot.entitlements === "object" ? snapshot.entitlements : {};
+    const membership = snapshot && typeof snapshot.membership === "object" ? snapshot.membership : {};
+    const family = snapshot && typeof snapshot.family === "object" ? snapshot.family : {};
+    const project = snapshot && typeof snapshot.project === "object" ? snapshot.project : {};
+
+    const packageName = firstText(
+      packageInfo.display_name,
+      packageInfo.name,
+      entitlements.package_name,
+      workspace.package_name,
+      project.package_name,
+    );
+    const packageCode = firstText(
+      packageInfo.code,
+      packageInfo.package_code,
+      entitlements.package_code,
+      workspace.package_code,
+      project.package_code,
+    );
+    const projectName = firstText(
+      workspace.project_name,
+      project.project_name,
+      project.name,
+      workspace.project_id,
+      project._id,
+      project.id,
+    );
+    const familyName = firstText(
+      workspace.family_name,
+      workspace.household_name,
+      family.family_name,
+      family.household_name,
+      family.name,
+      workspace.family_id,
+      family._id,
+      family.id,
+    );
+    const memberRole = firstText(
+      membership.member_role,
+      membership.role,
+      workspace.member_role,
+      snapshot && snapshot.member_role,
+    );
+
+    setText("[data-summary-account-status]", friendlyStatus(profile.status), "Unknown");
+    setText("[data-summary-email]", profile.email, "Not available");
+    setText(
+      "[data-summary-package]",
+      packageName || packageCode,
+      "No active package connected",
+    );
+    setText("[data-summary-project]", projectName, "No active project connected");
+    setText("[data-summary-family]", familyName, "No family or household connected");
+    setText("[data-summary-member-role]", friendlyRole(memberRole), "Not assigned");
+    setText(
+      "[data-summary-billing-sync]",
+      friendlyStatus(profile.billing_sync_status),
+      "Not linked",
+    );
+
+    const statusNode = document.querySelector("[data-customer-account-summary-status]");
+    if (statusNode) {
+      statusNode.textContent =
+        "Account and workspace details are loaded from your current Tomb of Light records.";
+    }
+  }
+
+  function formatTimestamp(value) {
+    const raw = text(value);
+    if (!raw) return "Time unavailable";
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return raw;
+    return date.toLocaleString();
+  }
+
+  function renderActivity(payload) {
+    const listNode = document.querySelector("[data-security-activity-list]");
+    const statusNode = document.querySelector("[data-security-activity-status]");
+    if (!listNode) return;
+
+    listNode.innerHTML = "";
+    const items = Array.isArray(payload && payload.items) ? payload.items : [];
+    if (!items.length) {
+      if (statusNode) statusNode.textContent = "No recent security activity is available for this account.";
+      return;
+    }
+
+    items.forEach(function (item) {
+      const card = document.createElement("div");
+      card.className = "portal-account-activity-item";
+
+      const title = document.createElement("strong");
+      title.textContent = text(item.label) || "Account security event";
+
+      const meta = document.createElement("p");
+      meta.className = "card-copy";
+      meta.textContent = `${formatTimestamp(item.timestamp)} · ${friendlyStatus(item.result || "recorded")}`;
+
+      card.appendChild(title);
+      card.appendChild(meta);
+      listNode.appendChild(card);
+    });
+
+    if (statusNode) {
+      statusNode.textContent = `Showing ${items.length} recent account security event${items.length === 1 ? "" : "s"}.`;
+    }
+  }
+
+  async function loadCustomerAccountDetails() {
+    const token = typeof app.getToken === "function" ? app.getToken() : "";
+    if (!token) {
+      const summaryStatus = document.querySelector("[data-customer-account-summary-status]");
+      const activityStatus = document.querySelector("[data-security-activity-status]");
+      if (summaryStatus) summaryStatus.textContent = "Sign in to view your account and workspace summary.";
+      if (activityStatus) activityStatus.textContent = "Sign in to view recent security activity.";
+      return;
+    }
+
+    if (summaryPanel) {
+      try {
+        const results = await Promise.all([
+          app.apiRequest("/users/me/profile", { method: "GET" }),
+          app.apiRequest("/users/me/workspace-context", { method: "GET" }),
+        ]);
+        renderSummary(results[0] || {}, results[1] || {});
+      } catch (error) {
+        const statusNode = document.querySelector("[data-customer-account-summary-status]");
+        if (statusNode) statusNode.textContent = "Your account summary could not be loaded right now.";
+      }
+    }
+
+    if (activityPanel) {
+      try {
+        const payload = await app.apiRequest("/users/me/security-activity", { method: "GET" });
+        renderActivity(payload || {});
+      } catch (error) {
+        const statusNode = document.querySelector("[data-security-activity-status]");
+        if (statusNode) statusNode.textContent = "Recent security activity could not be loaded right now.";
+      }
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", loadCustomerAccountDetails);
+})();


### PR DESCRIPTION
Implement only the remaining Step 5 customer-account-management completeness work on current `main` (`7ae7d83cdb67d6d13bec5b559ad3d1b9277fe1fb`). Do not change package entitlement policy, Link Keys, Vault behavior, permanent deletion execution, Stripe charging, MongoDB production data, blockchain state, or Continuity Kernel execution.

## Existing behavior to preserve
- `/users/me/profile` GET/PATCH is customer-only and `no-store`.
- Profile updates normalize phone/address, persist to the user record, and sync current Stripe customer contact data without changing login email or historical orders.
- Verified email changes require current password, email verification, single-use/expiring token, preserve old email alias, sync verified email to Stripe, and revoke existing sessions.
- Password/MFA/recovery controls from Step 4 remain unchanged.
- `/users/me/workspace-context` remains the authoritative source for active project/family/package/member-role context.
- Public `data-request.html` already supports deletion requests. Do NOT create a direct permanent-delete customer button in this step.

## 1. Consolidated customer account summary
Add a read-only account/workspace summary to the protected customer account-management surface (prefer `billing.html` because it already hosts Personal Details and Login Email).

Show only safe customer-facing fields sourced from existing authoritative endpoints:
- account status
- verified login email
- current package display name/code when available
- active project/workspace display name or identifier when available
- family/household display name when available
- current workspace member role (`billing_owner`, `co_owner`, etc.) in a customer-friendly label
- billing profile sync status if useful

Use `/users/me/profile` + `/users/me/workspace-context`; do not infer entitlements independently in new frontend code. Gracefully handle accounts with no active package/project.

## 2. Safe recent security activity
Add a customer-only read endpoint, e.g. `GET /users/me/security-activity`, backed by `audit_logs`.

Security/privacy requirements:
- require authenticated customer self-service; internal/admin identities must not use this customer endpoint;
- query only events belonging to the authenticated user (target user id and/or actor user id as appropriate);
- return a small bounded list, e.g. last 10-20;
- return only safe fields such as action/category, human-readable label, result, timestamp; optionally source/device category only if already safe;
- NEVER return raw `before`, `after`, `details`, `context`, token values, IP addresses, email verification tokens, password-reset tokens, MFA secrets, recovery codes, internal actor data, or another user's data;
- allowlist account/security actions rather than exposing every audit event. Relevant examples include profile update, email-change requested/completed, password reset requested/completed, password changed, MFA enrollment/disable/login events, session revocation/logout, activation/recovery events where present;
- return empty list safely when no events exist.

Display this on `account-security.html` as “Recent Security Activity” with timestamp + friendly event label/status. No raw JSON.

## 3. Account/data request path
Add a clear protected-account link from the account-management/security surface to `data-request.html`, labeled “Account & Data Requests” or equivalent. Explain that deletion requests start a reviewed request and do not immediately erase the account. Do NOT execute or preview permanent deletion here; full destructive deletion remains Master Step 25.

## Tests
Add focused backend tests proving:
- customer sees only their own allowlisted security activity;
- another user's audit rows are excluded;
- sensitive audit fields are never returned;
- internal/admin account is rejected from customer self-service activity endpoint;
- empty activity returns cleanly;
- account summary frontend uses `/users/me/profile` and `/users/me/workspace-context` rather than duplicating package truth.

Add/update Playwright customer-account coverage proving:
- account summary renders account/package/project/member role from mocked authoritative endpoints;
- recent security activity renders safe labels/timestamps only;
- empty activity state renders correctly;
- Account & Data Requests link points to the existing deletion/privacy request surface.

## Acceptance
- existing customer profile/email tests remain green;
- existing Step 4 auth tests remain green;
- no change to permanent deletion engine or customer data;
- no destructive live testing;
- normal CI guardrails, full backend regression, dependency audit, and browser suite pass.