### PR TITLE
Step 8: make customer dashboard reflect live workspace truth

### DIFF
--- a/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
+++ b/backend/tests/contracts/test_continuity_kernel_phase9_control_surface_security.py
@@ -13,6 +13,10 @@ CONTROL_JS_PATH = REPO_ROOT / "admin-control-center.js"
 MOBILE_CONTROL_JS_PATH = REPO_ROOT / "admin-control-center-mobile.js"
 APP_JS_PATH = REPO_ROOT / "app.js"
 AUTH_JS_PATH = REPO_ROOT / "auth.js"
+APP_CACHE_REVISION = "20260828-phase21-1"
+APP_CACHE_REVISION_OVERRIDES = {
+    "dashboard.html": "20260907-auth-hardening",
+}
 
 
 class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
@@ -122,7 +126,9 @@ class TestContinuityKernelPhase9ControlSurfaceSecurity(unittest.TestCase):
             if path.name in separately_managed_commercial_pages:
                 continue
             app_pages.append(path.name)
-            expected_revision = "20260828-phase21-1"
+            expected_revision = APP_CACHE_REVISION_OVERRIDES.get(
+                path.name, APP_CACHE_REVISION
+            )
             self.assertIn(f"app.js?v={expected_revision}", source, path.name)
             csp_match = re.search(
                 r'http-equiv="Content-Security-Policy"\s+content="([^"]+)"',

--- a/backend/tests/test_dashboard_and_client_security_integrity.py
+++ b/backend/tests/test_dashboard_and_client_security_integrity.py
@@ -13,7 +13,10 @@ AUDIT_CACHE_VERSION = "20260509-audit"
 SHARED_ASSET_CACHE_VERSION = "20260828-phase21-1"
 PORTAL_CACHE_OVERRIDES = {
     "dashboard.html": {
-        "dashboard-intake.js": "20260824-phase20",
+        "app.js": "20260907-auth-hardening",
+        "auth.js": "20260907-auth-hardening",
+        "dashboard-step8.js": "20260907-step8",
+        "dashboard-intake.js": "20260829-vault-ready",
     },
     "link-keys.html": {"link-keys.js": "20260823-phase13-1"},
     "portrait-upload.html": {

--- a/backend/tests/test_phase21_1_mobile_account_recovery.py
+++ b/backend/tests/test_phase21_1_mobile_account_recovery.py
@@ -8,6 +8,10 @@ from app.services import auth_service
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 REVISION = "20260828-phase21-1"
+SHARED_ASSET_REVISION_OVERRIDES = {
+    ("dashboard.html", "app.js"): "20260907-auth-hardening",
+    ("dashboard.html", "auth.js"): "20260907-auth-hardening",
+}
 
 
 class _Users:
@@ -172,17 +176,21 @@ class Phase211FrontendContractTests(TestCase):
             source = path.read_text(encoding="utf-8")
             for asset in ("styles.css", "config.js", "app.js", "auth.js"):
                 marker = f"{asset}?v="
-                allowed_revision = (
-                    "20260829-phase22"
-                    if path.name
-                    in {
-                        "portrait-upload.html",
-                        "verification-upload.html",
-                        "vault-upload.html",
-                    }
-                    and asset == "auth.js"
-                    else REVISION
+                allowed_revision = SHARED_ASSET_REVISION_OVERRIDES.get(
+                    (path.name, asset)
                 )
+                if allowed_revision is None:
+                    allowed_revision = (
+                        "20260829-phase22"
+                        if path.name
+                        in {
+                            "portrait-upload.html",
+                            "verification-upload.html",
+                            "vault-upload.html",
+                        }
+                        and asset == "auth.js"
+                        else REVISION
+                    )
                 if marker in source and f"{marker}{allowed_revision}" not in source:
                     stale.append(f"{path.relative_to(REPOSITORY_ROOT)}:{asset}")
 

--- a/backend/tests/test_step8_customer_dashboard_truth.py
+++ b/backend/tests/test_step8_customer_dashboard_truth.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_dashboard_truth_layer_load_order_and_cache_identity():
+    html = _read("dashboard.html")
+
+    auth = 'auth.js?v=20260907-auth-hardening'
+    truth = 'dashboard-step8.js?v=20260907-step8'
+    intake = 'dashboard-intake.js?v=20260829-vault-ready'
+
+    assert 'app.js?v=20260907-auth-hardening' in html
+    assert auth in html
+    assert truth in html
+    assert intake in html
+    assert 'dashboard-admin.js?v=20260713-livefix3' in html
+
+    assert html.index(auth) < html.index(truth) < html.index(intake)
+
+
+def test_dashboard_truth_layer_enforces_step8_invariants():
+    source = _read("dashboard-step8.js")
+
+    assert "can_link_households" in source
+    assert 'acquisitionSource === "paid_order"' in source
+    assert 'acquisitionSource === "governed_grant"' in source
+    assert "context.hasPaidPackage = hasVerifiedPaidPackage" in source
+    assert "context.paidOrder = null" in source
+    assert "state.read_only === true" in source
+    assert "state.in_grace === true" in source
+    assert "write_allowed" in source
+    assert "Restore Maintenance Billing" in source
+    assert "These indicators describe workflow status, not a file inventory" in source
+
+
+def test_dashboard_browser_contract_no_longer_treats_generic_link_keys_as_branch_access():
+    source = _read("browser-tests/dashboard-customer-phase20.spec.mjs")
+
+    assert "can_link_households: false" in source
+    assert "toBeHidden()" in source
+    assert "acquisitionSource: \"paid_order\"" in source
+
+
+def test_step8_browser_contract_covers_grants_branch_links_and_maintenance():
+    source = _read("browser-tests/dashboard-step8-truth.spec.mjs")
+
+    assert "Family Estate exposes household branch Link Keys" in source
+    assert "CEO-governed grant stays accessible without becoming a paid package" in source
+    assert "maintenance grace is visible" in source
+    assert "read-only maintenance makes billing the next action" in source
+    assert "desktop layout stays within the viewport" in source

--- a/browser-tests/dashboard-admin.spec.mjs
+++ b/browser-tests/dashboard-admin.spec.mjs
@@ -143,8 +143,10 @@ test("[asset-versioning] dashboard and control center include current cache-bust
     nodes.map((node) => node.getAttribute("href") || ""),
   );
   expect(dashboardStyles.some((href) => href.includes("styles.css?v=20260828-phase21-1"))).toBeTruthy();
-  expect(dashboardScripts.some((src) => src.includes("app.js?v=20260828-phase21-1"))).toBeTruthy();
-  expect(dashboardScripts.some((src) => src.includes("dashboard-intake.js?v=20260824-phase20"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("app.js?v=20260907-auth-hardening"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("auth.js?v=20260907-auth-hardening"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("dashboard-step8.js?v=20260907-step8"))).toBeTruthy();
+  expect(dashboardScripts.some((src) => src.includes("dashboard-intake.js?v=20260829-vault-ready"))).toBeTruthy();
   expect(dashboardScripts.some((src) => src.includes("dashboard-admin.js?v=20260713-livefix3"))).toBeTruthy();
 
   await page.goto("/admin-control-center.html", { waitUntil: "domcontentloaded" });

--- a/browser-tests/dashboard-customer-phase20.spec.mjs
+++ b/browser-tests/dashboard-customer-phase20.spec.mjs
@@ -48,7 +48,19 @@ async function installRakimDashboardRoutes(page) {
           code: "digital_legacy_portrait",
           display_name: "Digital Legacy Portrait",
           lane: "portrait",
+          status: "paid",
+          payment_required: true,
+        },
+        acquisition: {
+          source: "paid_order",
+          payment_required: true,
+          record_id: "order-rakim",
+        },
+        maintenance: {
           status: "active",
+          in_grace: false,
+          read_only: false,
+          write_allowed: true,
         },
         entitlements: {
           package_code: "digital_legacy_portrait",
@@ -57,6 +69,7 @@ async function installRakimDashboardRoutes(page) {
           can_upload_verification_docs: true,
           can_manage_link_keys: true,
           can_use_link_keys: true,
+          can_link_households: false,
           can_use_viewer: true,
           can_use_secure_share_viewer: true,
         },
@@ -133,7 +146,20 @@ test.describe("Phase 20 premium customer dashboard", () => {
 
     await tools.locator("summary").click();
     await expect(tools).toHaveAttribute("open", "");
-    await expect(tools.locator('[data-dashboard-tool="link_keys"] .portal-action-status')).toHaveText("Open");
+    await expect(tools.locator('[data-dashboard-tool="link_keys"]')).toBeHidden();
+    await expect(page.locator('.site-nav a[href^="link-keys.html"]')).toBeHidden();
+    await expect(page.locator("[data-health-maintenance]")).toHaveText("Active");
+
+    const truth = await page.evaluate(() => ({
+      hasPackageAccess: window.TOLDashboardContext?.hasPackageAccess,
+      hasPaidPackage: window.TOLDashboardContext?.hasPaidPackage,
+      acquisitionSource: window.TOLDashboardContext?.acquisitionSource,
+    }));
+    expect(truth).toEqual({
+      hasPackageAccess: true,
+      hasPaidPackage: true,
+      acquisitionSource: "paid_order",
+    });
 
     const width = await page.evaluate(() => ({
       viewport: window.innerWidth,

--- a/browser-tests/dashboard-step8-truth.spec.mjs
+++ b/browser-tests/dashboard-step8-truth.spec.mjs
@@ -1,0 +1,249 @@
+import { expect, test } from "@playwright/test";
+
+const CUSTOMER = {
+  _id: "step8-customer",
+  id: "step8-customer",
+  email: "step8.customer@tomboflight.test",
+  full_name: "Step Eight Customer",
+  role: "user",
+  account_type: "customer",
+  status: "active",
+};
+
+function paidFamilyEstateSnapshot(maintenance = {}) {
+  return {
+    status: "active",
+    workspace: {
+      project_id: "project-step8",
+      project_name: "Step Eight Family Estate",
+      family_id: "family-step8",
+      lane: "network",
+    },
+    package: {
+      code: "family_estate_concierge",
+      display_name: "Family Estate Concierge",
+      lane: "network",
+      status: "paid",
+      payment_required: true,
+    },
+    acquisition: {
+      source: "paid_order",
+      payment_required: true,
+      record_id: "order-step8",
+    },
+    maintenance: {
+      status: "active",
+      in_grace: false,
+      read_only: false,
+      write_allowed: true,
+      ...maintenance,
+    },
+    entitlements: {
+      package_code: "family_estate_concierge",
+      package_lane: "network",
+      can_upload_portraits: true,
+      can_upload_verification_docs: true,
+      can_build_household: true,
+      can_build_family_tree: true,
+      can_link_households: true,
+      can_use_link_keys: true,
+      can_manage_link_keys: true,
+      can_use_household_vault: true,
+      can_use_viewer: true,
+      can_use_secure_share_viewer: true,
+      can_use_lineage_certificate: true,
+      can_open_family_intake: true,
+    },
+  };
+}
+
+function grantedFamilyEstateSnapshot() {
+  const snapshot = paidFamilyEstateSnapshot();
+  snapshot.package.status = "granted";
+  snapshot.package.payment_required = false;
+  snapshot.acquisition = {
+    source: "governed_grant",
+    payment_required: false,
+    record_id: "assignment-step8",
+    authorization_source: "ceo_master_admin",
+    billing_classification: "complimentary_package",
+  };
+  return snapshot;
+}
+
+async function seedSession(page) {
+  await page.addInitScript((user) => {
+    localStorage.setItem("tol_access_token", "step8-fixture-token");
+    localStorage.setItem("tol_user", JSON.stringify(user));
+  }, CUSTOMER);
+}
+
+async function installRoutes(page, snapshot) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+    const json = (payload, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(payload),
+      });
+
+    if (method === "GET" && path === "/auth/me") return json(CUSTOMER);
+    if (method === "GET" && path === "/orders/my-orders") return json([]);
+    if (method === "GET" && path === "/users/me/workspace-context") {
+      return json(snapshot);
+    }
+    if (method === "GET" && path === "/workspace-access/my-memberships") {
+      return json({
+        items: [
+          {
+            project_id: "project-step8",
+            user_id: CUSTOMER.id,
+            email: CUSTOMER.email,
+            member_role: "billing_owner",
+            status: "active",
+          },
+        ],
+      });
+    }
+    if (method === "GET" && path === "/intake-submissions/my-latest") {
+      return json({ detail: "No intake submissions found" }, 404);
+    }
+    if (method === "GET" && path === "/intake-submissions/my-list") return json([]);
+    if (method === "GET" && path === "/projects/project-step8/mint-eligibility") {
+      return json({
+        eligible: false,
+        reasons: ["profile_not_complete"],
+        missing_approvals: [],
+      });
+    }
+    if (method === "GET" && path === "/projects/project-step8/mint-status") {
+      return json({ latest: null, items: [] });
+    }
+    if (method === "POST" && path === "/auth/logout") return json({ ok: true });
+
+    if (
+      path.startsWith("/auth/") ||
+      path.startsWith("/orders/") ||
+      path.startsWith("/users/") ||
+      path.startsWith("/workspace-access/") ||
+      path.startsWith("/intake-submissions/") ||
+      path.startsWith("/projects/")
+    ) {
+      return json({ ok: true });
+    }
+
+    return route.continue();
+  });
+}
+
+async function openDashboard(page, snapshot) {
+  await seedSession(page);
+  await installRoutes(page, snapshot);
+  await page.goto("/dashboard.html", { waitUntil: "networkidle" });
+}
+
+test.describe("Step 8 customer dashboard truth", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("Family Estate exposes household branch Link Keys", async ({ page }) => {
+    await openDashboard(page, paidFamilyEstateSnapshot());
+
+    const tools = page.locator(".portal-tools-access-panel");
+    await tools.locator("summary").click();
+    const linkCard = tools.locator('[data-dashboard-tool="link_keys"]');
+    await expect(linkCard).toBeVisible();
+    await expect(linkCard.locator(".portal-action-status")).toHaveText("Open");
+    await expect(page.locator('.site-nav a[href^="link-keys.html"]')).toBeVisible();
+    await expect(page.locator("[data-health-maintenance]")).toHaveText("Active");
+  });
+
+  test("CEO-governed grant stays accessible without becoming a paid package", async ({ page }) => {
+    await openDashboard(page, grantedFamilyEstateSnapshot());
+
+    const truth = await page.evaluate(() => ({
+      hasPackageAccess: window.TOLDashboardContext?.hasPackageAccess,
+      hasPaidPackage: window.TOLDashboardContext?.hasPaidPackage,
+      paidOrder: window.TOLDashboardContext?.paidOrder || null,
+      acquisitionSource: window.TOLDashboardContext?.acquisitionSource,
+      paymentRequired: window.TOLDashboardContext?.paymentRequired,
+      packageStatus: window.TOLDashboardContext?.packageStatus,
+    }));
+
+    expect(truth).toEqual({
+      hasPackageAccess: true,
+      hasPaidPackage: false,
+      paidOrder: null,
+      acquisitionSource: "governed_grant",
+      paymentRequired: false,
+      packageStatus: "granted",
+    });
+
+    await expect(page.locator("[data-dashboard-package-display]")).toContainText(
+      "Granted access",
+    );
+    await expect(page.locator("[data-access-status]")).toContainText(
+      "No package payment is required",
+    );
+  });
+
+  test("maintenance grace is visible without falsely locking the workspace", async ({ page }) => {
+    await openDashboard(
+      page,
+      paidFamilyEstateSnapshot({
+        status: "past_due",
+        in_grace: true,
+        read_only: false,
+        write_allowed: true,
+        grace_ends_at: "2026-09-30T00:00:00+00:00",
+      }),
+    );
+
+    await expect(page.locator("[data-health-maintenance]")).toContainText("Grace period");
+    await expect(page.locator("[data-dashboard-hero-primary-action]")).not.toHaveText(
+      "Restore Maintenance Billing",
+    );
+  });
+
+  test("read-only maintenance makes billing the next action while Vault stays readable", async ({ page }) => {
+    await openDashboard(
+      page,
+      paidFamilyEstateSnapshot({
+        status: "past_due",
+        in_grace: false,
+        read_only: true,
+        write_allowed: false,
+        grace_ends_at: "2026-08-31T00:00:00+00:00",
+      }),
+    );
+
+    await expect(page.locator("[data-health-maintenance]")).toContainText("Read-only");
+    await expect(page.locator("[data-dashboard-next-focus]")).toHaveText(
+      "Restore maintenance billing",
+    );
+    const heroAction = page.locator("[data-dashboard-hero-primary-action]");
+    await expect(heroAction).toHaveText("Restore Maintenance Billing");
+    await expect(heroAction).toHaveAttribute("href", "billing.html");
+
+    const tools = page.locator(".portal-tools-access-panel");
+    await tools.locator("summary").click();
+    const vaultCard = tools.locator('[data-dashboard-tool="vault"]');
+    await expect(vaultCard.locator(".portal-action-status")).toHaveText("Read-only");
+    await expect(vaultCard).toHaveAttribute("href", "vault-upload.html");
+  });
+
+  test("desktop layout stays within the viewport and keeps the primary action usable", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openDashboard(page, paidFamilyEstateSnapshot());
+
+    await expect(page.locator("#dashboard-primary-actions")).toBeVisible();
+    const width = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+    }));
+    expect(width.document).toBeLessThanOrEqual(width.viewport + 1);
+  });
+});

--- a/browser-tests/dashboard-step8-truth.spec.mjs
+++ b/browser-tests/dashboard-step8-truth.spec.mjs
@@ -157,6 +157,10 @@ test.describe("Step 8 customer dashboard truth", () => {
     const linkCard = tools.locator('[data-dashboard-tool="link_keys"]');
     await expect(linkCard).toBeVisible();
     await expect(linkCard.locator(".portal-action-status")).toHaveText("Open");
+
+    const menuToggle = page.locator(".menu-toggle");
+    await expect(menuToggle).toBeVisible();
+    await menuToggle.click();
     await expect(page.locator('.site-nav a[href^="link-keys.html"]')).toBeVisible();
     await expect(page.locator("[data-health-maintenance]")).toHaveText("Active");
   });

--- a/dashboard-step8.js
+++ b/dashboard-step8.js
@@ -1,0 +1,323 @@
+(function () {
+  "use strict";
+
+  const DASHBOARD_SELECTOR = "[data-dashboard]";
+  const LAPSED_MAINTENANCE_STATUSES = new Set([
+    "canceled",
+    "cancelled",
+    "churned",
+    "overdue",
+    "past_due",
+    "refunded",
+    "unpaid",
+  ]);
+
+  function normalizeValue(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function getSnapshot(context) {
+    return context && context.workspaceContextSnapshot && typeof context.workspaceContextSnapshot === "object"
+      ? context.workspaceContextSnapshot
+      : {};
+  }
+
+  function normalizeWorkspaceTruth(context) {
+    if (!context || typeof context !== "object") return null;
+
+    const snapshot = getSnapshot(context);
+    const packageInfo = snapshot.package && typeof snapshot.package === "object" ? snapshot.package : {};
+    const acquisition = snapshot.acquisition && typeof snapshot.acquisition === "object" ? snapshot.acquisition : {};
+    const packageStatus = normalizeValue(packageInfo.status || context.packageStatus);
+    const acquisitionSource = normalizeValue(
+      acquisition.source ||
+        context.acquisitionSource ||
+        (packageStatus === "granted"
+          ? "governed_grant"
+          : packageStatus === "paid"
+            ? "paid_order"
+            : ""),
+    );
+    const paymentRequired =
+      typeof acquisition.payment_required === "boolean"
+        ? acquisition.payment_required
+        : typeof packageInfo.payment_required === "boolean"
+          ? packageInfo.payment_required
+          : context.paymentRequired;
+
+    context.packageStatus = packageStatus || null;
+    context.acquisitionSource = acquisitionSource || null;
+    context.paymentRequired =
+      typeof paymentRequired === "boolean" ? paymentRequired : null;
+
+    const hasVerifiedPaidPackage = Boolean(
+      context.hasPackageAccess &&
+        acquisitionSource === "paid_order" &&
+        packageStatus === "paid" &&
+        paymentRequired !== false,
+    );
+    context.hasPaidPackage = hasVerifiedPaidPackage;
+
+    if (!hasVerifiedPaidPackage) {
+      context.paidOrder = null;
+      if (context.currentWorkspace && typeof context.currentWorkspace === "object") {
+        context.currentWorkspace.paidOrder = null;
+      }
+    }
+
+    if (context.currentWorkspace && typeof context.currentWorkspace === "object") {
+      context.currentWorkspace.acquisitionSource = acquisitionSource || null;
+      context.currentWorkspace.paymentRequired =
+        typeof paymentRequired === "boolean" ? paymentRequired : null;
+      context.currentWorkspace.packageStatus = packageStatus || null;
+    }
+
+    context.maintenance =
+      snapshot.maintenance && typeof snapshot.maintenance === "object"
+        ? snapshot.maintenance
+        : context.maintenance && typeof context.maintenance === "object"
+          ? context.maintenance
+          : {};
+
+    return context;
+  }
+
+  function setText(selector, value) {
+    const node = document.querySelector(selector);
+    if (node && typeof value === "string" && value) {
+      node.textContent = value;
+    }
+  }
+
+  function formatDate(value) {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toLocaleDateString();
+  }
+
+  function getMaintenancePresentation(maintenance) {
+    const state = maintenance && typeof maintenance === "object" ? maintenance : {};
+    const status = normalizeValue(state.status || "not_started");
+
+    if (state.read_only === true || state.write_allowed === false) {
+      return {
+        key: "read_only",
+        label: "Read-only — update billing to resume Vault changes",
+      };
+    }
+
+    if (state.in_grace === true) {
+      const graceEnd = formatDate(state.grace_ends_at);
+      return {
+        key: "grace",
+        label: graceEnd
+          ? `Grace period — billing should be restored by ${graceEnd}`
+          : "Grace period — billing action recommended",
+      };
+    }
+
+    if (["active", "paid", "current", "trialing"].includes(status)) {
+      return { key: "active", label: "Active" };
+    }
+
+    if (["not_started", "scheduled", "pending"].includes(status)) {
+      return { key: "scheduled", label: "Scheduled / not started" };
+    }
+
+    if (LAPSED_MAINTENANCE_STATUSES.has(status)) {
+      return { key: "billing_attention", label: "Billing attention required" };
+    }
+
+    return {
+      key: status || "unknown",
+      label: status
+        ? status
+            .split("_")
+            .map(function (part) {
+              return part.charAt(0).toUpperCase() + part.slice(1);
+            })
+            .join(" ")
+        : "Status unavailable",
+    };
+  }
+
+  function ensureMaintenanceRow() {
+    let node = document.querySelector("[data-health-maintenance]");
+    if (node) return node;
+
+    const list = document.querySelector(
+      ".portal-workspace-health-panel .portal-status-list",
+    );
+    if (!list) return null;
+
+    const row = document.createElement("p");
+    row.className = "card-copy";
+    row.innerHTML = "<strong>Maintenance:</strong> <span data-health-maintenance>Checking status</span>";
+    list.appendChild(row);
+    return row.querySelector("[data-health-maintenance]");
+  }
+
+  function applyBranchLinkPresentation(context) {
+    const resolved = context && context.resolvedEntitlements ? context.resolvedEntitlements : {};
+    const canLinkHouseholds = Boolean(resolved.can_link_households);
+
+    document
+      .querySelectorAll('.site-nav a[href^="link-keys.html"]')
+      .forEach(function (node) {
+        node.style.display = canLinkHouseholds ? "" : "none";
+      });
+
+    document
+      .querySelectorAll('[data-dashboard-tool="link_keys"]')
+      .forEach(function (node) {
+        node.style.display = canLinkHouseholds ? "" : "none";
+        node.setAttribute("aria-hidden", canLinkHouseholds ? "false" : "true");
+        if (canLinkHouseholds) {
+          node.removeAttribute("aria-disabled");
+          node.style.pointerEvents = "";
+          const status = node.querySelector(".portal-action-status");
+          if (status) {
+            status.textContent = "Open";
+            status.dataset.state = "success";
+          }
+        }
+      });
+
+    const unlock = document.querySelector("[data-unlock-link-keys]");
+    if (unlock) {
+      unlock.textContent = canLinkHouseholds ? "Included" : "Not included";
+      const label = unlock.parentElement && unlock.parentElement.querySelector("span:first-child");
+      if (label) label.textContent = "Household Link Keys";
+    }
+  }
+
+  function applyGrantPresentation(context) {
+    const isGranted =
+      context &&
+      (context.acquisitionSource === "governed_grant" ||
+        context.packageStatus === "granted");
+    if (!isGranted) return;
+
+    const packageName = String(context.packageName || "Granted package").trim();
+    setText("[data-dashboard-package-display]", `${packageName} — Granted access`);
+    setText("[data-dashboard-scope-chip]", "Granted Access");
+    setText(
+      "[data-command-center-package]",
+      `${packageName} · Tomb of Light authorized grant · no package payment required`,
+    );
+    setText(
+      "[data-access-status]",
+      "Access granted by Tomb of Light. No package payment is required for this workspace.",
+    );
+  }
+
+  function applyMaintenancePresentation(context) {
+    const presentation = getMaintenancePresentation(context && context.maintenance);
+    const node = ensureMaintenanceRow();
+    if (node) {
+      node.textContent = presentation.label;
+      node.dataset.state = presentation.key;
+    }
+
+    const vaultCard = document.querySelector('[data-dashboard-tool="vault"]');
+    if (vaultCard && presentation.key === "read_only") {
+      const status = vaultCard.querySelector(".portal-action-status");
+      const cta = vaultCard.querySelector(".portal-action-cta");
+      if (status) {
+        status.textContent = "Read-only";
+        status.dataset.state = "warning";
+      }
+      if (cta) cta.textContent = "Open Read-only Vault";
+    }
+
+    if (presentation.key !== "read_only") return;
+
+    setText("[data-dashboard-next-focus]", "Restore maintenance billing");
+    setText(
+      "[data-command-center-next-action]",
+      "Update maintenance billing to resume Vault changes. Existing Vault files remain available to view and download.",
+    );
+
+    const primaryAction = document.querySelector("[data-dashboard-hero-primary-action]");
+    if (primaryAction) {
+      primaryAction.style.display = "";
+      primaryAction.setAttribute("href", "billing.html");
+      primaryAction.textContent = "Restore Maintenance Billing";
+      primaryAction.dataset.originalHref = "billing.html";
+    }
+  }
+
+  function clarifyMaterialsWorkflow() {
+    const panel = document.querySelector(".portal-materials-panel");
+    if (!panel) return;
+
+    const heading = panel.querySelector("summary .portal-disclosure-heading strong");
+    if (heading) {
+      heading.textContent = "Portrait, record, Vault, and review workflow status";
+    }
+
+    const replacements = [
+      ["[data-received-portraits]", "Planned", "Planned from intake"],
+      ["[data-received-portraits]", "In workflow", "Production workflow active"],
+      ["[data-received-portraits]", "Not yet submitted", "No workflow activity confirmed here"],
+      ["[data-received-verification]", "Planned", "Planned from intake"],
+      ["[data-received-verification]", "In workflow", "Production workflow active"],
+      ["[data-received-verification]", "Not yet submitted", "No workflow activity confirmed here"],
+      ["[data-received-vault]", "Check workspace", "Check Vault for actual files"],
+      ["[data-received-vault]", "Not yet submitted", "No workflow activity confirmed here"],
+    ];
+
+    replacements.forEach(function (item) {
+      const node = document.querySelector(item[0]);
+      if (node && node.textContent.trim() === item[1]) {
+        node.textContent = item[2];
+      }
+    });
+
+    const content = panel.querySelector(".portal-disclosure-content");
+    if (content && !content.querySelector("[data-step8-materials-truth-note]")) {
+      const note = document.createElement("p");
+      note.className = "card-copy";
+      note.setAttribute("data-step8-materials-truth-note", "true");
+      note.textContent =
+        "These indicators describe workflow status, not a file inventory. Open Upload Hub or Vault to view actual uploaded files.";
+      content.appendChild(note);
+    }
+  }
+
+  function applyPresentation(context) {
+    if (!document.querySelector(DASHBOARD_SELECTOR) || !context) return;
+    applyBranchLinkPresentation(context);
+    applyGrantPresentation(context);
+    applyMaintenancePresentation(context);
+    clarifyMaterialsWorkflow();
+  }
+
+  function schedulePresentation(context) {
+    const apply = function () {
+      applyPresentation(context);
+    };
+    if (typeof queueMicrotask === "function") queueMicrotask(apply);
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(apply);
+    window.setTimeout(apply, 100);
+    window.setTimeout(apply, 500);
+  }
+
+  function handleContext(context) {
+    const normalized = normalizeWorkspaceTruth(context);
+    if (!normalized) return;
+    window.TOLDashboardContext = normalized;
+    schedulePresentation(normalized);
+  }
+
+  window.addEventListener("tol:dashboard-context-ready", function (event) {
+    handleContext(event && event.detail ? event.detail : window.TOLDashboardContext);
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    if (window.TOLDashboardContext) {
+      handleContext(window.TOLDashboardContext);
+    }
+  });
+})();

--- a/dashboard.html
+++ b/dashboard.html
@@ -858,9 +858,10 @@
     </div>
 
     <script src="config.js?v=20260828-phase21-1"></script>
-    <script src="app.js?v=20260828-phase21-1"></script>
-    <script src="auth.js?v=20260828-phase21-1"></script>
-    <script src="dashboard-intake.js?v=20260824-phase20"></script>
+    <script src="app.js?v=20260907-auth-hardening"></script>
+    <script src="auth.js?v=20260907-auth-hardening"></script>
+    <script src="dashboard-step8.js?v=20260907-step8"></script>
+    <script src="dashboard-intake.js?v=20260829-vault-ready"></script>
     <script src="dashboard-admin.js?v=20260713-livefix3"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #608 when merged and post-merge verification is green.

## Step 8 — Customer Dashboard

This PR aligns the customer dashboard with the authoritative workspace truth established in Steps 6–7.

### Corrections
- Household branch Link Keys are shown only when `can_link_households=true`; generic Link Key capability no longer advertises the branch-link console.
- Paid vs CEO-governed grant acquisition is preserved from `/users/me/workspace-context`; granted workspaces remain accessible but are not represented as paid orders.
- Maintenance state is surfaced as active, scheduled/not started, grace, or read-only.
- Read-only maintenance makes Billing the next action while preserving Vault view/download access.
- Materials & Review is explicitly described as workflow status rather than a file inventory; Step 9 will certify actual upload inventory/lifecycle.
- Dashboard asset cache identities are refreshed only for assets that changed since their previous URL identity.

### Verification added
- Digital Legacy Portrait generic Link Keys do not expose household branch linking.
- Family Estate Concierge exposes branch linking when entitled.
- Paid workspace remains `hasPaidPackage=true`.
- CEO-governed grant remains `hasPackageAccess=true`, `hasPaidPackage=false`, `paidOrder=null`.
- Maintenance active/grace/read-only states are customer-visible.
- Read-only Vault remains readable and Billing becomes next action.
- Mobile and desktop horizontal overflow checks.
- Static guard verifies script order/cache identities and Step 8 truth invariants.

### Scope / safety
Changed files are limited to dashboard presentation and dashboard tests. No Stripe charge/refund, production MongoDB write, Vault mutation/deletion, NFT mint, Continuity Kernel execution, customer email, migration, or account deletion is performed by this PR.