### PR TITLE
Step 6: unify published pricing SKUs and entitlement truth

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -14,13 +14,8 @@ except ModuleNotFoundError as exc:
         raise
     sys.modules.setdefault("app", import_module("backend.app"))
 
-try:
-    _package_catalog = import_module("app.core.package_catalog")
-    _overlay = import_module("app.core.commercial_catalog_overlay")
-except ModuleNotFoundError as exc:
-    if exc.name != "app":
-        raise
-else:
-    _overlay.apply_commercial_catalog_overlay(_package_catalog)
+_package_catalog = import_module(".package_catalog", __name__)
+_overlay = import_module(".commercial_catalog_overlay", __name__)
+_overlay.apply_commercial_catalog_overlay(_package_catalog)
 
 __all__: list[str] = []

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -6,8 +6,13 @@ all callers of package_catalog share the same published product truth.
 
 from importlib import import_module
 
-_package_catalog = import_module("app.core.package_catalog")
-_overlay = import_module("app.core.commercial_catalog_overlay")
-_overlay.apply_commercial_catalog_overlay(_package_catalog)
+try:
+    _package_catalog = import_module("app.core.package_catalog")
+    _overlay = import_module("app.core.commercial_catalog_overlay")
+except ModuleNotFoundError as exc:
+    if exc.name != "app":
+        raise
+else:
+    _overlay.apply_commercial_catalog_overlay(_package_catalog)
 
 __all__: list[str] = []

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -9,7 +9,9 @@ import sys
 
 try:
     import_module("app")
-except ModuleNotFoundError:
+except ModuleNotFoundError as exc:
+    if getattr(exc, "name", None) != "app":
+        raise
     sys.modules.setdefault("app", import_module("backend.app"))
 
 try:

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -5,6 +5,12 @@ all callers of package_catalog share the same published product truth.
 """
 
 from importlib import import_module
+import sys
+
+try:
+    import_module("app")
+except ModuleNotFoundError:
+    sys.modules.setdefault("app", import_module("backend.app"))
 
 try:
     _package_catalog = import_module("app.core.package_catalog")

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core Tomb of Light policy package.
+
+The commercial catalog overlay is applied once when the core package loads so
+all callers of package_catalog share the same published product truth.
+"""
+
+from importlib import import_module
+
+_package_catalog = import_module("app.core.package_catalog")
+_overlay = import_module("app.core.commercial_catalog_overlay")
+_overlay.apply_commercial_catalog_overlay(_package_catalog)
+
+__all__: list[str] = []

