### PR TITLE
Step 7: verified package acquisition and Link Key access truth

### DIFF
--- a/backend/app/services/link_key_service.py
+++ b/backend/app/services/link_key_service.py
@@ -8,11 +8,13 @@ from typing import Any
 from bson import ObjectId
 
 from app.config import settings
-from app.core.package_catalog import get_package
 from app.core.role_catalog import normalize_project_member_role
 from app.database import get_database
 from app.services.audit_log_service import create_audit_log
-from app.services.entitlement_service import resolve_project_entitlements
+from app.services.package_acquisition_service import (
+    ProjectAcquisitionError,
+    resolve_verified_project_acquisition,
+)
 from app.services.project_membership_service import (
     get_project_access_snapshot,
     list_accessible_project_ids,
@@ -45,16 +47,6 @@ def _keys_collection():
 def _projects_collection():
     db = get_database()
     return db["projects"]
-
-
-def _entitlements_collection():
-    db = get_database()
-    return db["project_entitlements"]
-
-
-def _orders_collection():
-    db = get_database()
-    return db["orders"]
 
 
 def _families_collection():
@@ -104,31 +96,13 @@ def _project_id_candidates(project_id: str) -> list[Any]:
     return values
 
 
-def _is_paid_package_order(order: dict[str, Any] | None) -> bool:
-    if not isinstance(order, dict):
-        return False
-
-    item_type = _normalize_value(order.get("item_type") or "package").lower()
-    status = _normalize_value(order.get("status")).lower()
-
-    return item_type == "package" and status in {
-        "paid",
-        "complete",
-        "completed",
-        "succeeded",
-    }
-
-
-def _get_paid_package_order(project_id: str) -> dict[str, Any] | None:
-    cursor = _orders_collection().find(
-        {"project_id": {"$in": _project_id_candidates(project_id)}}
-    ).sort("created_at", -1)
-
-    for order in cursor:
-        if _is_paid_package_order(order):
-            return order
-
-    return None
+def _verified_acquisition(project_id: str) -> dict[str, Any] | None:
+    try:
+        return resolve_verified_project_acquisition(project_id)
+    except ProjectAcquisitionError:
+        return None
+    except Exception:
+        return None
 
 
 def _serialize_key(document: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -179,17 +153,10 @@ def get_project_summary(project_id: str) -> dict[str, Any] | None:
 
     raw_id = project.get("_id")
     project_id_str = str(raw_id)
-    entitlement = _get_project_entitlement(project_id_str)
-    paid_order = _get_paid_package_order(project_id_str)
-    package_code = str(
-        (entitlement or {}).get("package_code")
-        or (paid_order or {}).get("package_code")
-        or (paid_order or {}).get("package_slug")
-        or project.get("package_code")
-        or project.get("package_slug")
-        or ""
-    ).strip()
-    package = get_package(package_code) or {}
+    acquisition = _verified_acquisition(project_id_str)
+    entitlement = (acquisition or {}).get("entitlement") or {}
+    acquisition_record = (acquisition or {}).get("acquisition_record") or {}
+    package_code = _normalize_value((acquisition or {}).get("package_code"))
 
     return {
         "project_id": str(raw_id),
@@ -197,23 +164,20 @@ def get_project_summary(project_id: str) -> dict[str, Any] | None:
         "owner_user_id": str(project.get("owner_user_id") or "").strip(),
         "owner_email": str(project.get("owner_email") or "").strip(),
         "package_code": package_code or None,
-        "package_name": str(
-            (entitlement or {}).get("package_name")
-            or (paid_order or {}).get("package_name")
+        "package_name": _normalize_value(
+            entitlement.get("package_name")
+            or acquisition_record.get("package_name")
             or project.get("package_name")
-            or package.get("display_name")
-            or ""
-        ).strip()
+        )
         or None,
-        "package_lane": str(
-            (entitlement or {}).get("package_lane")
-            or project.get("project_lane")
-            or package.get("package_lane")
-            or ""
-        ).strip()
+        "package_lane": _normalize_value(
+            (acquisition or {}).get("package_lane")
+            or entitlement.get("package_lane")
+        )
         or None,
         "household_id": str(project.get("household_id") or "").strip() or None,
         "family_id": str(project.get("family_id") or "").strip() or None,
+        "acquisition_source": _normalize_value((acquisition or {}).get("acquisition_source")) or None,
     }
 
 
@@ -233,11 +197,6 @@ def _can_user_access_project(
         email=str(user_email or "").strip().lower(),
     )
     return bool(access_snapshot.get("accessible"))
-
-
-def _get_project_entitlement(project_id: str) -> dict[str, Any] | None:
-    entitlements = _entitlements_collection()
-    return entitlements.find_one({"project_id": str(project_id), "status": "active"}) or entitlements.find_one({"project_id": str(project_id)})
 
 
 def _load_user_identity(user_id: str) -> tuple[str, str]:
@@ -296,62 +255,24 @@ def _family_allows_user_access(
 
 
 def _project_has_access_signal(project_id: str, project: dict[str, Any]) -> bool:
-    if _get_project_entitlement(project_id) or _get_paid_package_order(project_id):
-        return True
-
-    return bool(
-        _normalize_value(
-            project.get("package_code")
-            or project.get("package_slug")
-            or project.get("package_type")
-        )
-    )
+    del project
+    return _verified_acquisition(project_id) is not None
 
 
 def project_supports_link_keys(project_id: str) -> bool:
-    entitlement = _get_project_entitlement(project_id)
-    if entitlement:
-        try:
-            resolved = resolve_project_entitlements(
-                str(entitlement.get("package_code") or "").strip(),
-                list(entitlement.get("active_addons", [])),
-            )
-        except Exception:
-            resolved = entitlement.get("resolved_entitlements") or {}
-        if "can_use_link_keys" in resolved:
-            return bool(resolved.get("can_use_link_keys"))
-
-    paid_order = _get_paid_package_order(project_id)
-    package_code = str(
-        (paid_order or {}).get("package_code")
-        or (paid_order or {}).get("package_slug")
-        or ""
-    ).strip()
-    package = get_package(package_code) or {}
-    return bool(package.get("can_use_link_keys", False))
+    acquisition = _verified_acquisition(project_id)
+    if not acquisition:
+        return False
+    resolved = acquisition.get("resolved_entitlements") or {}
+    return bool(resolved.get("can_use_link_keys"))
 
 
 def project_supports_household_links(project_id: str) -> bool:
-    entitlement = _get_project_entitlement(project_id)
-    if entitlement:
-        try:
-            resolved = resolve_project_entitlements(
-                str(entitlement.get("package_code") or "").strip(),
-                list(entitlement.get("active_addons", [])),
-            )
-        except Exception:
-            resolved = entitlement.get("resolved_entitlements") or {}
-        if "can_link_households" in resolved:
-            return bool(resolved.get("can_link_households"))
-
-    paid_order = _get_paid_package_order(project_id)
-    package_code = str(
-        (paid_order or {}).get("package_code")
-        or (paid_order or {}).get("package_slug")
-        or ""
-    ).strip()
-    package = get_package(package_code) or {}
-    return bool(package.get("can_link_households", False))
+    acquisition = _verified_acquisition(project_id)
+    if not acquisition:
+        return False
+    resolved = acquisition.get("resolved_entitlements") or {}
+    return bool(resolved.get("can_link_households"))
 
 
 def user_can_access_project(
@@ -359,8 +280,8 @@ def user_can_access_project(
     user_id: str,
     user_email: str = "",
 ) -> bool:
-    summary = get_project_summary(project_id)
-    if not summary:
+    project = get_project_by_id(project_id)
+    if not project:
         return False
 
     if not _can_user_access_project(
@@ -368,9 +289,6 @@ def user_can_access_project(
         user_id=user_id,
         user_email=user_email,
     ):
-        return False
-    project = get_project_by_id(project_id)
-    if not project:
         return False
     return _project_has_access_signal(str(project.get("_id")), project)
 
@@ -573,8 +491,8 @@ def generate_link_key(
         raise ValueError("This package does not include link capabilities.")
 
     project_summary = get_project_summary(project_id)
-    if not project_summary:
-        raise ValueError("Project not found.")
+    if not project_summary or not project_summary.get("package_code"):
+        raise ValueError("Project does not have a verified package acquisition.")
 
     keys = _keys_collection()
     now = _utcnow_iso()

--- a/backend/app/services/package_acquisition_service.py
+++ b/backend/app/services/package_acquisition_service.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bson import ObjectId
+
+from app.core.package_mapping import resolve_package_identity
+from app.core.package_type_catalog import normalize_package_type
+from app.database import DatabaseUnavailableError, get_database
+from app.services.audit_log_service import create_audit_log
+from app.services.entitlement_service import resolve_project_entitlements
+
+PAID_PACKAGE_STATUSES = frozenset({"paid", "complete", "completed", "succeeded"})
+GOVERNED_PACKAGE_GRANT_TYPES = frozenset(
+    {"complimentary_package", "promotional_package", "internal_validation_account"}
+)
+GOVERNED_PACKAGE_GRANT_SOURCE = "ceo_admin_assignment"
+GOVERNED_PACKAGE_GRANT_AUTHORITY = "ceo_master_admin"
+
+_logger = logging.getLogger(__name__)
+
+
+class ProjectAcquisitionError(PermissionError):
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = str(reason or "").strip()
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _to_object_id(value: Any) -> ObjectId | None:
+    try:
+        return ObjectId(str(value))
+    except Exception:
+        return None
+
+
+def _project_id_candidates(project_id: str) -> list[Any]:
+    normalized = _normalize(project_id)
+    if not normalized:
+        return []
+    candidates: list[Any] = [normalized]
+    oid = _to_object_id(normalized)
+    if oid is not None:
+        candidates.append(oid)
+    return candidates
+
+
+def _db():
+    try:
+        db = get_database()
+    except DatabaseUnavailableError as exc:
+        raise ProjectAcquisitionError(
+            "database_unavailable", "Database is not connected."
+        ) from exc
+    if db is None:
+        raise ProjectAcquisitionError("database_unavailable", "Database is not connected.")
+    return db
+
+
+def _get_active_entitlement(project_id: str) -> dict[str, Any] | None:
+    return _db()["project_entitlements"].find_one(
+        {"project_id": {"$in": _project_id_candidates(project_id)}, "status": "active"}
+    )
+
+
+def _is_paid_package_order(order: dict[str, Any] | None) -> bool:
+    if not isinstance(order, dict):
+        return False
+    item_type = _normalize(order.get("item_type") or "package").lower()
+    status = _normalize(order.get("status")).lower()
+    return item_type == "package" and status in PAID_PACKAGE_STATUSES
+
+
+def _get_paid_package_order(project_id: str) -> dict[str, Any] | None:
+    cursor = _db()["orders"].find(
+        {"project_id": {"$in": _project_id_candidates(project_id)}}
+    ).sort("created_at", -1)
+    for order in cursor:
+        if _is_paid_package_order(order):
+            return order
+    return None
+
+
+def _is_governed_package_assignment(assignment: dict[str, Any] | None) -> bool:
+    if not isinstance(assignment, dict):
+        return False
+    return bool(
+        _normalize(assignment.get("status")).lower() == "active"
+        and assignment.get("payment_required") is False
+        and _normalize(assignment.get("source")).lower() == GOVERNED_PACKAGE_GRANT_SOURCE
+        and _normalize(assignment.get("authorization_source")).lower()
+        == GOVERNED_PACKAGE_GRANT_AUTHORITY
+        and _normalize(assignment.get("billing_classification")).lower()
+        in GOVERNED_PACKAGE_GRANT_TYPES
+        and _normalize(assignment.get("new_package"))
+    )
+
+
+def _get_active_governed_package_assignment(project_id: str) -> dict[str, Any] | None:
+    cursor = _db()["admin_package_assignments"].find(
+        {"project_id": {"$in": _project_id_candidates(project_id)}, "status": "active"}
+    ).sort("assigned_at", -1)
+    for assignment in cursor:
+        if _is_governed_package_assignment(assignment):
+            return assignment
+    return None
+
+
+def _package_code_from_identity(value: Any) -> str:
+    identity = resolve_package_identity(value)
+    return _normalize(identity.get("package_code") or value)
+
+
+def _package_lane_from_identity(value: Any, fallback: Any = "") -> str:
+    identity = resolve_package_identity(value)
+    return normalize_package_type(
+        _normalize(fallback or identity.get("package_lane") or identity.get("lane")),
+        default="",
+    )
+
+
+def _audit_drift(
+    project_id: str,
+    reason: str,
+    *,
+    entitlement: dict[str, Any] | None = None,
+    paid_order: dict[str, Any] | None = None,
+    governed_assignment: dict[str, Any] | None = None,
+) -> None:
+    try:
+        create_audit_log(
+            "verified_package_acquisition_drift",
+            None,
+            "project",
+            _normalize(project_id),
+            {
+                "reason": _normalize(reason),
+                "entitlement_package_code": _normalize((entitlement or {}).get("package_code")),
+                "entitlement_package_lane": _normalize((entitlement or {}).get("package_lane")),
+                "paid_order_id": _normalize((paid_order or {}).get("_id")) or None,
+                "paid_order_package_code": _normalize(
+                    (paid_order or {}).get("package_code") or (paid_order or {}).get("package_slug")
+                )
+                or None,
+                "governed_assignment_id": _normalize((governed_assignment or {}).get("_id")) or None,
+                "governed_assignment_package_code": _normalize(
+                    (governed_assignment or {}).get("new_package")
+                )
+                or None,
+                "governed_assignment_authority": _normalize(
+                    (governed_assignment or {}).get("authorization_source")
+                )
+                or None,
+            },
+        )
+    except Exception as exc:
+        _logger.warning(
+            "verified_package_acquisition_audit_failed",
+            extra={"project_id": _normalize(project_id), "reason": _normalize(reason)},
+            exc_info=exc,
+        )
+
+
+def resolve_verified_project_acquisition(project_id: str) -> dict[str, Any]:
+    """Verify the package authority behind a protected customer workspace.
+
+    A workspace is valid only when it has an active entitlement plus one of
+    the two supported acquisition authorities:
+
+    1. an authoritative paid package order, or
+    2. an active CEO-governed complimentary/promotional/internal-validation
+       assignment that explicitly records payment_required=False.
+
+    Raw package fields stored on a project document are never an acquisition
+    authority and cannot unlock protected capabilities.
+    """
+
+    normalized_project_id = _normalize(project_id)
+    if not normalized_project_id:
+        raise ProjectAcquisitionError("no_active_project", "Workspace project id is required.")
+
+    entitlement = _get_active_entitlement(normalized_project_id)
+    if entitlement is None:
+        _audit_drift(normalized_project_id, "missing_active_entitlement")
+        raise ProjectAcquisitionError(
+            "missing_active_entitlement",
+            "Active workspace entitlement is required.",
+        )
+
+    entitlement_package_code = _package_code_from_identity(entitlement.get("package_code"))
+    entitlement_lane = _package_lane_from_identity(
+        entitlement.get("package_code"),
+        entitlement.get("package_lane"),
+    )
+    if not entitlement_package_code:
+        _audit_drift(
+            normalized_project_id,
+            "unresolved_package_identity",
+            entitlement=entitlement,
+        )
+        raise ProjectAcquisitionError(
+            "entitlement_package_mismatch",
+            "Workspace entitlement package identity could not be verified.",
+        )
+
+    paid_order = _get_paid_package_order(normalized_project_id)
+    governed_assignment = _get_active_governed_package_assignment(normalized_project_id)
+
+    sources: list[dict[str, Any]] = []
+    if paid_order is not None:
+        paid_code_raw = paid_order.get("package_code") or paid_order.get("package_slug")
+        sources.append(
+            {
+                "source": "paid_order",
+                "record": paid_order,
+                "package_code": _package_code_from_identity(paid_code_raw),
+                "package_lane": _package_lane_from_identity(
+                    paid_code_raw,
+                    paid_order.get("package_lane") or paid_order.get("project_lane"),
+                ),
+                "payment_required": True,
+            }
+        )
+    if governed_assignment is not None:
+        grant_code_raw = governed_assignment.get("new_package")
+        sources.append(
+            {
+                "source": "governed_grant",
+                "record": governed_assignment,
+                "package_code": _package_code_from_identity(grant_code_raw),
+                "package_lane": _package_lane_from_identity(grant_code_raw),
+                "payment_required": False,
+            }
+        )
+
+    if not sources:
+        _audit_drift(
+            normalized_project_id,
+            "missing_acquisition_source",
+            entitlement=entitlement,
+        )
+        raise ProjectAcquisitionError(
+            "missing_acquisition_source",
+            "A verified paid package order or CEO-governed package grant is required.",
+        )
+
+    matching_sources = [
+        source for source in sources if source.get("package_code") == entitlement_package_code
+    ]
+    if not matching_sources:
+        _audit_drift(
+            normalized_project_id,
+            "package_code_mismatch",
+            entitlement=entitlement,
+            paid_order=paid_order,
+            governed_assignment=governed_assignment,
+        )
+        raise ProjectAcquisitionError(
+            "package_code_mismatch",
+            "Workspace entitlement does not match its verified package acquisition authority.",
+        )
+
+    # Prefer a paid acquisition when both authorities happen to describe the
+    # same current package; otherwise the matching governed grant is valid.
+    selected = next(
+        (source for source in matching_sources if source.get("source") == "paid_order"),
+        matching_sources[0],
+    )
+    source_lane = _normalize(selected.get("package_lane"))
+    if not entitlement_lane or not source_lane:
+        _audit_drift(
+            normalized_project_id,
+            "missing_package_lane",
+            entitlement=entitlement,
+            paid_order=paid_order,
+            governed_assignment=governed_assignment,
+        )
+        raise ProjectAcquisitionError(
+            "entitlement_lane_mismatch",
+            "Workspace package lane could not be verified.",
+        )
+    if entitlement_lane != source_lane:
+        _audit_drift(
+            normalized_project_id,
+            "entitlement_lane_mismatch",
+            entitlement=entitlement,
+            paid_order=paid_order,
+            governed_assignment=governed_assignment,
+        )
+        raise ProjectAcquisitionError(
+            "entitlement_lane_mismatch",
+            "Workspace entitlement lane does not match its package acquisition authority.",
+        )
+
+    active_addons = list(entitlement.get("active_addons") or [])
+    try:
+        resolved_entitlements = resolve_project_entitlements(
+            entitlement_package_code,
+            active_addons,
+        )
+    except Exception as exc:
+        _audit_drift(
+            normalized_project_id,
+            "entitlement_resolution_failed",
+            entitlement=entitlement,
+            paid_order=paid_order,
+            governed_assignment=governed_assignment,
+        )
+        raise ProjectAcquisitionError(
+            "missing_active_entitlement",
+            "Workspace entitlement could not be resolved.",
+        ) from exc
+
+    acquisition_source = _normalize(selected.get("source"))
+    acquisition_record = selected.get("record") or {}
+    return {
+        "project_id": normalized_project_id,
+        "package_code": entitlement_package_code,
+        "package_lane": entitlement_lane,
+        "active_addons": active_addons,
+        "resolved_entitlements": resolved_entitlements,
+        "entitlement": entitlement,
+        "paid_order": paid_order if acquisition_source == "paid_order" else None,
+        "governed_assignment": (
+            governed_assignment if acquisition_source == "governed_grant" else None
+        ),
+        "acquisition_source": acquisition_source,
+        "acquisition_record": acquisition_record,
+        "payment_required": bool(selected.get("payment_required")),
+    }

--- a/backend/app/services/workspace_access_service.py
+++ b/backend/app/services/workspace_access_service.py
@@ -15,6 +15,10 @@ from app.core.admin_permission_registry import has_canonical_internal_admin_auth
 from app.database import get_database
 from app.services.audit_log_service import create_audit_log
 from app.services.entitlement_service import resolve_project_entitlements
+from app.services.package_acquisition_service import (
+    ProjectAcquisitionError,
+    resolve_verified_project_acquisition,
+)
 from app.services.project_member_service import is_project_member
 from app.services.project_membership_service import get_project_access_snapshot
 
@@ -47,6 +51,7 @@ WORKSPACE_PIPELINE_READY_STATUSES = {
 }
 ENTITLEMENT_BLOCKING_REASON_MAP = {
     "missing_paid_order": "no_paid_order",
+    "missing_acquisition_source": "no_verified_package_acquisition",
     "missing_active_entitlement": "missing_active_entitlement",
     "package_code_mismatch": "entitlement_package_mismatch",
     "package_lane_mismatch": "entitlement_lane_mismatch",
@@ -909,29 +914,39 @@ def _resolve_project_entitlement_map(
 ) -> dict[str, Any]:
     project_id = _normalize_value(project.get("_id") or project.get("id"))
     try:
-        return resolve_strict_paid_active_project_entitlement(project_id)
-    except WorkspaceEntitlementError as exc:
+        return resolve_verified_project_acquisition(project_id)
+    except ProjectAcquisitionError as exc:
         blocking_reason = _effective_workspace_blocking_reason(exc.reason)
-        if current_user and blocking_reason in {
-            "missing_active_entitlement",
-            "entitlement_package_mismatch",
-            "entitlement_lane_mismatch",
-        }:
+        if (
+            current_user
+            and _get_paid_package_order_for_project(project_id) is not None
+            and blocking_reason
+            in {
+                "missing_active_entitlement",
+                "entitlement_package_mismatch",
+                "entitlement_lane_mismatch",
+            }
+        ):
             try:
                 repair_workspace_entitlements_for_user(
                     _current_user_email(current_user) or _normalize_email(project.get("owner_email")),
                     project_id=project_id,
                     dry_run=False,
                 )
-                return resolve_strict_paid_active_project_entitlement(project_id)
+                return resolve_verified_project_acquisition(project_id)
             except Exception:
                 pass
         return {
             "package_code": "",
+            "package_lane": "",
             "active_addons": [],
             "resolved_entitlements": {},
             "entitlement": _get_active_project_entitlement(project_id),
             "paid_order": _get_paid_package_order_for_project(project_id),
+            "governed_assignment": None,
+            "acquisition_source": None,
+            "acquisition_record": None,
+            "payment_required": None,
             "blocking_reason": blocking_reason,
         }
 
@@ -1083,6 +1098,9 @@ def resolve_workspace_context(
         "resolved_entitlements": entitlement_map.get("resolved_entitlements") or {},
         "entitlement": entitlement_map.get("entitlement"),
         "paid_order": entitlement_map.get("paid_order"),
+        "governed_assignment": entitlement_map.get("governed_assignment"),
+        "acquisition_source": entitlement_map.get("acquisition_source"),
+        "payment_required": entitlement_map.get("payment_required"),
         "maintenance_access": maintenance_access,
         "access_snapshot": access_snapshot,
         "member_role": _normalize_value(access_snapshot.get("member_role") or "viewer") or "viewer",
@@ -1108,14 +1126,14 @@ def build_workspace_context_snapshot(
         user_role = "customer"
 
     intake = _latest_ready_intake_for_user(current_user)
-    paid_order = _get_paid_package_order_for_user(
+    paid_order_hint = _get_paid_package_order_for_user(
         current_user,
         project_id=_normalize_value(project_id),
     )
     resolved_project = _resolve_active_project_for_user(
         current_user,
         explicit_project_id=_normalize_value(project_id),
-        paid_order=paid_order,
+        paid_order=paid_order_hint,
         intake_submission=intake,
     )
     if resolved_project is None:
@@ -1188,32 +1206,22 @@ def build_workspace_context_snapshot(
             "active_entitlements": [],
         }
 
-    paid_order = _get_paid_package_order_for_project(project_doc_id)
-    if paid_order is None:
-        return {
-            "status": "blocked",
-            "blocking_reason": "no_paid_order",
-            "user": {"id": user_id, "email": user_email, "role": user_role},
-            "workspace": {"project_id": project_doc_id},
-            "package": {},
-            "entitlements": {},
-            "membership": {},
-            "active_project_id": project_doc_id or None,
-            "active_family_id": None,
-            "package_lane": "",
-            "active_entitlements": [],
-        }
-
     entitlement_state = _resolve_project_entitlement_map(
         resolved_project,
         current_user=current_user,
     )
     blocking_reason = _normalize_value(entitlement_state.get("blocking_reason"))
     resolved_entitlements = entitlement_state.get("resolved_entitlements") or {}
+    paid_order = entitlement_state.get("paid_order") or {}
+    governed_assignment = entitlement_state.get("governed_assignment") or {}
+    acquisition_record = entitlement_state.get("acquisition_record") or {}
+    acquisition_source = _normalize_value(entitlement_state.get("acquisition_source"))
+    payment_required = entitlement_state.get("payment_required")
     package_identity = resolve_package_identity(
         entitlement_state.get("package_code")
         or paid_order.get("package_code")
         or paid_order.get("package_slug")
+        or governed_assignment.get("new_package")
     )
     workspace_family_id = _normalize_value(
         (resolved_family or {}).get("_id") or (resolved_family or {}).get("id")
@@ -1238,18 +1246,28 @@ def build_workspace_context_snapshot(
         "display_name": _normalize_value(
             package_identity.get("display_name")
             or paid_order.get("package_name")
+            or resolved_project.get("package_name")
         ),
         "slug": _normalize_value(package_identity.get("package_slug")),
         "code": _normalize_value(
             package_identity.get("package_code")
             or paid_order.get("package_code")
+            or governed_assignment.get("new_package")
         ),
         "lane": _normalize_package_lane_or_type(
             package_identity.get("package_lane")
             or paid_order.get("package_lane")
             or paid_order.get("project_lane")
+            or entitlement_state.get("package_lane")
         ),
-        "status": "paid",
+        "status": (
+            "paid"
+            if acquisition_source == "paid_order" or paid_order
+            else "granted"
+            if acquisition_source == "governed_grant" or governed_assignment
+            else "unverified"
+        ),
+        "payment_required": payment_required,
     }
 
     response = {
@@ -1267,6 +1285,19 @@ def build_workspace_context_snapshot(
             "access_via": _normalize_value(membership_snapshot.get("via"))
             or "owner_fallback_or_project_member",
         },
+        "acquisition": {
+            "source": acquisition_source or None,
+            "payment_required": payment_required,
+            "record_id": _normalize_value(acquisition_record.get("_id")) or None,
+            "authorization_source": _normalize_value(
+                governed_assignment.get("authorization_source")
+            )
+            or None,
+            "billing_classification": _normalize_value(
+                governed_assignment.get("billing_classification")
+            )
+            or None,
+        },
         "active_project_id": project_doc_id or None,
         "active_family_id": workspace_family_id or None,
         "package_lane": package_payload.get("lane") or "",
@@ -1283,7 +1314,13 @@ def build_workspace_context_snapshot(
         response["status"] = "blocked"
         response["blocking_reason"] = blocking_reason or "missing_active_entitlement"
 
-    response["billing"] = {"blocking_reason": _billing_blocking_reason(current_user)}
+    response["billing"] = {
+        "blocking_reason": (
+            _billing_blocking_reason(current_user)
+            if acquisition_source == "paid_order"
+            else None
+        )
+    }
 
     return response
 

--- a/backend/tests/test_step7_link_access_truth.py
+++ b/backend/tests/test_step7_link_access_truth.py
@@ -1,0 +1,313 @@
+import unittest
+from unittest.mock import patch
+
+from app.services import link_key_service, package_acquisition_service
+from app.services.package_acquisition_service import ProjectAcquisitionError
+
+
+class VerifiedPackageAcquisitionTests(unittest.TestCase):
+    def _entitlement(self, code="family_estate_concierge", lane="network"):
+        return {
+            "status": "active",
+            "package_code": code,
+            "package_lane": lane,
+            "active_addons": [],
+        }
+
+    def test_paid_order_plus_active_entitlement_is_verified(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=self._entitlement(),
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_paid_package_order",
+                return_value={
+                    "_id": "order-1",
+                    "item_type": "package",
+                    "status": "paid",
+                    "package_code": "family_estate_concierge",
+                    "package_lane": "network",
+                },
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_active_governed_package_assignment",
+                return_value=None,
+            ),
+        ):
+            result = package_acquisition_service.resolve_verified_project_acquisition(
+                "69c0402387082765345cff8c"
+            )
+
+        self.assertEqual(result["acquisition_source"], "paid_order")
+        self.assertTrue(result["payment_required"])
+        self.assertEqual(result["package_code"], "family_estate_concierge")
+        self.assertTrue(result["resolved_entitlements"]["can_link_households"])
+
+    def test_governed_grant_plus_active_entitlement_is_verified(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=self._entitlement(),
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_paid_package_order",
+                return_value=None,
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_active_governed_package_assignment",
+                return_value={
+                    "_id": "assignment-1",
+                    "status": "active",
+                    "new_package": "family_estate_concierge",
+                    "source": "ceo_admin_assignment",
+                    "authorization_source": "ceo_master_admin",
+                    "billing_classification": "complimentary_package",
+                    "payment_required": False,
+                },
+            ),
+        ):
+            result = package_acquisition_service.resolve_verified_project_acquisition(
+                "69c0402387082765345cff8c"
+            )
+
+        self.assertEqual(result["acquisition_source"], "governed_grant")
+        self.assertFalse(result["payment_required"])
+        self.assertIsNone(result["paid_order"])
+        self.assertEqual(
+            result["governed_assignment"]["authorization_source"],
+            "ceo_master_admin",
+        )
+
+    def test_entitlement_without_verified_acquisition_fails_closed(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=self._entitlement(),
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_paid_package_order",
+                return_value=None,
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_active_governed_package_assignment",
+                return_value=None,
+            ),
+            patch.object(package_acquisition_service, "_audit_drift"),
+        ):
+            with self.assertRaises(ProjectAcquisitionError) as captured:
+                package_acquisition_service.resolve_verified_project_acquisition(
+                    "69c0402387082765345cff8c"
+                )
+
+        self.assertEqual(captured.exception.reason, "missing_acquisition_source")
+
+    def test_missing_active_entitlement_fails_even_with_paid_order(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=None,
+            ),
+            patch.object(package_acquisition_service, "_audit_drift"),
+        ):
+            with self.assertRaises(ProjectAcquisitionError) as captured:
+                package_acquisition_service.resolve_verified_project_acquisition(
+                    "69c0402387082765345cff8c"
+                )
+
+        self.assertEqual(captured.exception.reason, "missing_active_entitlement")
+
+    def test_package_mismatch_between_entitlement_and_acquisition_fails(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=self._entitlement("legacy_plus", "household"),
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_paid_package_order",
+                return_value={
+                    "item_type": "package",
+                    "status": "paid",
+                    "package_code": "family_estate_concierge",
+                    "package_lane": "network",
+                },
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_active_governed_package_assignment",
+                return_value=None,
+            ),
+            patch.object(package_acquisition_service, "_audit_drift"),
+        ):
+            with self.assertRaises(ProjectAcquisitionError) as captured:
+                package_acquisition_service.resolve_verified_project_acquisition(
+                    "69c0402387082765345cff8c"
+                )
+
+        self.assertEqual(captured.exception.reason, "package_code_mismatch")
+
+    def test_lane_mismatch_fails_closed(self):
+        with (
+            patch.object(
+                package_acquisition_service,
+                "_get_active_entitlement",
+                return_value=self._entitlement("family_estate_concierge", "household"),
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_paid_package_order",
+                return_value={
+                    "item_type": "package",
+                    "status": "paid",
+                    "package_code": "family_estate_concierge",
+                    "package_lane": "network",
+                },
+            ),
+            patch.object(
+                package_acquisition_service,
+                "_get_active_governed_package_assignment",
+                return_value=None,
+            ),
+            patch.object(package_acquisition_service, "_audit_drift"),
+        ):
+            with self.assertRaises(ProjectAcquisitionError) as captured:
+                package_acquisition_service.resolve_verified_project_acquisition(
+                    "69c0402387082765345cff8c"
+                )
+
+        self.assertEqual(captured.exception.reason, "entitlement_lane_mismatch")
+
+
+class LinkKeyVerifiedAcquisitionTests(unittest.TestCase):
+    def test_raw_project_package_metadata_cannot_unlock_link_keys(self):
+        with patch.object(
+            link_key_service,
+            "resolve_verified_project_acquisition",
+            side_effect=ProjectAcquisitionError(
+                "missing_acquisition_source",
+                "no verified acquisition",
+            ),
+        ):
+            allowed = link_key_service._project_has_access_signal(
+                "69c0402387082765345cff8c",
+                {
+                    "package_code": "family_estate_concierge",
+                    "package_slug": "family_estate_concierge",
+                    "package_type": "family_estate_concierge",
+                },
+            )
+
+        self.assertFalse(allowed)
+
+    def test_governed_family_estate_grant_can_support_household_links(self):
+        acquisition = {
+            "acquisition_source": "governed_grant",
+            "resolved_entitlements": {
+                "can_use_link_keys": True,
+                "can_link_households": True,
+            },
+        }
+        with patch.object(
+            link_key_service,
+            "resolve_verified_project_acquisition",
+            return_value=acquisition,
+        ):
+            self.assertTrue(
+                link_key_service.project_supports_household_links(
+                    "69c0402387082765345cff8c"
+                )
+            )
+            self.assertTrue(
+                link_key_service.project_supports_link_keys(
+                    "69c0402387082765345cff8c"
+                )
+            )
+
+    def test_legacy_plus_generic_link_entitlement_does_not_equal_branch_linking(self):
+        acquisition = {
+            "acquisition_source": "paid_order",
+            "resolved_entitlements": {
+                "can_use_link_keys": True,
+                "can_manage_link_keys": True,
+                "can_link_households": False,
+            },
+        }
+        with patch.object(
+            link_key_service,
+            "resolve_verified_project_acquisition",
+            return_value=acquisition,
+        ):
+            self.assertTrue(
+                link_key_service.project_supports_link_keys(
+                    "69c0402387082765345cff8c"
+                )
+            )
+            self.assertFalse(
+                link_key_service.project_supports_household_links(
+                    "69c0402387082765345cff8c"
+                )
+            )
+
+    def test_manager_role_must_be_owner_or_co_owner(self):
+        project = {"_id": "69c0402387082765345cff8c"}
+        acquisition = {
+            "acquisition_source": "paid_order",
+            "resolved_entitlements": {"can_link_households": True},
+        }
+        with (
+            patch.object(link_key_service, "get_project_by_id", return_value=project),
+            patch.object(
+                link_key_service,
+                "resolve_verified_project_acquisition",
+                return_value=acquisition,
+            ),
+            patch.object(
+                link_key_service,
+                "get_project_access_snapshot",
+                return_value={"accessible": True, "member_role": "viewer"},
+            ),
+        ):
+            self.assertFalse(
+                link_key_service.user_can_manage_project(
+                    "69c0402387082765345cff8c",
+                    "user-1",
+                    "user@example.com",
+                )
+            )
+
+        with (
+            patch.object(link_key_service, "get_project_by_id", return_value=project),
+            patch.object(
+                link_key_service,
+                "resolve_verified_project_acquisition",
+                return_value=acquisition,
+            ),
+            patch.object(
+                link_key_service,
+                "get_project_access_snapshot",
+                return_value={"accessible": True, "member_role": "co_owner"},
+            ),
+        ):
+            self.assertTrue(
+                link_key_service.user_can_manage_project(
+                    "69c0402387082765345cff8c",
+                    "user-1",
+                    "user@example.com",
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_workspace_context_snapshot.py
+++ b/backend/tests/test_workspace_context_snapshot.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from app.routes import users as users_routes
 from app.services import workspace_access_service
+from app.services.package_acquisition_service import ProjectAcquisitionError
 
 
 class WorkspaceContextRouteTests(unittest.TestCase):
@@ -50,27 +51,36 @@ class WorkspaceContextRouteTests(unittest.TestCase):
 
 
 class WorkspaceEntitlementRepairTests(unittest.TestCase):
-    def test_entitlement_map_attempts_repair_for_package_mismatch(self):
+    def test_entitlement_map_attempts_repair_for_paid_package_mismatch(self):
         project = {"_id": "69c0402387082765345cff8c"}
         current_user = {"id": "user-1", "email": "larrycr27@gmail.com"}
         strict_result = {
             "package_code": "legacy_plus",
+            "package_lane": "household",
             "active_addons": [],
             "resolved_entitlements": {"can_use_link_keys": True},
             "entitlement": {"status": "active"},
             "paid_order": {"status": "paid"},
+            "governed_assignment": None,
+            "acquisition_source": "paid_order",
+            "payment_required": True,
         }
         with (
             patch.object(
                 workspace_access_service,
-                "resolve_strict_paid_active_project_entitlement",
+                "resolve_verified_project_acquisition",
                 side_effect=[
-                    workspace_access_service.WorkspaceEntitlementError(
+                    ProjectAcquisitionError(
                         "package_code_mismatch",
                         "mismatch",
                     ),
                     strict_result,
                 ],
+            ),
+            patch.object(
+                workspace_access_service,
+                "_get_paid_package_order_for_project",
+                return_value={"status": "paid"},
             ),
             patch.object(
                 workspace_access_service,
@@ -84,7 +94,46 @@ class WorkspaceEntitlementRepairTests(unittest.TestCase):
             )
 
         self.assertEqual(result.get("package_code"), "legacy_plus")
+        self.assertEqual(result.get("acquisition_source"), "paid_order")
         repair_mock.assert_called_once()
+
+    def test_governed_grant_does_not_require_paid_order_repair(self):
+        project = {"_id": "69c0402387082765345cff8c"}
+        current_user = {"id": "user-1", "email": "customer@example.com"}
+        grant_result = {
+            "package_code": "family_estate_concierge",
+            "package_lane": "network",
+            "active_addons": [],
+            "resolved_entitlements": {"can_link_households": True},
+            "entitlement": {"status": "active"},
+            "paid_order": None,
+            "governed_assignment": {
+                "status": "active",
+                "authorization_source": "ceo_master_admin",
+                "billing_classification": "complimentary_package",
+            },
+            "acquisition_source": "governed_grant",
+            "payment_required": False,
+        }
+        with (
+            patch.object(
+                workspace_access_service,
+                "resolve_verified_project_acquisition",
+                return_value=grant_result,
+            ),
+            patch.object(
+                workspace_access_service,
+                "repair_workspace_entitlements_for_user",
+            ) as repair_mock,
+        ):
+            result = workspace_access_service._resolve_project_entitlement_map(
+                project,
+                current_user=current_user,
+            )
+
+        self.assertEqual(result.get("acquisition_source"), "governed_grant")
+        self.assertFalse(result.get("payment_required"))
+        repair_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean, flattened replacement for stacked PR #603 after PR #606 was validated and merged into the Step 7 branch.

This PR contains the exact final five-file Step 7 state that passed the full guardrail suite on the stacked branch, but rebased as one clean commit directly on current `main` so GitHub can merge it normally.

### Security invariant
Verified paid package order OR verified CEO-governed non-payment package assignment -> active entitlement -> workspace membership -> authorized role -> capability ALLOW. Otherwise fail closed.

### Includes
- removes raw project package metadata as a Link Key access signal
- supports legitimate CEO-governed complimentary/promotional/internal-validation package assignments without fabricating Stripe orders
- verifies package code and lane consistency
- handles DB unavailability fail-closed
- fixes workspace package status derivation
- preserves branch-link capability separately from generic Link Key capability
- focused Step 7 regression coverage

### Safety
No Stripe mutation, payment, production DB mutation, Vault mutation, blockchain action, or customer-data migration is performed by this code change.