--- a/backend/app/core/commercial_catalog_overlay.py
+++ b/backend/app/core/commercial_catalog_overlay.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import ModuleType
+from typing import Any
+
+
+# Commercial SKU truth mirrors the currently published Tomb of Light checkout
+# catalog. Stripe links remain in config.js; this server-side map supplies the
+# exact product name/amount used to verify a paid Checkout Session and the
+# canonical entitlement effect (when one exists).
+COMMERCIAL_ADDON_SKUS: dict[str, dict[str, Any]] = {
+    "extra_upload_pack": {
+        "addon_code": "extra_upload_pack",
+        "display_name": "Extra Upload Pack",
+        "price_usd": 49,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "entitlement_code": "extra_upload_pack",
+        "entitlement_effects": {"max_uploads_delta": 10},
+        "status": "active",
+    },
+    "extra_storage_10gb_monthly": {
+        "addon_code": "extra_storage_10gb_monthly",
+        "display_name": "Extra Storage +10GB Monthly",
+        "price_usd": 15,
+        "billing_type": "monthly",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 10},
+        "status": "active",
+    },
+    "extra_storage_10gb_yearly": {
+        "addon_code": "extra_storage_10gb_yearly",
+        "display_name": "Extra Storage +10GB Annual",
+        "price_usd": 150,
+        "billing_type": "yearly",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 10},
+        "status": "active",
+    },
+    "vault_expansion_25gb_monthly": {
+        "addon_code": "vault_expansion_25gb_monthly",
+        "display_name": "Vault Expansion +25GB Monthly",
+        "price_usd": 29,
+        "billing_type": "monthly",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 25},
+        "status": "active",
+    },
+    "vault_expansion_25gb_yearly": {
+        "addon_code": "vault_expansion_25gb_yearly",
+        "display_name": "Vault Expansion +25GB Annual",
+        "price_usd": 290,
+        "billing_type": "yearly",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 25},
+        "status": "active",
+    },
+    "vault_expansion_50gb_monthly": {
+        "addon_code": "vault_expansion_50gb_monthly",
+        "display_name": "Vault Expansion +50GB Monthly",
+        "price_usd": 59,
+        "billing_type": "monthly",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 50},
+        "status": "active",
+    },
+    "vault_expansion_50gb_yearly": {
+        "addon_code": "vault_expansion_50gb_yearly",
+        "display_name": "Vault Expansion +50GB Annual",
+        "price_usd": 590,
+        "billing_type": "yearly",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "entitlement_code": "extra_storage",
+        "entitlement_effects": {"max_storage_gb_delta": 50},
+        "status": "active",
+    },
+    "private_vault_export": {
+        "addon_code": "private_vault_export",
+        "display_name": "Private Vault Export",
+        "price_usd": 199,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "requires_package_allowlist": False,
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "portrait_polish": {
+        "addon_code": "portrait_polish",
+        "display_name": "Portrait Polish",
+        "price_usd": 99,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait"],
+        "entitlement_code": "portrait_polish",
+        "status": "active",
+    },
+    "tribute_narration": {
+        "addon_code": "tribute_narration",
+        "display_name": "Tribute Narration",
+        "price_usd": 149,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait"],
+        "entitlement_code": "tribute_narration",
+        "status": "active",
+    },
+    "additional_narration_minute": {
+        "addon_code": "additional_narration_minute",
+        "display_name": "Additional Narration Minute",
+        "price_usd": 200,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household", "network"],
+        "entitlement_code": "additional_narration_minute",
+        "status": "active",
+    },
+    "extra_mapped_person": {
+        "addon_code": "extra_mapped_person",
+        "display_name": "Extra Mapped Person",
+        "price_usd": 49,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household", "network"],
+        "entitlement_code": "extra_mapped_person",
+        "entitlement_effects": {"max_members_delta": 1},
+        "status": "active",
+    },
+    "extra_zoom_layer": {
+        "addon_code": "extra_zoom_layer",
+        "display_name": "Extra Zoom Layer",
+        "price_usd": 199,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household", "network"],
+        "entitlement_code": "extra_zoom_layer",
+        "entitlement_effects": {"max_zoom_layers_delta": 1},
+        "status": "active",
+    },
+    "extra_linked_household": {
+        "addon_code": "extra_linked_household",
+        "display_name": "Extra Linked Household",
+        "price_usd": 1250,
+        "billing_type": "one_time",
+        "allowed_lanes": ["network"],
+        "allowed_packages": ["family_estate_concierge"],
+        "entitlement_code": "extra_linked_household",
+        "entitlement_effects": {
+            "max_households_delta": 1,
+            "can_link_households": True,
+        },
+        "status": "active",
+    },
+    "extra_branch": {
+        "addon_code": "extra_branch",
+        "display_name": "Extra Branch",
+        "price_usd": 1500,
+        "billing_type": "one_time",
+        "allowed_lanes": ["network"],
+        "allowed_packages": ["family_estate_concierge"],
+        "entitlement_code": "extra_branch",
+        "entitlement_effects": {
+            "max_households_delta": 1,
+            "max_family_branches_delta": 1,
+            "can_link_households": True,
+        },
+        "status": "active",
+    },
+    "extra_org_node": {
+        "addon_code": "extra_org_node",
+        "display_name": "Extra Organization Node",
+        "price_usd": 99,
+        "billing_type": "one_time",
+        "allowed_lanes": ["organization"],
+        "allowed_packages": ["command_structure_network"],
+        "entitlement_code": "extra_org_node",
+        "entitlement_effects": {"max_org_nodes_delta": 1},
+        "status": "active",
+    },
+    "extra_org_level": {
+        "addon_code": "extra_org_level",
+        "display_name": "Extra Organization Level",
+        "price_usd": 299,
+        "billing_type": "one_time",
+        "allowed_lanes": ["organization"],
+        "allowed_packages": ["command_structure_network"],
+        "entitlement_code": "extra_org_level",
+        "entitlement_effects": {"max_zoom_layers_delta": 1},
+        "status": "active",
+    },
+    "extra_admin_seat_monthly": {
+        "addon_code": "extra_admin_seat_monthly",
+        "display_name": "Extra Admin Seat Monthly",
+        "price_usd": 19,
+        "billing_type": "monthly",
+        "allowed_lanes": ["organization"],
+        "allowed_packages": ["command_structure_network"],
+        "entitlement_code": "extra_admin_seat",
+        "entitlement_effects": {"extra_admin_seats_delta": 1},
+        "status": "active",
+    },
+    "extra_admin_seat_yearly": {
+        "addon_code": "extra_admin_seat_yearly",
+        "display_name": "Extra Admin Seat Annual",
+        "price_usd": 190,
+        "billing_type": "yearly",
+        "allowed_lanes": ["organization"],
+        "allowed_packages": ["command_structure_network"],
+        "entitlement_code": "extra_admin_seat",
+        "entitlement_effects": {"extra_admin_seats_delta": 1},
+        "status": "active",
+    },
+    "command_report_addon": {
+        "addon_code": "command_report_addon",
+        "display_name": "Command Report",
+        "price_usd": 299,
+        "billing_type": "one_time",
+        "allowed_lanes": ["organization"],
+        "allowed_packages": ["command_structure_network"],
+        "entitlement_code": "command_report_addon",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "emergency_retrieval_support": {
+        "addon_code": "emergency_retrieval_support",
+        "display_name": "Emergency Retrieval Support",
+        "price_usd": 249,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "requires_package_allowlist": False,
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "family_correction_cycle": {
+        "addon_code": "family_correction_cycle",
+        "display_name": "Family Correction Cycle",
+        "price_usd": 149,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network"],
+        "requires_package_allowlist": False,
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "organization_correction_cycle": {
+        "addon_code": "organization_correction_cycle",
+        "display_name": "Organization Correction Cycle",
+        "price_usd": 249,
+        "billing_type": "one_time",
+        "allowed_lanes": ["organization"],
+        "requires_package_allowlist": False,
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "document_record_review_pack": {
+        "addon_code": "document_record_review_pack",
+        "display_name": "Document/Record Review Pack",
+        "price_usd": 299,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait", "household", "network", "organization"],
+        "requires_package_allowlist": False,
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "on_site_photo_scanning": {
+        "addon_code": "on_site_photo_scanning",
+        "display_name": "On-Site Photo Scanning",
+        "price_usd": 599,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household", "network"],
+        "entitlement_code": "on_site_photo_scanning",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "white_glove_archive_support": {
+        "addon_code": "white_glove_archive_support",
+        "display_name": "White-Glove Archive Support",
+        "price_usd": 1999,
+        "billing_type": "one_time",
+        "allowed_lanes": ["network"],
+        "allowed_packages": ["family_estate_concierge"],
+        "entitlement_code": "white_glove_archive_support",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_snapshot_portrait_intro": {
+        "addon_code": "rush_delivery_snapshot_portrait_intro",
+        "display_name": "Rush Delivery Snapshot / Portrait Intro",
+        "price_usd": 99,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait"],
+        "allowed_packages": ["legacy_snapshot", "legacy_portrait_intro"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_digital_legacy_portrait": {
+        "addon_code": "rush_delivery_digital_legacy_portrait",
+        "display_name": "Rush Delivery Digital Legacy Portrait",
+        "price_usd": 199,
+        "billing_type": "one_time",
+        "allowed_lanes": ["portrait"],
+        "allowed_packages": ["digital_legacy_portrait"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_household_foundation": {
+        "addon_code": "rush_delivery_household_foundation",
+        "display_name": "Rush Delivery Household Foundation",
+        "price_usd": 399,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household"],
+        "allowed_packages": ["household_foundation"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_heirloom_legacy_tree": {
+        "addon_code": "rush_delivery_heirloom_legacy_tree",
+        "display_name": "Rush Delivery Heirloom Legacy Tree",
+        "price_usd": 750,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household"],
+        "allowed_packages": ["heirloom_legacy_tree"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_legacy_plus": {
+        "addon_code": "rush_delivery_legacy_plus",
+        "display_name": "Rush Delivery Legacy Plus",
+        "price_usd": 1500,
+        "billing_type": "one_time",
+        "allowed_lanes": ["household"],
+        "allowed_packages": ["legacy_plus"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+    "rush_delivery_estate_command_minimum": {
+        "addon_code": "rush_delivery_estate_command_minimum",
+        "display_name": "Rush Delivery Estate / Command Minimum",
+        "price_usd": 2000,
+        "billing_type": "one_time",
+        "allowed_lanes": ["network", "organization"],
+        "allowed_packages": ["family_estate_concierge", "command_structure_network"],
+        "entitlement_code": "rush_delivery",
+        "fulfillment_type": "manual_service",
+        "status": "active",
+    },
+}
+
+
+PACKAGE_ALLOWED_ADDON_ADDITIONS: dict[str, tuple[str, ...]] = {
+    "family_estate_concierge": ("extra_linked_household", "extra_branch"),
+    "command_structure_network": ("extra_org_node",),
+}
+
+
+def _alias_forms(code: str) -> set[str]:
+    return {code, code.replace("_", "-"), code.replace("_", " ")}
+
+
+def apply_commercial_catalog_overlay(package_catalog: ModuleType) -> None:
+    """Apply published commercial SKU truth without changing checkout URLs.
+
+    The overlay deliberately mutates the existing catalog dictionaries in
+    place so every already-imported get_package/get_addon function observes the
+    same corrected data. It is idempotent and does not touch customer records.
+    """
+
+    for sku, definition in COMMERCIAL_ADDON_SKUS.items():
+        package_catalog.ADDON_CATALOG[sku] = deepcopy(definition)
+        for alias in _alias_forms(sku):
+            package_catalog.ADDON_CODE_ALIASES[alias] = sku
+
+    for package_code, additions in PACKAGE_ALLOWED_ADDON_ADDITIONS.items():
+        package = package_catalog.PACKAGE_CATALOG.get(package_code)
+        if not isinstance(package, dict):
+            continue
+        package["allowed_addons"] = list(
+            dict.fromkeys([*(package.get("allowed_addons") or []), *additions])
+        )

--- a/backend/app/services/entitlement_service.py
+++ b/backend/app/services/entitlement_service.py
@@ -27,6 +27,75 @@ def get_addon_or_raise(addon_code: str) -> dict[str, Any]:
     return addon
 
 
+def _addon_effect_code(addon: dict[str, Any], fallback: str) -> str:
+    return _normalize(addon.get("entitlement_code") or addon.get("addon_code") or fallback)
+
+
+def _addon_is_compatible(package: dict[str, Any], addon: dict[str, Any], addon_code: str) -> bool:
+    package_code = _normalize(package.get("package_code"))
+    package_lane = _normalize(package.get("package_lane"))
+    sku_code = _normalize(addon.get("addon_code") or addon_code)
+    effect_code = _addon_effect_code(addon, sku_code)
+
+    allowed_packages = {
+        _normalize(value)
+        for value in (addon.get("allowed_packages") or [])
+        if _normalize(value)
+    }
+    if allowed_packages and package_code not in allowed_packages:
+        return False
+
+    allowed_lanes = {
+        _normalize(value)
+        for value in (addon.get("allowed_lanes") or [])
+        if _normalize(value)
+    }
+    if allowed_lanes and package_lane not in allowed_lanes:
+        return False
+
+    if not bool(addon.get("requires_package_allowlist", True)):
+        return True
+
+    allowed_addons = {
+        _normalize(value)
+        for value in (package.get("allowed_addons") or [])
+        if _normalize(value)
+    }
+    return bool(sku_code in allowed_addons or effect_code in allowed_addons)
+
+
+def _apply_entitlement_effects(
+    entitlements: dict[str, Any],
+    effects: dict[str, Any],
+) -> None:
+    numeric_deltas: dict[str, str] = {
+        "max_uploads_delta": "max_uploads",
+        "max_storage_gb_delta": "max_storage_gb",
+        "max_members_delta": "max_members",
+        "max_zoom_layers_delta": "max_zoom_layers",
+        "max_households_delta": "max_households",
+        "max_family_branches_delta": "max_family_branches",
+        "max_org_nodes_delta": "max_org_nodes",
+        "extra_admin_seats_delta": "extra_admin_seats",
+    }
+    for effect_key, entitlement_key in numeric_deltas.items():
+        delta = effects.get(effect_key)
+        if delta is None:
+            continue
+        current = entitlements.get(entitlement_key, 0) or 0
+        if entitlement_key == "max_storage_gb":
+            entitlements[entitlement_key] = float(current) + float(delta)
+        else:
+            entitlements[entitlement_key] = int(current) + int(delta)
+
+    for boolean_key in (
+        "can_link_households",
+        "can_link_org_units",
+    ):
+        if boolean_key in effects:
+            entitlements[boolean_key] = bool(effects.get(boolean_key))
+
+
 def resolve_project_entitlements(
     package_code: str,
     active_addon_codes: list[str] | None = None,
@@ -34,70 +103,66 @@ def resolve_project_entitlements(
     package = get_package_or_raise(package_code)
     entitlements = deepcopy(package)
     entitlements["active_addons"] = []
-    allowed_addons = {
-        str(addon_code).strip()
-        for addon_code in (package.get("allowed_addons") or [])
-        if str(addon_code).strip()
-    }
     processed_addons: set[str] = set()
 
     for raw_addon_code in active_addon_codes or []:
         addon = get_addon_or_raise(raw_addon_code)
-        addon_code = str(addon.get("addon_code") or raw_addon_code).strip()
+        addon_code = _normalize(addon.get("addon_code") or raw_addon_code)
         if not addon_code or addon_code in processed_addons:
             continue
         processed_addons.add(addon_code)
 
-        if addon_code not in allowed_addons:
+        if not _addon_is_compatible(package, addon, addon_code):
             _logger.warning(
-                "Skipping addon '%s' because it is not allowed for package '%s'.",
+                "Skipping addon '%s' because it is not compatible with package '%s' in lane '%s'.",
                 addon_code,
                 package.get("package_code"),
-            )
-            continue
-
-        if package["package_lane"] not in addon.get("allowed_lanes", []):
-            _logger.warning(
-                "Skipping addon '%s' because lane '%s' is not in allowed lanes %s.",
-                addon_code,
                 package.get("package_lane"),
-                addon.get("allowed_lanes", []),
             )
             continue
 
         entitlements["active_addons"].append(addon_code)
+        effect_code = _addon_effect_code(addon, addon_code)
+        effects = addon.get("entitlement_effects")
+        if isinstance(effects, dict) and effects:
+            _apply_entitlement_effects(entitlements, effects)
+            continue
 
-        if addon_code == "extra_upload_pack":
+        # Backward-compatible effects for historical generic add-on codes.
+        if effect_code == "extra_upload_pack":
             entitlements["max_uploads"] = int(entitlements.get("max_uploads", 0)) + 10
-        elif addon_code == "extra_storage":
+        elif effect_code == "extra_storage":
             entitlements["max_storage_gb"] = float(
                 entitlements.get("max_storage_gb", 0)
             ) + 10
-        elif addon_code == "extra_mapped_person":
+        elif effect_code == "extra_mapped_person":
             entitlements["max_members"] = int(entitlements.get("max_members", 0)) + 1
-        elif addon_code == "extra_zoom_layer":
+        elif effect_code == "extra_zoom_layer":
             entitlements["max_zoom_layers"] = int(
                 entitlements.get("max_zoom_layers", 0)
             ) + 1
-        elif addon_code == "extra_linked_household":
+        elif effect_code == "extra_linked_household":
             entitlements["max_households"] = int(
                 entitlements.get("max_households", 0)
             ) + 1
             entitlements["can_link_households"] = True
-        elif addon_code == "extra_branch":
+        elif effect_code == "extra_branch":
             entitlements["max_households"] = int(
                 entitlements.get("max_households", 0)
             ) + 1
+            entitlements["max_family_branches"] = int(
+                entitlements.get("max_family_branches", 0)
+            ) + 1
             entitlements["can_link_households"] = True
-        elif addon_code == "extra_org_node":
+        elif effect_code == "extra_org_node":
             entitlements["max_org_nodes"] = int(
                 entitlements.get("max_org_nodes", 0)
             ) + 1
-        elif addon_code == "extra_org_level":
+        elif effect_code == "extra_org_level":
             entitlements["max_zoom_layers"] = int(
                 entitlements.get("max_zoom_layers", 0)
             ) + 1
-        elif addon_code == "extra_admin_seat":
+        elif effect_code == "extra_admin_seat":
             entitlements["extra_admin_seats"] = int(
                 entitlements.get("extra_admin_seats", 0)
             ) + 1
@@ -109,13 +174,7 @@ def resolve_project_entitlements(
 def can_purchase_addon(package_code: str, addon_code: str) -> bool:
     package = get_package_or_raise(package_code)
     addon = get_addon_or_raise(addon_code)
-    allowed_addons = {
-        str(value).strip() for value in (package.get("allowed_addons") or []) if str(value).strip()
-    }
-    normalized_addon_code = str(addon.get("addon_code") or addon_code).strip()
-    if normalized_addon_code not in allowed_addons:
-        return False
-    return package["package_lane"] in addon.get("allowed_lanes", [])
+    return _addon_is_compatible(package, addon, addon_code)
 
 
 def can_upgrade(from_package_code: str, to_package_code: str) -> bool:

--- a/backend/app/services/link_request_service.py
+++ b/backend/app/services/link_request_service.py
@@ -103,8 +103,6 @@ def _resolve_project_link_scope(project_id: str) -> dict[str, Any]:
     package_code = _normalize_value(
         entitlement.get("package_code") or summary.get("package_code")
     )
-    active_addons = list(entitlement.get("active_addons") or [])
-
     resolved: dict[str, Any] = {}
     embedded_resolved = entitlement.get("resolved_entitlements")
     if isinstance(embedded_resolved, dict) and embedded_resolved:
@@ -112,7 +110,7 @@ def _resolve_project_link_scope(project_id: str) -> dict[str, Any]:
 
     if not resolved and package_code:
         try:
-            resolved = resolve_project_entitlements(package_code, active_addons)
+            resolved = resolve_project_entitlements(package_code, [])
         except Exception:
             resolved = {}
 

--- a/backend/tests/test_legacy_snapshot_package_contract.py
+++ b/backend/tests/test_legacy_snapshot_package_contract.py
@@ -302,6 +302,8 @@ class FamilyEstateConciergePackageContractTests(unittest.TestCase):
                 "on_site_photo_scanning",
                 "additional_narration_minute",
                 "white_glove_archive_support",
+                "extra_linked_household",
+                "extra_branch",
                 *NFT_ADDON_CODES,
             ],
         )
@@ -372,6 +374,7 @@ class CommandStructureNetworkPackageContractTests(unittest.TestCase):
                 "extra_storage",
                 "rush_delivery",
                 "command_report_addon",
+                "extra_org_node",
                 *NFT_ADDON_CODES,
             ],
         )
@@ -433,7 +436,7 @@ class EntitlementAddonBoundaryTests(unittest.TestCase):
         self.assertFalse(can_purchase_addon("legacy_plus", "extra_storage"))
         self.assertFalse(can_purchase_addon("legacy_plus", "extra_linked_household"))
 
-    def test_family_estate_concierge_disallows_silent_branch_cap_expansion_addons(self):
+    def test_family_estate_concierge_expansion_addons_match_published_capacity_products(self):
         resolved = resolve_project_entitlements(
             "family_estate_concierge",
             [
@@ -442,19 +445,20 @@ class EntitlementAddonBoundaryTests(unittest.TestCase):
                 "white_glove_archive_support",
             ],
         )
-        self.assertEqual(resolved.get("max_households"), 3)
+        self.assertEqual(resolved.get("max_households"), 5)
+        self.assertEqual(resolved.get("max_family_branches"), 4)
         self.assertEqual(
             list(resolved.get("active_addons") or []),
-            ["white_glove_archive_support"],
+            ["extra_linked_household", "extra_branch", "white_glove_archive_support"],
         )
 
-    def test_family_estate_concierge_cannot_purchase_silent_branch_cap_expansion_addons(self):
-        self.assertFalse(
+    def test_family_estate_concierge_can_purchase_published_expansion_addons(self):
+        self.assertTrue(
             can_purchase_addon("family_estate_concierge", "extra_linked_household")
         )
-        self.assertFalse(can_purchase_addon("family_estate_concierge", "extra_branch"))
+        self.assertTrue(can_purchase_addon("family_estate_concierge", "extra_branch"))
 
-    def test_command_structure_network_disallows_org_node_cap_expansion_addon(self):
+    def test_command_structure_network_extra_node_matches_published_capacity_product(self):
         resolved = resolve_project_entitlements(
             "command_structure_network",
             [
@@ -463,14 +467,14 @@ class EntitlementAddonBoundaryTests(unittest.TestCase):
                 "command_report_addon",
             ],
         )
-        self.assertEqual(resolved.get("max_org_nodes"), 15)
+        self.assertEqual(resolved.get("max_org_nodes"), 16)
         self.assertEqual(
             list(resolved.get("active_addons") or []),
-            ["extra_admin_seat", "command_report_addon"],
+            ["extra_org_node", "extra_admin_seat", "command_report_addon"],
         )
 
-    def test_command_structure_network_cannot_purchase_extra_org_node_addon(self):
-        self.assertFalse(can_purchase_addon("command_structure_network", "extra_org_node"))
+    def test_command_structure_network_can_purchase_extra_org_node_addon(self):
+        self.assertTrue(can_purchase_addon("command_structure_network", "extra_org_node"))
 
 
 class LegacySnapshotGatingRegressionTests(unittest.TestCase):

--- a/backend/tests/test_step6_product_entitlement_truth.py
+++ b/backend/tests/test_step6_product_entitlement_truth.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from app.core.commercial_catalog_overlay import COMMERCIAL_ADDON_SKUS
+from app.core.package_catalog import get_addon, get_addon_catalog, get_package
+from app.services import entitlement_service, order_service
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _published_checkout_addons() -> dict[str, dict[str, str]]:
+    source = (REPO_ROOT / "config.js").read_text(encoding="utf-8")
+    start = source.index("addons: [")
+    end = source.index("maintenance: [", start)
+    section = source[start:end]
+    products: dict[str, dict[str, str]] = {}
+    for block in re.findall(r"\{\s*category:.*?\n\s*\},", section, flags=re.DOTALL):
+        slug_match = re.search(r'slug:\s*"([^"]+)"', block)
+        name_match = re.search(r'name:\s*"([^"]+)"', block)
+        price_match = re.search(r'priceLabel:\s*"([^"]+)"', block)
+        checkout_match = re.search(r'checkoutUrl:\s*"([^"]*)"', block)
+        if not slug_match or not name_match or not price_match or not checkout_match:
+            continue
+        if not checkout_match.group(1).strip():
+            continue
+        products[slug_match.group(1)] = {
+            "name": name_match.group(1),
+            "price_label": price_match.group(1),
+            "checkout_url": checkout_match.group(1),
+        }
+    return products
+
+
+def _first_dollar_amount(label: str) -> float:
+    match = re.search(r"\$([0-9][0-9,]*(?:\.[0-9]+)?)", label)
+    assert match, f"Missing published dollar amount: {label}"
+    return float(match.group(1).replace(",", ""))
+
+
+def _checkout_session(*, code: str, name: str, dollars: float, interval: str = "") -> dict:
+    recurring = {"interval": interval} if interval else {}
+    return {
+        "id": f"cs_{code}",
+        "status": "complete",
+        "payment_status": "paid",
+        "amount_total": int(round(dollars * 100)),
+        "currency": "usd",
+        "metadata": {"item_type": "addon", "addon_code": code},
+        "line_items": {
+            "data": [
+                {
+                    "quantity": 1,
+                    "description": name,
+                    "price": {
+                        "id": f"price_{code}",
+                        "unit_amount": int(round(dollars * 100)),
+                        "currency": "usd",
+                        "recurring": recurring,
+                        "product": {
+                            "id": f"prod_{code}",
+                            "name": name,
+                            "metadata": {"addon_code": code},
+                        },
+                    },
+                }
+            ]
+        },
+    }
+
+
+def test_every_published_paid_addon_has_exact_server_catalog_name_and_price():
+    published = _published_checkout_addons()
+    catalog = get_addon_catalog()
+    missing = sorted(set(published) - set(catalog))
+    assert missing == []
+
+    mismatches: list[str] = []
+    for sku, public in published.items():
+        addon = get_addon(sku) or {}
+        public_price = _first_dollar_amount(public["price_label"])
+        if str(addon.get("display_name") or "") != public["name"]:
+            mismatches.append(
+                f"{sku}: name public={public['name']!r} backend={addon.get('display_name')!r}"
+            )
+        if float(addon.get("price_usd") or 0) != public_price:
+            mismatches.append(
+                f"{sku}: price public={public_price} backend={addon.get('price_usd')!r}"
+            )
+    assert mismatches == []
+
+
+def test_overlay_contains_every_published_non_nft_checkout_sku():
+    published = _published_checkout_addons()
+    assert set(published).issubset(set(COMMERCIAL_ADDON_SKUS))
+
+
+def test_stripe_verifier_accepts_current_portrait_polish_price_and_rejects_stale_price():
+    purchase = order_service._extract_verified_catalog_purchase_from_session(
+        _checkout_session(code="portrait_polish", name="Portrait Polish", dollars=99)
+    )
+    assert purchase["addon_code"] == "portrait_polish"
+    assert purchase["amount_cents"] == 9900
+
+    with pytest.raises(ValueError, match="do not match"):
+        order_service._extract_verified_catalog_purchase_from_session(
+            _checkout_session(code="portrait_polish", name="Portrait Polish", dollars=79)
+        )
+
+
+def test_stripe_verifier_accepts_recurring_storage_and_admin_seat_skus():
+    storage = order_service._extract_verified_catalog_purchase_from_session(
+        _checkout_session(
+            code="extra_storage_10gb_monthly",
+            name="Extra Storage +10GB Monthly",
+            dollars=15,
+            interval="month",
+        )
+    )
+    assert storage["addon_code"] == "extra_storage_10gb_monthly"
+    assert storage["billing_plan"] == "monthly"
+
+    admin_seat = order_service._extract_verified_catalog_purchase_from_session(
+        _checkout_session(
+            code="extra_admin_seat_yearly",
+            name="Extra Admin Seat Annual",
+            dollars=190,
+            interval="year",
+        )
+    )
+    assert admin_seat["addon_code"] == "extra_admin_seat_yearly"
+    assert admin_seat["billing_plan"] == "yearly"
+
+
+def test_family_estate_paid_expansion_skus_are_allowed_and_expand_scope():
+    package = get_package("family_estate_concierge") or {}
+    assert "extra_linked_household" in (package.get("allowed_addons") or [])
+    assert "extra_branch" in (package.get("allowed_addons") or [])
+    assert entitlement_service.can_purchase_addon(
+        "family_estate_concierge", "extra_linked_household"
+    )
+    assert entitlement_service.can_purchase_addon("family_estate_concierge", "extra_branch")
+
+    resolved = entitlement_service.resolve_project_entitlements(
+        "family_estate_concierge",
+        ["extra_linked_household", "extra_branch"],
+    )
+    assert resolved["max_households"] == 5
+    assert resolved["max_family_branches"] == 4
+    assert resolved["can_link_households"] is True
+
+
+def test_command_extra_node_is_allowed_and_expands_node_limit():
+    package = get_package("command_structure_network") or {}
+    assert "extra_org_node" in (package.get("allowed_addons") or [])
+    assert entitlement_service.can_purchase_addon(
+        "command_structure_network", "extra_org_node"
+    )
+    resolved = entitlement_service.resolve_project_entitlements(
+        "command_structure_network", ["extra_org_node"]
+    )
+    assert resolved["max_org_nodes"] == 16
+
+
+def test_storage_variants_apply_the_purchased_capacity_not_a_generic_ten_gb():
+    resolved = entitlement_service.resolve_project_entitlements(
+        "family_estate_concierge", ["vault_expansion_50gb_yearly"]
+    )
+    assert resolved["max_storage_gb"] == 100.0
+
+
+def test_package_specific_rush_sku_cannot_cross_package_boundaries():
+    assert entitlement_service.can_purchase_addon(
+        "legacy_plus", "rush_delivery_legacy_plus"
+    )
+    assert not entitlement_service.can_purchase_addon(
+        "heirloom_legacy_tree", "rush_delivery_legacy_plus"
+    )
+
+
+def test_manual_service_skus_are_lane_scoped_without_fabricating_capacity():
+    assert entitlement_service.can_purchase_addon(
+        "legacy_plus", "family_correction_cycle"
+    )
+    assert not entitlement_service.can_purchase_addon(
+        "command_structure_network", "family_correction_cycle"
+    )
+    resolved = entitlement_service.resolve_project_entitlements(
+        "legacy_plus", ["family_correction_cycle"]
+    )
+    assert "family_correction_cycle" in resolved["active_addons"]
+    assert resolved["max_members"] == 30
+    assert resolved["max_storage_gb"] == 25


### PR DESCRIPTION
## Step 6 — Package / Pricing / Entitlement Truth

This PR fixes contradictions found between the live published checkout catalog and backend entitlement/catalog enforcement. It does not change Stripe Payment Link URLs, customer records, billing charges, Vault contents, blockchain state, or Continuity Kernel execution.

### Findings corrected
- Family Estate Concierge publicly sells Extra Linked Household / Extra Branch, but backend package policy rejected both.
- Command Structure Network publicly sells Extra Organization Node, but backend package policy rejected it.
- Multiple published add-on prices differed from backend verification amounts (e.g. Portrait Polish, Tribute Narration, Extra Linked Household, Extra Org Node, Command Report).
- Recurring storage/vault/admin-seat SKUs existed in `config.js` but were not recognized as exact backend catalog products, causing valid Stripe sessions to fail exact product verification.
- Package-specific rush SKUs likewise lacked exact server catalog identities.

### Implementation
- Adds a commercial SKU overlay containing exact published product names/prices while leaving checkout URLs in `config.js`.
- Applies the overlay to the existing package/add-on dictionaries at core import so all existing `get_package()` / `get_addon()` callers share the same corrected truth.
- Adds explicit SKU -> entitlement effect mapping for storage capacity, members, zoom layers, linked households/branches, organization nodes/levels, and admin seats.
- Adds package-specific restrictions for rush and expansion SKUs.
- Allows lane-scoped manual service products to be verified as paid orders without fabricating capacity effects.
- Adds Family Estate expansion and Command node expansion to their canonical package allowlists.

### Verification
`backend/tests/test_step6_product_entitlement_truth.py` dynamically parses all paid add-ons in `config.js` and requires every published checkout SKU to have the exact same server-side product name and dollar amount. It also verifies exact Stripe-session validation, recurring variants, Family Estate expansion, Command nodes, purchased storage capacity, package-specific rush boundaries, and manual-service lane scope.

### Safety boundary
No Stripe links or prices on the public frontend are changed by this PR. No live payment is executed. No production MongoDB rows are migrated or mutated. Historical generic add-on codes remain supported.